### PR TITLE
Getting started should include cupcakes

### DIFF
--- a/_includes/gettingstarted.md
+++ b/_includes/gettingstarted.md
@@ -99,6 +99,8 @@ Including this within the `MetroWindow` tag (under the `Window.Resources` sectio
         </Controls:WindowCommands>
 	</Controls:MetroWindow.WindowCommands>
 
+> Make sure to include the [icons](#icons) to get the cupcake
+
 Produces this window titlebar:
 
 ![](images/05_WindowCommands.png)


### PR DESCRIPTION
Adds a footnote to the GettingStarted customization example to load the Icons to get the cupcake icon.
