### PR TITLE
Define the flyout brushes in the theme dictionary

### DIFF
--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -34,12 +34,6 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty ExternalCloseButtonProperty = DependencyProperty.Register("ExternalCloseButton", typeof(MouseButton), typeof(Flyout), new PropertyMetadata(MouseButton.Left));
 
         /// <summary>
-        /// Gets the actual theme (dark/light) of this flyout.
-        /// Used to handle the WindowCommands overlay in the MetroWindow.
-        /// </summary>
-        internal AppTheme ActualTheme { get; private set; }
-
-        /// <summary>
         /// An ICommand that executes when the flyout's close button is clicked.
         /// </summary>
         public ICommand CloseCommand
@@ -159,64 +153,27 @@ namespace MahApps.Metro.Controls
                     ThemeManager.ChangeAppStyle(this.Resources, windowAccent, windowTheme);
                     this.SetResourceReference(BackgroundProperty, "HighlightBrush");
                     this.SetResourceReference(ForegroundProperty, "IdealForegroundColorBrush");
-                    this.ActualTheme = windowTheme;
                 break;
 
                 case FlyoutTheme.Adapt:
-                    ThemeManager.ChangeAppStyle(this.Resources, windowAccent, windowTheme);
-                    switch (windowTheme.Theme)
-                    {
-                        case Metro.Theme.Dark:
-                            this.SetResourceReference(ForegroundProperty, "BlackColorBrush");
-                            this.SetResourceReference(BackgroundProperty, "FlyoutDarkBrush");
-                            break;
-
-                        case Metro.Theme.Light:
-                            this.SetResourceReference(ForegroundProperty, "BlackColorBrush");
-                            this.SetResourceReference(BackgroundProperty, "FlyoutLightBrush");
-                            break;
-                    }
-                    this.ActualTheme = windowTheme;
+                    this.Background = (Brush)windowTheme.Resources["FlyoutAdaptiveBackgroundBrush"];
+                    this.Foreground = (Brush)windowTheme.Resources["FlyoutAdaptiveForegroundBrush"];
                     break;
 
                 case FlyoutTheme.Inverse:
-                    switch (windowTheme.Theme)
-                    {
-                        case Metro.Theme.Dark: {
-                            var newTheme = ThemeManager.GetAppTheme(windowTheme, Metro.Theme.Light);
-                            ThemeManager.ChangeAppStyle(this.Resources, windowAccent, newTheme);
-                            this.Background = (Brush)windowTheme.Resources["FlyoutLightBrush"];
-                            this.Foreground = (Brush)windowTheme.Resources["WhiteColorBrush"];
-                            this.ActualTheme = newTheme;
-                            break;
-                        }
-
-                        case Metro.Theme.Light: {
-                            var newTheme = ThemeManager.GetAppTheme(windowTheme, Metro.Theme.Dark);
-                            ThemeManager.ChangeAppStyle(this.Resources, windowAccent, newTheme);
-                            this.Background = (Brush)windowTheme.Resources["FlyoutDarkBrush"];
-                            this.Foreground = (Brush)windowTheme.Resources["WhiteColorBrush"];
-                            this.ActualTheme = newTheme;
-                            break;
-                        }
-                    }
+                    this.Background = (Brush)windowTheme.Resources["FlyoutInverseBackgroundBrush"];
+                    this.Foreground = (Brush)windowTheme.Resources["FlyoutInverseForegroundBrush"];
                     break;
                 
                 case FlyoutTheme.Dark: {
-                    var newTheme = ThemeManager.GetAppTheme(windowTheme, Metro.Theme.Dark);
-                    ThemeManager.ChangeAppStyle(this.Resources, windowAccent, newTheme);
-                    this.SetResourceReference(BackgroundProperty, "FlyoutDarkBrush");
-                    this.SetResourceReference(ForegroundProperty, "BlackColorBrush");
-                    this.ActualTheme = newTheme;
+                    this.Background = (Brush)windowTheme.Resources["FlyoutDarkBackgroundBrush"];
+                    this.Foreground = (Brush)windowTheme.Resources["FlyoutDarkForegroundBrush"];
                     break;
                 }
 
                 case FlyoutTheme.Light: {
-                    var newTheme = ThemeManager.GetAppTheme(windowTheme, Metro.Theme.Light);
-                    ThemeManager.ChangeAppStyle(this.Resources, windowAccent, newTheme);
-                    this.SetResourceReference(BackgroundProperty, "FlyoutLightBrush");
-                    this.SetResourceReference(ForegroundProperty, "BlackColorBrush");
-                    this.ActualTheme = newTheme;
+                    this.Background = (Brush)windowTheme.Resources["FlyoutLightBackgroundBrush"];
+                    this.Foreground = (Brush)windowTheme.Resources["FlyoutLightForegroundBrush"];
                     break;
                 }
             }

