### PR TITLE
fix for editable combobox background

### DIFF
--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -335,9 +335,10 @@
                             <Setter TargetName="PART_DropDownToggle"
                                     Property="Focusable"
                                     Value="False" />
+                            <!-- #1037 : don't know why we set this to transparent ???
                             <Setter TargetName="PART_DropDownToggle"
                                     Property="Background"
-                                    Value="Transparent" />
+                                    Value="Transparent" /> -->
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>


### PR DESCRIPTION
don't set the background for the toggle button to transparent (don't know why we do this)

Closes #1037 
