### PR TITLE
Fixed an issue when Minimum is set > 0 and user enters characters that are less then the maximum

### DIFF
--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -802,10 +802,6 @@ namespace MahApps.Metro.Controls
                 if (ValidateText(((TextBox)sender).Text, out convertedValue))
                 {
                     Value = convertedValue;
-                    if (convertedValue != Value)
-                    {
-                        InternalSetText(Value);
-                    }
                     e.Handled = true;
                 }
             }


### PR DESCRIPTION
Fixed an issue that if Min=1000, user selects all text and enters 1, then the NUD gets immediately value 1000.

Now 1 still remains as **text** (because the user will enter further characters) and internal **value** is 1000.
When the Value that the user is inserting is bigger than 1000 then the Value is set to that number.
When the Value that the user is inserting is lower than 1000 then Value not set and the text in NUD remains at that value (only when manual inserting, not with +/-) .At LostOfFocus the **text** gets updated to the corresponding Minimum.
