### PR TITLE
Fixed InvalidCastException when clicking on the ListView column header

### DIFF
--- a/MahApps.Metro/Styles/Controls.ListView.xaml
+++ b/MahApps.Metro/Styles/Controls.ListView.xaml
@@ -177,7 +177,7 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsPressed" Value="true">
-                            <Setter TargetName="HeaderBorder" Property="Background" Value="{DynamicResource GrayBrush3}" />
+                            <Setter TargetName="HeaderBorder" Property="Background" Value="{DynamicResource GrayBrush8}" />
                             <Setter TargetName="HeaderContent" Property="Margin" Value="1,1,0,0" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">


### PR DESCRIPTION
Commit 4a3efb2b61a4ae95a1a94eb138fe7765f1a1b770 introduced a bug, that caused an InvalidCastException, because the `Border`s `Background` property is of type `Brush`and not `Color` and before this commit, the resource was just not found.

So in my first commit I changed `Gray3` to `GrayBrush3`. The problem now was: The color had too much contrast in the light theme and IMHO not enough contrast in the dark theme:

![Light before](http://imageshack.us/a/img38/6829/listviewbeforelight.png)
![Dark before](http://imageshack.us/a/img208/1734/listviewbeforedark.png)

So I changed the brush from `GrayBrush3` to `GrayBrush8`:

![Light after](http://imageshack.us/a/img203/9853/listviewafterlight.png)
![Dark after](http://imageshack.us/a/img132/752/listviewafterdark.png)

BTW: Notice that the ListView in the MetroDemo doesn't load the tracks anymore. When receiving the JSON, it says "API key is deprecated"
