### PR TITLE
Window Buttons overlap Flyouts

### DIFF
--- a/MahApps.Metro/Controls/FlyoutsControl.cs
+++ b/MahApps.Metro/Controls/FlyoutsControl.cs
@@ -80,7 +80,13 @@ namespace MahApps.Metro.Controls
 
         private void FlyoutIsOpenChanged(object sender, EventArgs e)
         {
-            this.ReorderZIndices(this.GetFlyout(sender));
+            Flyout flyout = this.GetFlyout(sender); //Get the flyout that raised the handler.
+
+            this.ReorderZIndices(flyout);
+
+            MetroWindow parentWindow = this.TryFindParent<MetroWindow>();
+            if (parentWindow != null)
+                parentWindow.HandleFlyoutStatusChange(flyout);
         }
 
         private Flyout GetFlyout(object item)

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
@@ -31,6 +32,7 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty WindowTransitionsEnabledProperty = DependencyProperty.Register("WindowTransitionsEnabled", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
 
         bool isDragging;
+        ContentPresenter WindowCommandsPresenter = null;
 
         public bool WindowTransitionsEnabled
         {
@@ -171,6 +173,8 @@ namespace MahApps.Metro.Controls
                 MouseUp += TitleBarMouseUp;
                 MouseMove += TitleBarMouseMove;
             }
+
+            WindowCommandsPresenter = GetTemplateChild("PART_WindowCommands") as ContentPresenter;
         }
 
         protected override void OnStateChanged(EventArgs e)
@@ -284,6 +288,14 @@ namespace MahApps.Metro.Controls
             var cmd = UnsafeNativeMethods.TrackPopupMenuEx(hmenu, Constants.TPM_LEFTBUTTON | Constants.TPM_RETURNCMD, (int)physicalScreenLocation.X, (int)physicalScreenLocation.Y, hwnd, IntPtr.Zero);
             if (0 != cmd)
                 UnsafeNativeMethods.PostMessage(hwnd, Constants.SYSCOMMAND, new IntPtr(cmd), IntPtr.Zero);
+        }
+
+        internal void HandleFlyoutStatusChange(Flyout flyout)
+        {
+            if (flyout.Position == Position.Right && flyout.IsOpen)
+                WindowCommandsPresenter.SetValue(Panel.ZIndexProperty, 3);
+            else
+                WindowCommandsPresenter.SetValue(Panel.ZIndexProperty, 1); //in the style, the default is 1
         }
     }
 }

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -177,7 +177,7 @@
                         </ResourceDictionary>
                     </ControlTemplate.Resources>
                     
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Top" >
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Top">
                         <ItemsControl IsTabStop="False" ItemsSource="{Binding Items, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommands}}}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>


### PR DESCRIPTION
MetroWindow will show the Min/Max/Close buttons over Flyouts that are open and have Position=Right, like Github for Windows.
## Github for Windows

![f1](https://f.cloud.github.com/assets/251501/933752/54915efc-005c-11e3-81ce-7e26be3ee732.PNG)
## MahApps.Metro
### Before

![f3](https://f.cloud.github.com/assets/251501/933844/89c0118e-005e-11e3-9db7-a7fdff2e6a58.PNG)
### After

![f2](https://f.cloud.github.com/assets/251501/933753/548f6d4a-005c-11e3-8734-9d6710bd52a9.PNG)
