### PR TITLE
Optimize use of wpf controls

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -851,16 +851,6 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        protected override void OnStateChanged(EventArgs e)
-        {
-            if (WindowButtonCommands != null && !this.UseNoneWindowStyle)
-            {
-                WindowButtonCommands.RefreshMaximiseIconState();
-            }
-
-            base.OnStateChanged(e);
-        }
-
         private void IconMouseDown(object sender, MouseButtonEventArgs e)
         {
             if (e.ChangedButton == MouseButton.Left)

--- a/MahApps.Metro/Controls/WindowButtonCommands.cs
+++ b/MahApps.Metro/Controls/WindowButtonCommands.cs
@@ -96,13 +96,11 @@ namespace MahApps.Metro.Controls
 
             max = Template.FindName("PART_Max", this) as Button;
             if (max != null)
-                max.Click += MaximiseClick;
+                max.Click += MaximizeClick;
 
             min = Template.FindName("PART_Min", this) as Button;
             if (min != null)
-                min.Click += MinimiseClick;
-
-            RefreshMaximiseIconState();
+                min.Click += MinimizeClick;
         }
 
         protected void OnClosingWindow(ClosingWindowEventHandlerArgs args)
@@ -112,14 +110,14 @@ namespace MahApps.Metro.Controls
                 handler(this, args);
         }
 
-        private void MinimiseClick(object sender, RoutedEventArgs e)
+        private void MinimizeClick(object sender, RoutedEventArgs e)
         {
             var parentWindow = GetParentWindow();
             if (parentWindow != null)
                 Microsoft.Windows.Shell.SystemCommands.MinimizeWindow(parentWindow);
         }
 
-        private void MaximiseClick(object sender, RoutedEventArgs e)
+        private void MaximizeClick(object sender, RoutedEventArgs e)
         {
             var parentWindow = GetParentWindow();
             if (parentWindow == null)
@@ -132,39 +130,6 @@ namespace MahApps.Metro.Controls
             else
             {
                 Microsoft.Windows.Shell.SystemCommands.MaximizeWindow(parentWindow);
-            }
-            
-            RefreshMaximiseIconState(parentWindow);
-        }
-
-        public void RefreshMaximiseIconState()
-        {
-            RefreshMaximiseIconState(GetParentWindow());
-        }
-
-        private void RefreshMaximiseIconState(Window parentWindow)
-        {
-            if (parentWindow == null || max == null)
-                return;
-
-            if (parentWindow.WindowState == WindowState.Normal)
-            {
-                var maxpath = (Path)max.FindName("MaximisePath");
-                maxpath.Visibility = Visibility.Visible;
-
-                var restorepath = (Path)max.FindName("RestorePath");
-                restorepath.Visibility = Visibility.Collapsed;
-
-                max.ToolTip = Maximize;
-            }
-            else
-            {
-                var restorepath = (Path)max.FindName("RestorePath");
-                restorepath.Visibility = Visibility.Visible;
-
-                var maxpath = (Path)max.FindName("MaximisePath");
-                maxpath.Visibility = Visibility.Collapsed;
-                max.ToolTip = Restore;
             }
         }
 

--- a/MahApps.Metro/Converters/WindowStateToPathDataConverter.cs
+++ b/MahApps.Metro/Converters/WindowStateToPathDataConverter.cs
@@ -1,0 +1,47 @@
+//------------------------------------------------------------------------------
+//  File    : WindowStateToPathDataConverter.cs
+//  Author  : Mohammad Rahhal
+//  Created : 14/8/2014 7:25:55 PM
+//------------------------------------------------------------------------------
+
+namespace MahApps.Metro.Converters
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Text;
+	using System.Threading.Tasks;
+	using System.Windows;
+	using System.Windows.Data;
+
+	[ValueConversion(typeof(WindowState), typeof(string))]
+	public class WindowStateToPathDataConverter : IValueConverter
+	{
+		private static readonly string _MaximizePathData = "F1M0,0L0,9 9,9 9,0 0,0 0,3 8,3 8,8 1,8 1,3z";
+		private static readonly string _RestorePathData = "F1M0,10L0,3 3,3 3,0 10,0 10,2 4,2 4,3 7,3 7,6 6,6 6,5 1,5 1,10z M1,10L7,10 7,7 10,7 10,2 9,2 9,6 6,6 6,9 1,9z"; 
+
+		public WindowStateToPathDataConverter()
+		{
+		}
+
+		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		{
+			WindowState state = (WindowState)value;
+			switch (state)
+			{
+				case WindowState.Maximized:
+					return _RestorePathData;
+				case WindowState.Normal:
+				case WindowState.Minimized:
+				default:
+					return _MaximizePathData;
+			}
+		}
+
+		// Doesn't need to be implemented.
+		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Converters\ResizeModeMinMaxButtonVisibilityConverter.cs" />
     <Compile Include="Converters\ThicknessToDoubleConverter.cs" />
     <Compile Include="Converters\TreeViewMarginConverter.cs" />
+    <Compile Include="Converters\WindowStateToPathDataConverter.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\ComGuids.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\Debug.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\DoubleUtil.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Converters\ResizeModeMinMaxButtonVisibilityConverter.cs" />
     <Compile Include="Converters\ThicknessToDoubleConverter.cs" />
     <Compile Include="Converters\TreeViewMarginConverter.cs" />
+    <Compile Include="Converters\WindowStateToPathDataConverter.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\ComGuids.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\Debug.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\DoubleUtil.cs" />

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -11,7 +11,8 @@
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <conv:ToUpperConverter x:Key="ToUpperConverter" />
-
+    <conv:WindowStateToPathDataConverter x:Key="StateToDataConvertor" />
+    
     <ControlTemplate x:Key="WindowTemplateKey"
                      TargetType="{x:Type Controls:MetroWindow}">
         <Grid>
@@ -537,16 +538,9 @@
                                              Mode="OneWay" />
                                 </MultiBinding>
                             </Button.Visibility>
-                            <Grid>
-                                <Path x:Name="MaximisePath"
-                                      SnapsToDevicePixels="True"
-                                      Data="F1M0,0L0,9 9,9 9,0 0,0 0,3 8,3 8,8 1,8 1,3z"
-                                      Fill="{TemplateBinding Foreground}" />
-                                <Path x:Name="RestorePath"
-                                      SnapsToDevicePixels="True"
-                                      Data="F1M0,10L0,3 3,3 3,0 10,0 10,2 4,2 4,3 7,3 7,6 6,6 6,5 1,5 1,10z M1,10L7,10 7,7 10,7 10,2 9,2 9,6 6,6 6,9 1,9z"
-                                      Fill="{TemplateBinding Foreground}" />
-                            </Grid>
+                            <Path SnapsToDevicePixels="True"
+                                  Data="{Binding Converter={StaticResource StateToDataConvertor}, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=WindowState}"
+                                  Fill="{TemplateBinding Foreground}" />
                         </Button>
 
                         <Button x:Name="PART_Close"


### PR DESCRIPTION
One less Grid control and one less Path control in the WindowButtonCommands' default template, the same behavior holds. Optimizing for less WPF controls is always good.
