### PR TITLE
Fix some of the casts and a request

### DIFF
--- a/MahApps.Metro/Behaviours/TiltBehavior.cs
+++ b/MahApps.Metro/Behaviours/TiltBehavior.cs
@@ -47,21 +47,15 @@ namespace MahApps.Metro.Behaviours
             attachedElement = AssociatedObject;
             if (attachedElement is ListBox)
             {
-                var l = (ListBox) attachedElement;
-                l.Items.CurrentChanging += (s, e) =>
-                {
-                    Console.WriteLine("foo");
-                };
                 return;
             }
-            if (attachedElement as Panel != null)
-            {
-                var y = (attachedElement as ItemsControl);
-                y.Items.CurrentChanging += (s, e) => Console.WriteLine("foo");
 
-                (attachedElement as Panel).Loaded += (sl, el) =>
+            var attachedElementPanel = attachedElement as Panel;
+            if (attachedElementPanel != null)
+            {
+                attachedElementPanel.Loaded += (sl, el) =>
                 {
-                    var elements = (attachedElement as Panel).Children.Cast<UIElement>().ToList();
+                    var elements = attachedElementPanel.Children.Cast<UIElement>().ToList();
 
                     elements.ForEach(element =>
                         Interaction.GetBehaviors(element).Add(

--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -25,7 +25,7 @@ namespace MahApps.Metro.Controls.Dialogs
         public static readonly DependencyProperty TitleProperty = DependencyProperty.Register("Title", typeof(string), typeof(BaseMetroDialog), new PropertyMetadata(default(string)));
         public static readonly DependencyProperty DialogBodyProperty = DependencyProperty.Register("DialogBody", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null, (o, e) =>
         {
-            BaseMetroDialog dialog = (o as BaseMetroDialog);
+            var dialog = o as BaseMetroDialog;
             if (dialog != null)
             {
                 if (e.OldValue != null)
@@ -100,7 +100,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="owningWindow">The window that is the parent of the dialog.</param>
         protected BaseMetroDialog(MetroWindow owningWindow, MetroDialogSettings settings)
         {
-            DialogSettings = settings == null ? owningWindow.MetroDialogOptions : settings;
+            DialogSettings = settings ?? owningWindow.MetroDialogOptions;
 
             OwningWindow = owningWindow;
             

--- a/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
@@ -263,15 +263,6 @@ namespace MahApps.Metro.Controls.Dialogs
             get { return (string)GetValue(SecondAuxiliaryButtonTextProperty); }
             set { SetValue(SecondAuxiliaryButtonTextProperty, value); }
         }
-
-
-        public override void OnApplyTemplate()
-        {
-            //AffirmativeButton = GetTemplateChild(PART_AffirmativeButton) as Button;
-            //NegativeButton = GetTemplateChild(PART_NegativeButton) as Button;
-
-            base.OnApplyTemplate();
-        }
     }
 
     /// <summary>

--- a/MahApps.Metro/Controls/MetroNavigationWindow.cs
+++ b/MahApps.Metro/Controls/MetroNavigationWindow.cs
@@ -109,7 +109,7 @@ namespace MahApps.Metro.Controls
         [System.Diagnostics.DebuggerNonUserCode]
         void PART_Frame_Navigated(object sender, NavigationEventArgs e)
         {
-            PART_Title.Content = (PART_Frame.Content as Page).Title;
+            PART_Title.Content = ((Page) PART_Frame.Content).Title;
             (this as IUriContext).BaseUri = e.Uri;
 
             PageContent = PART_Frame.Content;

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -653,11 +653,11 @@ namespace MahApps.Metro.Controls
         private void MetroWindow_SizeChanged(object sender, RoutedEventArgs e)
         {
             // this all works only for CleanWindow style
-            
-            var titleBarGrid = titleBar as Grid;
-            var titleBarLabel = titleBarGrid.Children[0] as Label;
-            var titleControl = titleBarLabel.Content as ContentControl;
-            var iconContentControl = icon as ContentControl;
+
+            var titleBarGrid = (Grid)titleBar;
+            var titleBarLabel = (Label)titleBarGrid.Children[0];
+            var titleControl = (ContentControl)titleBarLabel.Content;
+            var iconContentControl = (ContentControl)icon;
 
             // Half of this MetroWindow
             var halfDistance = this.Width / 2;
@@ -757,7 +757,7 @@ namespace MahApps.Metro.Controls
 
             overlayBox = GetTemplateChild(PART_OverlayBox) as Grid;
             metroDialogContainer = GetTemplateChild(PART_MetroDialogContainer) as Grid;
-            flyoutModal = GetTemplateChild(PART_FlyoutModal) as Rectangle;
+            flyoutModal = (Rectangle) GetTemplateChild(PART_FlyoutModal);
             flyoutModal.PreviewMouseDown += FlyoutsPreviewMouseDown;
             this.PreviewMouseDown += FlyoutsPreviewMouseDown;
 


### PR DESCRIPTION
The PR fixes some of the "as" casts that access the element even if it could be null.

This also brings me to my request: 

Please stop using the "as" operator, but use a simple cast. This ensures that we catch an invalid cast immediately and don't run into any `NullReferenceException`s when accessing the object.