--- a/MahApps.Metro/Controls/MetroWindowHelpers.cs
+++ b/MahApps.Metro/Controls/MetroWindowHelpers.cs
@@ -77,23 +77,7 @@ namespace MahApps.Metro.Controls
 
         public static void UpdateWindowCommandsForFlyout(this MetroWindow window, Flyout flyout)
         {
-            Brush brush = null;
-
-            if (flyout.Theme == FlyoutTheme.Accent)
-            {
-                brush = (Brush)flyout.FindResource("IdealForegroundColorBrush");
-            }
-            else if (flyout.ActualTheme != null)
-            {
-                if (flyout.ActualTheme.Theme == Theme.Light)
-                {
-                    brush = (Brush)flyout.ActualTheme.Resources["BlackBrush"];
-                }
-                else if (flyout.ActualTheme.Theme == Theme.Dark)
-                {
-                    brush = (Brush)flyout.ActualTheme.Resources["BlackBrush"];
-                }
-            }
+            Brush brush = flyout.Foreground;
 
             window.ChangeAllWindowCommandsBrush(brush, flyout.Position);
         }

--- a/MahApps.Metro/Styles/Accents/BaseDark.xaml
+++ b/MahApps.Metro/Styles/Accents/BaseDark.xaml
@@ -59,8 +59,14 @@
     <SolidColorBrush x:Key="SliderTrackHover" Color="#FF737373" />
     <SolidColorBrush x:Key="SliderTrackNormal" Color="#FF6C6C6C" />
 
-    <SolidColorBrush x:Key="FlyoutDarkBrush" Color="{StaticResource FlyoutDarkColor}" />
-    <SolidColorBrush x:Key="FlyoutLightBrush" Color="{StaticResource FlyoutLightColor}" />
+    <SolidColorBrush x:Key="FlyoutDarkForegroundBrush" Color="{StaticResource BlackColor}" />
+    <SolidColorBrush x:Key="FlyoutDarkBackgroundBrush" Color="{StaticResource FlyoutDarkColor}" />
+    <SolidColorBrush x:Key="FlyoutLightForegroundBrush" Color="{StaticResource WhiteColor}" />
+    <SolidColorBrush x:Key="FlyoutLightBackgroundBrush" Color="{StaticResource FlyoutLightColor}" />
+    <SolidColorBrush x:Key="FlyoutAdaptiveBackgroundBrush" Color="{StaticResource FlyoutDarkColor}" />
+    <SolidColorBrush x:Key="FlyoutAdaptiveForegroundBrush" Color="{StaticResource BlackColor}" />
+    <SolidColorBrush x:Key="FlyoutInverseBackgroundBrush" Color="{StaticResource FlyoutLightColor}" />
+    <SolidColorBrush x:Key="FlyoutInverseForegroundBrush" Color="{StaticResource WhiteColor}" />
 
     <SolidColorBrush x:Key="FlatButtonPressedBackgroundBrush" Color="#444444"/>
 

--- a/MahApps.Metro/Styles/Accents/BaseLight.xaml
+++ b/MahApps.Metro/Styles/Accents/BaseLight.xaml
@@ -59,8 +59,14 @@
     <SolidColorBrush x:Key="SliderTrackHover" Color="#FFD0D0D0" />
     <SolidColorBrush x:Key="SliderTrackNormal" Color="#FFC6C6C6" />
 
-    <SolidColorBrush x:Key="FlyoutDarkBrush" Color="{StaticResource FlyoutDarkColor}" />
-    <SolidColorBrush x:Key="FlyoutLightBrush" Color="{StaticResource FlyoutLightColor}" />
+    <SolidColorBrush x:Key="FlyoutDarkForegroundBrush" Color="{StaticResource WhiteColor}" />
+    <SolidColorBrush x:Key="FlyoutDarkBackgroundBrush" Color="{StaticResource FlyoutDarkColor}" />
+    <SolidColorBrush x:Key="FlyoutLightForegroundBrush" Color="{StaticResource BlackColor}" />
+    <SolidColorBrush x:Key="FlyoutLightBackgroundBrush" Color="{StaticResource FlyoutLightColor}" />
+    <SolidColorBrush x:Key="FlyoutAdaptiveBackgroundBrush" Color="{StaticResource FlyoutLightColor}" />
+    <SolidColorBrush x:Key="FlyoutAdaptiveForegroundBrush" Color="{StaticResource BlackColor}" />
+    <SolidColorBrush x:Key="FlyoutInverseBackgroundBrush" Color="{StaticResource FlyoutDarkColor}" />
+    <SolidColorBrush x:Key="FlyoutInverseForegroundBrush" Color="{StaticResource WhiteColor}" />
 
     <SolidColorBrush x:Key="FlatButtonPressedBackgroundBrush" Color="#222222"/>
 

