### PR TITLE
Added the base background icon feature for dialogs

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -40,6 +40,7 @@ namespace MahApps.Metro.Controls.Dialogs
         }));
         public static readonly DependencyProperty DialogTopProperty = DependencyProperty.Register("DialogTop", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
         public static readonly DependencyProperty DialogBottomProperty = DependencyProperty.Register("DialogBottom", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
+        public static readonly DependencyProperty BackgroundVisualProperty = DependencyProperty.Register("BackgroundVisual", typeof(Brush), typeof(BaseMetroDialog), new FrameworkPropertyMetadata(null));
 
         protected MetroDialogSettings DialogSettings { get; private set; }
 
@@ -77,6 +78,19 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             get { return GetValue(DialogBottomProperty); }
             set { SetValue(DialogBottomProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets/sets the dialog's background visual.
+        /// </summary>
+        /// <remarks>
+        /// Use Background for normal background colors. Use this (BackgroundVisual) for showing an overlay visual behind the content.
+        /// Recommended: Use a DrawingBrush or a VisualBrush for this property. Other brushes should be used in Background.
+        /// </remarks>
+        public Brush BackgroundVisual
+        {
+            get { return (Brush)GetValue(BackgroundVisualProperty); }
+            set { SetValue(BackgroundVisualProperty, value); }
         }
 
         internal SizeChangedEventHandler SizeChangedHandler { get; set; }

--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -20,6 +20,8 @@ namespace MahApps.Metro.Controls.Dialogs
     public abstract class BaseMetroDialog : Control
     {
         private const string PART_DialogBody_ContentPresenter = "PART_DialogBody_ContentPresenter";
+        private const string PART_VisualBackgroundRectangle = "PART_VisualBackgroundRectangle";
+
         protected ContentPresenter DialogBody_ContentPresenter = null;
 
         public static readonly DependencyProperty TitleProperty = DependencyProperty.Register("Title", typeof(string), typeof(BaseMetroDialog), new PropertyMetadata(default(string)));
@@ -40,7 +42,6 @@ namespace MahApps.Metro.Controls.Dialogs
         }));
         public static readonly DependencyProperty DialogTopProperty = DependencyProperty.Register("DialogTop", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
         public static readonly DependencyProperty DialogBottomProperty = DependencyProperty.Register("DialogBottom", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
-        public static readonly DependencyProperty BackgroundVisualProperty = DependencyProperty.Register("BackgroundVisual", typeof(Brush), typeof(BaseMetroDialog), new FrameworkPropertyMetadata(null));
 
         protected MetroDialogSettings DialogSettings { get; private set; }
 
@@ -80,19 +81,6 @@ namespace MahApps.Metro.Controls.Dialogs
             set { SetValue(DialogBottomProperty, value); }
         }
 
-        /// <summary>
-        /// Gets/sets the dialog's background visual.
-        /// </summary>
-        /// <remarks>
-        /// Use Background for normal background colors. Use this (BackgroundVisual) for showing an overlay visual behind the content.
-        /// Recommended: Use a DrawingBrush or a VisualBrush for this property. Other brushes should be used in Background.
-        /// </remarks>
-        public Brush BackgroundVisual
-        {
-            get { return (Brush)GetValue(BackgroundVisualProperty); }
-            set { SetValue(BackgroundVisualProperty, value); }
-        }
-
         internal SizeChangedEventHandler SizeChangedHandler { get; set; }
 
 
@@ -104,6 +92,12 @@ namespace MahApps.Metro.Controls.Dialogs
         public override void OnApplyTemplate()
         {
             DialogBody_ContentPresenter = GetTemplateChild(PART_DialogBody_ContentPresenter) as ContentPresenter;
+
+            System.Windows.Shapes.Rectangle r = GetTemplateChild(PART_VisualBackgroundRectangle) as System.Windows.Shapes.Rectangle;
+            if (r != null)
+            {
+                r.Fill = this.DialogSettings.VisualBackground;
+            }
 
             base.OnApplyTemplate();
         }
@@ -352,6 +346,15 @@ namespace MahApps.Metro.Controls.Dialogs
         /// Gets/sets the default text( just the inputdialog needed)
         /// </summary>
         public string DefaultText { get; set; }
+
+        /// <summary>
+        /// Gets/sets the dialog's visual background.
+        /// </summary>
+        /// <remarks>
+        /// Use BaseMetroDialog.Background dp for normal background colors. Use this for showing an overlay visual behind the content.
+        /// Recommended: Use a DrawingBrush or a VisualBrush for this property. Other brushes should be used in Background.
+        /// </remarks>
+        public Brush VisualBackground { get; set; }
     }
 
     /// <summary>

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -21,7 +21,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="message">The message contained within the LoginDialog.</param>
         /// <param name="settings">Optional settings that override the global metro dialog settings.</param>
         /// <returns>The text that was entered or null (Nothing in Visual Basic) if the user cancelled the operation.</returns>
-        public static Task<LoginDialogData> ShowLoginAsync(this MetroWindow window, string title, string message, LoginDialogSettings settings = null, Brush backgroundViusal = null)
+        public static Task<LoginDialogData> ShowLoginAsync(this MetroWindow window, string title, string message, LoginDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
@@ -35,7 +35,7 @@ namespace MahApps.Metro.Controls.Dialogs
                     dialog.Title = title;
                     dialog.Message = message;
 
-                    SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog, backgroundViusal);
+                    SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                     dialog.SizeChangedHandler = sizeHandler;
 
                     return dialog.WaitForLoadAsync().ContinueWith(x =>
@@ -82,7 +82,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="message">The message contained within the MessageDialog.</param>
         /// <param name="settings">Optional settings that override the global metro dialog settings.</param>
         /// <returns>The text that was entered or null (Nothing in Visual Basic) if the user cancelled the operation.</returns>
-        public static Task<string> ShowInputAsync(this MetroWindow window, string title, string message, MetroDialogSettings settings = null, Brush backgroundViusal = null)
+        public static Task<string> ShowInputAsync(this MetroWindow window, string title, string message, MetroDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
@@ -98,7 +98,7 @@ namespace MahApps.Metro.Controls.Dialogs
                             dialog.Message = message;
                             dialog.Input = settings.DefaultText;
 
-                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog, backgroundViusal);
+                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                             dialog.SizeChangedHandler = sizeHandler;
 
                             return dialog.WaitForLoadAsync().ContinueWith(x =>
@@ -150,7 +150,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="style">The type of buttons to use.</param>
         /// <param name="settings">Optional settings that override the global metro dialog settings.</param>
         /// <returns>A task promising the result of which button was pressed.</returns>
-        public static Task<MessageDialogResult> ShowMessageAsync(this MetroWindow window, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, MetroDialogSettings settings = null, Brush backgroundViusal = null)
+        public static Task<MessageDialogResult> ShowMessageAsync(this MetroWindow window, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, MetroDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
@@ -166,7 +166,7 @@ namespace MahApps.Metro.Controls.Dialogs
                             dialog.Title = title;
                             dialog.ButtonStyle = style;
 
-                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog, backgroundViusal);
+                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                             dialog.SizeChangedHandler = sizeHandler;
 
                             return dialog.WaitForLoadAsync().ContinueWith(x =>
@@ -219,7 +219,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="isCancelable">Determines if the cancel button is visible.</param>
         /// <param name="settings">Optional Settings that override the global metro dialog settings.</param>
         /// <returns>A task promising the instance of ProgressDialogController for this operation.</returns>
-        public static Task<ProgressDialogController> ShowProgressAsync(this MetroWindow window, string title, string message, bool isCancelable = false, MetroDialogSettings settings = null, Brush backgroundViusal = null)
+        public static Task<ProgressDialogController> ShowProgressAsync(this MetroWindow window, string title, string message, bool isCancelable = false, MetroDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
 
@@ -238,7 +238,7 @@ namespace MahApps.Metro.Controls.Dialogs
 
                         dialog.NegativeButtonText = settings.NegativeButtonText;
 
-                        SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog, backgroundViusal);
+                        SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                         dialog.SizeChangedHandler = sizeHandler;
 
                         return dialog.WaitForLoadAsync().ContinueWith(x =>
@@ -308,7 +308,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 {
                     dialog.Dispatcher.Invoke(new Action(() =>
                         {
-                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog, dialog.BackgroundVisual);
+                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                             dialog.SizeChangedHandler = sizeHandler;
                         }));
                 }).ContinueWith(y =>
@@ -363,12 +363,11 @@ namespace MahApps.Metro.Controls.Dialogs
             }).Unwrap();
         }
 
-        private static SizeChangedEventHandler SetupAndOpenDialog(MetroWindow window, BaseMetroDialog dialog, Brush backgroundViusal)
+        private static SizeChangedEventHandler SetupAndOpenDialog(MetroWindow window, BaseMetroDialog dialog)
         {
             dialog.SetValue(Panel.ZIndexProperty, (int)window.overlayBox.GetValue(Panel.ZIndexProperty) + 1);
             dialog.MinHeight = window.ActualHeight / 4.0;
             dialog.MaxHeight = window.ActualHeight;
-            dialog.BackgroundVisual = backgroundViusal;
 
             SizeChangedEventHandler sizeHandler = null; //an event handler for auto resizing an open dialog.
             sizeHandler = new SizeChangedEventHandler((sender, args) =>

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -21,7 +21,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="message">The message contained within the LoginDialog.</param>
         /// <param name="settings">Optional settings that override the global metro dialog settings.</param>
         /// <returns>The text that was entered or null (Nothing in Visual Basic) if the user cancelled the operation.</returns>
-        public static Task<LoginDialogData> ShowLoginAsync(this MetroWindow window, string title, string message, LoginDialogSettings settings = null)
+        public static Task<LoginDialogData> ShowLoginAsync(this MetroWindow window, string title, string message, LoginDialogSettings settings = null, Brush backgroundViusal = null)
         {
             window.Dispatcher.VerifyAccess();
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
@@ -35,7 +35,7 @@ namespace MahApps.Metro.Controls.Dialogs
                     dialog.Title = title;
                     dialog.Message = message;
 
-                    SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
+                    SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog, backgroundViusal);
                     dialog.SizeChangedHandler = sizeHandler;
 
                     return dialog.WaitForLoadAsync().ContinueWith(x =>
@@ -82,7 +82,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="message">The message contained within the MessageDialog.</param>
         /// <param name="settings">Optional settings that override the global metro dialog settings.</param>
         /// <returns>The text that was entered or null (Nothing in Visual Basic) if the user cancelled the operation.</returns>
-        public static Task<string> ShowInputAsync(this MetroWindow window, string title, string message, MetroDialogSettings settings = null)
+        public static Task<string> ShowInputAsync(this MetroWindow window, string title, string message, MetroDialogSettings settings = null, Brush backgroundViusal = null)
         {
             window.Dispatcher.VerifyAccess();
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
@@ -98,7 +98,7 @@ namespace MahApps.Metro.Controls.Dialogs
                             dialog.Message = message;
                             dialog.Input = settings.DefaultText;
 
-                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
+                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog, backgroundViusal);
                             dialog.SizeChangedHandler = sizeHandler;
 
                             return dialog.WaitForLoadAsync().ContinueWith(x =>
@@ -150,7 +150,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="style">The type of buttons to use.</param>
         /// <param name="settings">Optional settings that override the global metro dialog settings.</param>
         /// <returns>A task promising the result of which button was pressed.</returns>
-        public static Task<MessageDialogResult> ShowMessageAsync(this MetroWindow window, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, MetroDialogSettings settings = null)
+        public static Task<MessageDialogResult> ShowMessageAsync(this MetroWindow window, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, MetroDialogSettings settings = null, Brush backgroundViusal = null)
         {
             window.Dispatcher.VerifyAccess();
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
@@ -166,7 +166,7 @@ namespace MahApps.Metro.Controls.Dialogs
                             dialog.Title = title;
                             dialog.ButtonStyle = style;
 
-                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
+                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog, backgroundViusal);
                             dialog.SizeChangedHandler = sizeHandler;
 
                             return dialog.WaitForLoadAsync().ContinueWith(x =>
@@ -219,7 +219,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="isCancelable">Determines if the cancel button is visible.</param>
         /// <param name="settings">Optional Settings that override the global metro dialog settings.</param>
         /// <returns>A task promising the instance of ProgressDialogController for this operation.</returns>
-        public static Task<ProgressDialogController> ShowProgressAsync(this MetroWindow window, string title, string message, bool isCancelable = false, MetroDialogSettings settings = null)
+        public static Task<ProgressDialogController> ShowProgressAsync(this MetroWindow window, string title, string message, bool isCancelable = false, MetroDialogSettings settings = null, Brush backgroundViusal = null)
         {
             window.Dispatcher.VerifyAccess();
 
@@ -238,7 +238,7 @@ namespace MahApps.Metro.Controls.Dialogs
 
                         dialog.NegativeButtonText = settings.NegativeButtonText;
 
-                        SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
+                        SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog, backgroundViusal);
                         dialog.SizeChangedHandler = sizeHandler;
 
                         return dialog.WaitForLoadAsync().ContinueWith(x =>
@@ -308,7 +308,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 {
                     dialog.Dispatcher.Invoke(new Action(() =>
                         {
-                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
+                            SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog, dialog.BackgroundVisual);
                             dialog.SizeChangedHandler = sizeHandler;
                         }));
                 }).ContinueWith(y =>
@@ -363,11 +363,12 @@ namespace MahApps.Metro.Controls.Dialogs
             }).Unwrap();
         }
 
-        private static SizeChangedEventHandler SetupAndOpenDialog(MetroWindow window, BaseMetroDialog dialog)
+        private static SizeChangedEventHandler SetupAndOpenDialog(MetroWindow window, BaseMetroDialog dialog, Brush backgroundViusal)
         {
             dialog.SetValue(Panel.ZIndexProperty, (int)window.overlayBox.GetValue(Panel.ZIndexProperty) + 1);
             dialog.MinHeight = window.ActualHeight / 4.0;
             dialog.MaxHeight = window.ActualHeight;
+            dialog.BackgroundVisual = backgroundViusal;
 
             SizeChangedEventHandler sizeHandler = null; //an event handler for auto resizing an open dialog.
             sizeHandler = new SizeChangedEventHandler((sender, args) =>

--- a/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -61,6 +61,7 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
+                            <Rectangle Grid.RowSpan="2" Margin="5" Stretch="Uniform" Fill="{TemplateBinding BackgroundVisual}" Opacity=".1"/>
                             <TextBlock Grid.Row="0"
                                        FontSize="26"
                                        Foreground="{TemplateBinding Foreground}"

--- a/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
                     xmlns:Dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs">
 
     <ResourceDictionary.MergedDictionaries>
@@ -61,7 +62,7 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
-                            <Rectangle Grid.RowSpan="2" Margin="5" Stretch="Uniform" Fill="{TemplateBinding BackgroundVisual}" Opacity=".1"/>
+                            <Rectangle x:Name="PART_VisualBackgroundRectangle" Grid.RowSpan="2" Margin="5" Stretch="Uniform" Opacity=".1"/>
                             <TextBlock Grid.Row="0"
                                        FontSize="26"
                                        Foreground="{TemplateBinding Foreground}"


### PR DESCRIPTION
Added a dp called BackgroundVisual that's responsible for displaying an
overlay visual behind the contents of a dialog. Useful for showing a
warning icon for example.
Closes #1474 

Usage:
```
Canvas visual = (Canvas)App.Current.Resources["appbar_warning"];
MetroDialogSettings s = new MetroDialogSettings() { VisualBackground = new VisualBrush(visual) };
await this.ShowMessageAsync("Error", "Connection error: unable to connect", settings: s);
```

If you're creating the dialog yourself:
```
Canvas visual = (Canvas)App.Current.Resources["appbar_warning"];
MetroDialogSettings s = new MetroDialogSettings() { VisualBackground = new VisualBrush(visual) };
// Create your dialog with s as the Dialog settings.
[...]
```
![capture1](https://cloud.githubusercontent.com/assets/4404199/3944212/e020b9c0-25f1-11e4-9bdb-c1f6d4f4638f.PNG)