### PR TITLE
MetroTabItem Patch #1

### DIFF
--- a/MahApps.Metro/Controls/MetroAnimatedSingleRowTabControl.cs
+++ b/MahApps.Metro/Controls/MetroAnimatedSingleRowTabControl.cs
@@ -23,7 +23,7 @@ namespace MahApps.Metro.Controls
 
         protected override DependencyObject GetContainerForItemOverride()
         {
-            return new MetroTabItem(); //Overrides the TabControl's default behavior and returns a MetroTabItem instead of a regular one.
+            return new MetroTabItem() { OwningTabControl = this }; //Overrides the TabControl's default behavior and returns a MetroTabItem instead of a regular one.
         }
 
         public ICommand CloseTabCommand

--- a/MahApps.Metro/Controls/MetroAnimatedTabControl.cs
+++ b/MahApps.Metro/Controls/MetroAnimatedTabControl.cs
@@ -23,7 +23,7 @@ namespace MahApps.Metro.Controls
 
         protected override DependencyObject GetContainerForItemOverride()
         {
-            return new MetroTabItem(); //Overrides the TabControl's default behavior and returns a MetroTabItem instead of a regular one.
+            return new MetroTabItem() { OwningTabControl = this }; //Overrides the TabControl's default behavior and returns a MetroTabItem instead of a regular one.
         }
 
         public ICommand CloseTabCommand

--- a/MahApps.Metro/Controls/MetroTabControl.cs
+++ b/MahApps.Metro/Controls/MetroTabControl.cs
@@ -23,7 +23,7 @@ namespace MahApps.Metro.Controls
 
         protected override DependencyObject GetContainerForItemOverride()
         {
-            return new MetroTabItem(); //Overrides the TabControl's default behavior and returns a MetroTabItem instead of a regular one.
+            return new MetroTabItem() { OwningTabControl = this }; //Overrides the TabControl's default behavior and returns a MetroTabItem instead of a regular one.
         }
 
         public ICommand CloseTabCommand
@@ -50,7 +50,7 @@ namespace MahApps.Metro.Controls
                 {
                     var tabItem = (MetroTabItem)parameter;
 
-                    ((TabControl)tabItem.Parent).Items.Remove(tabItem);
+                    ((TabControl)tabItem.OwningTabControl).Items.Remove(tabItem);
                 }
             }
         }

--- a/MahApps.Metro/Controls/MetroTabItem.cs
+++ b/MahApps.Metro/Controls/MetroTabItem.cs
@@ -64,5 +64,7 @@ namespace MahApps.Metro.Controls
 
             rootLabel = GetTemplateChild("root") as Label;
         }
+
+        public TabControl OwningTabControl { get; internal set; }
     }
 }


### PR DESCRIPTION
- Fixed a bug where closing a tab would result in a NullReferenceException. Added a property when a MetroTabItem is created by a Metro*TabControl.