--- a/MahApps.Metro/Theme.cs
+++ b/MahApps.Metro/Theme.cs
@@ -7,6 +7,7 @@ namespace MahApps.Metro
     /// <summary>
     /// An enum that represents the two Metro styles: Light and Dark.
     /// </summary>
+    [Obsolete("This class is obsolete")]
     public enum Theme
     {
         Light,
@@ -29,7 +30,7 @@ namespace MahApps.Metro
         /// </summary>
         public string Name { get; private set; }
 
-        public AppTheme(string name, Uri resourceAddress, Theme theme)
+        public AppTheme(string name, Uri resourceAddress)
         {
             if(name == null)
                 throw new ArgumentException("name");
@@ -39,12 +40,6 @@ namespace MahApps.Metro
 
             this.Name = name;
             this.Resources = new ResourceDictionary {Source = resourceAddress};
-            this.Theme = theme;
         }
-
-        /// <summary>
-        /// Gets an enum that defines whether this application theme is light or dark.
-        /// </summary>
-        public Theme Theme { get; private set; }
     }
 }

--- a/MahApps.Metro/ThemeManager.cs
+++ b/MahApps.Metro/ThemeManager.cs
@@ -16,6 +16,21 @@ namespace MahApps.Metro
         private static IList<Accent> _accents;
         private static IList<AppTheme> _appThemes;
 
+        // We use this mapping to lookup the corresponding (obsolete) theme for the default themes
+        private static readonly Dictionary<string, Theme> compatibilityThemeMapping = 
+            new Dictionary<string, Theme>
+            {
+                {"BaseDark", Theme.Dark},
+                {"BaseLight", Theme.Light}
+            };
+
+        private static readonly Dictionary<Theme, string> reverseCompatibilityThemeMapping =
+            new Dictionary<Theme, string>
+            {
+                {Theme.Dark, "BaseDark"},
+                {Theme.Light, "BaseLight"}
+            }; 
+
         /// <summary>
         /// Gets a list of all of default themes.
         /// </summary>
@@ -58,8 +73,7 @@ namespace MahApps.Metro
 
                 foreach (var color in themes)
                 {
-                    Theme theme = color.ToLower().Contains("light") ? Theme.Light : Theme.Dark;
-                    var appTheme = new AppTheme(color, new Uri(string.Format("pack://application:,,,/MahApps.Metro;component/Styles/Accents/{0}.xaml", color)), theme);
+                    var appTheme = new AppTheme(color, new Uri(string.Format("pack://application:,,,/MahApps.Metro;component/Styles/Accents/{0}.xaml", color)));
 
                     _appThemes.Add(appTheme);
                 }
@@ -94,9 +108,8 @@ namespace MahApps.Metro
         /// </summary>
         /// <param name="name"></param>
         /// <param name="resourceAddress"></param>
-        /// <param name="theme"></param>
         /// <returns>true if the app theme does not exists and can be added.</returns>
-        public static bool AddAppTheme(string name, Uri resourceAddress, Theme theme)
+        public static bool AddAppTheme(string name, Uri resourceAddress)
         {
             if (name == null) throw new ArgumentNullException("name");
             if (resourceAddress == null) throw new ArgumentNullException("resourceAddress");
@@ -107,20 +120,8 @@ namespace MahApps.Metro
                 return false;
             }
 
-            _appThemes.Add(new AppTheme(name, resourceAddress, theme));
+            _appThemes.Add(new AppTheme(name, resourceAddress));
             return true;
-        }
-
-        /// <summary>
-        /// Gets app theme with the given name.
-        /// </summary>
-        /// <param name="appThemeName"></param>
-        /// <returns>AppTheme</returns>
-        public static AppTheme GetAppTheme(string appThemeName)
-        {
-            if (appThemeName == null) throw new ArgumentNullException("appThemeName");
-
-            return AppThemes.FirstOrDefault(x => x.Name == appThemeName);
         }
 
         /// <summary>
