### PR TITLE
Fix for overflow exception (multi monitor)

### DIFF
--- a/MahApps.Metro/Native/UnsafeNativeMethods.cs
+++ b/MahApps.Metro/Native/UnsafeNativeMethods.cs
@@ -131,22 +131,22 @@ namespace MahApps.Metro.Native
             public readonly Int32 Y;
         };
 
-        internal static int GET_X_LPARAM(UIntPtr lParam)
+        internal static int GET_X_LPARAM(IntPtr lParam)
         {
-            return LOWORD(lParam.ToUInt32());
+            return LOWORD(lParam.ToInt64());
         }
 
-        internal static int GET_Y_LPARAM(UIntPtr lParam)
+        internal static int GET_Y_LPARAM(IntPtr lParam)
         {
-            return HIWORD(lParam.ToUInt32());
+            return HIWORD(lParam.ToInt64());
         }
 
-        private static int HIWORD(uint i)
+        private static int HIWORD(long i)
         {
             return (short)(i >> 16);
         }
 
-        private static int LOWORD(uint i)
+        private static int LOWORD(long i)
         {
             return (short)(i & 0xFFFF);
         }


### PR DESCRIPTION
If `X` and `Y` are both `-1`, the packed integer is `0xFFFFFFFF` which is not a valid `Int32`, thus a `System.OverflowException` is thrown in `IntPtr.ToInt32()`.

To fix this, `IntPtr.ToInt64()` is used instead.

Fixes #624
