### PR TITLE
Fix for issue #511 - AlternatingRowBackground

### DIFF
--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -222,7 +222,6 @@
     </Style>
 
     <Style x:Key="MetroDataGridRow" TargetType="{x:Type DataGridRow}">
-        <Setter Property="Background" Value="{DynamicResource WhiteColorBrush}" />
         <Setter Property="MinHeight" Value="25"/>
         <Setter Property="Margin" Value="0,0,0,0"/>
         <Style.Triggers>


### PR DESCRIPTION
This fixes https://github.com/MahApps/MahApps.Metro/issues/511. 

AlternatingRowBackground must be set from a DataGrid style to work correctly with this fix.

``` c#
<DataGrid ItemsSource="{Binding Path=Albums}" 
          Grid.Row="0"
          AutoGenerateColumns="False">
    <DataGrid.Style>
        <Style TargetType="DataGrid" BasedOn="{StaticResource {x:Type DataGrid}}">
            <Setter Property="AlternatingRowBackground" Value="#FF282828"/>
        </Style>
    </DataGrid.Style>
    <DataGrid.Columns>
        <DataGridTextColumn Header="Title" Binding="{Binding Title}" />
        <DataGridTextColumn Header="Artist" Binding="{Binding Artist.Name}" />
        <DataGridTextColumn Header="Genre" Binding="{Binding Genre.Name}" />
        <DataGridTextColumn Header="Price" Binding="{Binding Price,StringFormat=c}" />
    </DataGrid.Columns>
</DataGrid>
```
