### PR TITLE
The AccentColorBrush is wrong when switching themes

### DIFF
--- a/MahApps.Metro/Styles/Accents/Blue.xaml
+++ b/MahApps.Metro/Styles/Accents/Blue.xaml
@@ -25,7 +25,7 @@
     </LinearGradientBrush>
 
     <SolidColorBrush x:Key="AccentColorBrush"
-                     Color="{DynamicResource AccentColor}" />
+                     Color="{StaticResource AccentColor}" />
 
 
 

--- a/MahApps.Metro/Styles/Accents/Green.xaml
+++ b/MahApps.Metro/Styles/Accents/Green.xaml
@@ -17,6 +17,6 @@
     </LinearGradientBrush>
 
     <SolidColorBrush x:Key="AccentColorBrush"
-                     Color="{DynamicResource AccentColor}" />
+                     Color="{StaticResource AccentColor}" />
 
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Orange.xaml
+++ b/MahApps.Metro/Styles/Accents/Orange.xaml
@@ -25,7 +25,7 @@
     </LinearGradientBrush>
 
     <SolidColorBrush x:Key="AccentColorBrush"
-                     Color="{DynamicResource AccentColor}" />
+                     Color="{StaticResource AccentColor}" />
 
 
 

--- a/MahApps.Metro/Styles/Accents/Purple.xaml
+++ b/MahApps.Metro/Styles/Accents/Purple.xaml
@@ -18,6 +18,6 @@
     </LinearGradientBrush>
 
     <SolidColorBrush x:Key="AccentColorBrush"
-                     Color="{DynamicResource AccentColor}" />
+                     Color="{StaticResource AccentColor}" />
 
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Red.xaml
+++ b/MahApps.Metro/Styles/Accents/Red.xaml
@@ -17,7 +17,7 @@
     </LinearGradientBrush>
 
     <SolidColorBrush x:Key="AccentColorBrush"
-                     Color="{DynamicResource AccentColor}" />
+                     Color="{StaticResource AccentColor}" />
 
 
 


### PR DESCRIPTION
There is an issue with the AccentColorBrush when switching themes.

I have created a repro here, so you can test it:

```
https://github.com/blooksa/MahApps.Metro/tree/accentcolor-repro
```

Set the AccentColorRepro project in that solution to be the Startup Project, and run it. Have a look at the screenshots below:

Before:
![accentcolor_before](https://f.cloud.github.com/assets/631724/89307/6be4ed0c-6535-11e2-8f77-81503fd30168.png)

After:
![accentcolor_after](https://f.cloud.github.com/assets/631724/89308/77ab96f4-6535-11e2-92a6-35e200812d86.png)

This is what fails:
When starting the app (using light blue theme), you can see everything displayed correctly.
If you change theme to dark (for example), the GroupBox header looses its color.
The same goes for switching to other colors, and various combinations of dark/light.

I have spent quite some time trying to track this error down. I have added/removed the BaseDark/BaseLight resource dictionaries, but that didn't affect anything.

To make a long story short, I can see that the AccentColorBrush isn't loaded correctly. I added debug logging to the ThemeManager, and at initial startup (when I set the theme in the MainWindow ctor) I get:
  Replace resource 'AccentColor' with value #CC119EDA
  Add resource 'AccentColorBrush' with value #00FFFFFF
So the AccentColor is correct, but the AccentColorBrush is set to transparent (!).
Strangely enough, it still looks ok when first run.

Then I change theme using the buttons in the window, and I get:
  Replace resource 'AccentColor' with value #CC119EDA
  Replace resource 'AccentColorBrush' with value #CC119EDA
This time the AccentColorBrush has the correct value, but the GroupBox looses its color (i.e. is displayed with transparent background).

I don't know whether this is some kind of wpf resource caching issue or not, but I found out there is an easy way to fix it. I have simply changed the AccentColorBrush's reference to the AccentColor from DynamicResource to StaticResource. I tested this in the Demo app also,
to make sure I didn't break anything, and it looks good.

This PR fixes that.
