### PR TITLE
Fixed bug in MetroAnimatedSingleRowTabControl when tabs not on top

### DIFF
--- a/MahApps.Metro/Themes/MetroAnimatedSingleRowTabControl.xaml
+++ b/MahApps.Metro/Themes/MetroAnimatedSingleRowTabControl.xaml
@@ -54,6 +54,56 @@
         </Grid>
     </ControlTemplate>
 
+    <ControlTemplate x:Key="VerticalScrollBarTemplate" TargetType="{x:Type ScrollBar}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition MaxHeight="{DynamicResource {x:Static SystemParameters.VerticalScrollBarButtonHeightKey}}"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition MaxHeight="{DynamicResource {x:Static SystemParameters.VerticalScrollBarButtonHeightKey}}"/>
+            </Grid.RowDefinitions>
+            <RepeatButton IsEnabled="{TemplateBinding IsMouseOver}" Command="ScrollBar.PageUpCommand">
+                <RepeatButton.Style>
+                    <Style TargetType="{x:Type RepeatButton}">
+                        <Setter Property="OverridesDefaultStyle" Value="True"/>
+                        <Setter Property="Focusable" Value="False"/>
+                        <Setter Property="IsTabStop" Value="False"/>
+                        <Setter Property="Padding" Value="0,0,0,0"/>
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type RepeatButton}">
+                                    <Border Background="{x:Null}" Height="18" Width="18" >
+                                        <Path Data=" M 2 9 L 14 9 L 8 3 Z" Fill="{DynamicResource BlackBrush}" />
+                                    </Border>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </RepeatButton.Style>
+            </RepeatButton>
+            <RepeatButton IsEnabled="{TemplateBinding IsMouseOver}" Command="ScrollBar.PageDownCommand" Grid.Row="2">
+                <RepeatButton.Style>
+                    <Style TargetType="{x:Type RepeatButton}">
+                        <Setter Property="OverridesDefaultStyle" Value="True"/>
+                        <Setter Property="Focusable" Value="False"/>
+                        <Setter Property="IsTabStop" Value="False"/>
+                        <Setter Property="Padding" Value="0,0,0,0"/>
+                        <Setter Property="BorderThickness" Value="0"/>
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="{x:Type RepeatButton}">
+                                    <Border Background="{x:Null}" Height="18" Width="18" >
+                                        <Path Data=" M 2 10 L 14 10 L 8 16 Z" Fill="{DynamicResource BlackBrush}" />
+                                    </Border>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </RepeatButton.Style>
+            </RepeatButton>
+        </Grid>
+    </ControlTemplate>
+
     <ControlTemplate x:Key="ScrollViewerTemplate" TargetType="{x:Type ScrollViewer}">
         <Grid>
             <Grid.ColumnDefinitions>
@@ -66,6 +116,21 @@
             </Grid.RowDefinitions>
             <ScrollBar x:Name="PART_HorizontalScrollBar" Height="14" Cursor="Arrow" Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" Grid.Column="0" Grid.Row="0" Orientation="Horizontal" ViewportSize="{TemplateBinding ViewportWidth}" Maximum="{TemplateBinding ScrollableWidth}" Minimum="0" Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" AutomationProperties.AutomationId="HorizontalScrollBar" Template="{DynamicResource HorizontalScrollBarTemplate}"/>
             <ScrollContentPresenter x:Name="PART_ScrollContentPresenter" Margin="15,2,15,0" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Grid.Column="0" Grid.Row="0" CanContentScroll="{TemplateBinding CanContentScroll}" CanHorizontallyScroll="False" CanVerticallyScroll="False"/>
+        </Grid>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="VerticalScrollViewerTemplate" TargetType="{x:Type ScrollViewer}">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <ScrollBar x:Name="PART_VerticalScrollBar" Width="14" Cursor="Arrow" Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}" Grid.Column="0" Grid.Row="0" Orientation="Vertical" ViewportSize="{TemplateBinding ViewportHeight}" Maximum="{TemplateBinding ScrollableHeight}" Minimum="0" Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" AutomationProperties.AutomationId="VerticalScrollBar" Template="{DynamicResource VerticalScrollBarTemplate}"/>
+            <ScrollContentPresenter x:Name="PART_ScrollContentPresenter" Margin="0,20,0,20" Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Grid.Column="0" Grid.Row="0" CanContentScroll="{TemplateBinding CanContentScroll}" CanHorizontallyScroll="False" CanVerticallyScroll="False"/>
         </Grid>
     </ControlTemplate>
 
@@ -82,8 +147,8 @@
                             <RowDefinition x:Name="RowDefinition0" Height="Auto"/>
                             <RowDefinition x:Name="RowDefinition1" Height="*"/>
                         </Grid.RowDefinitions>
-                        <ScrollViewer Margin="{TemplateBinding TabStripMargin}" VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto" Template="{DynamicResource ScrollViewerTemplate}">
-                            <TabPanel x:Name="HeaderPanel" IsItemsHost="True" Panel.ZIndex="1" Grid.Column="0" Grid.Row="0" KeyboardNavigation.TabIndex="1"/>
+                        <ScrollViewer x:Name="HeaderPanelScroll" Margin="{TemplateBinding TabStripMargin}" VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto" Template="{DynamicResource ScrollViewerTemplate}" Grid.Column="0" Grid.Row="0">
+                            <TabPanel x:Name="HeaderPanel" IsItemsHost="True" Panel.ZIndex="1" KeyboardNavigation.TabIndex="1"/>
                         </ScrollViewer>
                         <Controls:MetroContentControl x:Name="ContentPanel" Behaviours:ReloadBehavior.OnSelectedTabChanged="True" Grid.Column="0" Grid.Row="1">
                             <ContentPresenter x:Name="PART_SelectedContentHost"
