### PR TITLE
Fix ShowIconOnTitleBar=true + TitlebarHeight=0

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -499,6 +499,10 @@ namespace MahApps.Metro.Controls
 
         protected void TitleBarMouseDown(object sender, MouseButtonEventArgs e)
         {
+            if (this.TitlebarHeight <= 0) {
+                return;
+            }
+            
             var mousePosition = e.GetPosition(this);
             bool isIconClick = ShowIconOnTitleBar && mousePosition.X <= TitlebarHeight && mousePosition.Y <= TitlebarHeight;
 


### PR DESCRIPTION
`ShowIconOnTitleBar=true` together with `TitlebarHeight=0` results in any clicks on the window closing it.

Fixes #1124
