### PR TITLE
ProgressRing OneWay Binding Fix.

### DIFF
--- a/MahApps.Metro/Controls/ProgressRing.cs
+++ b/MahApps.Metro/Controls/ProgressRing.cs
@@ -130,14 +130,22 @@ namespace MahApps.Metro.Controls
             var ring = dependencyObject as ProgressRing;
             if (ring == null)
                 return;
+
+            ring.UpdateLargeState();
+        }
+
+        private void UpdateLargeState()
+        {
             Action action;
 
-            if ((bool)dependencyPropertyChangedEventArgs.NewValue)
-                action = () => VisualStateManager.GoToState(ring, "Large", true);
+            if (IsLarge)
+                action = () => VisualStateManager.GoToState(this, "Large", true);
             else
-                action = () => VisualStateManager.GoToState(ring, "Small", true);
-            if (ring._deferredActions != null)
-                ring._deferredActions.Add(action);
+                action = () => VisualStateManager.GoToState(this, "Small", true);
+
+            if (_deferredActions != null)
+                _deferredActions.Add(action);
+
             else
                 action();
         }
@@ -152,35 +160,36 @@ namespace MahApps.Metro.Controls
             var ring = dependencyObject as ProgressRing;
             if (ring == null)
                 return;
+
+            ring.UpdateActiveState();
+        }
+
+        private void UpdateActiveState()
+        {
             Action action;
 
-            if ((bool)dependencyPropertyChangedEventArgs.NewValue)
-                action = () => VisualStateManager.GoToState(ring, "Active", true);
+            if (IsActive)
+                action = () => VisualStateManager.GoToState(this, "Active", true);
             else
-                action = () => VisualStateManager.GoToState(ring, "Inactive", true);
-            if (ring._deferredActions != null)
-                ring._deferredActions.Add(action);
+                action = () => VisualStateManager.GoToState(this, "Inactive", true);
+
+            if (_deferredActions != null)
+                _deferredActions.Add(action);
+
             else
                 action();
         }
 
         public override void OnApplyTemplate()
         {
-            UpdateStates();
+            //make sure the states get updated
+            UpdateLargeState();
+            UpdateActiveState();
             base.OnApplyTemplate();
             if (_deferredActions != null)
                 foreach (var action in _deferredActions)
                     action();
             _deferredActions = null;
-        }
-
-        private void UpdateStates()
-        {
-            //make sure the states get updated
-            IsLarge = !IsLarge;
-            IsLarge = !IsLarge;
-            IsActive = !IsActive;
-            IsActive = !IsActive;
         }
     }
 


### PR DESCRIPTION
The Progress Ring IsActive Dependency Property didn't work when binding against a read-only(Mode=OneWay) property, it would never call the viewmodel, since the property was being set internally (This seems to disconnect OneWay Bindings).

This change allows OneWay Bindings to work correctly, by not changing the Dependency Property internally, but calling only the side-effect code directly instead.

To Reproduce:

Xaml:

```
<Controls:ProgressRing  IsActive="{Binding IsDoingWork, Mode=OneWay}" />
```

ViewModel:

```
public bool IsDoingWork 
{
    get 
    {
        //never called
        return _isDoingWork;
    }
}
```
