### PR TITLE
Removed tab stop from the window and the tab stop from the window commands container.

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -10,7 +10,7 @@
     <ControlTemplate x:Key="WindowTemplateKey" TargetType="{x:Type Controls:MetroWindow}">
         <Grid Background="{TemplateBinding Background}">
             <AdornerDecorator>
-                <Controls:MetroContentControl>
+                <Controls:MetroContentControl IsTabStop="False">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
@@ -102,6 +102,7 @@
 
     <Style TargetType="{x:Type Controls:WindowCommands}">
         <Setter Property="Foreground" Value="{DynamicResource BlackBrush}" />
+        <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Controls:WindowCommands">


### PR DESCRIPTION
This pull request removes the tab stop for the whole window (Notice the border around the window):

![Window TabStop](http://imageshack.us/a/img593/6643/mahappstabstop1.png)

And the tab stop for the container of the window commands:

![Window command TabStop](http://imageshack.us/a/img211/3528/mahappstabstop2.png)
