### PR TITLE
fix keyboard focus for flyouts

### DIFF
--- a/FlyoutDemo/MainWindow.xaml
+++ b/FlyoutDemo/MainWindow.xaml
@@ -21,6 +21,7 @@
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro.Resources;component/Icons.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/Blue.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/FlatButton.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -138,6 +138,8 @@
             <SolidColorBrush x:Key="LabelTextBrush"
                              Color="{StaticResource FlyoutWhiteColor}" />
         </Style.Resources>
+        <Setter Property="KeyboardNavigation.TabNavigation"
+                Value="Cycle" />
         <Setter Property="VerticalAlignment"
                 Value="Stretch" />
         <Setter Property="VerticalContentAlignment"
@@ -145,7 +147,7 @@
         <Setter Property="HeaderTemplate"
                 Value="{StaticResource HeaderTemplate}" />
         <Setter Property="Background"
-                Value="#FF252525" />
+                Value="#333333" />
         <Setter Property="Template"
                 Value="{StaticResource FlyoutTemplate}" />
     </Style>

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -50,18 +50,23 @@
                                 HorizontalAlignment="Right"
 								Height="{Binding TitlebarHeight, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}" />
                         <ContentPresenter Grid.Row="1"/>
+
+                        <ItemsControl Grid.Row="0"
+                                      Grid.RowSpan="2"
+                                      Panel.ZIndex="2"
+                                      ItemsSource="{Binding Flyouts, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}"
+                                      VerticalAlignment="Stretch">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <Grid TextElement.Foreground="{DynamicResource FlyoutWhiteBrush}" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
                     </Grid>
                 </Controls:MetroContentControl>
             </AdornerDecorator>
             <Border x:Name="PART_Border" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
             <ResizeGrip x:Name="WindowResizeGrip" HorizontalAlignment="Right" IsTabStop="false" Visibility="Collapsed" VerticalAlignment="Bottom"/>
-            <ItemsControl ItemsSource="{Binding Flyouts, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}" VerticalAlignment="Stretch">
-                <ItemsControl.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <Grid TextElement.Foreground="{DynamicResource FlyoutWhiteBrush}" />
-                    </ItemsPanelTemplate>
-                </ItemsControl.ItemsPanel>
-            </ItemsControl>
         </Grid>
         <ControlTemplate.Triggers>
             <MultiTrigger>


### PR DESCRIPTION
hi,

this is a fix for a keyboard focus (tab navigation) problem. The tab navigation keeps withon the flyout. next feature must be a "IsModal" flyout, to prevent mouse clicks outsides the flyout.

I will create another branch to create metro styles for dark/light flyouts with better focused visual style. And another branch for "IsModal" flyouts.

jan