@@ -139,25 +140,22 @@ namespace MahApps.Metro
         /// Gets app theme with the given name and theme type (light or dark).
         /// </summary>
         /// <param name="appThemeName"></param>
-        /// <param name="theme"></param>
         /// <returns>AppTheme</returns>
-        public static AppTheme GetAppTheme(string appThemeName, Theme theme)
+        public static AppTheme GetAppTheme(string appThemeName)
         {
             if (appThemeName == null) throw new ArgumentNullException("appThemeName");
 
-            appThemeName = appThemeName.ToLower().Replace("light", "").Replace("dark", "");
-            return AppThemes.FirstOrDefault(x => x.Name.ToLower().Contains(appThemeName) && x.Theme == theme);
+            return AppThemes.FirstOrDefault(x => x.Name.Equals(appThemeName, StringComparison.InvariantCultureIgnoreCase));
         }
 
         /// <summary>
         /// Gets app theme with the given app theme and theme type (light or dark).
         /// </summary>
         /// <param name="currentAppTheme"></param>
-        /// <param name="theme"></param>
         /// <returns>AppTheme</returns>
-        public static AppTheme GetAppTheme(AppTheme currentAppTheme, Theme theme)
+        public static AppTheme GetAppTheme(AppTheme currentAppTheme)
         {
-            return GetAppTheme(currentAppTheme.Name, theme);
+            return GetAppTheme(currentAppTheme.Name);
         }
 
         /// <summary>
@@ -487,8 +485,8 @@ namespace MahApps.Metro
             if (app == null) throw new ArgumentNullException("app");
 
             var oldTheme = DetectTheme(app);
-            AppTheme oldAppTheme = AppThemes.First(x => x.Theme == oldTheme.Item1);
-            AppTheme newAppTheme = AppThemes.First(x => x.Theme == newTheme);
+            AppTheme oldAppTheme = AppThemes.First(x => x.Name == reverseCompatibilityThemeMapping[oldTheme.Item1]);
+            AppTheme newAppTheme = AppThemes.First(x => x.Name == reverseCompatibilityThemeMapping[newTheme]);
 
             ChangeAppStyle(app.Resources, Tuple.Create(oldAppTheme, oldTheme.Item2), newAccent, newAppTheme);
         }
@@ -500,8 +498,8 @@ namespace MahApps.Metro
             if (window == null) throw new ArgumentNullException("window");
 
             var oldTheme = DetectTheme(window);
-            AppTheme oldAppTheme = AppThemes.First(x => x.Theme == oldTheme.Item1);
-            AppTheme newAppTheme = AppThemes.First(x => x.Theme == newTheme);
+            AppTheme oldAppTheme = AppThemes.First(x => x.Name == reverseCompatibilityThemeMapping[oldTheme.Item1]);
+            AppTheme newAppTheme = AppThemes.First(x => x.Name == reverseCompatibilityThemeMapping[newTheme]);
 
             ChangeAppStyle(window.Resources, Tuple.Create(oldAppTheme, oldTheme.Item2), newAccent, newAppTheme);
         }
@@ -511,7 +509,7 @@ namespace MahApps.Metro
         {
             if (resources == null) throw new ArgumentNullException("resources");
 
-            AppTheme appTheme = AppThemes.First(x => x.Theme == newTheme);
+            AppTheme appTheme = AppThemes.First(x => x.Name == reverseCompatibilityThemeMapping[newTheme]);
 
             ChangeAppStyle(resources, newAccent, appTheme);
         }
@@ -536,7 +534,7 @@ namespace MahApps.Metro
 
             var appStyle = DetectAppStyle(window);
 
-            return Tuple.Create(appStyle.Item1.Theme, appStyle.Item2);
+            return Tuple.Create(compatibilityThemeMapping[appStyle.Item1.Name], appStyle.Item2);
         }
 
         [Obsolete("This method is obsolete. Use DetectAppStyle instead.")]
@@ -546,7 +544,7 @@ namespace MahApps.Metro
 
             var appStyle = DetectAppStyle(app);
 
-            return Tuple.Create(appStyle.Item1.Theme, appStyle.Item2);
+            return Tuple.Create(compatibilityThemeMapping[appStyle.Item1.Name], appStyle.Item2);
         }
 
 


### PR DESCRIPTION
This effectively removes the `Theme` class from use (we keep it for compatibility reasons) and we are more flexible when it comes to flyout theming
