### PR TITLE
Removed title parameter from ShowMetroDialogAsync 

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/MetroWindowDialogExtensions.cs
+++ b/MahApps.Metro/Controls/Dialogs/MetroWindowDialogExtensions.cs
@@ -28,12 +28,13 @@ namespace MahApps.Metro.Controls.Dialogs
                             //create the dialog control
                             MessageDialog dialog = new MessageDialog(window);
                             dialog.Message = message;
+                            dialog.Title = title;
                             dialog.ButtonStyle = style;
 
                             dialog.AffirmativeButtonText = window.MetroDialogOptions.AffirmativeButtonText;
                             dialog.NegativeButtonText = window.MetroDialogOptions.NegativeButtonText;
 
-                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, title, dialog);
+                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                             dialog.SizeChangedHandler = sizeHandler;
 
                             return dialog.WaitForLoadAsync().ContinueWith(x =>
@@ -76,9 +77,10 @@ namespace MahApps.Metro.Controls.Dialogs
                         //create the dialog control
                         ProgressDialog dialog = new ProgressDialog(window);
                         dialog.Message = message;
+                        dialog.Title = title;
                         dialog.IsCancelable = isCancelable;
                         dialog.NegativeButtonText = window.MetroDialogOptions.NegativeButtonText;
-                        SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, title, dialog);
+                        SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                         dialog.SizeChangedHandler = sizeHandler;
 
                         return dialog.WaitForLoadAsync().ContinueWith(x =>
@@ -109,7 +111,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="title">The title to be set in the dialog.</param>
         /// <param name="dialog">The dialog instance itself.</param>
         /// <returns>A task representing the operation.</returns>
-        public static Task ShowMetroDialogAsync(this MetroWindow window, string title, BaseMetroDialog dialog)
+        public static Task ShowMetroDialogAsync(this MetroWindow window, BaseMetroDialog dialog)
         {
             window.Dispatcher.VerifyAccess();
             if (window.messageDialogContainer.Children.Contains(dialog))
@@ -119,7 +121,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 {
                     dialog.Dispatcher.Invoke(new Action(() =>
                         {
-                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, title, dialog);
+                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                             dialog.SizeChangedHandler = sizeHandler;
                         }));
                 }).ContinueWith(y =>
@@ -144,11 +146,10 @@ namespace MahApps.Metro.Controls.Dialogs
             return window.HideOverlayAsync();
         }
 
-        private static SizeChangedEventHandler SetupAndOpenDialog(MetroWindow window, string title, BaseMetroDialog dialog)
+        private static SizeChangedEventHandler SetupAndOpenDialog(MetroWindow window, BaseMetroDialog dialog)
         {
             dialog.SetValue(Panel.ZIndexProperty, (int)window.overlayBox.GetValue(Panel.ZIndexProperty) + 1);
             dialog.MinHeight = window.ActualHeight / 4.0;
-            dialog.Title = title;
 
             SizeChangedEventHandler sizeHandler = null; //an event handler for auto resizing an open dialog.
             sizeHandler = new SizeChangedEventHandler((sender, args) =>

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -56,6 +56,7 @@
             </Style>
             
             <Dialog:SimpleDialog x:Key="SimpleDialogTest"
+                                 Title="This dialog allows arbitrary content. It will close in 5 seconds."
                                  x:Name="SimpleTestDialog">
                 <Button Content="Hello"/>
             </Dialog:SimpleDialog>

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -91,7 +91,7 @@ namespace MetroDemo
         {
             var dialog = this.Resources["SimpleDialogTest"] as BaseMetroDialog;
 
-            this.ShowMetroDialogAsync("This dialog allows arbitrary content. It will close in 5 seconds.", dialog).ContinueWith(x => System.Threading.Thread.Sleep(5000)).ContinueWith(y =>
+            this.ShowMetroDialogAsync(dialog).ContinueWith(x => System.Threading.Thread.Sleep(5000)).ContinueWith(y =>
                 {
                     Dispatcher.Invoke(new Action(() =>
                         {


### PR DESCRIPTION
Since we can pass an already initialized `BaseMetroDialog` instance to `ShowMetroDialogAsync`, there's no need to have an additional `title` parameter.
