### PR TITLE
Fixes misspelled gray colour references.

### DIFF
--- a/MahApps.Metro/Styles/Controls.ListView.xaml
+++ b/MahApps.Metro/Styles/Controls.ListView.xaml
@@ -29,7 +29,7 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="MinHeight" Value="25" />
         <Setter Property="Margin" Value="0,0,0,0" />
-        <Setter Property="Border.BorderBrush" Value="{DynamicResource Grey3}" />
+        <Setter Property="Border.BorderBrush" Value="{DynamicResource Gray3}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListViewItem}">
@@ -107,7 +107,7 @@
         <Setter Property="MinHeight" Value="25" />
         <Setter Property="Margin" Value="0,0,0,0" />
         <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="Border.BorderBrush" Value="{DynamicResource Grey3}" />
+        <Setter Property="Border.BorderBrush" Value="{DynamicResource Gray3}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListViewItem}">
@@ -177,7 +177,7 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsPressed" Value="true">
-                            <Setter TargetName="HeaderBorder" Property="Background" Value="{DynamicResource Grey3}" />
+                            <Setter TargetName="HeaderBorder" Property="Background" Value="{DynamicResource Gray3}" />
                             <Setter TargetName="HeaderContent" Property="Margin" Value="1,1,0,0" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">

--- a/MahApps.Metro/Themes/Pivot.xaml
+++ b/MahApps.Metro/Themes/Pivot.xaml
@@ -13,7 +13,7 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="MinHeight" Value="25" />
         <Setter Property="Margin" Value="0,0,0,0" />
-        <Setter Property="Border.BorderBrush" Value="{DynamicResource Grey3}" />
+        <Setter Property="Border.BorderBrush" Value="{DynamicResource Gray3}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListViewItem}">


### PR DESCRIPTION
This commit fixes misspelled references to gray colour resources.

e.g. `{DynamicResource Grey3}` should be `{DynamicResource Gray3}`.
