### PR TITLE
MetroProgressBar clips now

### DIFF
--- a/MahApps.Metro/Themes/Generic.xaml
+++ b/MahApps.Metro/Themes/Generic.xaml
@@ -987,7 +987,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Controls:MetroProgressBar}">
-                    <Grid x:Name="ContainingGrid">
+                    <Grid x:Name="ContainingGrid" ClipToBounds="True">
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">                         
                                 <VisualState x:Name="Determinate"/>


### PR DESCRIPTION
MetroProgressBar clips to it's bounds now. Previously the ellipses would go way over the bounds, now you only see them when they're within the bounds of the box.
