### PR TITLE
Option to disable MetroWindow's entrance transition.

### DIFF
--- a/MahApps.Metro/Controls/MetroContentControl.cs
+++ b/MahApps.Metro/Controls/MetroContentControl.cs
@@ -16,6 +16,13 @@ namespace MahApps.Metro.Controls
             set { SetValue(ReverseTransitionProperty, value); }
         }
 
+        public static readonly DependencyProperty TransitionsEnabledProperty = DependencyProperty.Register("TransitionsEnabled", typeof(bool), typeof(MetroContentControl), new FrameworkPropertyMetadata(true));
+
+        public bool TransitionsEnabled
+        {
+            get { return (bool)GetValue(TransitionsEnabledProperty); }
+            set { SetValue(TransitionsEnabledProperty, value); }
+        }
 
         public MetroContentControl()
         {
@@ -29,35 +36,48 @@ namespace MahApps.Metro.Controls
 
         void MetroContentControlIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            if (!IsVisible)
-                VisualStateManager.GoToState(this, ReverseTransition ? "AfterUnLoadedReverse" : "AfterUnLoaded", false);
-            else
-                VisualStateManager.GoToState(this, ReverseTransition ? "AfterLoadedReverse" : "AfterLoaded", true);
+            if (TransitionsEnabled)
+            {
+                if (!IsVisible)
+                    VisualStateManager.GoToState(this, ReverseTransition ? "AfterUnLoadedReverse" : "AfterUnLoaded", false);
+                else
+                    VisualStateManager.GoToState(this, ReverseTransition ? "AfterLoadedReverse" : "AfterLoaded", true);
+            }
         }
 
         private void MetroContentControlUnloaded(object sender, RoutedEventArgs e)
         {
-            VisualStateManager.GoToState(this, ReverseTransition ? "AfterUnLoadedReverse" : "AfterUnLoaded", false);
+            if (TransitionsEnabled)
+                VisualStateManager.GoToState(this, ReverseTransition ? "AfterUnLoadedReverse" : "AfterUnLoaded", false);
         }
 
         private void MetroContentControlLoaded(object sender, RoutedEventArgs e)
         {
-            VisualStateManager.GoToState(this, ReverseTransition ? "AfterLoadedReverse" : "AfterLoaded", true);
+            if (TransitionsEnabled)
+                VisualStateManager.GoToState(this, ReverseTransition ? "AfterLoadedReverse" : "AfterLoaded", true);
+            else
+            {
+                var root = ((Grid)GetTemplateChild("root"));
+                root.Opacity = 1.0;
+                ((System.Windows.Media.TranslateTransform)root.RenderTransform).X = 0;
+            }
         }
 
         public void Reload()
         {
+            if (!TransitionsEnabled) return;
+
             if (ReverseTransition)
             {
                 VisualStateManager.GoToState(this, "BeforeLoaded", true);
-                VisualStateManager.GoToState(this, "AfterUnLoadedReverse", true);            
+                VisualStateManager.GoToState(this, "AfterUnLoadedReverse", true);
             }
             else
             {
                 VisualStateManager.GoToState(this, "BeforeLoaded", true);
-                VisualStateManager.GoToState(this, "AfterLoaded", true);                
+                VisualStateManager.GoToState(this, "AfterLoaded", true);
             }
-            
+
         }
     }
 }

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -28,8 +28,15 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty IgnoreTaskbarOnMaximizeProperty = DependencyProperty.Register("IgnoreTaskbarOnMaximize", typeof(bool), typeof(MetroWindow), new PropertyMetadata(false));
         public static readonly DependencyProperty GlowBrushProperty = DependencyProperty.Register("GlowBrush", typeof(SolidColorBrush), typeof(MetroWindow), new PropertyMetadata(null));
         public static readonly DependencyProperty FlyoutsProperty = DependencyProperty.Register("Flyouts", typeof(FreezableCollection<Flyout>), typeof(MetroWindow), new PropertyMetadata(null));
+        public static readonly DependencyProperty WindowTransitionsEnabledProperty = DependencyProperty.Register("WindowTransitionsEnabled", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
 
         bool isDragging;
+
+        public bool WindowTransitionsEnabled
+        {
+            get { return (bool)this.GetValue(WindowTransitionsEnabledProperty); }
+            set { SetValue(WindowTransitionsEnabledProperty, value); }
+        }
 
         public FreezableCollection<Flyout> Flyouts
         {

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -28,7 +28,7 @@
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
             <AdornerDecorator>
-                <Controls:MetroContentControl IsTabStop="False" FocusVisualStyle="{x:Null}">
+                <Controls:MetroContentControl IsTabStop="False" FocusVisualStyle="{x:Null}" TransitionsEnabled="{TemplateBinding WindowTransitionsEnabled}">
                     <Grid>
                         <Grid.Background>
                             <SolidColorBrush Color="{DynamicResource WhiteColor}"/>


### PR DESCRIPTION
You can now disable the window transition animation and MetroContentControl's transitions in general.
