### PR TITLE
ComboBox autosizing

### DIFF
--- a/MahApps.Metro/Styles/Controls.xaml
+++ b/MahApps.Metro/Styles/Controls.xaml
@@ -1323,7 +1323,11 @@
                         </VisualStateManager.VisualStateGroups>
                         <Border x:Name="ContentPresenterBorder">
                             <Grid>
-                                <ToggleButton x:Name="DropDownToggle"
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ToggleButton x:Name="DropDownToggle" Grid.Column="1"
                                               BorderBrush="{TemplateBinding BorderBrush}"
                                               BorderThickness="{TemplateBinding BorderThickness}"
                                               Background="{TemplateBinding Background}"

--- a/MetroDemo/MainWindow.xaml
+++ b/MetroDemo/MainWindow.xaml
@@ -84,7 +84,7 @@
                                 <ComboBox Margin="88.292,176.84,0,0"
                                           VerticalAlignment="Top"
                                           HorizontalAlignment="Left"
-                                          Width="154.404">
+                                          SelectedIndex="0">
                                     <ComboBoxItem Content="ComboBoxItem" />
                                     <ComboBoxItem Content="ComboBoxItem" />
                                     <ComboBoxItem Content="ComboBoxItem" />


### PR DESCRIPTION
When you didn't specify the width for a ComboBox element, the ToggleButton overlapped the content.
