### PR TITLE
If isEditable is enabled Background is not properly set

### DIFF
--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -252,7 +252,7 @@
                                     BorderBrush="Transparent"
                                     BorderThickness="1,1,0,1"
                                     Margin="0,0,-2,0"
-                                    Background="{DynamicResource ControlBackgroundBrush}">
+                                    Background="{TemplateBinding Background}">
                                 <TextBox x:Name="PART_EditableTextBox"
                                          HorizontalAlignment="Stretch"
                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"


### PR DESCRIPTION
Currently if you attempt to change the background color of a combobox that has the property `isEditable="true"` only the background of the dropdown arrow will change.

![Bug](https://cloud.githubusercontent.com/assets/5459225/4566653/d9476cf4-4f2a-11e4-9886-d03b8718f9a2.png)

This commit makes sure the property is correctly set.
