### PR TITLE
Added MetroIconButton

### DIFF
--- a/MahApps.Metro/Controls/MetroIconButton.cs
+++ b/MahApps.Metro/Controls/MetroIconButton.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace MahApps.Metro.Controls
+{
+    public class MetroIconButton : Button
+    {
+        public static readonly DependencyProperty IconProperty =
+            DependencyProperty.Register("Icon", typeof(Object), typeof(MetroIconButton));
+
+        public static readonly DependencyProperty IconRenderTransformProperty =
+            DependencyProperty.Register("IconRenderTransform", typeof(Transform), typeof(MetroIconButton));
+
+        public static readonly DependencyProperty IconWidthProperty = DependencyProperty.Register(
+            "IconWidth", typeof(Double), typeof(MetroIconButton), new PropertyMetadata(18.0));
+
+        public static readonly DependencyProperty IconHeightProperty = DependencyProperty.Register(
+            "IconHeight", typeof(Double), typeof(MetroIconButton), new PropertyMetadata(18.0));
+
+        public static readonly DependencyProperty IconMarginProperty = DependencyProperty.Register(
+            "IconMargin", typeof(Thickness), typeof(MetroIconButton), new PropertyMetadata(default(Thickness)));
+
+        static MetroIconButton()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(MetroIconButton),
+                new FrameworkPropertyMetadata(typeof(MetroIconButton)));
+        }
+
+        public Transform IconRenderTransform
+        {
+            get { return (Transform)GetValue(IconRenderTransformProperty); }
+            set { SetValue(IconRenderTransformProperty, value); }
+        }
+
+        public Object Icon
+        {
+            get { return GetValue(IconProperty); }
+            set { SetValue(IconProperty, value); }
+        }
+
+        public Double IconWidth
+        {
+            get { return (Double)GetValue(IconWidthProperty); }
+            set { SetValue(IconWidthProperty, value); }
+        }
+
+        public Double IconHeight
+        {
+            get { return (Double)GetValue(IconHeightProperty); }
+            set { SetValue(IconHeightProperty, value); }
+        }
+
+        public Thickness IconMargin
+        {
+            get { return (Thickness)GetValue(IconMarginProperty); }
+            set { SetValue(IconMarginProperty, value); }
+        }
+    }
+}

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Controls\LayoutInvalidationCatcher.cs" />
     <Compile Include="Controls\MetroAnimatedSingleRowTabControl.cs" />
     <Compile Include="Controls\MetroAnimatedTabControl.cs" />
+    <Compile Include="Controls\MetroIconButton.cs" />
     <Compile Include="Controls\MetroNavigationWindow.cs" />
     <Compile Include="Controls\MetroProgressBar.cs" />
     <Compile Include="Controls\MetroTabControl.cs" />
@@ -474,6 +475,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Themes\MetroContentControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Themes\MetroIconButton.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/MahApps.Metro/Themes/Generic.xaml
+++ b/MahApps.Metro/Themes/Generic.xaml
@@ -24,6 +24,7 @@
         <ResourceDictionary Source="/MahApps.Metro;component/Themes/Tile.xaml" />
         <ResourceDictionary Source="/MahApps.Metro;component/Themes/ToggleSwitch.xaml" />
         <ResourceDictionary Source="/MahApps.Metro;component/Themes/TransitioningContentControl.xaml" />
+        <ResourceDictionary Source="/MahApps.Metro;component/Themes/MetroIconButton.xaml"/>
 
         <ResourceDictionary Source="/MahApps.Metro;component/Themes/Dialogs/BaseMetroDialog.xaml" />
     </ResourceDictionary.MergedDictionaries>

