### PR TITLE
Implemented window resize functionality as described in #30.

### DIFF
--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -224,8 +224,64 @@ namespace MahApps.Metro.Behaviours
                      * as mentioned by jason.bullard (comment from September 22, 2011) on http://gallery.expression.microsoft.com/ZuneWindowBehavior/ */
                     handled = false;
                     break;
-            }
+                case Constants.WM_NCHITTEST:
 
+                    // don't process the message on windows that can't be resized
+                    var resizeMode = AssociatedObject.ResizeMode;
+                    if (resizeMode == ResizeMode.CanMinimize || resizeMode == ResizeMode.NoResize)
+                        break;
+
+                    // get X & Y out of the message                   
+                    var screenPoint = new Point(UnsafeNativeMethods.GET_X_LPARAM(lParam), UnsafeNativeMethods.GET_Y_LPARAM(lParam));
+
+                    // convert to window coordinates
+                    var windowPoint = AssociatedObject.PointFromScreen(screenPoint);
+                    var windowSize = AssociatedObject.RenderSize;
+                    var windowRect = new Rect(windowSize);
+                    windowRect.Inflate(-6,-6);
+
+                    // don't process the message if the mouse is outside the 6px resize border
+                    if (windowRect.Contains(windowPoint))
+                        break;
+
+                    var windowHeight = (int)windowSize.Height;
+                    var windowWidth = (int)windowSize.Width;
+
+                    // create the rectangles where resize arrows are shown
+                    var topLeft = new Rect(0, 0, 6, 6);
+                    var top = new Rect(6, 0, windowWidth - 12, 6);
+                    var topRight = new Rect(windowWidth - 6, 0, 6, 6);
+
+                    var left = new Rect(0, 6, 6, windowHeight - 12);
+                    var right = new Rect(windowWidth - 6, 6, 6, windowHeight - 12);
+
+                    var bottomLeft = new Rect(0, windowHeight - 6, 6, 6);
+                    var bottom = new Rect(6, windowHeight - 6, windowWidth - 12, 6);
+                    var bottomRight = new Rect(windowWidth - 6, windowHeight - 6, 6, 6);
+
+                    // check if the mouse is within one of the rectangles
+                    if (topLeft.Contains(windowPoint))
+                        returnval = (IntPtr)Constants.HTTOPLEFT;
+                    else if (top.Contains(windowPoint))
+                        returnval = (IntPtr)Constants.HTTOP;
+                    else if (topRight.Contains(windowPoint))
+                        returnval = (IntPtr)Constants.HTTOPRIGHT;
+                    else if (left.Contains(windowPoint))
+                        returnval = (IntPtr)Constants.HTLEFT;
+                    else if (right.Contains(windowPoint))
+                        returnval = (IntPtr)Constants.HTRIGHT;
+                    else if (bottomLeft.Contains(windowPoint))
+                        returnval = (IntPtr)Constants.HTBOTTOMLEFT;
+                    else if (bottom.Contains(windowPoint))
+                        returnval = (IntPtr)Constants.HTBOTTOM;
+                    else if (bottomRight.Contains(windowPoint))
+                        returnval = (IntPtr)Constants.HTBOTTOMRIGHT;
+
+                    if (returnval != IntPtr.Zero)
+                        handled = true;
+
+                    break;
+            }
 
             return returnval;
         }

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -117,7 +117,11 @@ namespace MahApps.Metro.Controls
                 double virtualScreenWidth = SystemParameters.VirtualScreenWidth;
                 left = left + width > virtualScreenWidth ? virtualScreenWidth - width : left;
 
-                Top = mouseAbsolute.Y - e.MouseDevice.GetPosition(this).Y;
+                var mousePosition = e.MouseDevice.GetPosition(this);
+
+                // When dragging the window down at the very top of the border,
+                // move the window a bit upwards to avoid showing the resize handle as soon as the mouse button is released
+                Top = mousePosition.Y < 5 ? -5 : mouseAbsolute.Y - mousePosition.Y;
                 Left = left;
 
                 // Restore window to normal state.

--- a/MahApps.Metro/Native/Constants.cs
+++ b/MahApps.Metro/Native/Constants.cs
@@ -10,5 +10,14 @@
         public const int WM_CREATE = 0x0001;
         public const long WS_MAXIMIZE = 0x01000000;
         public const int GCLP_HBRBACKGROUND = -0x0A;
+        public const int WM_NCHITTEST = 0x84;
+        public const int HTLEFT = 0x0A;
+        public const int HTRIGHT = 0x0B;
+        public const int HTTOP = 0x0C;
+        public const int HTTOPLEFT = 0x0D;
+        public const int HTTOPRIGHT = 0x0E;
+        public const int HTBOTTOM = 0x0F;
+        public const int HTBOTTOMLEFT = 0x10;
+        public const int HTBOTTOMRIGHT = 0x11;
     }
 }

--- a/MahApps.Metro/Native/UnsafeNativeMethods.cs
+++ b/MahApps.Metro/Native/UnsafeNativeMethods.cs
@@ -60,5 +60,25 @@ namespace MahApps.Metro.Native
 
         [DllImport("gdi32.dll")]
         internal static extern bool DeleteObject(IntPtr hObject);
+
+        internal static int GET_X_LPARAM(IntPtr lParam)
+        {
+            return LOWORD(lParam.ToInt32());
+        }
+
+        internal static int GET_Y_LPARAM(IntPtr lParam)
+        {
+            return HIWORD(lParam.ToInt32());
+        }
+
+        internal static int HIWORD(int i)
+        {
+            return (short)(i >> 16);
+        }
+
+        internal static int LOWORD(int i)
+        {
+            return (short)(i & 0xFFFF);
+        }
     }
 }


### PR DESCRIPTION
This implements window resizing on all four window borders.

I originally stated in #30 that I'll implement it with four invisible rectangles. This approach however led to really annoying problems with getting the cursor right and resizing the window was terribly slow when using the WPF properties (width, height, top, left) directly.
This instead uses the window message WM_NCHITTEST, with the advantage that the OS figures out which cursor to use, disables resizing when the window is maximized and handles the resizing itself.
