### PR TITLE
thickness of minus sign in NumericUpDown

### DIFF
--- a/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -52,7 +52,7 @@
                                 IsTabStop="False">
                             <Path x:Name="PolygonDown"
                                     Width="14"
-                                    Height="3"
+                                    Height="2"
                                     Stretch="Fill"
                                     Fill="{DynamicResource BlackBrush}"
                                     Data="F1 M 19,38L 57,38L 57,44L 19,44L 19,38 Z " />


### PR DESCRIPTION
The minus sign in the `NumericUpDown` control is thicker than the plus sign.

**Before my changes:**
![image](https://f.cloud.github.com/assets/73690/1700820/e235d0f2-602f-11e3-9e5c-b6e46b2d4277.png)

**After:**
![image](https://f.cloud.github.com/assets/73690/1700821/f1413f82-602f-11e3-8023-b7b64aebb415.png)
