### PR TITLE
Support multiple errors in ValidationToolTipTemplate

### DIFF
--- a/MahApps.Metro/Styles/ValidationToolTipTemplate.xaml
+++ b/MahApps.Metro/Styles/ValidationToolTipTemplate.xaml
@@ -1,6 +1,9 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:MahApps.Metro.Controls">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
+    </ResourceDictionary.MergedDictionaries>
 
     <!-- is obsolete -->
     <ControlTemplate x:Key="ValidationToolTipTemplate">
@@ -203,11 +206,12 @@
                                                MaxWidth="250"
                                                Margin="8,4,8,4"
                                                TextWrapping="Wrap"
+                                               FontSize="{Binding ElementName=placeholder, Path=AdornedElement.FontSize, FallbackValue={StaticResource ContentFontSize}}"
                                                Text="{Binding ErrorContent}"
                                                UseLayoutRounding="false" />
                                 </DataTemplate>
                             </Border.Resources>
-                            <ContentPresenter Content="{Binding CurrentItem}" />
+                            <ItemsControl ItemsSource="{Binding}"/>
                         </Border>
                     </Grid>
                 </controls:CustomValidationPopup>

--- a/samples/MetroDemo/ExampleViews/ValidationErrors.xaml
+++ b/samples/MetroDemo/ExampleViews/ValidationErrors.xaml
@@ -1,0 +1,33 @@
+﻿<UserControl x:Class="MetroDemo.ExampleViews.ValidationErrors"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:viewModels="clr-namespace:MetroDemo.ViewModels"
+             mc:Ignorable="d"
+             d:DataContext="{d:DesignInstance viewModels:ValidationErrorsViewModel}"
+             d:DesignHeight="600" d:DesignWidth="800">
+    <Viewbox>
+        <Grid Margin="10" Height="300" Width="400" >
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition />
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" >
+                <Run>Enter 'one' for one error message.</Run>
+                <LineBreak/>
+                <Run>Enter 'two' for two error messagses.</Run>
+            </TextBlock>
+
+            <TextBox Grid.Row="1" Margin="0,5" Width="100" HorizontalAlignment="Left" Text="{Binding SomeText, UpdateSourceTrigger=PropertyChanged}"/>
+
+            <TextBlock Grid.Row="2" Text="Non default font size"/>
+
+            <TextBox Grid.Row="3" Margin="0,5" FontSize="24" Width="150" HorizontalAlignment="Left" Text="{Binding SomeText, UpdateSourceTrigger=PropertyChanged}"/>
+        </Grid>
+    </Viewbox>
+</UserControl>

