### PR TITLE
Better approach for combobox autosizing

### DIFF
--- a/MahApps.Metro/Styles/Controls.xaml
+++ b/MahApps.Metro/Styles/Controls.xaml
@@ -1346,7 +1346,9 @@
                                         </Path.Fill>
                                     </Path>
                                 </ToggleButton>
-                                <ContentPresenter ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" Content="{TemplateBinding SelectionBoxItem}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" IsHitTestVisible="false" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                <Grid Margin="0 0 16 0">
+                                    <ContentPresenter ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}" Content="{TemplateBinding SelectionBoxItem}" ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" IsHitTestVisible="false" Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                </Grid>
                             </Grid>
                         </Border>
                         <Rectangle x:Name="FocusRectangle"

--- a/MetroDemo/MainWindow.xaml
+++ b/MetroDemo/MainWindow.xaml
@@ -84,7 +84,7 @@
                                 <ComboBox Margin="88.292,176.84,0,0"
                                           VerticalAlignment="Top"
                                           HorizontalAlignment="Left"
-                                          Width="154.404">
+                                          SelectedIndex="0">
                                     <ComboBoxItem Content="ComboBoxItem" />
                                     <ComboBoxItem Content="ComboBoxItem" />
                                     <ComboBoxItem Content="ComboBoxItem" />


### PR DESCRIPTION
I surrounded the ComboBox's ContentPresenter with a grid with margin 0,0,16,0, so it doesn't overlap the ToggleButton's down arrow
