### PR TITLE
Fix missing flyout external click code

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -406,8 +406,14 @@ namespace MahApps.Metro.Controls
             }
         }
         
-        private void FlyoutsPreviewKeyDown(object sender, MouseButtonEventArgs e)
+        private void FlyoutsPreviewMouseDown(object sender, MouseButtonEventArgs e)
         {
+            FrameworkElement element = (e.OriginalSource as FrameworkElement);
+            if (element != null && element.TryFindParent<Flyout>() != null)
+            {
+                return;
+            }
+            
             if (Flyouts.OverrideExternalCloseButton == null)
             {
                 foreach (Flyout flyout in Flyouts.GetFlyouts())
@@ -453,8 +459,8 @@ namespace MahApps.Metro.Controls
             overlayBox = GetTemplateChild(PART_OverlayBox) as Grid;
             metroDialogContainer = GetTemplateChild(PART_MetroDialogContainer) as Grid;
             flyoutModal = GetTemplateChild(PART_FlyoutModal) as Rectangle;
-            flyoutModal.PreviewMouseDown += FlyoutsPreviewKeyDown;
-            this.PreviewMouseDown += FlyoutsPreviewKeyDown;
+            flyoutModal.PreviewMouseDown += FlyoutsPreviewMouseDown;
+            this.PreviewMouseDown += FlyoutsPreviewMouseDown;
 
             titleBar = GetTemplateChild(PART_TitleBar) as UIElement;
 


### PR DESCRIPTION
How did I forget that piece of code and named a `MouseDown` event handler `KeyDown`!?

Related: #1000 #965 
Fixes #1010
