### PR TITLE
some TextboxHelper issues fixed

### DIFF
--- a/MahApps.Metro/Controls/TextboxHelper.cs
+++ b/MahApps.Metro/Controls/TextboxHelper.cs
@@ -16,7 +16,7 @@ namespace MahApps.Metro.Controls
     /// <remarks>
     /// Password watermarking code from: http://prabu-guru.blogspot.com/2010/06/how-to-add-watermark-text-to-textbox.html
     /// </remarks>
-    public class TextboxHelper : DependencyObject
+    public class TextboxHelper
     {
         public static readonly DependencyProperty IsMonitoringProperty = DependencyProperty.RegisterAttached("IsMonitoring", typeof(bool), typeof(TextboxHelper), new UIPropertyMetadata(false, OnIsMonitoringChanged));
         public static readonly DependencyProperty WatermarkProperty = DependencyProperty.RegisterAttached("Watermark", typeof(string), typeof(TextboxHelper), new UIPropertyMetadata(string.Empty));
@@ -217,9 +217,14 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Gets if the attached TextBox has text.
         /// </summary>
-        public bool HasText
+        public static bool GetHasText(DependencyObject obj)
         {
-            get { return (bool)GetValue(HasTextProperty); }
+            return (bool)obj.GetValue(HasTextProperty);
+        }
+
+        public static void SetHasText(DependencyObject obj, bool value)
+        {
+            obj.SetValue(HasTextProperty, value);
         }
 
         static void OnIsMonitoringChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -431,6 +436,7 @@ namespace MahApps.Metro.Controls
                 // only one event, because loaded event fires more than once, if the textbox is hosted in a tab item
                 button.Click -= ButtonClicked;
                 button.Click += ButtonClicked;
+                comboBox.SetValue(HasTextProperty, !string.IsNullOrWhiteSpace(comboBox.Text) || comboBox.SelectedItem != null);
             }
             else
             {
@@ -457,6 +463,7 @@ namespace MahApps.Metro.Controls
                 // only one event, because loaded event fires more than once, if the textbox is hosted in a tab item
                 button.Click -= ButtonClicked;
                 button.Click += ButtonClicked;
+                passbox.SetValue(HasTextProperty, !string.IsNullOrWhiteSpace(passbox.Password));
             }
             else
             {
@@ -483,10 +490,12 @@ namespace MahApps.Metro.Controls
                 // only one event, because loaded event fires more than once, if the textbox is hosted in a tab item
                 button.Click -= ButtonClicked;
                 button.Click += ButtonClicked;
+                textbox.SetValue(HasTextProperty, !string.IsNullOrWhiteSpace(textbox.Text));
             }
             else
             {
                 button.Click -= ButtonClicked;
+                textbox.SetValue(HasTextProperty, !string.IsNullOrWhiteSpace(textbox.Text));
             }
         }
 

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
-                    xmlns:System="clr-namespace:System;assembly=mscorlib"
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
@@ -115,7 +114,7 @@
                                     Foreground="{TemplateBinding Foreground}"
                                     FontFamily="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ButtonFontFamily), Mode=OneWay}"
                                     Content="r"
-                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}"
+                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
                                     IsTabStop="False" />
                         </Grid>
                         <Rectangle x:Name="DisabledVisualElement"
@@ -126,7 +125,7 @@
                                    Opacity="0" />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <DataTrigger Binding="{Binding Path=Password}"
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Password}"
                                      Value="{x:Null}">
                             <Setter TargetName="Message"
                                     Property="Visibility"
@@ -308,7 +307,7 @@
                                    Opacity="0" />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <DataTrigger Binding="{Binding Path=Password}"
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Password}"
                                      Value="{x:Null}">
                             <Setter TargetName="Message"
                                     Property="Visibility"

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -1,7 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
-                    xmlns:System="clr-namespace:System;assembly=mscorlib"
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
@@ -118,7 +117,7 @@
                                     Foreground="{TemplateBinding Foreground}"
                                     FontFamily="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ButtonFontFamily), Mode=OneWay}"
                                     Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ButtonContent), Mode=OneWay}"
-                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}"
+                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
                                     IsTabStop="False" />
                         </Grid>
                         <Rectangle x:Name="DisabledVisualElement"

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -38,15 +38,46 @@
                          Controls:TextboxHelper.IsWaitingForData="True"
                          ToolTip="Default alignment" />
                 <TextBox Margin="0, 10, 0, 0"
-                         Controls:TextboxHelper.ClearTextButton="True"
                          Controls:TextboxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
-                         Controls:TextboxHelper.Watermark="Watermark"
-                         Text="Clear button" />
+                         Text="Clear button">
+                    <TextBox.Style>
+                        <Style TargetType="{x:Type TextBox}"
+                               BasedOn="{StaticResource MetroTextBox}">
+                            <Setter Property="Controls:TextboxHelper.ClearTextButton" Value="True"></Setter>
+                            <Style.Triggers>
+                                <Trigger Property="Controls:TextboxHelper.HasText"
+                                         Value="False">
+                                    <Setter Property="Controls:TextboxHelper.ClearTextButton"
+                                            Value="False" />
+                                    <Setter Property="Controls:TextboxHelper.Watermark"
+                                            Value="Now enter some text..." />
+                                </Trigger>
+                                <Trigger Property="Controls:TextboxHelper.HasText"
+                                         Value="True">
+                                    <Setter Property="Controls:TextboxHelper.ClearTextButton"
+                                            Value="True" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
                 <TextBox Margin="0, 10, 0, 0"
-                         Name="test1"
-                         Controls:TextboxHelper.Watermark="Search style"
-                         Controls:TextboxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
-                         Style="{DynamicResource SearchMetroTextBox}" />
+                         Controls:TextboxHelper.Watermark="Search..."
+                         Controls:TextboxHelper.ClearTextButton="True"
+                         Controls:TextboxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}">
+                    <TextBox.Style>
+                        <Style TargetType="{x:Type TextBox}"
+                               BasedOn="{StaticResource SearchMetroTextBox}">
+                            <Style.Triggers>
+                                <Trigger Property="Controls:TextboxHelper.HasText"
+                                         Value="True">
+                                    <Setter Property="Controls:TextboxHelper.ButtonTemplate"
+                                            Value="{DynamicResource ChromelessButtonTemplate}" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
                 <TextBox Margin="0, 10, 0, 0"
                          Name="test2"
                          Controls:TextboxHelper.Watermark="Enter parameter"


### PR DESCRIPTION
- add example for this issue: TextboxHelper.ClearTextButton does not
  work when is applied via Trigger #1283
- remove inheritance to DependencyObject to avoid possible bugs with
  attached properties
- change getter for HasText and add a setter
- fire HasText property on controls loaded event
- fix BindingExpression error for PasswordBox
- add example from @thoemmi for:  a search box with a magnifier on its
  button, but as soon as text is entered, the button content should change
  to an X.

Closes #1283 
