### PR TITLE
Fixed the dotted focus border that shows up on the MetroWindow.

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -10,7 +10,7 @@
     <ControlTemplate x:Key="WindowTemplateKey" TargetType="{x:Type Controls:MetroWindow}">
         <Grid Background="{TemplateBinding Background}">
             <AdornerDecorator>
-                <Controls:MetroContentControl IsTabStop="False">
+                <Controls:MetroContentControl IsTabStop="False" FocusVisualStyle="{x:Null}">
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
![BorderScreenshot](https://f.cloud.github.com/assets/631724/19130/9317a3a8-48ff-11e2-9307-19212411b934.png)

I get this dotted border around the MetroWindow under certain conditions, see attached screenshot. This PR fixes that issue.
