### PR TITLE
fix #647 System.NotSupportedException at MetroDataGridColumnHeader style

### DIFF
--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -158,7 +158,7 @@
         <Setter Property="ContentTemplate">
             <Setter.Value>
                 <DataTemplate DataType="{x:Type system:String}">
-                    <TextBlock Text="{TemplateBinding Content, Converter={StaticResource ToUpperConverter}}"/>
+                    <TextBlock Text="{Binding Converter={StaticResource ToUpperConverter}}"/>
                 </DataTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
System.NotSupportedException occurred
Message=Cannot convert the value in attribute 'Property' to object of
type 'System.Windows.DependencyProperty'.
Source=PresentationFramework
StackTrace:
at
System.Windows.Markup.DependencyPropertyConverter.ResolveProperty(IServiceProvider
serviceProvider, String targetName, Object source)
