### PR TITLE
gray7 was missing; caused xaml parse exceptions

### DIFF
--- a/MahApps.Metro/Styles/Accents/BaseLight.xaml
+++ b/MahApps.Metro/Styles/Accents/BaseLight.xaml
@@ -4,6 +4,8 @@
     <Color x:Key="BlackColor">#FF000000</Color>
     <Color x:Key="WhiteColor">#FFFFFFFF</Color>
 
+    <Color x:Key="Gray7">#FFF7F7F7</Color>
+
     <Color x:Key="GrayNormal">#FFBEBEBE</Color>
     <Color x:Key="GrayHover">#FF333333</Color>
 


### PR DESCRIPTION
Went though a lot of the color changes but not sure if this was intentional? It's used lower in the xaml so added it back. If that's incorrect let me know.

Thanks!
