### PR TITLE
Fixed radiobutton foreground bug

### DIFF
--- a/MahApps.Metro/Styles/Controls.RadioButton.xaml
+++ b/MahApps.Metro/Styles/Controls.RadioButton.xaml
@@ -58,10 +58,7 @@
                                 </Grid>
                             </Grid>
                         </Grid>
-                        <ContentControl Grid.Column="1" IsTabStop="False">
-                            <ContentControl.Foreground>
-                                <SolidColorBrush x:Name="ContentPresenterWrapperColor" Color="{DynamicResource BlackColor}" />
-                            </ContentControl.Foreground>
+                        <ContentControl Grid.Column="1" IsTabStop="False" Foreground="{TemplateBinding Foreground}">
                             <ContentPresenter x:Name="contentPresenter"
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                 Content="{TemplateBinding Content}"


### PR DESCRIPTION
You can't set the Foreground property on a RadioButton. Well, actually, you can, but it is being ignored, as the RadioButton always uses the theme color (BlackBrush). The theme is nice, but you should be able to override it. This commit fixes that issue. I have tested it with both the dark and light theme. See attached images, when setting the Foreground to green the text ("Radio Button 1") should turn green.

![RadioButtonsbefore](https://f.cloud.github.com/assets/631724/59776/960f800c-5be3-11e2-841f-ee2497eafd78.png)

![RadioButtonsafter](https://f.cloud.github.com/assets/631724/59778/9c6b9738-5be3-11e2-98a1-4d6ff4307838.png)
