### PR TITLE
Changed MessageDialog and ProgressDialog's constructor visibility.

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
@@ -26,11 +26,11 @@ namespace MahApps.Metro.Controls.Dialogs
         //    //DefaultStyleKeyProperty.OverrideMetadata(typeof(MessageDialog), new FrameworkPropertyMetadata(typeof(MessageDialog)));
         //}
 
-        internal MessageDialog(MetroWindow parentWindow)
+        protected internal MessageDialog(MetroWindow parentWindow)
             : this(parentWindow, null)
         {
         }
-        internal MessageDialog(MetroWindow parentWindow, MetroDialogSettings settings)
+        protected internal MessageDialog(MetroWindow parentWindow, MetroDialogSettings settings)
             : base(parentWindow, settings)
         {
             InitializeComponent();

--- a/MahApps.Metro/Controls/Dialogs/ProgressDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/ProgressDialog.cs
@@ -25,7 +25,7 @@ namespace MahApps.Metro.Controls.Dialogs
         //{
         //    //DefaultStyleKeyProperty.OverrideMetadata(typeof(MessageDialog), new FrameworkPropertyMetadata(typeof(MessageDialog)));
         //}
-        internal ProgressDialog(MetroWindow parentWindow, MetroDialogSettings settings)
+        protected internal ProgressDialog(MetroWindow parentWindow, MetroDialogSettings settings)
             : base(parentWindow, settings)
         {
             InitializeComponent();
@@ -41,7 +41,7 @@ namespace MahApps.Metro.Controls.Dialogs
             else
                 ProgressBarForeground = Brushes.White;
         }
-        internal ProgressDialog(MetroWindow parentWindow)
+        protected internal ProgressDialog(MetroWindow parentWindow)
             : this(parentWindow, null)
         {
             


### PR DESCRIPTION
Changed `MessageDialog` and `ProgressDialog`'s constructor visibility to allow users to inherit from `MessageDialog` and `ProgressDialog` and provide their own spin to them.

Related: #1088 
