### PR TITLE
Make titlebar on MetroWindow non-focusable

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -72,6 +72,7 @@
                                     Grid.Column="2"
                                     Content="{TemplateBinding Title}"
                                     ContentTemplate="{TemplateBinding TitleTemplate}"
+                                    Focusable="False"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"
                                     Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"


### PR DESCRIPTION
By default the first "tab" pressed focuses the titlebar of a MetroWindow, as shown here:

![tabfocus](https://cloud.githubusercontent.com/assets/548524/2717247/7406cd58-c53c-11e3-8432-9d4ea84f904c.png)

This pull request adds `Focusable="False"` to the `ContentControl` responsible for this to stop it happening.
