### PR TITLE
ToggleSwitch changes theme color resource globally

### DIFF
--- a/MahApps.Metro/Themes/Generic.xaml
+++ b/MahApps.Metro/Themes/Generic.xaml
@@ -127,9 +127,9 @@
         											Storyboard.TargetProperty="(TranslateTransform.X)"
         											Duration="0"
         											To="0" />
-                                        <ColorAnimationUsingKeyFrames Storyboard.TargetProperty="(Panel.Background).(SolidColorBrush.Color)" Storyboard.TargetName="border">
-                                            <EasingColorKeyFrame KeyTime="0" Value="#CC9B9B9B"/>
-                                        </ColorAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="border">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}"/>
+                                        </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -148,7 +148,8 @@
                                     </Rectangle>
                                     <Border BorderThickness="2" BorderBrush="{DynamicResource GrayBrush9}">
                                         <Grid Margin="2">
-                                            <Border x:Name="border" BorderThickness="0" Background="{DynamicResource AccentColorBrush}" Margin="0" />
+                                            <Border BorderThickness="0" Background="{DynamicResource AccentColorBrush}" Margin="0" />
+                                            <Border x:Name="border" BorderThickness="0" Background="{DynamicResource GrayBrush9}" Visibility="Collapsed" Margin="0" />
                                             <Border x:Name="pressed" BorderThickness="0" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" Opacity="0.25" Visibility="Collapsed" Margin="0" />
                                             <Border x:Name="hover" BorderThickness="0" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" Opacity="0.15" Visibility="Collapsed" Margin="0" />
                                         </Grid>


### PR DESCRIPTION
Variating resource brush color directly (AccentBorderBrush) changed in all toggle switches, so if you had more than one toggler on your form then all changed colors when one of them was switched.
