### PR TITLE
The clear text button in textboxes doesn't match the textbox foreground

### DIFF
--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -79,7 +79,7 @@
                                        Text="{TemplateBinding Controls:TextboxHelper.Watermark}" 
                                        Foreground="{DynamicResource TextBrush}" IsHitTestVisible="False"
                                        Opacity="0.6" HorizontalAlignment="Left" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" Margin="6,0,0,0"/>
-                            <Button x:Name="PART_ClearText" Style="{DynamicResource ChromelessButtonStyle}" Width="20"  HorizontalAlignment="Right"  FontFamily="Marlett" Content="r" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" IsTabStop="False" />
+                            <Button x:Name="PART_ClearText" Style="{DynamicResource ChromelessButtonStyle}" Foreground="{TemplateBinding Foreground}" Width="20"  HorizontalAlignment="Right"  FontFamily="Marlett" Content="r" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" IsTabStop="False" />
                         </Grid>
                         <Rectangle x:Name="DisabledVisualElement"
                                    Stroke="{DynamicResource ControlsDisabledBrush}"

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -81,7 +81,7 @@
                                        Foreground="{DynamicResource TextBrush}" IsHitTestVisible="False" Opacity="0.6" HorizontalAlignment="Left" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                        Margin="6,0,0,0"/>
 
-                            <Button x:Name="PART_ClearText" Style="{DynamicResource ChromelessButtonStyle}" Width="20"  HorizontalAlignment="Right"  FontFamily="Marlett" Content="r" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" IsTabStop="False" />
+                            <Button x:Name="PART_ClearText" Style="{DynamicResource ChromelessButtonStyle}" Foreground="{TemplateBinding Foreground}" Width="20"  HorizontalAlignment="Right"  FontFamily="Marlett" Content="r" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" IsTabStop="False" />
                         </Grid>
                         <Rectangle x:Name="DisabledVisualElement"
                                    Stroke="{DynamicResource ControlsDisabledBrush}"


### PR DESCRIPTION
This looks funny if you change the foreground of the textbox/passwordbox. See attached screen shots.

Before:
![textbox_before](https://f.cloud.github.com/assets/631724/64605/b7407dfa-5e52-11e2-80b8-1db64742a905.png)

After:
![textbox_after](https://f.cloud.github.com/assets/631724/64606/ba7a38bc-5e52-11e2-8a76-57fceb7a2be3.png)

This PR fixes that issue.
