### PR TITLE
DataGrid: introduce MetroDataGridCheckBox and fix GridLines Brushes

### DIFF
--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -2,7 +2,22 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.CheckBox.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
     <Converters:ToUpperConverter x:Key="ToUpperConverter" />
+
+    <Style x:Key="MetroDataGridCheckBox"
+           TargetType="CheckBox"
+           BasedOn="{StaticResource MetroCheckBox}">
+        <Setter Property="Margin"
+                Value="0" />
+        <Setter Property="HorizontalAlignment"
+                Value="Center" />
+        <Setter Property="VerticalAlignment"
+                Value="Center" />
+    </Style>
 
     <Style x:Key="{ComponentResourceKey ResourceId=MetroDataGridSelectAllButtonStyle, TypeInTargetAssembly={x:Type DataGrid}}"
            TargetType="{x:Type Button}">
@@ -383,6 +398,10 @@
                 Value="{DynamicResource AccentColorBrush}" />
         <Setter Property="BorderThickness"
                 Value="0,0,0,0" />
+        <Setter Property="HorizontalGridLinesBrush"
+                Value="{DynamicResource GrayBrush7}" />
+        <Setter Property="VerticalGridLinesBrush"
+                Value="{DynamicResource GrayBrush7}" />
         <Setter Property="ColumnHeaderStyle"
                 Value="{StaticResource MetroDataGridColumnHeader}" />
         <Setter Property="RowHeaderStyle"
@@ -584,8 +603,10 @@
     <Style x:Key="AzureDataGridRow"
            TargetType="{x:Type DataGridRow}"
            BasedOn="{StaticResource MetroDataGridRow}">
-        <Setter Property="Foreground"
-                Value="{DynamicResource BlackBrush}" />
+    </Style>
+    <Style x:Key="AzureDataGridRowWithMargin"
+           TargetType="{x:Type DataGridRow}"
+           BasedOn="{StaticResource AzureDataGridRow}">
         <Setter Property="Margin"
                 Value="0,0,0,1" />
     </Style>
@@ -601,6 +622,12 @@
                 Value="{StaticResource AzureDataGridRow}" />
         <Setter Property="RowHeaderStyle"
                 Value="{StaticResource AzureDataGridRowHeader}" />
+        <Style.Triggers>
+            <Trigger Property="GridLinesVisibility" Value="None">
+                <Setter Property="RowStyle"
+                        Value="{StaticResource AzureDataGridRowWithMargin}" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
 </ResourceDictionary>

--- a/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
@@ -30,6 +30,9 @@
                   Grid.Row="0"
                   AutoGenerateColumns="False">
             <DataGrid.Columns>
+                <DataGridCheckBoxColumn ElementStyle="{DynamicResource MetroDataGridCheckBox}"
+                                        Header="IsSelected"
+                                        Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsSelected, Mode=OneWay}" />
                 <DataGridTextColumn Header="Title"
                                     Binding="{Binding Title}" />
                 <DataGridTextColumn Header="Artist"


### PR DESCRIPTION
- [x] add MetroDataGridCheckBox

``` xml
<DataGridCheckBoxColumn ElementStyle="{DynamicResource MetroDataGridCheckBox}"
                        Header="IsSelected"
                        Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsSelected, Mode=OneWay}" />
```

[WPF: DataGridCheckBoxColumn ElementStyle uses a wrong default value.](https://connect.microsoft.com/VisualStudio/feedback/details/687303/wpf-datagridcheckboxcolumn-elementstyle-uses-a-wrong-default-value)

![2014-03-24_13h13_13](https://f.cloud.github.com/assets/658431/2498916/b0506dc4-b34d-11e3-9619-198bc4dc845e.png)
- [x] fix GridLine Brushes

Closes #1157 DataGridCheckBoxColumn does not follow MA.M styles
Closes #943 Fix GridLines Color
