### PR TITLE
Fixed a bug with the unsnapping of a maximized window on a multi-monitor...

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -81,16 +81,15 @@ namespace MahApps.Metro.Controls
                 && e.LeftButton == MouseButtonState.Pressed && WindowState == WindowState.Maximized)
             {
                 // Calcualting correct left coordinate for multi-screen system.
-                double mouseX = PointToScreen(Mouse.GetPosition(this)).X;
+                Point mouseAbsolute = PointToScreen(Mouse.GetPosition(this));
                 double width = RestoreBounds.Width;
-                double left = mouseX - width / 2;
+                double left = mouseAbsolute.X - width / 2;
 
                 // Aligning window's position to fit the screen.
                 double virtualScreenWidth = SystemParameters.VirtualScreenWidth;
-                left = left < 0 ? 0 : left;
                 left = left + width > virtualScreenWidth ? virtualScreenWidth - width : left;
 
-                Top = 0;
+                Top = mouseAbsolute.Y - e.MouseDevice.GetPosition(this).Y;
                 Left = left;
 
                 // Restore window to normal state.


### PR DESCRIPTION
When the window was in maximized state on a secondary screen and dragged down, it suddenly popped up on the primary screen, instead of dragging down on the secondary screen.
