### PR TITLE
Fix font size in MetroWindow

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -160,6 +160,8 @@
     <Style TargetType="{x:Type Controls:MetroWindow}">
         <Setter Property="TextBlockStyle"
                 Value="{StaticResource MetroTextBlock}" />
+        <Setter Property="TextBlock.FontSize"
+                Value="{DynamicResource ContentFontSize}"/>
         <Setter Property="Background"
                 Value="{DynamicResource WhiteBrush}" />
         <Setter Property="Foreground"


### PR DESCRIPTION
Since the designated TextBlock style was removed, the dynamic font size wasn't respected anymore.
