### PR TITLE
Update MahApps.Metro/Styles/Controls.ContextMenu.xaml

### DIFF
--- a/MahApps.Metro/Styles/Controls.ContextMenu.xaml
+++ b/MahApps.Metro/Styles/Controls.ContextMenu.xaml
@@ -3,6 +3,8 @@
     
     <Geometry x:Key="Checkmark">M 0,5.1 L 1.7,5.2 L 3.4,7.1 L 8,0.4 L 9.2,0 L 3.3,10.8 Z</Geometry>
     <Geometry x:Key="RightArrow">M 0,0 L 4,3.5 L 0,7 Z</Geometry>
+    
+    <SolidColorBrush x:Key="DisabledMenuItemBrush" Color="#FF9A9A9A" />
 
     <!-- Original style from http://www.jeff.wilcox.name/2010/05/zunelike-contextmenu-style/ -->
     <Style TargetType="{x:Type Separator}" x:Key="MetroSeparator">
@@ -126,7 +128,7 @@
         </Border>
         <ControlTemplate.Triggers>
             <Trigger Property="IsEnabled" Value="false">
-                <Setter Property="Foreground" Value="#FF9A9A9A"/>
+                <Setter Property="Foreground" Value="{DynamicResource DisabledMenuItemBrush}"/>
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource TextBrush}"/>


### PR DESCRIPTION
When a sub menu is popped-up, it's foreground colour would follow the parent. Since the parent's foreground is white, its foreground is also white. The update force the foreground colour the dirty way.
