### PR TITLE
LoginDialog Password Preview Feature

### DIFF
--- a/MahApps.Metro/Behaviours/PasswordBoxBindingBehavior.cs
+++ b/MahApps.Metro/Behaviours/PasswordBoxBindingBehavior.cs
@@ -1,0 +1,72 @@
+//	--------------------------------------------------------------------
+//		Obtained from: WPFSmartLibrary
+//		For more information see : http://wpfsmartlibrary.codeplex.com/
+//		(by DotNetMastermind)
+//	--------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interactivity;
+
+namespace MahApps.Metro.Behaviours
+{
+    public class PasswordBoxBindingBehavior : Behavior<PasswordBox>
+    {
+            #region Fields
+
+            private static bool IsUpdating;
+
+            #endregion
+
+            #region DependencyProperty - Password ("string")
+
+            public static string GetPassword(DependencyObject dpo)
+            {
+                return (string)dpo.GetValue(PasswordProperty);
+            }
+            public static void SetPassword(DependencyObject dpo, string value)
+            {
+                dpo.SetValue(PasswordProperty, value);
+            }
+            /// <summary>
+            /// Gets or sets the bindable Password property on the PasswordBox control. This is a dependency property.
+            /// </summary>
+            public static readonly DependencyProperty PasswordProperty =
+                        DependencyProperty.RegisterAttached("Password", typeof(string),
+                                                                         typeof(PasswordBoxBindingBehavior),
+                                                                         new FrameworkPropertyMetadata(String.Empty,
+                                                                         new PropertyChangedCallback(OnPasswordPropertyChanged)));
+            /// <summary>
+            /// Handles changes to the 'Password' attached property.
+            /// </summary>
+            private static void OnPasswordPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+            {
+                PasswordBox targetPasswordBox = sender as PasswordBox;
+                if (targetPasswordBox != null)
+                {
+                    targetPasswordBox.PasswordChanged -= PasswordBox_PasswordChanged;
+                    if (IsUpdating == false)
+                    {
+                        targetPasswordBox.Password = (string)e.NewValue;
+                    }
+                    targetPasswordBox.PasswordChanged += PasswordBox_PasswordChanged;
+                }
+            }
+
+            /// <summary>
+            /// Handle the 'PasswordChanged'-event on the PasswordBox
+            /// </summary>
+            private static void PasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
+            {
+                PasswordBox passwordBox = sender as PasswordBox;
+                IsUpdating = true;
+                SetPassword(passwordBox, passwordBox.Password);
+                IsUpdating = false;
+            }
+
+            #endregion
+    }
+}

--- a/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 
 namespace MahApps.Metro.Controls.Dialogs
@@ -10,6 +11,7 @@ namespace MahApps.Metro.Controls.Dialogs
         private const string DEFAULT_USERNAME_WATERMARK = "Username...";
         private const string DEFAULT_PASSWORD_WATERMARK = "Password...";
         private const Visibility DEFAULT_NEGATIVE_BUTTON_VISIBILITY = Visibility.Collapsed;
+        private const bool DEFAULT_ENABLE_PASSWORD_PREVIEW = false;
 
         public LoginDialogSettings()
             : base()
@@ -18,6 +20,7 @@ namespace MahApps.Metro.Controls.Dialogs
             PasswordWatermark = DEFAULT_PASSWORD_WATERMARK;
             NegativeButtonVisibility = DEFAULT_NEGATIVE_BUTTON_VISIBILITY;
             AffirmativeButtonText = "Login";
+            EnablePasswordPreview = DEFAULT_ENABLE_PASSWORD_PREVIEW;
         }
 
         public string InitialUsername { get; set; }
@@ -27,6 +30,8 @@ namespace MahApps.Metro.Controls.Dialogs
         public string PasswordWatermark { get; set; }
 
         public Visibility NegativeButtonVisibility { get; set; }
+
+        public bool EnablePasswordPreview { get; set; }
     }
 
     public class LoginDialogData
