### PR TITLE
[BUG] Fix for finding real Flyout visual control when using MVVM

### DIFF
--- a/MahApps.Metro/Behaviours/InternalCleanWindowGlueBehavior.cs
+++ b/MahApps.Metro/Behaviours/InternalCleanWindowGlueBehavior.cs
@@ -54,7 +54,7 @@ namespace MahApps.Metro.Behaviours
 
         void AssociatedMetroWindow_FlyoutsStatusChanged(object sender, RoutedEventArgs e)
         {
-            var flyouts = this.AssociatedMetroWindow.Flyouts.Items.Cast<Flyout>().ToList();
+            var flyouts = this.AssociatedMetroWindow.Flyouts.FindVisualChildren<Flyout>().ToList();
             this.AssociatedMetroWindow.HandleWindowCommandsForFlyouts(flyouts, (Brush) this.AssociatedMetroWindow.FindResource("BlackColorBrush"));
         }
     }

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -382,7 +382,7 @@ namespace MahApps.Metro.Controls
         {
             if (e.Accent != null)
             {
-                var flyouts = this.Flyouts.Items.Cast<Flyout>().ToList();
+                var flyouts = this.Flyouts.FindVisualChildren<Flyout>().ToList();
 
                 if (!flyouts.Any())
                     return;

--- a/MahApps.Metro/Controls/TreeHelper.cs
+++ b/MahApps.Metro/Controls/TreeHelper.cs
@@ -101,6 +101,34 @@ namespace MahApps.Metro.Controls
         }
 
         /// <summary>
+        /// Analyzes the visual tree in order to find all elements of a given
+        /// type that are descendants of the <paramref name="source"/> item.
+        /// </summary>
+        /// <typeparam name="T">The type of the queried items.</typeparam>
+        /// <param name="source">The root element that marks the source of the search. If the
+        /// source is already of the requested type, it will not be included in the result.</param>
+        /// <returns>All visual descendants of <paramref name="source"/> that match the requested type.</returns>
+        public static IEnumerable<T> FindVisualChildren<T>(this DependencyObject source) where T : DependencyObject
+        {
+            if (source != null)
+            {
+                for (int i = 0; i < VisualTreeHelper.GetChildrenCount(source); i++)
+                {
+                    var child = VisualTreeHelper.GetChild(source, i);
+                    if (child is T)
+                    {
+                        yield return (T)child;
+                    }
+
+                    foreach (T childOfChild in FindVisualChildren<T>(child))
+                    {
+                        yield return childOfChild;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// This method is an alternative to WPF's
         /// <see cref="VisualTreeHelper.GetChild"/> method, which also
         /// supports content elements. Keep in mind that for content elements,


### PR DESCRIPTION
MetroWindow and InternalCleanWindowGlueBehavior handle the FlyoutsControl.Items collection wrong.

In an MVVM scenario, the Items collection does not contain the actual Flyout control, but the viewmodel object.

I changed it to use a 'FindVisualChildren' helper to obtain the real Flyout control.

Note that I couldn't use the existing FindChildren<T> extension method, because that one uses the logical tree, resulting in nothing found at all.

This is a show stopper bug, as in an MVVM scenario a 'Cast exception' was thrown on casting the Items collection to Flyout.
