### PR TITLE
#998 fix fo FlipView not applying template from ItemTemplate

### DIFF
--- a/MahApps.Metro/Controls/TransitioningContentControl.cs
+++ b/MahApps.Metro/Controls/TransitioningContentControl.cs
@@ -235,8 +235,6 @@ namespace MahApps.Metro.Controls
             {
                 if (ContentTemplateSelector != null)
                     CurrentContentPresentationSite.ContentTemplate = ContentTemplateSelector.SelectTemplate(Content, this);
-                else
-                    CurrentContentPresentationSite.ContentTemplate = null;
 
                 CurrentContentPresentationSite.Content = Content;
             }


### PR DESCRIPTION
if ContentTemplateSelector was null ContentTemplate was set null which
nullified the effects of ItemTemplate. Fix deletes two lines responsible
for clearing the ContentTemplate in that situation (content template may
be applied from ItemTemplate)
