### PR TITLE
Don't tab to WindowCommand group, only commands

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -160,7 +160,7 @@
                     </ControlTemplate.Resources>
                     
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Top" >
-                        <ItemsControl ItemsSource="{Binding Items, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommands}}}">
+                        <ItemsControl IsTabStop="False" ItemsSource="{Binding Items, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommands}}}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Horizontal" />


### PR DESCRIPTION
Previously if the user added WindowCommands to TitleBar (like
"Settings", "Help", etc.) tabbing would first select the group of all commands
before selecting individual buttons. Like so:

![Bad tab stop](http://i.imgur.com/YhnUV.png)

Since (amusing as it would be) it doesn't really makes sense to press all the things at once, 
this PR makes it so tabbing **only** goes through individual buttons.

![Good tab stop](http://i.imgur.com/2FwWy.png)
