### PR TITLE
BorderlessWindowBehavior should not throw on missing parts

### DIFF
--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -125,9 +125,9 @@ namespace MahApps.Metro.Behaviours
             AssociatedObject.StateChanged += AssociatedObjectStateChanged;
             AssociatedObject.SetValue(WindowChrome.GlassFrameThicknessProperty, new Thickness(-1));
 
-            if (AssociatedObject is MetroWindow)
+            var window = AssociatedObject as MetroWindow;
+            if (window != null)
             {
-                var window = ((MetroWindow)AssociatedObject);
                 //MetroWindow already has a border we can use
                 AssociatedObject.Loaded += (s, e) =>
                 {


### PR DESCRIPTION
Currently `BorderlessWindowBehavior` throws NREs if the associated window is a `MetroWindow`, but is missing a  `PART_TitleBar` or `PART_WindowCommands` element.
