### PR TITLE
MetroWindow: Added ShowWindowCommandsOnTop

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -46,7 +46,6 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty FlyoutsProperty = DependencyProperty.Register("Flyouts", typeof(FlyoutsControl), typeof(MetroWindow), new PropertyMetadata(null));
         public static readonly DependencyProperty WindowTransitionsEnabledProperty = DependencyProperty.Register("WindowTransitionsEnabled", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
         public static readonly DependencyProperty ShowWindowCommandsOnTopProperty = DependencyProperty.Register("ShowWindowCommandsOnTop", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
-        public static readonly DependencyProperty ShowWindowButtonsOnTopProperty = DependencyProperty.Register("ShowWindowButtonsOnTop", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
         public static readonly DependencyProperty TextBlockStyleProperty = DependencyProperty.Register("TextBlockStyle", typeof(Style), typeof(MetroWindow), new PropertyMetadata(default(Style)));
         public static readonly DependencyProperty UseNoneWindowStyleProperty = DependencyProperty.Register("UseNoneWindowStyle", typeof(bool), typeof(MetroWindow), new PropertyMetadata(false, OnUseNoneWindowStylePropertyChangedCallback));
 
@@ -85,15 +84,6 @@ namespace MahApps.Metro.Controls
         {
             get { return (bool)this.GetValue(ShowWindowCommandsOnTopProperty); }
             set { SetValue(ShowWindowCommandsOnTopProperty, value); }
-        }
-        
-        /// <summary>
-        /// Gets/sets whether the Window Buttons will show on top of a Flyout with it's position set to Top or Right.
-        /// </summary>
-        public bool ShowWindowButtonsOnTop
-        {
-            get { return (bool) GetValue(ShowWindowButtonsOnTopProperty); }
-            set { SetValue(ShowWindowButtonsOnTopProperty, value); }
         }
 
         /// <summary>
@@ -572,7 +562,7 @@ namespace MahApps.Metro.Controls
 
                 //if ShowWindowCommandsOnTop is true, set the window commands' zindex to a number that is higher than the flyout's. 
                 WindowCommandsPresenter.SetValue(Panel.ZIndexProperty, this.ShowWindowCommandsOnTop ? zIndex : (zIndex > 0 ? zIndex - 1 : 0));
-                WindowButtonCommands.SetValue(Panel.ZIndexProperty, this.ShowWindowButtonsOnTop ? zIndex : (zIndex > 0 ? zIndex - 1 : 0));
+                WindowButtonCommands.SetValue(Panel.ZIndexProperty, this.ShowWindowCommandsOnTop ? zIndex : (zIndex > 0 ? zIndex - 1 : 0));
                 
                 this.HandleWindowCommandsForFlyouts(visibleFlyouts);
             }


### PR DESCRIPTION
Added the property `ShowWindowButtonsOnTop` which, when set to false, hides the minimize, maximize/restore and close buttons, just like `ShowWindowCommandsOnTop`.

Fixes #966 
