### PR TITLE
Fixed GroupBox foreground color issue.

### DIFF
--- a/MahApps.Metro/Styles/Controls.GroupBox.xaml
+++ b/MahApps.Metro/Styles/Controls.GroupBox.xaml
@@ -7,6 +7,7 @@
     <Style x:Key="MetroGroupBox"
            TargetType="{x:Type GroupBox}">
         <Setter Property="Margin" Value="5" />
+        <Setter Property="Foreground" Value="{DynamicResource BlackBrush}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type GroupBox}">


### PR DESCRIPTION
If you add a ToggleSwitch (for example) to the GroupBox, it doesn't update its foreground color properly when switching themes. See attached screenshots below.

Using a light theme:
![toggleswitch_before](https://f.cloud.github.com/assets/631724/127522/ad030090-6f9d-11e2-9c97-e283bd628b6a.png)

Then switching to the dark theme:
![toggleswitch_after](https://f.cloud.github.com/assets/631724/127523/b74c3544-6f9d-11e2-92aa-128e8d4a86c3.png)

As you can see it is hard to read the text. The GroupBox template was missing a default parameter. This PR fixes that problem.
