### PR TITLE
Fix to Tile control, 

### DIFF
--- a/MahApps.Metro/Controls/Tile.cs
+++ b/MahApps.Metro/Controls/Tile.cs
@@ -6,9 +6,9 @@ namespace MahApps.Metro.Controls
 {
     public class Tile : Button
     {
-        public Tile()
+        static Tile()
         {
-            DefaultStyleKey = typeof (Tile);
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(Tile), new FrameworkPropertyMetadata(typeof(Tile)));
         }
 
         public static readonly DependencyProperty TitleProperty = DependencyProperty.Register("Title", typeof(string), typeof(Tile), new PropertyMetadata(default(string)));


### PR DESCRIPTION
Proper way of setting DefaultStyleKey dependency property for custom control. RTFM.
I will scan through the source for this kind of fixes in other controls.

Current implementation requires code changes in constructors (if you inherit from Tile).
