### PR TITLE
Made MetroCircleToggleButtonStyle's foreground GrayBrush6 when it is disabled

### DIFF
--- a/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -685,6 +685,9 @@
                                     Property="Opacity"
                                     Value=".5" />
                         </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource GrayBrush6}"></Setter>
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
ToggleButtons implementing MetroCircleToggleButtonStyle will now have their contents grayed out when disabled. (If the contents bind to the toggle button's foreground)

![untitled](https://f.cloud.github.com/assets/574734/2462678/c33045d6-af83-11e3-8584-33415e0f6a54.png)

Changes made in addition to 41b8d657b7035e5ef44337d875b3fb275a1032f7.
