### PR TITLE
ShowMessageAsync recieving MaxHeight as optional parameter

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -150,7 +150,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="style">The type of buttons to use.</param>
         /// <param name="settings">Optional settings that override the global metro dialog settings.</param>
         /// <returns>A task promising the result of which button was pressed.</returns>
-        public static Task<MessageDialogResult> ShowMessageAsync(this MetroWindow window, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, MetroDialogSettings settings = null)
+        public static Task<MessageDialogResult> ShowMessageAsync(this MetroWindow window, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, MetroDialogSettings settings = null, int maxHeight = Int32.MaxValue)
         {
             window.Dispatcher.VerifyAccess();
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
@@ -165,6 +165,7 @@ namespace MahApps.Metro.Controls.Dialogs
                             dialog.Message = message;
                             dialog.Title = title;
                             dialog.ButtonStyle = style;
+                            dialog.MaxHeight = maxHeight;
 
                             SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                             dialog.SizeChangedHandler = sizeHandler;

--- a/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
@@ -170,6 +170,7 @@ namespace MahApps.Metro.Controls.Dialogs
         public static readonly DependencyProperty NegativeButtonTextProperty = DependencyProperty.Register("NegativeButtonText", typeof(string), typeof(MessageDialog), new PropertyMetadata("Cancel"));
         public static readonly DependencyProperty FirstAuxiliaryButtonTextProperty = DependencyProperty.Register("FirstAuxiliaryButtonText", typeof(string), typeof(MessageDialog), new PropertyMetadata("Cancel"));
         public static readonly DependencyProperty SecondAuxiliaryButtonTextProperty = DependencyProperty.Register("SecondAuxiliaryButtonText", typeof(string), typeof(MessageDialog), new PropertyMetadata("Cancel"));
+        public static readonly DependencyProperty MaxHeightProperty = DependencyProperty.Register("MaxHeight", typeof(int), typeof(MessageDialog), new PropertyMetadata(default(int)));
         public static readonly DependencyProperty ButtonStyleProperty = DependencyProperty.Register("ButtonStyle", typeof(MessageDialogStyle), typeof(MessageDialog), new PropertyMetadata(MessageDialogStyle.Affirmative, new PropertyChangedCallback((s, e) =>
             {
                 MessageDialog md = (MessageDialog)s;
@@ -262,6 +263,12 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             get { return (string)GetValue(SecondAuxiliaryButtonTextProperty); }
             set { SetValue(SecondAuxiliaryButtonTextProperty, value); }
+        }
+
+        public int MaxHeight
+        {
+            get { return (int)GetValue(MaxHeightProperty); }
+            set { SetValue(MaxHeightProperty, value); }
         }
     }
 

--- a/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
@@ -9,7 +9,7 @@
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
-            <ScrollViewer Grid.Row="0" MaxHeight="50" 
+            <ScrollViewer Grid.Row="0" MaxHeight="{Binding MaxHeight, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" 
                        Margin="0 5 0 0" VerticalScrollBarVisibility="Auto">
                 <TextBlock FontSize="{StaticResource DialogMessageFontSize}"
                            Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"


### PR DESCRIPTION
Currently when a message is too long, bigger than the window, the content of the messsage is lost.
This message has 61 lines and you can only see the first 20 or so.
![image](https://cloud.githubusercontent.com/assets/1263856/4686241/2d682c00-5643-11e4-9189-a5d29961d2c2.png)

With this pull request, if the message is too long, an scrollbar will appear.
![image](https://cloud.githubusercontent.com/assets/1263856/4686267/860aba9e-5643-11e4-8157-921c4370ed7d.png)

If the message is short, it will not appear
![image](https://cloud.githubusercontent.com/assets/1263856/4686276/9a1a2f38-5643-11e4-81cc-b6d647ec2724.png)

Optionally you can pass the parameter MaxHeight to ShowMessageAsync this way, where the number **200** is the MaxHeight.:

```
await _metroWindow.ShowMessageAsync(title, message, style, settings, 200);
```

With this you can have an scrollbar even if the text's size is not bigger than the window's size
![image](https://cloud.githubusercontent.com/assets/1263856/4686303/f873ceb8-5643-11e4-8e24-3597a9a467fb.png)

Fixes #1451 
