### PR TITLE
Hidden flyout resize fix

### DIFF
--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -101,6 +101,16 @@ namespace MahApps.Metro.Controls
 
         protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
         {
+            base.OnRenderSizeChanged(sizeInfo);
+
+            if (!sizeInfo.WidthChanged) return;
+
+            if (!IsOpen)
+            {
+                ApplyAnimation(Position);
+                return;
+            }
+
             var root = (Grid)GetTemplateChild("root");
             if (root == null)
                 return;
@@ -120,7 +130,6 @@ namespace MahApps.Metro.Controls
             {
                 hideFrame.Value = -root.DesiredSize.Width;
             }
-            base.OnRenderSizeChanged(sizeInfo);
         }
     }
 }


### PR DESCRIPTION
The last flyout resize fix only handled resizes where the flyouts were shown, if the flyout is resized while hidden a similar issue occurs. This pull request fixes it for hidden flyouts aswell.

(Thanks to @RenEvo for [this code](https://github.com/MahApps/MahApps.Metro/issues/117#issuecomment-9187182) )
