### PR TITLE
change to animation of toggleswitchbutton

### DIFF
--- a/MahApps.Metro/Themes/ToggleSwitch.xaml
+++ b/MahApps.Metro/Themes/ToggleSwitch.xaml
@@ -36,7 +36,7 @@
                                     <VisualTransition GeneratedDuration="0:0:0.05" To="Unchecked" />
                                     <VisualTransition GeneratedDuration="0:0:0.05" To="Checked" >
                                         <Storyboard>
-                                            <DoubleAnimation Duration="0:0:0.05" To="47" Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[3].(TranslateTransform.X)" Storyboard.TargetName="SwitchThumb">
+                                            <DoubleAnimation Duration="0:0:0.05" To="47" Storyboard.TargetProperty="(TranslateTransform.X)" Storyboard.TargetName="SwitchThumbTranslate">
                                                 <DoubleAnimation.EasingFunction>
                                                     <CircleEase EasingMode="EaseIn"/>
                                                 </DoubleAnimation.EasingFunction>
@@ -106,7 +106,7 @@
                                             <ScaleTransform/>
                                             <SkewTransform/>
                                             <RotateTransform/>
-                                            <TranslateTransform/>
+                                            <TranslateTransform x:Name="SwitchThumbTranslate"/>
                                         </TransformGroup>
                                     </Border.RenderTransform>
                                     <Border x:Name="ThumbCenter" BorderBrush="{TemplateBinding Foreground}" BorderThickness="0" Background="{DynamicResource BlackBrush}" />


### PR DESCRIPTION
reference the transition directly instead of iterating through the properties

XAML generates an error if not already compiled

same problem as this:

http://stackoverflow.com/questions/13168740/unknown-property-does-not-point-to-a-dependencyobject-in-path-0-13-2/15106546#15106546
