### PR TITLE
#1346 Add Behavior for TabControls to select the first visible TabItem

### DIFF
--- a/MahApps.Metro/Behaviours/TabControlSelectFirstVisibleTabBehavior.cs
+++ b/MahApps.Metro/Behaviours/TabControlSelectFirstVisibleTabBehavior.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interactivity;
+
+namespace MahApps.Metro.Behaviours
+{
+    /// <summary>
+    /// <para>
+    ///     Sets the first TabItem with Visibility="<see cref="Visibility.Visible"/>" as
+    ///     the SelectedItem of the TabControl.
+    /// </para>
+    /// <para>
+    ///     If there is no visible TabItem, null is set as the SelectedItem
+    /// </para>
+    /// </summary>
+    public class TabControlSelectFirstVisibleTabBehavior : Behavior<TabControl>
+    {
+        protected override void OnAttached()
+        {
+            AssociatedObject.SelectionChanged += OnSelectionChanged;
+        }
+
+        private void OnSelectionChanged(object sender, SelectionChangedEventArgs args)
+        {
+            List<TabItem> tabItems = AssociatedObject.Items.Cast<TabItem>().ToList();
+            TabItem selectedItem = AssociatedObject.SelectedItem as TabItem;
+
+            //if the selected item is visible already, return
+            if (selectedItem != null && selectedItem.Visibility == Visibility.Visible)
+            {
+                return;
+            }
+
+            //get first visible item
+            TabItem firstVisible = tabItems.FirstOrDefault(t => t.Visibility == Visibility.Visible);
+            if (firstVisible != null)
+            {
+                AssociatedObject.SelectedIndex = tabItems.IndexOf(firstVisible);
+            }
+            else
+            {
+                //there is no visible item
+                //Raises SelectionChanged again one time (second time, oldValue == newValue)
+                AssociatedObject.SelectedItem = null;
+            }
+        }
+        protected override void OnDetaching()
+        {
+            AssociatedObject.SelectionChanged -= OnSelectionChanged;
+        }
+    }
+}

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Behaviours\BorderlessWindowBehavior.cs" />
     <Compile Include="Behaviours\GlowWindowBehavior.cs" />
     <Compile Include="Behaviours\StylizedBehaviorCollection.cs" />
+    <Compile Include="Behaviours\TabControlSelectFirstVisibleTabBehavior.cs" />
     <Compile Include="Behaviours\WindowsSettingBehaviour.cs" />
     <Compile Include="Controls\ClosingWindowEventHandlerArgs.cs" />
     <Compile Include="Controls\ComboBoxHelper.cs" />


### PR DESCRIPTION
Added Behavior for TabControls to select the first visible TabItem.
If there is no visible TabItem, null will be set as the SelectedItem for the TabControl
