### PR TITLE
Panorama in tabs causes apps to crash

### DIFF
--- a/MahApps.Metro/Controls/Panorama.cs
+++ b/MahApps.Metro/Controls/Panorama.cs
@@ -97,6 +97,8 @@ namespace MahApps.Metro.Controls
 
         private void HandleWorldTimerTick(object sender, EventArgs e)
         {
+            if (sv == null)
+                return;
             var prop = DesignerProperties.IsInDesignModeProperty;
             var isInDesignMode = (bool)DependencyPropertyDescriptor.FromProperty(prop, typeof(FrameworkElement)).Metadata.DefaultValue;
 


### PR DESCRIPTION
Apparently sv (ScrollViewer) is not set when panorama is in another tab than the first. This seems to fix that.
