### PR TITLE
ToggleSwitchButton: Removed accent border when unchecked

### DIFF
--- a/MahApps.Metro/Themes/ToggleSwitch.xaml
+++ b/MahApps.Metro/Themes/ToggleSwitch.xaml
@@ -78,6 +78,7 @@
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="border">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}"/>
                                         </ObjectAnimationUsingKeyFrames>
+                                        <ThicknessAnimation Duration="0" To="1" Storyboard.TargetProperty="(Border.Margin)" Storyboard.TargetName="checked"/>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -96,11 +97,11 @@
                                     </Rectangle>
                                     <Border BorderThickness="2" BorderBrush="{DynamicResource GrayBrush9}">
                                         <Grid Margin="2">
-                                            <Border BorderThickness="0" Background="{DynamicResource AccentColorBrush}" Margin="0" />
+                                            <Border x:Name="checked" BorderThickness="0" Background="{DynamicResource AccentColorBrush}" Margin="0" />
                                             <Border x:Name="border" BorderThickness="0" Background="{DynamicResource GrayBrush9}" Visibility="Collapsed" Margin="0" />
                                             <Border x:Name="pressed" BorderThickness="0" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" Opacity="0.25" Visibility="Collapsed" Margin="0" />
                                             <Border x:Name="hover" BorderThickness="0" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" Opacity="0.15" Visibility="Collapsed" Margin="0" />
-                                            <Border x:Name="disabled" BorderThickness="0" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" Opacity="0.25" Visibility="Collapsed" Margin="0" />
+                                            <Border x:Name="disabled" BorderThickness="0" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" Opacity="0.5" Visibility="Collapsed" Margin="0" />
                                         </Grid>
                                     </Border>
                                 </Grid>
@@ -121,7 +122,7 @@
                                     </Border.RenderTransform>
                                     <Grid>
                                         <Border x:Name="ThumbCenter" BorderBrush="{TemplateBinding Foreground}" BorderThickness="0" Background="{DynamicResource BlackBrush}" />
-                                        <Border x:Name="disabledTumb" BorderBrush="{TemplateBinding Foreground}" BorderThickness="0" Background="{DynamicResource WhiteBrush}" Opacity="0.25" Visibility="Collapsed" />
+                                        <Border x:Name="disabledTumb" BorderBrush="{TemplateBinding Foreground}" BorderThickness="0" Background="{DynamicResource WhiteBrush}" Opacity="0.5" Visibility="Collapsed" />
                                     </Grid>
                                 </Border>
                             </Grid>


### PR DESCRIPTION
When unchecked there was always a little bit of the accent border visible, so I added a margin when the element is unchecked.

Old:
![SwitchButtonBorder](https://f.cloud.github.com/assets/3532342/338038/6124f536-9cff-11e2-89d8-ca44643e9275.png)
New:
![SwitchButtonWithoutBorder](https://f.cloud.github.com/assets/3532342/338039/6706cf60-9cff-11e2-8d21-4f0af26bd670.png)

Also I made the disabled state, better to tell apart from enabled state.

New:
![SwitchButtonDisabled](https://f.cloud.github.com/assets/3532342/338041/787b3b50-9cff-11e2-9e7d-53b89acba78e.png)
![SwitchButtonDisabledChecked](https://f.cloud.github.com/assets/3532342/338042/78f499a0-9cff-11e2-82b2-6d9d90e6fe28.png)
