### PR TITLE
use GetFlyouts() helper method instead of Flyouts.Items for MVVM scenariios

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -410,7 +410,7 @@ namespace MahApps.Metro.Controls
         {
             if (Flyouts.OverrideExternalCloseButton == null)
             {
-                foreach (Flyout flyout in Flyouts.Items)
+                foreach (Flyout flyout in Flyouts.GetFlyouts())
                 {
                     if (flyout.ExternalCloseButton == e.ChangedButton && (flyout.IsPinned == false || Flyouts.OverrideIsPinned == true))
                     {
@@ -420,7 +420,7 @@ namespace MahApps.Metro.Controls
             }
             else if (Flyouts.OverrideExternalCloseButton == e.ChangedButton)
             {
-                foreach (Flyout flyout in Flyouts.Items)
+                foreach (Flyout flyout in Flyouts.GetFlyouts())
                 {
                     if (flyout.IsPinned == false || Flyouts.OverrideIsPinned == true)
                     {


### PR DESCRIPTION
Just updated to try the performance patch, and now my app crashes :hammer: :hammer:. don't forget to use the helper method ;)
