### PR TITLE
Update MetroProgressBar.cs

### DIFF
--- a/MahApps.Metro/Controls/MetroProgressBar.cs
+++ b/MahApps.Metro/Controls/MetroProgressBar.cs
@@ -133,7 +133,7 @@ namespace MahApps.Metro.Controls
                         
                         if (!IsIndeterminate)
                         {
-                        return;
+                            return;
                         }
                         
                         indeterminate.Storyboard.Begin((FrameworkElement)GetTemplateChild("ContainingGrid"), true);


### PR DESCRIPTION
Fix of the control when you set isindeterminate = false and in runtime change to true, the size of the storyboard not have the new size.
