### PR TITLE
fix for combox popup redrawn bug

### DIFF
--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -286,7 +286,10 @@
                                    Fill="{DynamicResource DisabledWhiteBrush}"
                                    IsHitTestVisible="false"
                                    Opacity="0" />
+                        <!-- AllowsTransparency="true" fixes the redraw problem under windows vista/7 with a selected non aero theme -->
                         <Popup x:Name="PART_Popup"
+                               AllowsTransparency="true"
+                               Focusable="False"
                                IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}}"
                                PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}"
                                MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"


### PR DESCRIPTION
set only AllowsTransparency="true" and all works fine

set the windows theme to non aero to test this issue

Closes #985 
Closes #830 
Closes #576 
