### PR TITLE
Reverted change to Virutalizing ComboBox because it breaks grouping

### DIFF
--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -266,7 +266,7 @@
                                     BorderBrush="{DynamicResource ComboBoxPopupBrush}"
                                     Background="{DynamicResource WhiteBrush}">
                                 <ScrollViewer x:Name="DropDownScrollViewer" BorderThickness="0" Margin="2" Padding="1">
-                                    <VirtualizingStackPanel x:Name="ItemsPresenter" IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained" />
+                                    <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained" />
                                 </ScrollViewer>
                             </Border>
                         </Popup>


### PR DESCRIPTION
Last change set the itemspanel to virtualizing but this breaks the grouping behaviour of the combobox:

With Virtualizing:
![2013-05-24 13-19-24_](https://f.cloud.github.com/assets/3532342/560022/0a3646b2-c464-11e2-97ea-367454ef5dc0.png)

Without Virtualizing:
![2013-05-24 13-20-21_](https://f.cloud.github.com/assets/3532342/560023/0a4bd0a4-c464-11e2-8738-263b6bd602c1.png)

If there is need for a virtualizing ComboBox simply use:

```
<ComboBox.ItemsPanel>
    <ItemsPanelTemplate>
        <VirtualizingStackPanel />
    </ItemsPanelTemplate>
</ComboBox.ItemsPanel>
```

Or make an seperate style.
