### PR TITLE
Checkbox had a weird default minimum width

### DIFF
--- a/MahApps.Metro/Styles/Controls.xaml
+++ b/MahApps.Metro/Styles/Controls.xaml
@@ -480,8 +480,6 @@
                 Value="{DynamicResource ContentFontSize}" />
         <Setter Property="Background"
                 Value="{DynamicResource CheckBoxBackgroundBrush}" />
-        <Setter Property="MinWidth"
-                Value="100" />
         <Setter Property="Foreground"
                 Value="{DynamicResource TextBrush}" />
         <Setter Property="HorizontalContentAlignment"


### PR DESCRIPTION
For some reasons the checkbox control had a default minimum width of 100. I don't really think this is intended.