@@ -97,37 +162,44 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
-                            <Setter Property="Grid.Row" TargetName="HeaderPanel" Value="1"/>
+                            <Setter Property="Grid.Row" TargetName="HeaderPanelScroll" Value="1"/>
                             <Setter Property="Grid.Row" TargetName="ContentPanel" Value="0"/>
                             <Setter Property="Height" TargetName="RowDefinition0" Value="*"/>
                             <Setter Property="Height" TargetName="RowDefinition1" Value="Auto"/>
-                            <Setter Property="Margin" TargetName="HeaderPanel" Value="2,0,2,2"/>
+                            <Setter Property="Margin" TargetName="HeaderPanelScroll" Value="2,0,2,2"/>
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Left">
-                            <Setter Property="Grid.Row" TargetName="HeaderPanel" Value="0"/>
+                            <Setter Property="Grid.Row" TargetName="HeaderPanelScroll" Value="0"/>
                             <Setter Property="Grid.Row" TargetName="ContentPanel" Value="0"/>
-                            <Setter Property="Grid.Column" TargetName="HeaderPanel" Value="0"/>
+                            <Setter Property="Grid.Column" TargetName="HeaderPanelScroll" Value="0"/>
                             <Setter Property="Grid.Column" TargetName="ContentPanel" Value="1"/>
                             <Setter Property="Width" TargetName="ColumnDefinition0" Value="Auto"/>
                             <Setter Property="Width" TargetName="ColumnDefinition1" Value="*"/>
                             <Setter Property="Height" TargetName="RowDefinition0" Value="*"/>
                             <Setter Property="Height" TargetName="RowDefinition1" Value="0"/>
-                            <Setter Property="Margin" TargetName="HeaderPanel" Value="2,2,0,2"/>
+                            <Setter Property="Margin" TargetName="HeaderPanelScroll" Value="2,2,0,2"/>
+                            <Setter Property="VerticalScrollBarVisibility" TargetName="HeaderPanelScroll" Value="Auto"/>
+                            <Setter Property="HorizontalScrollBarVisibility" TargetName="HeaderPanelScroll" Value="Disabled"/>
+                            <Setter Property="Template" TargetName="HeaderPanelScroll" Value="{DynamicResource VerticalScrollViewerTemplate}"/>
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
-                            <Setter Property="Grid.Row" TargetName="HeaderPanel" Value="0"/>
+                            <Setter Property="Grid.Row" TargetName="HeaderPanelScroll" Value="0"/>
                             <Setter Property="Grid.Row" TargetName="ContentPanel" Value="0"/>
-                            <Setter Property="Grid.Column" TargetName="HeaderPanel" Value="1"/>
+                            <Setter Property="Grid.Column" TargetName="HeaderPanelScroll" Value="1"/>
                             <Setter Property="Grid.Column" TargetName="ContentPanel" Value="0"/>
                             <Setter Property="Width" TargetName="ColumnDefinition0" Value="*"/>
                             <Setter Property="Width" TargetName="ColumnDefinition1" Value="Auto"/>
                             <Setter Property="Height" TargetName="RowDefinition0" Value="*"/>
                             <Setter Property="Height" TargetName="RowDefinition1" Value="0"/>
-                            <Setter Property="Margin" TargetName="HeaderPanel" Value="0,2,2,2"/>
+                            <Setter Property="Margin" TargetName="HeaderPanelScroll" Value="0,2,2,2"/>
+                            <Setter Property="VerticalScrollBarVisibility" TargetName="HeaderPanelScroll" Value="Auto"/>
+                            <Setter Property="HorizontalScrollBarVisibility" TargetName="HeaderPanelScroll" Value="Disabled"/>
+                            <Setter Property="Template" TargetName="HeaderPanelScroll" Value="{DynamicResource VerticalScrollViewerTemplate}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
+
 </ResourceDictionary>


### PR DESCRIPTION
This should work with TabStripPlacement="Left", for example this way:

```
<mahappsmc:MetroAnimatedSingleRowTabControl TabStripPlacement="Left">  
        <TabControl.Resources>
            <Style TargetType="{x:Type TabItem}" BasedOn="{StaticResource {x:Type TabItem}}">
                <Setter Property="HeaderTemplate">
                    <Setter.Value>
                        <DataTemplate>
                            <ContentPresenter Content="{TemplateBinding Content}">
                                <ContentPresenter.LayoutTransform>
                                    <RotateTransform Angle="270" />
                                </ContentPresenter.LayoutTransform>
                            </ContentPresenter>
                        </DataTemplate>
                    </Setter.Value>
                </Setter>
            </Style>
        </TabControl.Resources>
        <TabItem Header="Test">
            Test
        </TabItem>
</mahappsmc:MetroAnimatedSingleRowTabControl>
```
