### PR TITLE
Click on Expander header support

### DIFF
--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -403,8 +403,8 @@
                                                   IsChecked="{Binding IsExpanded,
                                                                   Mode=TwoWay,
                                                                   RelativeSource={RelativeSource TemplatedParent}}"
-                                                  Style="{StaticResource ExpanderDownHeaderStyle}" />
-                                    <ContentPresenter Margin="{TemplateBinding Padding}"
+                                                  Style="{StaticResource ExpanderDownHeaderStyle}" >
+                                        <ContentPresenter Margin="{TemplateBinding Padding}"
                                                       Content="{TemplateBinding Header}"
                                                       ContentTemplate="{TemplateBinding HeaderTemplate}"
                                                       ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
@@ -412,6 +412,7 @@
                                                       TextElement.FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
                                                       TextElement.FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
                                                       TextElement.FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}" />
+                                    </ToggleButton>
                                 </DockPanel>
                             </Border>
                             <Border x:Name="ExpandSite"


### PR DESCRIPTION
I noticed that the Expander control does not open when you click the header text, which is not the default behavior, and may be annoying.

I set the Header as the content of the ToggleButton that determines whether the Expander is open or not, which fixed the problem.
