### PR TITLE
Fixed the vertical alignment of the WindowsCommands

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -108,6 +108,7 @@
     <Style TargetType="{x:Type Controls:WindowCommands}">
         <Setter Property="Foreground" Value="{DynamicResource BlackBrush}" />
         <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Controls:WindowCommands">


### PR DESCRIPTION
If the maximize, minimize and close buttons were hidden, the vertical
alignment of the WindowCommands was not centered
### Before:

![wrongalignment](https://f.cloud.github.com/assets/964691/548026/bd0f046e-c2d8-11e2-9564-b8abaab38835.png)
### After:

![correctalignment](https://f.cloud.github.com/assets/964691/548027/c2af3826-c2d8-11e2-8edc-ecb8c49d0e58.png)
