### PR TITLE
updated TextboxHelper.Watermark to respect Textbox Padding

### DIFF
--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -104,6 +104,7 @@
                             <TextBlock x:Name="Message"
                                        Grid.Column="0"
                                        Text="{TemplateBinding Controls:TextboxHelper.Watermark}"
+                                       Padding="{TemplateBinding Padding}"
                                        Visibility="Collapsed"
                                        Foreground="{TemplateBinding Foreground}"
                                        IsHitTestVisible="False"


### PR DESCRIPTION
When I tried adding padding to a TextBox while using TextboxHelper.Watermark, the watermark does not respect the padding value, making it awkward and out of place.

![](http://i.imgur.com/CtXLfjN.png)

I've updated the styles for the watermark TextBlock to respect the TextBox's padding value. Hope that works!
