### PR TITLE
Changed Titlebar events to protected.

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -61,7 +61,7 @@ namespace MahApps.Metro.Controls
             base.OnStateChanged(e);
         }
 
-        private void TitleBarMouseDown(object sender, MouseButtonEventArgs e)
+        protected void TitleBarMouseDown(object sender, MouseButtonEventArgs e)
         {
             if (e.RightButton != MouseButtonState.Pressed && e.MiddleButton != MouseButtonState.Pressed && e.LeftButton == MouseButtonState.Pressed)
                 DragMove();
@@ -75,7 +75,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        private void TitleBarMouseMove(object sender, MouseEventArgs e)
+        protected void TitleBarMouseMove(object sender, MouseEventArgs e)
         {
             if (e.RightButton != MouseButtonState.Pressed && e.MiddleButton != MouseButtonState.Pressed
                 && e.LeftButton == MouseButtonState.Pressed && WindowState == WindowState.Maximized)


### PR DESCRIPTION
This allows reuse of the titlebar events in windows where the titlebar is not displayed.

For example, you can now do this in the window:

```
<controls:MetroWindow x:Class="MainWindow" ShowTitleBar="False">

<Grid>
    <Grid.RowDefinitions>
        <RowDefinition Height="30"/>
        <RowDefinition Height="*"/>
    </Grid.RowDefinitions>

    <Grid x:Name="DragArea" Background="Transparent" />

    ...
</Grid>

public partial class MainWindow : MetroWindow
{
    public MainWindow()
    {
        InitializeComponent();

        DragArea.MouseDown += this.TitleBarMouseDown;
        DragArea.MouseMove += this.TitleBarMouseMove;
    }
}
```
