### PR TITLE
fix flyout warnings

### DIFF
--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -31,8 +31,9 @@
                     </i:EventTrigger>
                 </i:Interaction.Triggers>
                 <Rectangle Width="20"
-                           Height="15">
-                    <Rectangle.Fill>
+                           Height="15"
+                           Fill="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=Foreground}">
+                    <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Fill">
                             <VisualBrush.Visual>
                                 <Canvas Width="48"
@@ -44,12 +45,12 @@
                                           Canvas.Left="12"
                                           Canvas.Top="15"
                                           Stretch="Fill"
-                                          Fill="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=Foreground}"
+                                          Fill="Black"
                                           Data="F1 M 12,22L 12,26L 28.25,26L 21,33L 27.5,33L 37,24L 27.5,15L 21,15L 28.25,22L 12,22 Z " />
                                 </Canvas>
                             </VisualBrush.Visual>
                         </VisualBrush>
-                    </Rectangle.Fill>
+                    </Rectangle.OpacityMask>
                 </Rectangle>
             </Button>
             <TextBlock Text="{Binding}"


### PR DESCRIPTION
this fixes the warnings for setting the foreground at the visual brush via relative resource binding...

Closes #955 
