### PR TITLE
Enable text wrapping in ToggleSwitch Header

### DIFF
--- a/MahApps.Metro/Themes/ToggleSwitch.xaml
+++ b/MahApps.Metro/Themes/ToggleSwitch.xaml
@@ -214,6 +214,7 @@
             <Setter.Value>
                 <DataTemplate>
                     <TextBlock Text="{Binding Mode=OneWay}"
+                               TextWrapping="Wrap"
                                FontWeight="Normal"
                                HorizontalAlignment="Left"
                                VerticalAlignment="Top"


### PR DESCRIPTION
When a ToggleSwitch's `Header` content is too long to be displayed, wrap to new line using the built-in `TextWrapping` property.

**Before:**
![](http://i.imgur.com/64HDu8x.png)

**After:**
![](http://i.imgur.com/yIcNAUz.png)
