### PR TITLE
Use DockPanel in Flyouts instead of StackPanel.

### DIFF
--- a/FlyoutDemo/MainWindow.xaml
+++ b/FlyoutDemo/MainWindow.xaml
@@ -10,7 +10,35 @@
         x:Class="FlyoutDemo.MainWindow">
     <Controls:MetroWindow.Flyouts>
         <Controls:Flyout Header="settings" Position="Right">
-            <TextBlock Text="Will hold settings information" />
+            <Grid Margin="24">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <TextBlock Grid.Row="0" Text="Something above the ScrollPanel" />
+
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+                    <StackPanel Orientation="Vertical">
+                        <TextBox Controls:TextboxHelper.Watermark="TextBox 01" />
+                        <TextBox Controls:TextboxHelper.Watermark="TextBox 02" Margin="0,5,0,0" />
+                        <TextBox Controls:TextboxHelper.Watermark="TextBox 03" Margin="0,5,0,0" />
+                        <TextBox Controls:TextboxHelper.Watermark="TextBox 04" Margin="0,5,0,0" />
+                        <TextBox Controls:TextboxHelper.Watermark="TextBox 05" Margin="0,5,0,0" />
+                        <TextBox Controls:TextboxHelper.Watermark="TextBox 06" Margin="0,5,0,0" />
+                        <TextBox Controls:TextboxHelper.Watermark="TextBox 07" Margin="0,5,0,0" />
+                        <TextBox Controls:TextboxHelper.Watermark="TextBox 08" Margin="0,5,0,0" />
+                        <TextBox Controls:TextboxHelper.Watermark="TextBox 09" Margin="0,5,0,0" />
+                        <TextBox Controls:TextboxHelper.Watermark="TextBox 10" Margin="0,5,0,0" />
+                    </StackPanel>
+                </ScrollViewer>
+                
+                <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,5,0,0">
+                    <Button Content="create" Margin="0,0,10,0" />
+                    <Button Content="cancel" />
+                </StackPanel>
+
+            </Grid>
         </Controls:Flyout>
 
         <Controls:Flyout Header="new goodness" Position="Right">

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -98,10 +98,10 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <StackPanel>
-                            <ContentPresenter x:Name="PART_Header" ContentSource="Header" ContentTemplate="{TemplateBinding HeaderTemplate}" />
-                            <ContentPresenter x:Name="PART_Content"/>
-                        </StackPanel>
+                        <DockPanel>
+                            <ContentPresenter x:Name="PART_Header" DockPanel.Dock="Top" ContentSource="Header" ContentTemplate="{TemplateBinding HeaderTemplate}" />
+                            <ContentPresenter x:Name="PART_Content" DockPanel.Dock="Bottom" />
+                        </DockPanel>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
Using `DockPanel`, instead of `StackPanel`, for `Flyout`s.  This allows content to scale on resize (e.g. `ScrollViewers`), it also allows for forcing content to the bottom of the `Flyout` -- such as confirm/cancel buttons.

The Flyout demo code was also updated to show how the changes allow a `ScrollViewer` to properly behave.
