### PR TITLE
gray2 should be gray7 or exception occurs

### DIFF
--- a/MahApps.Metro/Styles/Accents/BaseLight.xaml
+++ b/MahApps.Metro/Styles/Accents/BaseLight.xaml
@@ -74,7 +74,7 @@
     <SolidColorBrush x:Key="TopMenuItemSelectionStroke" Color="#90717070" />
 
     <!-- original #FF9A9A9A" -->
-    <SolidColorBrush x:Key="DisabledMenuItemForeground" Color="{StaticResource Gray2}" />
+    <SolidColorBrush x:Key="DisabledMenuItemForeground" Color="{StaticResource Gray7}" />
     <SolidColorBrush x:Key="DisabledMenuItemGlyphPanel" Color="#848589" />
 
     <SolidColorBrush x:Key="{x:Static SystemColors.MenuTextBrushKey}" Color="{StaticResource BlackColor}" />


### PR DESCRIPTION
BaseDark.xaml has Gray7 for this one; assuming it's the corresponding match as well for Light
