### PR TITLE
[Fix] Row is always of constant height:

### DIFF
--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -401,7 +401,7 @@
 
     <Style x:Key="MetroDataGrid"
            TargetType="{x:Type DataGrid}">
-        <Setter Property="RowHeight"
+        <Setter Property="MinRowHeight"
                 Value="25" />
         <Setter Property="GridLinesVisibility"
                 Value="None" />


### PR DESCRIPTION
[Solution Steps] Set MinRowHeight instead of RowHeight of MetroDataGrid