--- a/MahApps.Metro/Themes/MetroIconButton.xaml
+++ b/MahApps.Metro/Themes/MetroIconButton.xaml
@@ -1,0 +1,142 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
+
+    <Converters:ToUpperConverter x:Key="ToUpperConverter" />
+    <Converters:ToLowerConverter x:Key="ToLowerConverter" />
+
+    <Style TargetType="{x:Type Controls:MetroIconButton}">
+        <Setter Property="MinHeight" Value="25" />
+        <Setter Property="FontWeight" Value="Bold" />
+        <Setter Property="FontSize" Value="{DynamicResource UpperCaseContentFontSize}" />
+        <Setter Property="FontFamily" Value="{DynamicResource DefaultFont}" />
+        <Setter Property="Background" Value="{DynamicResource GrayBrush10}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+        <Setter Property="IconMargin" Value="0,1,0,7"/>
+        <Setter Property="IconWidth" Value="18"/>
+        <Setter Property="IconHeight" Value="18"/>
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Padding" Value="5,6" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="IconRenderTransform">
+            <Setter.Value>
+                <TransformGroup>
+                    <ScaleTransform ScaleX="0.5" ScaleY="0.5"></ScaleTransform>
+                </TransformGroup>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Controls:MetroIconButton">
+                    <Grid>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="MouseOver">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MouseOverBorder" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <EasingDoubleKeyFrame KeyTime="0" Value="1" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PressedBorder" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <EasingDoubleKeyFrame KeyTime="0" Value="1" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Disabled">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="DisabledVisualElement" Storyboard.TargetProperty="Opacity">
+                                            <SplineDoubleKeyFrame KeyTime="0" Value="0.7" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="contentPresenter" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <EasingDoubleKeyFrame KeyTime="0" Value="0.3" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="FocusStates">
+                                <VisualState x:Name="Focused">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FocusRectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <EasingDoubleKeyFrame KeyTime="0" Value="1" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FocusInnerRectangle" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <EasingDoubleKeyFrame KeyTime="0" Value="1" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Unfocused" />
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <Border x:Name="Background"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3" />
+                        <Rectangle x:Name="DisabledVisualElement"
+                                   Fill="{DynamicResource ControlsDisabledBrush}"
+                                   IsHitTestVisible="false"
+                                   Opacity="0"
+                                   RadiusX="3"
+                                   RadiusY="3" />
+                        <Border x:Name="MouseOverBorder"
+                                Background="{DynamicResource GrayBrush8}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3.5"
+                                Opacity="0" />
+                        <Border x:Name="PressedBorder"
+                                Background="{DynamicResource GrayBrush7}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="3.5"
+                                Opacity="0" />
+                        <Rectangle x:Name="FocusRectangle"
+                                   Margin="-1"
+                                   Opacity="0"
+                                   RadiusX="4"
+                                   RadiusY="4"
+                                   Stroke="{DynamicResource ButtonMouseOverInnerBorderBrush}" />
+                        <Rectangle x:Name="FocusInnerRectangle"
+                                   Opacity="0"
+                                   RadiusX="3"
+                                   RadiusY="3"
+                                   Stroke="{DynamicResource ButtonMouseOverBorderBrush}"
+                                   StrokeThickness="{TemplateBinding BorderThickness}" />
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="2.5*" />
+                                <ColumnDefinition Width="5*" />
+                            </Grid.ColumnDefinitions>
+
+                            <ContentPresenter Width="{TemplateBinding IconWidth}"
+                                              Height="{TemplateBinding IconHeight}"
+                                              Margin="{TemplateBinding IconMargin}"
+                                              HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              Content="{TemplateBinding Icon}"
+                                              RecognizesAccessKey="True"
+                                              RenderTransform="{TemplateBinding IconRenderTransform}" />
+
+                            <ContentPresenter x:Name="contentPresenter"
+                                              Grid.Column="1"
+                                              Margin="{TemplateBinding Padding}"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              Content="{TemplateBinding Content,
+                                                                        Converter={StaticResource ToUpperConverter}}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              RecognizesAccessKey="True" />
+                        </Grid>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+
+</ResourceDictionary>

--- a/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
+++ b/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
@@ -40,6 +40,14 @@
                     Margin="0, 10, 0, 0"
                     Content="Disabled"
                     IsEnabled="False" />
+            <Controls:MetroIconButton Width="100"
+                                      Margin="0,10,0,0"
+                                      Content="BUTTON"
+                                      Icon="{DynamicResource appbar_alien}"/>
+            <Controls:MetroIconButton Width="100"
+                                      Margin="0,10,0,0"
+                                      Content="BUTTON"
+                                      Icon="{DynamicResource appbar_anchor}"/>
         </StackPanel>
         <StackPanel Grid.Row="0"
                     Grid.Column="1">


### PR DESCRIPTION
### MetroIconButton

![iconbuttons](https://cloud.githubusercontent.com/assets/574734/2590625/da17a9c4-ba5f-11e3-9e6a-11ac6a962bf4.png)
### Usage

``` xml

<Controls:MetroIconButton Width="100"
                          Margin="0,10,0,0"
                          Content="BUTTON"
                          Icon="{DynamicResource appbar_anchor}"/>
```

Has support for all the icons packaged with [MahApps.Metro.Resources](http://www.nuget.org/packages/MahApps.Metro.Resources). 
### Structure of Control

`MetroIconButton` uses a `ContentPresenter` placed at the left of the button's default `ContentPresenter` to display the icons. 

``` xml
<Grid>
    <Grid.ColumnDefinitions>
        <ColumnDefinition Width="2.5*" />
        <ColumnDefinition Width="5*" />
    </Grid.ColumnDefinitions>

    <ContentPresenter Width="{TemplateBinding IconWidth}"
                      Height="{TemplateBinding IconHeight}"
                      Margin="{TemplateBinding IconMargin}"
                      HorizontalAlignment="Center"
                      VerticalAlignment="Center"
                      Content="{TemplateBinding Icon}"
                      RecognizesAccessKey="True"
                      RenderTransform="{TemplateBinding IconRenderTransform}" />

    <ContentPresenter x:Name="contentPresenter"
                      Grid.Column="1"
                      Margin="{TemplateBinding Padding}"
                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                      Content="{TemplateBinding Content,
                                                Converter={StaticResource ToUpperConverter}}"
                      ContentTemplate="{TemplateBinding ContentTemplate}"
                      RecognizesAccessKey="True" />
</Grid>
```
### Customization

The control comes with a few DependencyProperties for users to customize the position of the icon's `ContentPresenter`. This is necessary as icons are sometimes too large or do not align correctly. Listed below are the DependencyProperties that come built in with the `MetroIconButton`. 
-   `Icon`:   This property is bound to the `Content` property of a `ContentPresenter`. You can either use the icons packaged with `MahApps.Metro.Resources` (`{Dynamicresource appbar_alien}`) or set it to any FrameworkElement of your choice.
-   `IconRenderTransform`:    Bound to the `RenderTransform` property of the `ContentPresenter`. Used this to adjust the size of the icon.
-   `IconWidth`:  Bound to the `Width` property of the ContentPresenter. Use this to adjust the icon's container space.
-   `IconHeight`: Bound to the `Height` property of the ContentPresenter. Use this to adjust the icon's container space.
-   `IconMargin`: Bound to the `Margin` property of the ContentPresenter. Use this to adjust the icon's position relative to the button's text

> Note, the `ContentPresenter` mentioned in the documentation above refers to the `ContentPresenter` responsible for displaying the image
