### PR TITLE
Get the dialog from a MetroWindow

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -364,22 +363,14 @@ namespace MahApps.Metro.Controls.Dialogs
             }).Unwrap();
         }
         
-        //Get the current dialog of a MetroWindow (using Reflection, can be used outside this assembly) TESTED AND WORKS GREAT
+        //Get the current dialog of a MetroWindow
         public static async Task<TDialog> GetDialogAsync<TDialog>(MetroWindow owner) where TDialog : BaseMetroDialog
         {
             TDialog dialog = null;
             await owner.Dispatcher.BeginInvoke(new Action(() =>
             {
-                try
-                {
-                    BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
-                    MethodInfo minfo = typeof(MetroWindow).GetMethod("GetPart", bindingFlags);
-                    MethodInfo toInvoke = minfo.MakeGenericMethod(typeof(Grid));
-                    Grid dialogContainer = (Grid)toInvoke.Invoke(App._appWindow, new object[] { "PART_MetroDialogContainer" });
-                    if (dialogContainer.Children.Count != 0)
-                        dialog = dialogContainer.Children[0] as TDialog;
-                }
-                catch { dialog = null; }
+                if (owner.metroDialogContainer.Children.Count != 0)
+                    dialog = owner.metroDialogContainer.Children[0] as TDialog;
             }));
             return dialog;
         }

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -362,6 +362,26 @@ namespace MahApps.Metro.Controls.Dialogs
                 }));
             }).Unwrap();
         }
+        
+        //Get the current dialog of a MetroWindow (using Reflection, can be used outside this assembly) TESTED AND WORKS GREAT
+        public static async Task<TDialog> GetDialogAsync<TDialog>(MetroWindow owner) where TDialog : BaseMetroDialog
+        {
+            TDialog dialog = null;
+            await owner.Dispatcher.BeginInvoke(new Action(() =>
+            {
+                try
+                {
+                    BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+                    MethodInfo minfo = typeof(MetroWindow).GetMethod("GetPart", bindingFlags);
+                    MethodInfo toInvoke = minfo.MakeGenericMethod(typeof(Grid));
+                    Grid dialogContainer = (Grid)toInvoke.Invoke(App._appWindow, new object[] { "PART_MetroDialogContainer" });
+                    if (dialogContainer.Children.Count != 0)
+                        dialog = dialogContainer.Children[0] as TDialog;
+                }
+                catch { dialog = null; }
+            }));
+            return dialog;
+        }
 
         private static SizeChangedEventHandler SetupAndOpenDialog(MetroWindow window, BaseMetroDialog dialog)
         {

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -367,13 +367,13 @@ namespace MahApps.Metro.Controls.Dialogs
         public static Task<TDialog> GetCurrentDialogAsync<TDialog>(this MetroWindow window) where TDialog : BaseMetroDialog
         {
             var t = new TaskCompletionSource<TDialog>();
-            window.Dispatcher.Invoke(() =>
+            window.Dispatcher.Invoke((Action)(() =>
             {
                 TDialog dialog = null;
                 if (window.metroDialogContainer.Children.Count != 0)
                     dialog = window.metroDialogContainer.Children[0] as TDialog;
                 t.TrySetResult(dialog);
-            });
+            }));
             return t.Task;
         }
 

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -364,15 +364,17 @@ namespace MahApps.Metro.Controls.Dialogs
         }
         
         //Get the current dialog of a MetroWindow
-        public static async Task<TDialog> GetDialogAsync<TDialog>(MetroWindow owner) where TDialog : BaseMetroDialog
+        public static Task<TDialog> GetCurrentDialogAsync<TDialog>(this MetroWindow window) where TDialog : BaseMetroDialog
         {
-            TDialog dialog = null;
-            await owner.Dispatcher.BeginInvoke(new Action(() =>
+            var t = new TaskCompletionSource<TDialog>();
+            window.Dispatcher.Invoke(() =>
             {
-                if (owner.metroDialogContainer.Children.Count != 0)
-                    dialog = owner.metroDialogContainer.Children[0] as TDialog;
-            }));
-            return dialog;
+                TDialog dialog = null;
+                if (window.metroDialogContainer.Children.Count != 0)
+                    dialog = window.metroDialogContainer.Children[0] as TDialog;
+                t.TrySetResult(dialog);
+            });
+            return t.Task;
         }
 
         private static SizeChangedEventHandler SetupAndOpenDialog(MetroWindow window, BaseMetroDialog dialog)


### PR DESCRIPTION
I need this because i need to fill InputDialog from a barcode scanner.
This function can be used outside from the MahApps.Metro namespace.
This can be modified to not use Reflection, but it should be merged in DialogManager.cs like this
```
public static async Task<TDialog> GetDialogAsync<TDialog>(MetroWindow owner) where TDialog : BaseMetroDialog
{
    TDialog dialog = null;
    await owner.Dispatcher.BeginInvoke(new Action(() =>
    {
        if (owner.metroDialogContainer.Children.Count != 0)
            dialog = owner.metroDialogContainer.Children[0] as TDialog;
    }));
    return dialog;
}
```

Sorry for my bad english...