### PR TITLE
The min/max/close buttons can be tabbed to...

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -168,6 +168,7 @@
                             </ItemsControl.ItemsPanel>
                         </ItemsControl>
                         <Button x:Name="PART_Min"
+                            IsTabStop="False"
                             Width="34"
                             Height="{Binding TitlebarHeight, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"
                             MaxHeight="34"    
@@ -179,6 +180,7 @@
                         </Button>
 
                         <Button x:Name="PART_Max"
+                            IsTabStop="False"
                             Width="34"
                             Height="{Binding TitlebarHeight, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"
                             MaxHeight="34"
@@ -194,6 +196,7 @@
                         </Button>
 
                         <Button x:Name="PART_Close"
+                            IsTabStop="False"
                             Width="34"
                             Height="{Binding TitlebarHeight, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"
                             MaxHeight="34"


### PR DESCRIPTION
...but that should not be the case. Create an empty MetroWindow, add some control, and run it. Start tabbing around, and you will see the min/max/close buttons with a focus rect. This is the case regardless of the WindowCommands being used or not. See screen shot.

![minmaxclosebuttons](https://f.cloud.github.com/assets/631724/59959/5b9cebac-5bee-11e2-9dd3-c41e5e952a6b.png)

See the changes made in this branch, which fixes the issue.
