### PR TITLE
Made MetroCircleToggleButtonStyle use accent color when toggled. Fixes #963

### DIFF
--- a/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -617,6 +617,7 @@
                 Value="2" />
         <Setter Property="HorizontalContentAlignment"
                 Value="Center" />
+        <Setter Property="Foreground" Value="Black"/>
         <Setter Property="VerticalContentAlignment"
                 Value="Center" />
         <Setter Property="Padding"
@@ -629,13 +630,13 @@
                                  Margin="4"
                                  StrokeThickness="0" />
                         <Ellipse x:Name="ellipsebg"
-                                 Fill="{DynamicResource BlackBrush}"
+                                 Fill="{DynamicResource AccentColorBrush}"
                                  Opacity="0"
                                  Margin="4"
                                  StrokeThickness="0" />
                         <Ellipse x:Name="ellipse"
                                  Margin="4"
-                                 Stroke="{TemplateBinding Foreground}"
+                                 Stroke="#ADADAD"
                                  StrokeThickness="{Binding RelativeSource={x:Static RelativeSource.TemplatedParent}, Path=BorderThickness.Left}" />
                         <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           Margin="{TemplateBinding Padding}"
@@ -652,8 +653,8 @@
                                         <DoubleAnimation Storyboard.TargetName="ellipsebg"
                                                          Storyboard.TargetProperty="Opacity"
                                                          From="0"
-                                                         To="0.3"
-                                                         Duration="0:0:0" />
+                                                         To="1"
+                                                         Duration="0:0:0.3" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.EnterActions>
@@ -664,12 +665,13 @@
                                         <DoubleAnimation Storyboard.TargetName="ellipsebg"
                                                          Storyboard.TargetProperty="Opacity"
                                                          To="0"
-                                                         Duration="0:0:0.5" />
+                                                         Duration="0:0:0.3" />
                                     </Storyboard>
                                 </BeginStoryboard>
                             </Trigger.ExitActions>
                             <Setter Property="Foreground"
-                                    Value="{DynamicResource AccentColorBrush}" />
+                                    Value="White" />
+                            <Setter TargetName="ellipse" Property="Stroke" Value="{DynamicResource AccentColorBrush}"/>
                         </Trigger>
                         <Trigger Property="IsMouseOver"
                                  Value="True">
@@ -682,11 +684,6 @@
                             <Setter TargetName="ellipse"
                                     Property="Opacity"
                                     Value=".5" />
-                        </Trigger>
-                        <Trigger Property="IsEnabled"
-                                 Value="false">
-                            <Setter Property="Foreground"
-                                    Value="#ADADAD" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
+++ b/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
@@ -81,10 +81,10 @@
                           Style="{DynamicResource MetroCircleToggleButtonStyle}">
                 <Rectangle Width="20"
                            Height="20"
-                           Fill="{DynamicResource BlackBrush}">
+                           Fill="{Binding Path=Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ToggleButton}}}">
                     <Rectangle.OpacityMask>
                         <VisualBrush Stretch="Fill"
-                                     Visual="{DynamicResource appbar_city}" />
+                                     Visual="{DynamicResource appbar_city}"/>
                     </Rectangle.OpacityMask>
                 </Rectangle>
             </ToggleButton>


### PR DESCRIPTION
When checked, ToggleButton using the MetroCircleToggleButtonStyle will turn to the AccentColorBrush instead of turning gray as show in the image below. Fixes #963.

In order to make sure that the content turns white when the toggle button is checked, just bind the glyph's foreground / fill / whatever is used as content to the ToggleButton's foreground.

For example:

``` xml
<!-- Take note of the Rectangle's Fill. It is bound to the control's foreground -->
<Rectangle Width="20"
        Height="20"
        Fill="{Binding Path=Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ToggleButton}}}">
    <Rectangle.OpacityMask>
        <VisualBrush Stretch="Fill"
                    Visual="{DynamicResource appbar_city}"/>
    </Rectangle.OpacityMask>
</Rectangle>
```
## Before:

![image](https://f.cloud.github.com/assets/574734/2462221/28a3359a-af7f-11e3-9c7d-f9e6897505e1.png)
## After:

![image](https://f.cloud.github.com/assets/574734/2462128/4fb40f0c-af7e-11e3-8eb7-411c9d55a9ec.png)
