### PR TITLE
Improved MetroWindow style

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -168,7 +168,8 @@
                         </ItemsControl>
                         <Button x:Name="PART_Min"
                             Width="34"
-                            Height="34"
+                            Height="{Binding TitlebarHeight, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"
+                            MaxHeight="34"    
                             Style="{DynamicResource IronicallyNamedChromelessButtonStyle}"
                             Padding="0"
                             ToolTip="{Binding Minimize, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommands}}}"
@@ -178,7 +179,8 @@
 
                         <Button x:Name="PART_Max"
                             Width="34"
-                            Height="34"
+                            Height="{Binding TitlebarHeight, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"
+                            MaxHeight="34"
                             Style="{DynamicResource IronicallyNamedChromelessButtonStyle}"
                             Padding="0"
                             Foreground="{TemplateBinding Foreground}"
@@ -192,7 +194,8 @@
 
                         <Button x:Name="PART_Close"
                             Width="34"
-                            Height="34"
+                            Height="{Binding TitlebarHeight, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"
+                            MaxHeight="34"
                             Style="{DynamicResource IronicallyNamedChromelessButtonStyle}"
                             ToolTip="{Binding Close, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommands}}}"
                             Visibility="{Binding ShowCloseButton, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Converter={StaticResource BooleanToVisibilityConverter}}"


### PR DESCRIPTION
The Buttons for the window commands should never be larger than the
Titlebar, because this leads to the upper left and the upper right pixel
of the Button to appear white, wich looks very ugly.
