### PR TITLE
Maximize/Normal states of window in Win7

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -4,12 +4,16 @@ using System.Windows.Input;
 namespace MahApps.Metro.Controls
 {
     [TemplatePart(Name = PART_TitleBar, Type = typeof(UIElement))]
+    [TemplatePart(Name = PART_WindowCommands, Type = typeof(WindowCommands))]
     public class MetroWindow : Window
     {
         private const string PART_TitleBar = "PART_TitleBar";
+        private const string PART_WindowCommands = "PART_WindowCommands";
 
         public static readonly DependencyProperty ShowIconOnTitleBarProperty = DependencyProperty.Register("ShowIconOnTitleBar", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
         public static readonly DependencyProperty ShowTitleBarProperty = DependencyProperty.Register("ShowTitleBar", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
+
+        private WindowCommands windowCommands;
 
         static MetroWindow()
         {
@@ -33,6 +37,8 @@ namespace MahApps.Metro.Controls
             base.OnApplyTemplate();
 
             var titleBar = GetTemplateChild(PART_TitleBar) as UIElement;
+            windowCommands = GetTemplateChild(PART_WindowCommands) as WindowCommands;
+
             if (titleBar != null)
             {
                 titleBar.MouseDown += TitleBarMouseDown;
@@ -45,10 +51,28 @@ namespace MahApps.Metro.Controls
             }
         }
 
+        protected override void OnStateChanged(System.EventArgs e)
+        {
+            if (windowCommands != null)
+            {
+                windowCommands.RefreshMaximiseIconState();
+            }
+
+            base.OnStateChanged(e);
+        }
+
         private void TitleBarMouseDown(object sender, MouseButtonEventArgs e)
         {
             if (e.RightButton != MouseButtonState.Pressed && e.MiddleButton != MouseButtonState.Pressed && e.LeftButton == MouseButtonState.Pressed)
                 DragMove();
+
+            if (e.ClickCount == 2)
+            {
+                if (WindowState == WindowState.Maximized)
+                    WindowState = WindowState.Normal;
+                else
+                    WindowState = WindowState.Maximized;
+            }
         }
 
         private void TitleBarMouseMove(object sender, MouseEventArgs e)

--- a/MahApps.Metro/Controls/WindowCommands.xaml
+++ b/MahApps.Metro/Controls/WindowCommands.xaml
@@ -3,8 +3,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d"
              x:Name="windowCommands">
+    <UserControl.Resources>
+        <sys:String x:Key="WindowCommandsMinimiseToolTip">Minimise</sys:String>
+        <sys:String x:Key="WindowCommandsMaximiseToolTip">Maximise</sys:String>
+        <sys:String x:Key="WindowCommandsRestoreToolTip">Restore</sys:String>
+        <sys:String x:Key="WindowCommandsCloseToolTip">Close</sys:String>
+    </UserControl.Resources>
     <StackPanel Height="20" Margin="0,5,5,0" Orientation="Horizontal" Width="66">
         <Button x:Name="btnMin"
                 Click="MinimiseClick"
@@ -13,7 +20,7 @@
                 Height="20"
                 Style="{DynamicResource ChromelessButtonStyle}"
                 Padding="0"
-                ToolTip="Minimise"
+                ToolTip="{DynamicResource WindowCommandsMinimiseToolTip}"
                 FontFamily="Marlett"
                 Opacity="0.8" Content="0" />
         <Button x:Name="btnMax"
@@ -23,7 +30,7 @@
                 Height="20"
                 Style="{DynamicResource ChromelessButtonStyle}"
                 Padding="0"
-                ToolTip="Maximise"
+                ToolTip="{DynamicResource WindowCommandsMaximiseToolTip}"
                 Opacity="0.8" FontFamily="Marlett"
                 Content="1" />
         <Button x:Name="btnClose"
@@ -32,7 +39,7 @@
                 Width="20"
                 Height="20"
                 Style="{DynamicResource ChromelessButtonStyle}"
-                ToolTip="Close"
+                ToolTip="{DynamicResource WindowCommandsCloseToolTip}"
                 Opacity="0.8" FontFamily="Marlett"
                 Content="r" />
     </StackPanel>

--- a/MahApps.Metro/Controls/WindowCommands.xaml.cs
+++ b/MahApps.Metro/Controls/WindowCommands.xaml.cs
@@ -34,14 +34,32 @@ namespace MahApps.Metro.Controls
             if (parentWindow != null)
             {
                 if (parentWindow.WindowState == WindowState.Maximized)
-                {
                     parentWindow.WindowState = WindowState.Normal;
+                else
+                    parentWindow.WindowState = WindowState.Maximized;
+
+                RefreshMaximiseIconState(parentWindow);
+            }
+        }
+
+        public void RefreshMaximiseIconState()
+        {
+            RefreshMaximiseIconState(GetParentWindow());
+        }
+
+        private void RefreshMaximiseIconState(Window parentWindow)
+        {
+            if (parentWindow != null)
+            {
+                if (parentWindow.WindowState == WindowState.Normal)
+                {
                     btnMax.Content = "1";
+                    btnMax.SetResourceReference(System.Windows.Controls.Button.ToolTipProperty, "WindowCommandsMaximiseToolTip");
                 }
                 else
                 {
-                    parentWindow.WindowState = WindowState.Maximized;
                     btnMax.Content = "2";
+                    btnMax.SetResourceReference(System.Windows.Controls.Button.ToolTipProperty, "WindowCommandsRestoreToolTip");
                 }
             }
         }

--- a/MahApps.Metro/Themes/Generic.xaml
+++ b/MahApps.Metro/Themes/Generic.xaml
@@ -554,6 +554,7 @@
                                     Foreground="White"/>
                             </Grid>
                             <Controls:WindowCommands 
+                                x:Name="PART_WindowCommands"
                                 Panel.ZIndex="1"
                                 Grid.RowSpan="2"
                                 VerticalAlignment="Top"


### PR DESCRIPTION
This corrects the behaviour of maximizing/restoring a MetroWindow when dragging it to/from the top of the screen in Win7 (see #11).
