### PR TITLE
metro circle button demo fix

### DIFF
--- a/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
+++ b/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
@@ -80,11 +80,12 @@
                           Margin="0, 10, 0, 0"
                           Style="{DynamicResource MetroCircleToggleButtonStyle}">
                 <Rectangle Width="20"
-                           Height="20">
-                    <Rectangle.Fill>
+                           Height="20"
+                           Fill="{DynamicResource BlackBrush}">
+                    <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Fill"
                                      Visual="{DynamicResource appbar_city}" />
-                    </Rectangle.Fill>
+                    </Rectangle.OpacityMask>
                 </Rectangle>
             </ToggleButton>
             <ToggleButton Width="50"
@@ -93,11 +94,12 @@
                           IsEnabled="False"
                           Style="{DynamicResource MetroCircleToggleButtonStyle}">
                 <Rectangle Width="20"
-                           Height="20">
-                    <Rectangle.Fill>
+                           Height="20"
+                           Fill="{DynamicResource BlackBrush}">
+                    <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Fill"
                                      Visual="{DynamicResource appbar_city}" />
-                    </Rectangle.Fill>
+                    </Rectangle.OpacityMask>
                 </Rectangle>
             </ToggleButton>
         </StackPanel>
@@ -129,11 +131,12 @@
                     Margin="0, 10, 0, 0"
                     Style="{DynamicResource MetroCircleButtonStyle}">
                 <Rectangle Width="20"
-                           Height="20">
-                    <Rectangle.Fill>
+                           Height="20"
+                           Fill="{DynamicResource BlackBrush}">
+                    <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Fill"
                                      Visual="{DynamicResource appbar_city}" />
-                    </Rectangle.Fill>
+                    </Rectangle.OpacityMask>
                 </Rectangle>
             </Button>
             <Button Width="50"
@@ -142,11 +145,12 @@
                     IsEnabled="False"
                     Style="{DynamicResource MetroCircleButtonStyle}">
                 <Rectangle Width="20"
-                           Height="20">
-                    <Rectangle.Fill>
+                           Height="20"
+                           Fill="{DynamicResource BlackBrush}">
+                    <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Fill"
                                      Visual="{DynamicResource appbar_city}" />
-                    </Rectangle.Fill>
+                    </Rectangle.OpacityMask>
                 </Rectangle>
             </Button>
         </StackPanel>


### PR DESCRIPTION
fixes the button demo

workaround

``` xml
<Rectangle Width="20"
           Height="20"
           Fill="{DynamicResource BlackBrush}">
    <Rectangle.OpacityMask>
        <VisualBrush Stretch="Fill"
                     Visual="{DynamicResource appbar_city}" />
    </Rectangle.OpacityMask>
</Rectangle>
```

it's not MahApps.Metro issue...

http://social.msdn.microsoft.com/Forums/vstudio/en-US/7e9e0817-9cc3-497a-b21f-dc69e7b946cb/visualbrush-not-updated-when-we-change-palette?forum=wpf

http://connect.microsoft.com/VisualStudio/feedback/details/633535/msdn-forum-dynamicresource-in-nested-resource-dictionary-not-working

![6nx28giopkoql0ywrknurx6yq5d1y](https://f.cloud.github.com/assets/658431/2369110/2b80909e-a7cf-11e3-86b2-3c5f6341f2fd.jpg)
