### PR TITLE
Fixed TextBox watermark alignment

### DIFF
--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -80,9 +80,10 @@
                             <Border x:Name="ReadOnlyVisualElement" Background="{x:Null}" Opacity="0" />
                             <ScrollViewer x:Name="PART_ContentHost" BorderThickness="0" IsTabStop="False" Margin="2" VerticalAlignment="Stretch" Background="{x:Null}" />
                             <TextBlock x:Name="Message" Text="{TemplateBinding Controls:TextboxHelper.Watermark}" Visibility="Collapsed"
-                                       Foreground="{TemplateBinding Foreground}" IsHitTestVisible="False" Opacity="0.6" HorizontalAlignment="Left" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                       Margin="6,0,0,0"/>
-
+                                       Foreground="{TemplateBinding Foreground}" IsHitTestVisible="False" Opacity="0.6"
+                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                       Margin="6,2,6,2" />
                             <Button x:Name="PART_ClearText" Style="{DynamicResource ChromelessButtonStyle}" FontSize="16" Foreground="{TemplateBinding Foreground}" Width="20"  HorizontalAlignment="Right"  FontFamily="Marlett" Content="r" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" IsTabStop="False" />
                         </Grid>
                         <Rectangle x:Name="DisabledVisualElement"
@@ -250,9 +251,10 @@
                             <Border x:Name="ReadOnlyVisualElement" Background="{x:Null}" Opacity="0" />
                             <ScrollViewer x:Name="PART_ContentHost" BorderThickness="0" IsTabStop="False" Margin="2" VerticalAlignment="Stretch" Background="{x:Null}" />
                             <TextBlock x:Name="Message" Text="{TemplateBinding Controls:TextboxHelper.Watermark}" Visibility="Collapsed"
-                                       Foreground="{TemplateBinding Foreground}" IsHitTestVisible="False" Opacity="0.6" HorizontalAlignment="Left" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                       Margin="6,0,0,0"/>
-
+                                       Foreground="{TemplateBinding Foreground}" IsHitTestVisible="False" Opacity="0.6"
+                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                       Margin="6,2,6,2" />
                             <Button x:Name="PART_ClearText" Style="{DynamicResource ChromelessButtonStyle}" FontSize="16" Foreground="{TemplateBinding Foreground}" Width="20"  HorizontalAlignment="Right"  FontFamily="Marlett" Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" IsTabStop="False">
                                 <Canvas Width="15" Height="15" Clip="F1 M 0,0L 48,0L 48,48L 0,48L 0,0">
                                     <!-- x:Key="appbar_magnify"-->

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -241,22 +241,28 @@
                             <ColumnDefinition />
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0" Width="150">
-                            <Label Content="Textbox" Style="{StaticResource DescriptionHeaderStyle}" />
+                            <Label Content="TextBox" Style="{StaticResource DescriptionHeaderStyle}" />
                             <TextBox Margin="0, 10, 0, 0" Text="Enabled" />
                             <TextBox Margin="0, 10, 0, 0"
-                                     VerticalContentAlignment="Center"
-                                     Controls:TextboxHelper.Watermark="Watermark" />
+                                     Controls:TextboxHelper.Watermark="Watermark"
+                                     ToolTip="Default alignment" />
                             <TextBox Margin="0, 10, 0, 0"
-                                     VerticalContentAlignment="Center"
+                                     HorizontalContentAlignment="Center"
+                                     Controls:TextboxHelper.Watermark="Watermark"
+                                     ToolTip="Text and watermark at center" />
+                            <TextBox Margin="0, 10, 0, 0"
+                                     HorizontalContentAlignment="Right"
+                                     TextAlignment="Left"
+                                     Controls:TextboxHelper.Watermark="Watermark"
+                                     ToolTip="Text at left, watermark at right" />
+                            <TextBox Margin="0, 10, 0, 0"
                                      Controls:TextboxHelper.ClearTextButton="True"
                                      Controls:TextboxHelper.Watermark="Watermark"
                                      Text="Clear button" />
                             <TextBox Margin="0, 10, 0, 0"
-                                     VerticalContentAlignment="Center"
                                      Controls:TextboxHelper.Watermark="Search style"
                                      Style="{DynamicResource SearchMetroTextBox}" />
                             <TextBox Margin="0, 10, 0, 0"
-                                     VerticalContentAlignment="Center"
                                      Controls:TextboxHelper.Watermark="Number smaller than 10"
                                      Text="{Binding IntegerGreater10Property,
                                                     ValidatesOnDataErrors=True,
@@ -266,22 +272,18 @@
                                      IsEnabled="False"
                                      Text="Disabled" />
                             <TextBox Margin="0, 10, 0, 0"
-                                     VerticalContentAlignment="Center"
                                      Controls:TextboxHelper.Watermark="Watermark"
                                      IsEnabled="False" />
                             <TextBox Margin="0, 10, 0, 0"
-                                     VerticalContentAlignment="Center"
                                      Controls:TextboxHelper.ClearTextButton="True"
                                      Controls:TextboxHelper.Watermark="Watermark"
                                      IsEnabled="False"
                                      Text="Clear button" />
                             <TextBox Margin="0, 10, 0, 0"
-                                     VerticalContentAlignment="Center"
                                      Controls:TextboxHelper.Watermark="Search style"
                                      IsEnabled="False"
                                      Style="{DynamicResource SearchMetroTextBox}" />
                             <TextBox Margin="0, 10, 0, 0"
-                                     VerticalContentAlignment="Center"
                                      Controls:TextboxHelper.Watermark="Number smaller than 10"
                                      IsEnabled="False"
                                      Text="{Binding IntegerGreater10Property,
@@ -309,7 +311,7 @@
                             </RichTextBox>
                         </StackPanel>
                         <StackPanel Grid.Column="2" Width="150">
-                            <Label Content="Passwordbox" Style="{StaticResource DescriptionHeaderStyle}" />
+                            <Label Content="PasswordBox" Style="{StaticResource DescriptionHeaderStyle}" />
                             <PasswordBox Margin="0, 10, 0, 0" Password="Password" />
                             <PasswordBox Margin="0, 10, 0, 0"
                                          Controls:TextboxHelper.ClearTextButton="True"


### PR DESCRIPTION
Fixes #603

MetroTextBox and SearchMetroTextBox styles:
1. Added template binding for watermark horizontal alignment.
2. Changed watermark margins for better look when vertical alignment
active.

MetroDemo:
1. Added some TextBoxes and ToolTips to show horizontal alignments.
2. Removed unnecessary vertical alignments.
3. Make equal appearance for headers in text tab (capital B in TextBox,
PasswordBox as was in RichTextBox).