@@ -50,6 +55,14 @@ namespace MahApps.Metro.Controls.Dialogs
             UsernameWatermark = settings.UsernameWatermark;
             PasswordWatermark = settings.PasswordWatermark;
             NegativeButtonButtonVisibility = settings.NegativeButtonVisibility;
+            if (settings.EnablePasswordPreview)
+            {
+                object resource = Application.Current.FindResource("Win8MetroPasswordBox");
+                if (resource != null && resource.GetType() == typeof(Style))
+                {
+                    PART_TextBox2.Style = (Style)resource;
+                }
+            }
         }
 
         internal Task<LoginDialogData> WaitForButtonPressAsync()

--- a/MahApps.Metro/Converters/StringToVisibilityConverter.cs
+++ b/MahApps.Metro/Converters/StringToVisibilityConverter.cs
@@ -1,0 +1,87 @@
+//	--------------------------------------------------------------------
+//		Obtained from: WPFSmartLibrary
+//		For more information see : http://wpfsmartlibrary.codeplex.com/
+//		(by DotNetMastermind)
+//	--------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace MahApps.Metro.Converters
+{
+    /// <summary>
+    /// Converts a String into a Visibility enumeration (and back)
+    /// The FalseEquivalent can be declared with the "FalseEquivalent" property
+    /// </summary>
+    [ValueConversion(typeof(string), typeof(Visibility))]
+    [MarkupExtensionReturnType(typeof(StringToVisibilityConverter))]
+    public class StringToVisibilityConverter : MarkupExtension, IValueConverter
+    {
+        /// <summary>
+        /// FalseEquivalent (default : Visibility.Collapsed => see Constructor)
+        /// </summary>
+        public Visibility FalseEquivalent { get; set; }
+
+        /// <summary>
+        /// Define whether the opposite boolean value is crucial (default : false)
+        /// </summary>
+        public bool OppositeStringValue { get; set; }
+
+        /// <summary>
+        /// Initialize the properties with standard values
+        /// </summary>
+        public StringToVisibilityConverter()
+        {
+            this.FalseEquivalent = Visibility.Collapsed;
+            this.OppositeStringValue = false;
+        }
+
+        #region IValueConverter Members
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string && targetType == typeof(Visibility))
+            {
+                if (this.OppositeStringValue == true)
+                {
+                    return ((value as string).ToLower().Equals(String.Empty)) ? Visibility.Visible : this.FalseEquivalent;
+                }
+                return ((value as string).ToLower().Equals(String.Empty)) ? this.FalseEquivalent : Visibility.Visible;
+            }
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Visibility)
+            {
+                if (this.OppositeStringValue == true)
+                {
+                    return ((Visibility)value == Visibility.Visible) ? String.Empty : "visible";
+                }
+                return ((Visibility)value == Visibility.Visible) ? "visible" : String.Empty;
+            }
+            return value;
+        }
+
+        #endregion
+
+        #region MarkupExtension "overrides"
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return new StringToVisibilityConverter
+            {
+                FalseEquivalent = this.FalseEquivalent,
+                OppositeStringValue = this.OppositeStringValue
+            };
+        }
+
+        #endregion
+    }
+}

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -1,10 +1,203 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:Behaviors="clr-namespace:MahApps.Metro.Behaviours"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <Converters:ThicknessToDoubleConverter x:Key="ThicknessToDoubleConverter" />
+    <Converters:StringToVisibilityConverter x:Key="StringToVisibilityConverter" />
+    <Converters:StringToVisibilityConverter x:Key="StringToOppositeVisibilityConverter" OppositeStringValue="True" />
+
+    <!--Button Style for Win8MetroPasswordBox-->
+    <Style x:Key="RevealButtonStyle" TargetType="{x:Type Button}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Grid>
+                        <Border x:Name="PasswordRevealIconEyeBorder" Background="Transparent" Margin="1,1,3,1" BorderThickness="{TemplateBinding BorderThickness}">
+                            <Rectangle Width="20" Height="15" x:Name="IconEye" VerticalAlignment="Center" Margin="3,0" HorizontalAlignment="Center" Fill="{Binding Path=Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Button}}}">
+                                <Rectangle.OpacityMask>
+                                    <VisualBrush Stretch="Fill" Visual="{DynamicResource appbar_eye}" />
+                                </Rectangle.OpacityMask>
+                            </Rectangle>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding ElementName=PasswordRevealIconEyeBorder, Path=IsMouseOver}" Value="True">
+                            <Setter TargetName="PasswordRevealIconEyeBorder" Property="Background" Value="Gainsboro" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True">
+                            <Setter TargetName="PasswordRevealIconEyeBorder" Property="Background" Value="Black" />
+                            <Setter TargetName="IconEye" Property="Fill" Value="White" />
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <!--Win8MetroPasswordBox Style-->
+    <Style TargetType="{x:Type PasswordBox}" x:Key="Win8MetroPasswordBox">
+        <Setter Property="ContextMenu" Value="{DynamicResource TextBoxMetroContextMenu}" />
+        <Setter Property="Controls:TextboxHelper.IsMonitoring" Value="True" />
+        <Setter Property="Controls:ControlsHelper.ButtonWidth" Value="22" />
+        <Setter Property="PasswordChar" Value="●"/>
+        <Setter Property="SelectionBrush" Value="{DynamicResource HighlightBrush}" />
+        <Setter Property="FontFamily" Value="{DynamicResource ContentFontFamily}" />
+        <Setter Property="FontSize" Value="15" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="MinHeight" Value="26" />
+        <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+        <Setter Property="Padding" Value="4,1,4,1" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
+        <Setter Property="Controls:TextboxHelper.FocusBorderBrush" Value="{DynamicResource TextBoxFocusBorderBrush}" />
+        <Setter Property="Controls:TextboxHelper.MouseOverBorderBrush" Value="{DynamicResource TextBoxMouseOverBorderBrush}" />
+        <!-- change SnapsToDevicePixels to true to view a better border and validation error -->
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
+        <Setter Property="AllowDrop" Value="true"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type PasswordBox}">
+                    <ControlTemplate.Resources>
+                        <Storyboard x:Key="enterGotFocus">
+                            <DoubleAnimation Duration="0:0:0.2" To=".2" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="TextBoxHint" />
+                        </Storyboard>
+                        <Storyboard x:Key="exitGotFocus">
+                            <DoubleAnimation Duration="0:0:0.2" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="TextBoxHint" />
+                        </Storyboard>
+                        <Storyboard x:Key="enterHasText">
+                            <DoubleAnimation Duration="0:0:0.2" From=".2" To="0" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="TextBoxHint" />
+                        </Storyboard>
+                        <Storyboard x:Key="exitHasText">
+                            <DoubleAnimation Duration="0:0:0.2" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="TextBoxHint" />
+                        </Storyboard>
+                    </ControlTemplate.Resources>
+                    <Grid Margin="0" VerticalAlignment="Stretch">
+                        <Rectangle x:Name="Base"
+                                Stroke="{TemplateBinding BorderBrush}"
+                                StrokeThickness="{TemplateBinding BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}}"
+                                Opacity="1"
+                                Fill="{TemplateBinding Background}" />
+                        <Rectangle x:Name="FocusRectangle"
+                                Visibility="Collapsed"
+                                StrokeThickness="{TemplateBinding BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}}" />
+                        <Grid VerticalAlignment="Stretch" Margin="0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <ScrollViewer x:Name="PART_ContentHost" Margin="0" Padding="0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <TextBox x:Name="RevealedPassword"
+                                     Grid.Column="0" Grid.Row="0"
+									Text="{TemplateBinding Behaviors:PasswordBoxBindingBehavior.Password}"
+                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                       VerticalAlignment="Stretch"
+									VerticalContentAlignment="Stretch"
+					                Margin="1,1,1,1"
+                                     Padding="-1,1,1,1"
+                                        FontSize="15"
+                                     BorderBrush="Transparent"
+									Visibility="Hidden" BorderThickness="1" IsReadOnly="True" />
+                            <TextBlock x:Name="TextBoxHint"
+									    Text="{TemplateBinding Controls:TextboxHelper.Watermark}"
+					                    Grid.Column="0" Grid.Row="0"
+                                        FontSize="15"
+                                       Padding="6,0,6,0"
+                                       Margin="2,0,2,0"
+                                        IsHitTestVisible="False"
+                                        Opacity="0.6"
+										Cursor="IBeam" Foreground="{TemplateBinding Foreground}"
+                                       HorizontalAlignment="Stretch"
+                                       VerticalAlignment="Center"
+										Visibility="{Binding ElementName=RevealedPassword, Path=Text, Converter={StaticResource StringToOppositeVisibilityConverter}}" />
+                            <Button x:Name="RevealButton"
+									Grid.Column="1" Grid.Row="0" SnapsToDevicePixels="True"
+									Style="{StaticResource RevealButtonStyle}"
+									Visibility="{Binding ElementName=RevealedPassword, Path=Text, Converter={StaticResource StringToVisibilityConverter}}">
+                            </Button>
+                        </Grid>
+                        <Rectangle x:Name="DisabledVisualElement"
+                                Stroke="{DynamicResource ControlsDisabledBrush}"
+                                StrokeThickness="{TemplateBinding BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}}"
+                                Fill="{DynamicResource ControlsDisabledBrush}"
+                                IsHitTestVisible="False"
+                                Opacity="0" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="{StaticResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                            <Setter Property="Opacity" TargetName="RevealButton" Value="0.5" />
+                            <Setter Property="Text" TargetName="TextBoxHint" Value="{}{disabled} "/>
+                            <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
+                        </Trigger>
+                        <DataTrigger Binding="{Binding ElementName=RevealButton, Path=IsPressed}" Value="True">
+                            <Setter TargetName="RevealedPassword" Property="Visibility" Value="Visible" />
+                            <Setter Property="Foreground" Value="Transparent" />
+                            <Setter Property="PasswordChar" Value=" " />
+                            
+                            
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Text}" Value="">
+                            <Setter TargetName="TextBoxHint" Property="Visibility" Value="Visible" />
+                        </DataTrigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="FocusRectangle" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="FocusRectangle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.MouseOverBorderBrush)}" />
+                        </Trigger>
+                        <Trigger Property="IsFocused" Value="True">
+                            <Setter TargetName="FocusRectangle" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="FocusRectangle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextboxHelper.FocusBorderBrush)}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Controls:TextboxHelper.HasText" Value="False" />
+                                <Condition Property="IsFocused" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <MultiTrigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource enterGotFocus}" />
+                            </MultiTrigger.EnterActions>
+                            <MultiTrigger.ExitActions>
+                                <BeginStoryboard Storyboard="{StaticResource exitGotFocus}" />
+                            </MultiTrigger.ExitActions>
+                        </MultiTrigger>
+                        <Trigger Property="Controls:TextboxHelper.HasText" Value="True">
+                            <Trigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource enterHasText}" />
+                            </Trigger.EnterActions>
+                            <Trigger.ExitActions>
+                                <BeginStoryboard Storyboard="{StaticResource exitHasText}" />
+                            </Trigger.ExitActions>
+                        </Trigger>
+                        <Trigger Property="Controls:TextboxHelper.IsWaitingForData" Value="True">
+                            <Setter TargetName="Base" Property="Effect">
+                                <Setter.Value>
+                                    <DropShadowEffect ShadowDepth="0" Color="{DynamicResource BlackColor}" Opacity="0" BlurRadius="10" />
+                                </Setter.Value>
+                            </Setter>
+                            <Trigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation From="0" To="1" Storyboard.TargetName="Base" Storyboard.TargetProperty="(Effect).Opacity" Duration="00:00:02" AutoReverse="True" RepeatBehavior="Forever" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.EnterActions>
+                        </Trigger>
+                        <Trigger Property="Controls:TextboxHelper.IsWaitingForData" Value="False">
+                            <Setter TargetName="Base" Property="Effect" Value="{x:Null}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
     <!--PasswordBox Style-->
     <Style TargetType="{x:Type PasswordBox}"

