### PR TITLE
Use FlatButtonStyle without referencing an additional ResourceDict

### DIFF
--- a/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -699,6 +699,56 @@
         </Setter>
     </Style>
 
+    <Style x:Key="MetroFlatButtonStyle"
+           TargetType="{x:Type Button}">
+        <Setter Property="Background"
+                Value="{DynamicResource FlatButtonBackgroundBrush}" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource FlatButtonForegroundBrush}" />
+        <Setter Property="FontSize"
+                Value="{DynamicResource FlatButtonFontSize}" />
+        <Setter Property="Padding"
+                Value="10,5,10,5" />
+        <Setter Property="BorderThickness"
+                Value="0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Border x:Name="Border"
+                            Margin="0"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          Margin="{TemplateBinding Padding}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          RecognizesAccessKey="True" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsPressed"
+                                 Value="True">
+                            <Setter Property="Background"
+                                    Value="{DynamicResource FlatButtonPressedBackgroundBrush}"
+                                    TargetName="Border" />
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource FlatButtonPressedForegroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                 Value="False">
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource GrayBrush2}" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver"
+                                 Value="True">
+                            <Setter Property="Background"
+                                    Value="DarkGray" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
     <Style TargetType="ToggleButton"
            x:Key="MetroToggleButton">
         <Setter Property="Background"


### PR DESCRIPTION
See: #1210
## Previously:

``` xml
<StackPanel.Resources>
                 <ResourceDictionary>
                     <ResourceDictionary.MergedDictionaries>
                         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/FlatButton.xaml" />
            </ResourceDictionary.MergedDictionaries>
        </ResourceDictionary>
 </StackPanel.Resources>
```

You had to include an extra `FlatButton.xaml` resource dictionary to make all your buttons `FlatButtonStyle`.
## After Pull Request, You Can Also

define a default style for buttons that is based on the `MetroFlatButton` style in your existing dictionary / within the `.Resources` property of your control.

**This is consistent with how all the other buttons in the program are used**

``` xml
<Grid>
    <Grid.Resources>
        <Style TargetType="{x:Type Button}" BasedOn="{StaticResource MetroFlatButtonStyle}"/>
    </Grid.Resources>
</Grid>
```

Backwards compatibility is maintained as well.
