### PR TITLE
Changed MetroDialogOptions to a DependencyProperty

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -110,10 +110,6 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(OverrideDefaultWindowCommandsBrushProperty, value); }
         }
 
-
-        public static readonly DependencyProperty MetroDialogOptionsProperty = DependencyProperty.Register(
-                                                        "MetroDialogOptions", typeof(MetroDialogSettings), typeof(MetroWindow), new PropertyMetadata(new MetroDialogSettings()));
-
         public MetroDialogSettings MetroDialogOptions
         {
             get { return (MetroDialogSettings)GetValue(MetroDialogOptionsProperty); }


### PR DESCRIPTION
This would allow me to configure MetroDialogOptions at **Style** level:

``` xml
<Style x:Key="CustomWindowsStyle"
       TargetType="{x:Type controls:MetroWindow}">
  <Style.Setters>
    <Setter Property="MetroDialogOptions">
      <Setter.Value>
        <dialogs:MetroDialogSettings ColorScheme="Accented" 
                                     NegativeButtonText="Abbrechen" />
      </Setter.Value>
    </Setter>
  </Style.Setters>
</Style>
```
