### PR TITLE
fix not resetting window commands/buttons brushes after theme change

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -558,13 +558,16 @@ namespace MahApps.Metro.Controls
                 var flyouts = this.Flyouts.GetFlyouts().ToList();
 
                 if (!flyouts.Any())
+                {
+                    // we must update the window command brushes!!!
+                    this.ResetAllWindowCommandsBrush();
                     return;
+                }
 
-                foreach (Flyout flyout in flyouts)
+                foreach (var flyout in flyouts)
                 {
                     flyout.ChangeFlyoutTheme(e.Accent, e.Theme);
                 }
-
                 this.HandleWindowCommandsForFlyouts(flyouts);
             }
         }


### PR DESCRIPTION
if no flyouts exists and the clean window style is used, the window commands/buttons bruhes are not updating after using the theme manager that changes the theme from dark to light or light to dark.
