### PR TITLE
Fixes Issue #244

### DIFF
--- a/MahApps.Metro/Controls/Panorama.cs
+++ b/MahApps.Metro/Controls/Panorama.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Controls;
 using System.Windows;
 using System.Windows.Threading;
@@ -168,8 +168,6 @@ namespace MahApps.Metro.Controls
                         tile = (IPanoramaTile)data;
                     }
                 }
-
-                CaptureMouse();
             }
 
             base.OnPreviewMouseDown(e);
@@ -177,7 +175,7 @@ namespace MahApps.Metro.Controls
 
         protected override void OnPreviewMouseMove(MouseEventArgs e)
         {
-            if (IsMouseCaptured)
+            if (e.LeftButton == MouseButtonState.Pressed)
             {
                 Point currentPoint = e.GetPosition(this);
 
@@ -194,6 +192,7 @@ namespace MahApps.Metro.Controls
                 // Scroll to the new position.
                 sv.ScrollToHorizontalOffset(scrollTarget.X);
                 sv.ScrollToVerticalOffset(scrollTarget.Y);
+                CaptureMouse();
             }
 
             base.OnPreviewMouseMove(e);
@@ -203,10 +202,9 @@ namespace MahApps.Metro.Controls
         {
             if (IsMouseCaptured)
             {
-                Cursor = Cursors.Arrow;
                 ReleaseMouseCapture();
             }
-
+            Cursor = Cursors.Arrow;
             Point currentPoint = e.GetPosition(this);
 
             // Determine the new amount to scroll.


### PR DESCRIPTION
When setting ShowTitleBar="False" on a Metro Window the mouse event for scrolling on the Panorama control does not work.

Repo with repro of issue can be found here https://github.com/alfhenrik/MahAppsPanorama
