### PR TITLE
Add an AdornerDecorator to the tabitem template

### DIFF
--- a/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -48,5 +48,14 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <AdornerDecorator>
+                        <ContentPresenter ContentSource="Content"></ContentPresenter>
+                    </AdornerDecorator>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
Add an AdornerDecorator to the tabitem template to fix validation overlays when switching between tabs