--- a/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
@@ -1,5 +1,6 @@
 ﻿<Dialogs:BaseMetroDialog xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                         xmlns:Behaviors="clr-namespace:MahApps.Metro.Behaviours"
                          xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
                          xmlns:Dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs"
                          x:Class="MahApps.Metro.Controls.Dialogs.LoginDialog"
@@ -32,6 +33,7 @@
                          Margin="0 5 0 0"
                          FontSize="15"
                          x:Name="PART_TextBox2"
+                         Behaviors:PasswordBoxBindingBehavior.Password="{Binding Password, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                          Controls:TextboxHelper.Watermark="{Binding PasswordWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                          Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
             <StackPanel Grid.Row="3"

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -149,6 +149,8 @@
                               Header="Show InputDialog" />
                     <MenuItem Click="ShowLoginDialog"
                               Header="Show LoginDialog" />
+                    <MenuItem Click="ShowLoginDialogPasswordPreview"
+                              Header="Show Password Preview LoginDialog" />
                     <MenuItem Click="ShowMessageDialog"
                               Header="Show MessageDialog" />
                     <MenuItem Click="ShowProgressDialog"

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -183,6 +183,20 @@ namespace MetroDemo
             }
         }
 
+        private async void ShowLoginDialogPasswordPreview(object sender, RoutedEventArgs e)
+        {
+            this.MetroDialogOptions.ColorScheme = UseAccentForDialogsMenuItem.IsChecked ? MetroDialogColorScheme.Accented : MetroDialogColorScheme.Theme;
+            LoginDialogData result = await this.ShowLoginAsync("Authentication", "Enter your credentials", new LoginDialogSettings { ColorScheme = this.MetroDialogOptions.ColorScheme, InitialUsername = "MahApps", EnablePasswordPreview = true });
+            if (result == null)
+            {
+                //User pressed cancel
+            }
+            else
+            {
+                MessageDialogResult messageResult = await this.ShowMessageAsync("Authentication Information", String.Format("Username: {0}\nPassword: {1}", result.Username, result.Password));
+            }
+        }
+
         private void InteropDemo(object sender, RoutedEventArgs e)
         {
             new InteropDemo().Show();


### PR DESCRIPTION
Adding the ability to use the Password Preview feature like in Windows 8 login to the LoginDialog.  It's optional and doesn't have to be used.  I used the eye icon in the MahApps icon library for the password preview button.

I merged templates and styles from MahApps & from WPFSmartLibrary.  I integrated in what was needed from the WPFSmartLibrary into the MahApps w/o adding a DLL reference to WPFSmartLibrary (https://wpfsmartlibrary.codeplex.com/).

![mahappslogindialogpassprevmenuitem](https://cloud.githubusercontent.com/assets/1051590/4238377/dab049ac-39d7-11e4-80f6-bf2facc4eed6.png)

![mahappslogindialogpassprevinitscreen](https://cloud.githubusercontent.com/assets/1051590/4238380/e209f572-39d7-11e4-9641-10eb635067e8.png)

![mahappslogindialogpassprevpasswordtyped](https://cloud.githubusercontent.com/assets/1051590/4238384/ec80a0c8-39d7-11e4-84aa-2580cd559542.png)

![mahappslogindialogpassprevhoveroverpreviewbutton](https://cloud.githubusercontent.com/assets/1051590/4238388/f4337de0-39d7-11e4-995b-a3717cb5014c.png)

![mahappslogindialogpassprevclickedonpreviewbutton](https://cloud.githubusercontent.com/assets/1051590/4238393/ffaf066c-39d7-11e4-9613-1fce62e830c8.png)

![mahappslogindialogpassprevpreviewbuttonmouseup](https://cloud.githubusercontent.com/assets/1051590/4238396/02dcb38e-39d8-11e4-988c-3b5839fc9167.png)
