### PR TITLE
try fix disappeared taskbar item

### DIFF
--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -192,7 +192,7 @@ namespace MahApps.Metro.Behaviours
 
         private bool IsGreaterOrEqualWin8()
         {
-            return Environment.OSVersion.Version >= new Version(6, 0);
+            return Environment.OSVersion.Version.CompareTo(new Version(6, 2)) > 0;
         }
 
         private void AssociatedObject_Activated(object sender, EventArgs e)


### PR DESCRIPTION
Steps to reproduce (UNDER WINDOWS 8 or 8.1):
- Set `IgnoreTaskbarOnMaximize="True"`
- Maximize the application
- Minimize the app and focus another application OR click somewhere on a second monitor
- Focus/Activate the original application again
- The taskbar item disappeared (maybe only after second repro)

Closes #1240 
