### PR TITLE
The panorama demo can be exited by pressing the escape key.

### DIFF
--- a/MetroDemo/PanoramaDemo.xaml
+++ b/MetroDemo/PanoramaDemo.xaml
@@ -7,7 +7,7 @@
         xmlns:effect="clr-namespace:GrayscaleEffect;assembly=GrayscaleEffect"
         xmlns:Models="clr-namespace:MetroDemo.Models" x:Class="MetroDemo.PanoramaDemo"
 		Background="Black"
-        Title="PanoramaDemo" Height="600" Width="900">
+        Title="PanoramaDemo" Height="600" Width="900" KeyUp="Window_KeyUp">
     <Window.Resources>
         <ResourceDictionary>
             

--- a/MetroDemo/PanoramaDemo.xaml.cs
+++ b/MetroDemo/PanoramaDemo.xaml.cs
@@ -14,5 +14,10 @@ namespace MetroDemo
         {
             DataContext = new MainWindowViewModel();
         }
+
+        private void Window_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Escape) this.Close();
+        }
     }
 }


### PR DESCRIPTION
The panorama demo can be exited by pressing the escape key. I thought it was quite annoying to be forced to stop debugging or use task manager in order to close the panorama window.
