### PR TITLE
fix System.InvalidOperationException with AllowsTransparency

### DIFF
--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -40,7 +40,8 @@ namespace MahApps.Metro.Behaviours
             AssociatedObject.SetValue(WindowChrome.WindowChromeProperty, windowChrome);
 
             // no transparany, because it hase more then one unwanted issues
-            if (!AssociatedObject.IsLoaded)
+            var windowHandle = new WindowInteropHelper(AssociatedObject).Handle;
+            if (!AssociatedObject.IsLoaded && windowHandle == IntPtr.Zero)
             {
                 try
                 {


### PR DESCRIPTION
i forgot that issue from the old behavior

> System.InvalidOperationException Cannot change AllowsTransparency after a Window has been shown or WindowInteropHelper.EnsureHandle has been called.

Closes #1214 
