### PR TITLE
Fixing problem of window icon quality.

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -39,6 +39,7 @@ namespace MahApps.Metro.Controls
         private const string PART_FlyoutModal = "PART_FlyoutModal";
 
         public static readonly DependencyProperty ShowIconOnTitleBarProperty = DependencyProperty.Register("ShowIconOnTitleBar", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
+        public static readonly DependencyProperty IconEdgeModeProperty = DependencyProperty.Register("IconEdgeMode", typeof(EdgeMode), typeof(MetroWindow), new PropertyMetadata(EdgeMode.Aliased));
         public static readonly DependencyProperty ShowTitleBarProperty = DependencyProperty.Register("ShowTitleBar", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true, OnShowTitleBarPropertyChangedCallback, OnShowTitleBarCoerceValueCallback));
         public static readonly DependencyProperty ShowMinButtonProperty = DependencyProperty.Register("ShowMinButton", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
         public static readonly DependencyProperty ShowCloseButtonProperty = DependencyProperty.Register("ShowCloseButton", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
@@ -280,6 +281,15 @@ namespace MahApps.Metro.Controls
         {
             get { return (bool)GetValue(ShowIconOnTitleBarProperty); }
             set { SetValue(ShowIconOnTitleBarProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets/sets edge mode of the titlebar icon.
+        /// </summary>
+        public EdgeMode IconEdgeMode
+        {
+            get { return (EdgeMode)this.GetValue(IconEdgeModeProperty); }
+            set { SetValue(IconEdgeModeProperty, value); }
         }
 
         /// <summary>

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -295,7 +295,7 @@
                             <Image Width="{TemplateBinding Width}"
                                    Height="{TemplateBinding Height}"
                                    Source="{TemplateBinding Content}"
-                                   RenderOptions.EdgeMode="Aliased"
+                                   RenderOptions.EdgeMode="{Binding IconEdgeMode, RelativeSource={RelativeSource TemplatedParent}}"
                                    RenderOptions.BitmapScalingMode="HighQuality" />
                         </DataTemplate>
                     </Setter.Value>


### PR DESCRIPTION
Window icon is rendering with `EdgeMode="Aliased"` by #417.
But sometimes icon is rendered too ugly because  `EdgeMode="Aliased"` option suppresses anti-aliasing of the icon.

So, I add the dependency property for edge mode of the titlebar icon.
This fix gives option for user how to display icon of the window.
