### PR TITLE
Modified system menu show behavior

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -526,14 +526,16 @@ namespace MahApps.Metro.Controls
                     }
                 }
             }
-            else if (e.ChangedButton == MouseButton.Right)
-            {
-                ShowSystemMenuPhysicalCoordinates(this, PointToScreen(mousePosition));
-            }
         }
 
         protected void TitleBarMouseUp(object sender, MouseButtonEventArgs e)
         {
+            var mousePosition = e.GetPosition(this);
+            bool isIconClick = ShowIconOnTitleBar && mousePosition.X <= TitlebarHeight && mousePosition.Y <= TitlebarHeight;
+            if (e.ChangedButton == MouseButton.Right && !isIconClick)
+            {
+                ShowSystemMenuPhysicalCoordinates(this, PointToScreen(mousePosition));
+            }
             isDragging = false;
         }
 


### PR DESCRIPTION
The system menu usually opens when the right mouse button is released (except for the window icon). In this package the menu is shown when the right mouse button is pressed.
