### PR TITLE
Fixes the black stripes that appear when resizing the window

### DIFF
--- a/MahApps.Metro/Native/Constants.cs
+++ b/MahApps.Metro/Native/Constants.cs
@@ -9,5 +9,6 @@
         public const int WM_GETMINMAXINFO = 0x24;
         public const int WM_CREATE = 0x0001;
         public const long WS_MAXIMIZE = 0x01000000;
+        public const int GCLP_HBRBACKGROUND = -0x0A;
     }
 }


### PR DESCRIPTION
When resizing a WPF window, you normally notice some black spots that fill in the remaining space until the layout catches up and resizes the window content.

This is especially noticeably on windows with white background and a complex layout like MetroWindow. To better demonstrate the effect, I've put 1000 buttons inside the MetroDemo application. During resize, the following happens: http://i43.tinypic.com/i57skk.png

To mitigate the issue, I've included a p/invoke call to set the default background color of the window to the WPF window background color. Now you get this during resize: http://i40.tinypic.com/29d16e.png
Far better in my opinion and on layouts with reasonable complexity, you won't notice the spots during resize anymore because they now have the same color as the background.

There's one issue though: The color set as the (native) background color is based on the color the window had during startup. If you change the window color afterwards, the "resize spots" will still have the old color.
I think this is tolerable, as many windows have a fixed background color anyway (and even if they don't, having another color is as good/bad as black).
