### PR TITLE
Fix for #134: InvalidOperationException on validation tooltip opening

### DIFF
--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -96,21 +96,6 @@
                                          Placement="Right"
                                          PlacementTarget="{Binding RelativeSource={RelativeSource TemplatedParent}}"
                                          Template="{DynamicResource ValidationToolTipTemplate}">
-                                    <ToolTip.Triggers>
-                                        <EventTrigger RoutedEvent="Canvas.Loaded">
-                                            <BeginStoryboard>
-                                                <Storyboard>
-                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="IsHitTestVisible" Storyboard.TargetName="validationTooltip">
-                                                        <DiscreteObjectKeyFrame KeyTime="0">
-                                                            <DiscreteObjectKeyFrame.Value>
-                                                                <System:Boolean>true</System:Boolean>
-                                                            </DiscreteObjectKeyFrame.Value>
-                                                        </DiscreteObjectKeyFrame>
-                                                    </ObjectAnimationUsingKeyFrames>
-                                                </Storyboard>
-                                            </BeginStoryboard>
-                                        </EventTrigger>
-                                    </ToolTip.Triggers>
                                 </ToolTip>
                             </ToolTipService.ToolTip>
                             <Grid Background="Transparent" HorizontalAlignment="Right" Height="12" Margin="1,-4,-4,0" VerticalAlignment="Top" Width="12">


### PR DESCRIPTION
I had this for a long time, but wanted some confirmations: https://github.com/MahApps/MahApps.Metro/issues/134

Repro is here: https://github.com/Shazbot/MahApps.Metro/compare/tooltipExceptionRepro

If I start typing text/incorrect input into the textbox I get an exception.