--- a/samples/MetroDemo/ExampleViews/ValidationErrors.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/ValidationErrors.xaml.cs
@@ -1,0 +1,13 @@
+﻿namespace MetroDemo.ExampleViews
+{
+    /// <summary>
+    ///     Interaction logic for ValidationErrors.xaml
+    /// </summary>
+    public partial class ValidationErrors
+    {
+        public ValidationErrors()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -173,7 +173,7 @@
                 </MenuItem>
             </Menu>
 
-            <Controls:MetroAnimatedSingleRowTabControl Grid.Row="1">
+            <Controls:MetroAnimatedSingleRowTabControl x:Name="TabControl" Grid.Row="1">
                 <TabItem Header="buttons">
                     <exampleViews:ButtonsExample DataContext="{Binding}" />
                 </TabItem>

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Controls.Dialogs;
+using MetroDemo.ExampleViews;
 using MetroDemo.ExampleWindows;
-
+#if NET_4_5
+using MetroDemo.ViewModels;
+#endif
 namespace MetroDemo
 {
     public partial class MainWindow
@@ -17,6 +21,14 @@ namespace MetroDemo
             _viewModel = new MainWindowViewModel();
             DataContext = _viewModel;
             InitializeComponent();
+
+#if NET_4_5
+            TabControl.Items.Add(new TabItem
+            {
+                Header = "validation-errors",
+                Content = new ValidationErrors { DataContext = new ValidationErrorsViewModel() }
+            });
+#endif
         }
 
         private void LaunchMahAppsOnGitHub(object sender, RoutedEventArgs e)

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -120,6 +120,7 @@ namespace MetroDemo
 
             await this.HideMetroDialogAsync(dialog);
         }
+
         private async void ShowProgressDialog(object sender, RoutedEventArgs e)
         {
             this.MetroDialogOptions.ColorScheme = UseAccentForDialogsMenuItem.IsChecked ? MetroDialogColorScheme.Accented : MetroDialogColorScheme.Theme;

--- a/samples/MetroDemo/MetroDemo.NET45.csproj
+++ b/samples/MetroDemo/MetroDemo.NET45.csproj
@@ -121,6 +121,9 @@
     <Compile Include="ExampleViews\TextExamples.xaml.cs">
       <DependentUpon>TextExamples.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ExampleViews\ValidationErrors.xaml.cs">
+      <DependentUpon>ValidationErrors.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ExampleWindows\CleanWindowDemo.xaml.cs">
       <DependentUpon>CleanWindowDemo.xaml</DependentUpon>
     </Compile>
@@ -153,6 +156,7 @@
     <Compile Include="Navigation\InterestingPage.xaml.cs">
       <DependentUpon>InterestingPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ViewModels\ValidationErrorsViewModel.cs" />
     <Page Include="ExampleViews\ButtonsExample.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -188,6 +192,10 @@
     <Page Include="ExampleViews\TextExamples.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="ExampleViews\ValidationErrors.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="ExampleWindows\CleanWindowDemo.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/samples/MetroDemo/ViewModels/ValidationErrorsViewModel.cs
+++ b/samples/MetroDemo/ViewModels/ValidationErrorsViewModel.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace MetroDemo.ViewModels
+{
+#if NET_4_5
+    internal class ValidationErrorsViewModel : INotifyPropertyChanged, INotifyDataErrorInfo
+    {
+        private string _someText;
+
+        public string SomeText
+        {
+            get { return _someText; }
+            set
+            {
+                if (value != _someText)
+                {
+                    _someText = value;
+
+                    OnPropertyChanged();
+
+                    ClearPropertyValidationErrors();
+
+                    if (_someText == "one")
+                    {
+                        AddPropertyValidationError("First message");
+                    }
+                    else if (_someText == "two")
+                    {
+                        AddPropertyValidationError("First message");
+                        AddPropertyValidationError("Second message");
+                    }
+                }
+            }
+        }
+
+        #region INotifyPropertyChanged
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChangedEventHandler handler = PropertyChanged;
+
+            if (handler != null)
+            {
+                handler(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+
+        #endregion
+
+        #region INotifyDataErrorInfo
+
+        private readonly Dictionary<string, HashSet<string>> _validationErrors =
+            new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+        public IEnumerable GetErrors(string propertyName)
+        {
+            if (propertyName != null && _validationErrors.ContainsKey(propertyName))
+            {
+                return _validationErrors[propertyName].AsEnumerable();
+            }
+
+            return Enumerable.Empty<string>();
+        }
+
+        public bool HasErrors
+        {
+            get { return _validationErrors.Any(kvp => kvp.Value.Any()); }
+        }
+
+        public event EventHandler<DataErrorsChangedEventArgs> ErrorsChanged;
+
+        private void NotifyOfDataError(string propertyName)
+        {
+            EventHandler<DataErrorsChangedEventArgs> handler = ErrorsChanged;
+
+            if (handler != null)
+            {
+                handler(this, new DataErrorsChangedEventArgs(propertyName));
+            }
+        }
+
+        protected void AddPropertyValidationError(string message, [CallerMemberName] string propertyName = null)
+        {
+            AddValidationError(message, propertyName);
+        }
+
+        private void AddValidationError(string message, string propertyName)
+        {
+            if (propertyName == null)
+            {
+                return;
+            }
+
+            if (_validationErrors.ContainsKey(propertyName))
+            {
+                _validationErrors[propertyName].Add(message);
+            }
+            else
+            {
+                _validationErrors.Add(propertyName, new HashSet<string> { message });
+            }
+
+            NotifyOfDataError(propertyName);
+        }
+
+        protected void ClearAllValidationErrors()
+        {
+            _validationErrors.Clear();
+            NotifyOfDataError(null);
+        }
+
+        protected void ClearPropertyValidationErrors([CallerMemberName] string propertyName = null)
+        {
+            ClearValidationErrors(propertyName);
+        }
+
+        private void ClearValidationErrors(string propertyName)
+        {
+            if (propertyName != null)
+            {
+                _validationErrors.Remove(propertyName);
+                NotifyOfDataError(propertyName);
+            }
+        }
+
+        #endregion
+    }
+#endif
+}


### PR DESCRIPTION
With INotifyDataErrorInfo in .NET 4.5 it's possible to have more than one validation error per property.
This is fixed easily by modifying the ValidationToolTipTemplate to bind to the errors collection instead of the current item.
I've also modified the popup's FontSize to match the font size of the adorned item. This feels like the correct behaviour to me.

Added some sample code.

One additional (minor) issue that I don't know how to fix, is if a control is inside a viewbox and the validation error is displayed, the popup control doesn't resize while the viewbox is resized. Try it using the sample.