### PR TITLE
ControlsHelper split up

### DIFF
--- a/MahApps.Metro/Controls/ControlsHelper.cs
+++ b/MahApps.Metro/Controls/ControlsHelper.cs
@@ -7,123 +7,10 @@ using System.Windows.Media;
 namespace MahApps.Metro.Controls
 {
     /// <summary>
-    /// A helper class that provides various attached properties for the GroupBox, TabItem and MetroTabItem controls.
+    /// A helper class that provides various attached properties for multiple control types.
     /// </summary>
     public static class ControlsHelper
     {
-        public static readonly DependencyProperty GroupBoxHeaderForegroundProperty =
-            DependencyProperty.RegisterAttached("GroupBoxHeaderForeground", typeof(Brush), typeof(ControlsHelper), new UIPropertyMetadata(Brushes.White));
-
-        [AttachedPropertyBrowsableForType(typeof(GroupBox))]
-        public static Brush GetGroupBoxHeaderForeground(UIElement element)
-        {
-            return (Brush)element.GetValue(GroupBoxHeaderForegroundProperty);
-        }
-
-        public static void SetGroupBoxHeaderForeground(UIElement element, Brush value)
-        {
-            element.SetValue(GroupBoxHeaderForegroundProperty, value);
-        }
-
-        /// <summary>
-        /// Defines whether the underline below the <see cref="TabControl"/> is shown or not.
-        /// </summary>
-        public static readonly DependencyProperty IsUnderlinedProperty =
-            DependencyProperty.RegisterAttached("IsUnderlined", typeof(bool), typeof(ControlsHelper), new PropertyMetadata(false));
-
-        [AttachedPropertyBrowsableForType(typeof(TabControl))]
-        public static bool GetIsUnderlined(UIElement element)
-        {
-            return (bool)element.GetValue(IsUnderlinedProperty);
-        }
-
-        public static void SetIsUnderlined(UIElement element, bool value)
-        {
-            element.SetValue(IsUnderlinedProperty, value);
-        }
-
-        public static readonly DependencyProperty HeaderFontSizeProperty =
-            DependencyProperty.RegisterAttached("HeaderFontSize", typeof(double), typeof(ControlsHelper), new FrameworkPropertyMetadata(26.67, HeaderFontSizePropertyChangedCallback){ Inherits = true});
-
-        private static void HeaderFontSizePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
-        {
-            if (e.NewValue is double)
-            {
-                // close button only for MetroTabItem
-                var metroTabItem = dependencyObject as MetroTabItem;
-                if (metroTabItem == null)
-                {
-                    return;
-                }
-
-                if (metroTabItem.closeButton == null)
-                {
-                    metroTabItem.ApplyTemplate();
-                }
-
-                if (metroTabItem.closeButton != null && metroTabItem.contentSite != null)
-                {
-                    // punker76: i don't like this! i think this must be done with xaml.
-                    var fontDpiSize = (double)e.NewValue;
-                    var fontHeight = Math.Ceiling(fontDpiSize * metroTabItem.FontFamily.LineSpacing);
-                    var newMargin = (Math.Round(fontHeight) / 2.8)
-                                    - metroTabItem.Padding.Top - metroTabItem.Padding.Bottom
-                                    - metroTabItem.contentSite.Margin.Top - metroTabItem.contentSite.Margin.Bottom;
-
-                    var previousMargin = metroTabItem.closeButton.Margin;
-                    metroTabItem.newButtonMargin = new Thickness(previousMargin.Left, newMargin, previousMargin.Right, previousMargin.Bottom);
-                    metroTabItem.closeButton.Margin = metroTabItem.newButtonMargin;
-
-                    metroTabItem.closeButton.UpdateLayout();
-                }
-            }
-        }
-
-        [AttachedPropertyBrowsableForType(typeof(MetroTabItem))]
-        [AttachedPropertyBrowsableForType(typeof(TabItem))]
-        [AttachedPropertyBrowsableForType(typeof(GroupBox))]
-        public static double GetHeaderFontSize(UIElement element)
-        {
-            return (double)element.GetValue(HeaderFontSizeProperty);
-        }
-
-        public static void SetHeaderFontSize(UIElement element, double value)
-        {
-            element.SetValue(HeaderFontSizeProperty, value);
-        }
-
-        public static readonly DependencyProperty HeaderFontStretchProperty =
-            DependencyProperty.RegisterAttached("HeaderFontStretch", typeof(FontStretch), typeof(ControlsHelper), new UIPropertyMetadata(FontStretches.Normal));
-
-        [AttachedPropertyBrowsableForType(typeof(MetroTabItem))]
-        [AttachedPropertyBrowsableForType(typeof(TabItem))]
-        [AttachedPropertyBrowsableForType(typeof(GroupBox))]
-        public static FontStretch GetHeaderFontStretch(UIElement element)
-        {
-            return (FontStretch)element.GetValue(HeaderFontStretchProperty);
-        }
-
-        public static void SetHeaderFontStretch(UIElement element, FontStretch value)
-        {
-            element.SetValue(HeaderFontStretchProperty, value);
-        }
-
-        public static readonly DependencyProperty HeaderFontWeightProperty =
-            DependencyProperty.RegisterAttached("HeaderFontWeight", typeof(FontWeight), typeof(ControlsHelper), new UIPropertyMetadata(FontWeights.Normal));
-
-        [AttachedPropertyBrowsableForType(typeof(MetroTabItem))]
-        [AttachedPropertyBrowsableForType(typeof(TabItem))]
-        [AttachedPropertyBrowsableForType(typeof(GroupBox))]
-        public static FontWeight GetHeaderFontWeight(UIElement element)
-        {
-            return (FontWeight)element.GetValue(HeaderFontWeightProperty);
-        }
-
-        public static void SetHeaderFontWeight(UIElement element, FontWeight value)
-        {
-            element.SetValue(HeaderFontWeightProperty, value);
-        }
-
         /// <summary>
         /// This property can be used to set the button width (PART_ClearText) of TextBox, PasswordBox, ComboBox
         /// For multiline TextBox, PasswordBox is this the fallback for the clear text button! so it must set manually!
@@ -135,46 +22,12 @@ namespace MahApps.Metro.Controls
 
         public static double GetButtonWidth(DependencyObject obj)
         {
-            return (double)obj.GetValue(ButtonWidthProperty);
+            return (double) obj.GetValue(ButtonWidthProperty);
         }
 
         public static void SetButtonWidth(DependencyObject obj, double value)
         {
             obj.SetValue(ButtonWidthProperty, value);
-        }
-
-        /// <summary>
-        /// This property can be used to set vertical scrollbar left side from the tabpanel (look at MetroAnimatedSingleRowTabControl)
-        /// </summary>
-        public static readonly DependencyProperty VerticalScrollBarOnLeftSideProperty =
-            DependencyProperty.RegisterAttached("VerticalScrollBarOnLeftSide", typeof(bool), typeof(ControlsHelper),
-                                                new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits));
-
-        public static bool GetVerticalScrollBarOnLeftSide(DependencyObject obj)
-        {
-            return (bool)obj.GetValue(VerticalScrollBarOnLeftSideProperty);
-        }
-
-        public static void SetVerticalScrollBarOnLeftSide(DependencyObject obj, bool value)
-        {
-            obj.SetValue(VerticalScrollBarOnLeftSideProperty, value);
-        }
-
-        /// <summary>
-        /// This property can be used to set the Transition for animated TabControls
-        /// </summary>
-        public static readonly DependencyProperty TransitionProperty =
-            DependencyProperty.RegisterAttached("Transition", typeof(TransitionType), typeof(ControlsHelper),
-                                                new FrameworkPropertyMetadata(TransitionType.Default, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits));
-
-        public static TransitionType GetTransition(DependencyObject obj)
-        {
-            return (TransitionType)obj.GetValue(TransitionProperty);
-        }
-
-        public static void SetTransition(DependencyObject obj, TransitionType value)
-        {
-            obj.SetValue(TransitionProperty, value);
         }
 
         /// <summary>
@@ -184,7 +37,7 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty ContentDirectionProperty =
             DependencyProperty.RegisterAttached("ContentDirection", typeof(FlowDirection), typeof(ControlsHelper),
                                                 new FrameworkPropertyMetadata(FlowDirection.LeftToRight,
-                                                                              //FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits,
+            //FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits,
                                                                               ContentDirectionPropertyChanged));
 
         /// <summary>
@@ -194,7 +47,7 @@ namespace MahApps.Metro.Controls
         [AttachedPropertyBrowsableForType(typeof(ToggleButton))]
         public static FlowDirection GetContentDirection(UIElement element)
         {
-            return (FlowDirection)element.GetValue(ContentDirectionProperty);
+            return (FlowDirection) element.GetValue(ContentDirectionProperty);
         }
 
         public static void SetContentDirection(UIElement element, FlowDirection value)

--- a/MahApps.Metro/Controls/GroupBoxHelper.cs
+++ b/MahApps.Metro/Controls/GroupBoxHelper.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace MahApps.Metro.Controls
+{
+    /// <summary>
+    /// A helper class that provides various attached properties for the GroupBox.
+    /// </summary>
+    public static class GroupBoxHelper
+    {
+        public static readonly DependencyProperty HeaderForegroundProperty =
+            DependencyProperty.RegisterAttached("HeaderForeground", typeof(Brush), typeof(GroupBoxHelper), new UIPropertyMetadata(Brushes.White));
+
+        [AttachedPropertyBrowsableForType(typeof(GroupBox))]
+        public static Brush GetHeaderForeground(UIElement element)
+        {
+            return (Brush) element.GetValue(HeaderForegroundProperty);
+        }
+
+        public static void SetHeaderForeground(UIElement element, Brush value)
+        {
+            element.SetValue(HeaderForegroundProperty, value);
+        }
+    }
+}

--- a/MahApps.Metro/Controls/TabControlHelper.cs
+++ b/MahApps.Metro/Controls/TabControlHelper.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace MahApps.Metro.Controls
+{
+    /// <summary>
+    /// A helper class that provides various attached properties for the TabItem and MetroTabItem controls.
+    /// </summary>
+    public static class TabControlHelper
+    {
+        /// <summary>
+        /// Defines whether the underline below the <see cref="TabControl"/> is shown or not.
+        /// </summary>
+        public static readonly DependencyProperty IsUnderlinedProperty =
+            DependencyProperty.RegisterAttached("IsUnderlined", typeof(bool), typeof(TabControlHelper), new PropertyMetadata(false));
+
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static bool GetIsUnderlined(UIElement element)
+        {
+            return (bool) element.GetValue(IsUnderlinedProperty);
+        }
+
+        public static void SetIsUnderlined(UIElement element, bool value)
+        {
+            element.SetValue(IsUnderlinedProperty, value);
+        }
+
+        public static readonly DependencyProperty HeaderFontSizeProperty =
+            DependencyProperty.RegisterAttached("HeaderFontSize", typeof(double), typeof(TabControlHelper), new FrameworkPropertyMetadata(26.67, HeaderFontSizePropertyChangedCallback) { Inherits = true });
+
+        private static void HeaderFontSizePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is double)
+            {
+                // close button only for MetroTabItem
+                var metroTabItem = dependencyObject as MetroTabItem;
+                if (metroTabItem == null)
+                {
+                    return;
+                }
+
+                if (metroTabItem.closeButton == null)
+                {
+                    metroTabItem.ApplyTemplate();
+                }
+
+                if (metroTabItem.closeButton != null && metroTabItem.contentSite != null)
+                {
+                    // punker76: i don't like this! i think this must be done with xaml.
+                    var fontDpiSize = (double) e.NewValue;
+                    var fontHeight = Math.Ceiling(fontDpiSize * metroTabItem.FontFamily.LineSpacing);
+                    var newMargin = (Math.Round(fontHeight) / 2.8)
+                                    - metroTabItem.Padding.Top - metroTabItem.Padding.Bottom
+                                    - metroTabItem.contentSite.Margin.Top - metroTabItem.contentSite.Margin.Bottom;
+
+                    var previousMargin = metroTabItem.closeButton.Margin;
+                    metroTabItem.newButtonMargin = new Thickness(previousMargin.Left, newMargin, previousMargin.Right, previousMargin.Bottom);
+                    metroTabItem.closeButton.Margin = metroTabItem.newButtonMargin;
+
+                    metroTabItem.closeButton.UpdateLayout();
+                }
+            }
+        }
+
+        [AttachedPropertyBrowsableForType(typeof(MetroTabItem))]
+        [AttachedPropertyBrowsableForType(typeof(TabItem))]
+        [AttachedPropertyBrowsableForType(typeof(GroupBox))]
+        public static double GetHeaderFontSize(UIElement element)
+        {
+            return (double) element.GetValue(HeaderFontSizeProperty);
+        }
+
+        public static void SetHeaderFontSize(UIElement element, double value)
+        {
+            element.SetValue(HeaderFontSizeProperty, value);
+        }
+
+        public static readonly DependencyProperty HeaderFontStretchProperty =
+            DependencyProperty.RegisterAttached("HeaderFontStretch", typeof(FontStretch), typeof(TabControlHelper), new UIPropertyMetadata(FontStretches.Normal));
+
+        [AttachedPropertyBrowsableForType(typeof(MetroTabItem))]
+        [AttachedPropertyBrowsableForType(typeof(TabItem))]
+        [AttachedPropertyBrowsableForType(typeof(GroupBox))]
+        public static FontStretch GetHeaderFontStretch(UIElement element)
+        {
+            return (FontStretch) element.GetValue(HeaderFontStretchProperty);
+        }
+
+        public static void SetHeaderFontStretch(UIElement element, FontStretch value)
+        {
+            element.SetValue(HeaderFontStretchProperty, value);
+        }
+
+        public static readonly DependencyProperty HeaderFontWeightProperty =
+            DependencyProperty.RegisterAttached("HeaderFontWeight", typeof(FontWeight), typeof(TabControlHelper), new UIPropertyMetadata(FontWeights.Normal));
+
+        [AttachedPropertyBrowsableForType(typeof(MetroTabItem))]
+        [AttachedPropertyBrowsableForType(typeof(TabItem))]
+        [AttachedPropertyBrowsableForType(typeof(GroupBox))]
+        public static FontWeight GetHeaderFontWeight(UIElement element)
+        {
+            return (FontWeight) element.GetValue(HeaderFontWeightProperty);
+        }
+
+        public static void SetHeaderFontWeight(UIElement element, FontWeight value)
+        {
+            element.SetValue(HeaderFontWeightProperty, value);
+        }
+
+        /// <summary>
+        /// This property can be used to set vertical scrollbar left side from the tabpanel (look at MetroAnimatedSingleRowTabControl)
+        /// </summary>
+        public static readonly DependencyProperty VerticalScrollBarOnLeftSideProperty =
+            DependencyProperty.RegisterAttached("VerticalScrollBarOnLeftSide", typeof(bool), typeof(TabControlHelper),
+                                                new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits));
+
+        public static bool GetVerticalScrollBarOnLeftSide(DependencyObject obj)
+        {
+            return (bool) obj.GetValue(VerticalScrollBarOnLeftSideProperty);
+        }
+
+        public static void SetVerticalScrollBarOnLeftSide(DependencyObject obj, bool value)
+        {
+            obj.SetValue(VerticalScrollBarOnLeftSideProperty, value);
+        }
+
+        /// <summary>
+        /// This property can be used to set the Transition for animated TabControls
+        /// </summary>
+        public static readonly DependencyProperty TransitionProperty =
+            DependencyProperty.RegisterAttached("Transition", typeof(TransitionType), typeof(TabControlHelper),
+                                                new FrameworkPropertyMetadata(TransitionType.Default, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits));
+
+        public static TransitionType GetTransition(DependencyObject obj)
+        {
+            return (TransitionType) obj.GetValue(TransitionProperty);
+        }
+
+        public static void SetTransition(DependencyObject obj, TransitionType value)
+        {
+            obj.SetValue(TransitionProperty, value);
+        }
+    }
+}

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Controls\GlowWindow.xaml.cs">
       <DependentUpon>GlowWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\GroupBoxHelper.cs" />
     <Compile Include="Controls\MetroAnimatedSingleRowTabControl.cs" />
     <Compile Include="Controls\MetroAnimatedTabControl.cs" />
     <Compile Include="Controls\MetroNavigationWindow.cs" />
@@ -128,6 +129,7 @@
     <Compile Include="Controls\SafeRaise.cs" />
     <Compile Include="Controls\ScrollViewerOffsetMediator.cs" />
     <Compile Include="Controls\SplitButton.cs" />
+    <Compile Include="Controls\TabControlHelper.cs" />
     <Compile Include="Controls\WindowButtonCommands.cs" />
     <Compile Include="Controls\WindowCommandsOverlayBehavior.cs" />
     <Compile Include="Converters\BackgroundToForegroundConverter.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -112,6 +112,7 @@
       <DependentUpon>GlowWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\Dialogs\MessageDialog.cs" />
+    <Compile Include="Controls\GroupBoxHelper.cs" />
     <Compile Include="Controls\LayoutInvalidationCatcher.cs" />
     <Compile Include="Controls\MetroAnimatedSingleRowTabControl.cs" />
     <Compile Include="Controls\MetroAnimatedTabControl.cs" />
@@ -131,6 +132,9 @@
     <Compile Include="Controls\SafeRaise.cs" />
     <Compile Include="Controls\ScrollViewerOffsetMediator.cs" />
     <Compile Include="Controls\SplitButton.cs" />
+    <Compile Include="Controls\TabControlHelper.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Controls\WindowButtonCommands.cs" />
     <Compile Include="Controls\WindowCommands.cs">
       <SubType>Code</SubType>

--- a/MahApps.Metro/Styles/Clean/CleanGroupBox.xaml
+++ b/MahApps.Metro/Styles/Clean/CleanGroupBox.xaml
@@ -5,7 +5,7 @@
     <Style TargetType="GroupBox" 
            x:Key="CleanGroupBoxStyleKey">
         <Setter Property="BorderThickness" Value="0.3" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize"
+        <Setter Property="Controls:TabControlHelper.HeaderFontSize"
                 Value="16" />
         <Setter Property="Template">
             <Setter.Value>
@@ -17,9 +17,9 @@
                         </Grid.RowDefinitions>
 
                         <ContentPresenter Margin="{TemplateBinding Padding}"
-                                          TextElement.FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
-                                          TextElement.FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
-                                          TextElement.FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
+                                          TextElement.FontSize="{TemplateBinding Controls:TabControlHelper.HeaderFontSize}"
+                                          TextElement.FontStretch="{TemplateBinding Controls:TabControlHelper.HeaderFontStretch}"
+                                          TextElement.FontWeight="{TemplateBinding Controls:TabControlHelper.HeaderFontWeight}"
                                           ContentSource="Header"
                                           ContentTemplate="{TemplateBinding HeaderTemplate}"
                                           RecognizesAccessKey="True"

--- a/MahApps.Metro/Styles/Controls.AnimatedSingleRowTabControl.xaml
+++ b/MahApps.Metro/Styles/Controls.AnimatedSingleRowTabControl.xaml
@@ -222,7 +222,7 @@
     </ControlTemplate>
 
     <Style TargetType="{x:Type TabControl}">
-        <Setter Property="Controls:ControlsHelper.Transition"
+        <Setter Property="Controls:TabControlHelper.Transition"
                 Value="Left" />
         <Setter Property="Template">
             <Setter.Value>
@@ -251,7 +251,7 @@
                                       KeyboardNavigation.TabIndex="1" />
                         </ScrollViewer>
                         <Controls:TransitioningContentControl x:Name="ContentPanel"
-                                                              Transition="{TemplateBinding Controls:ControlsHelper.Transition}"
+                                                              Transition="{TemplateBinding Controls:TabControlHelper.Transition}"
                                                               Behaviours:ReloadBehavior.OnSelectedTabChanged="True"
                                                               RestartTransitionOnContentChange="True"
                                                               Grid.Column="0"
@@ -286,7 +286,7 @@
                         </Trigger>
                         <Trigger Property="TabStripPlacement"
                                  Value="Left">
-                            <Setter Property="Controls:ControlsHelper.Transition"
+                            <Setter Property="Controls:TabControlHelper.Transition"
                                     Value="Right" />
                             <Setter Property="Grid.Row"
                                     TargetName="HeaderPanelScroll"

--- a/MahApps.Metro/Styles/Controls.AnimatedTabControl.xaml
+++ b/MahApps.Metro/Styles/Controls.AnimatedTabControl.xaml
@@ -4,7 +4,7 @@
                     xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours">
 
     <Style TargetType="{x:Type TabControl}">
-        <Setter Property="Controls:ControlsHelper.Transition"
+        <Setter Property="Controls:TabControlHelper.Transition"
                 Value="Left" />
         <Setter Property="Background"
                 Value="{x:Null}" />
@@ -42,7 +42,7 @@
                                 Grid.Row="1"
                                 KeyboardNavigation.TabIndex="2"
                                 KeyboardNavigation.TabNavigation="Local">
-                            <Controls:TransitioningContentControl Transition="{TemplateBinding Controls:ControlsHelper.Transition}"
+                            <Controls:TransitioningContentControl Transition="{TemplateBinding Controls:TabControlHelper.Transition}"
                                                                   Behaviours:ReloadBehavior.OnSelectedTabChanged="True"
                                                                   RestartTransitionOnContentChange="True">
                                 <ContentPresenter x:Name="PART_SelectedContentHost"
@@ -73,7 +73,7 @@
                         </Trigger>
                         <Trigger Property="TabStripPlacement"
                                  Value="Left">
-                            <Setter Property="Controls:ControlsHelper.Transition"
+                            <Setter Property="Controls:TabControlHelper.Transition"
                                     Value="Right" />
                             <Setter Property="Grid.Row"
                                     TargetName="HeaderPanel"

--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -330,9 +330,9 @@
                 Value="{DynamicResource AccentColorBrush}" />
         <Setter Property="BorderBrush"
                 Value="{DynamicResource AccentColorBrush}" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize"
+        <Setter Property="Controls:TabControlHelper.HeaderFontSize"
                 Value="{DynamicResource ContentFontSize}" />
-        <Setter Property="Controls:ControlsHelper.GroupBoxHeaderForeground"
+        <Setter Property="Controls:GroupBoxHelper.HeaderForeground"
                 Value="{x:Null}" />
         <Setter Property="HeaderTemplate">
             <Setter.Value>
@@ -348,7 +348,7 @@
                                          RelativeSource="{RelativeSource FindAncestor,
                                                                          AncestorType={x:Type Expander}}" />
                                 <Binding Mode="OneWay"
-                                         Path="(Controls:ControlsHelper.GroupBoxHeaderForeground)"
+                                         Path="(Controls:GroupBoxHelper.HeaderForeground)"
                                          RelativeSource="{RelativeSource FindAncestor,
                                                                          AncestorType={x:Type Expander}}" />
                             </MultiBinding>
@@ -409,9 +409,9 @@
                                                       ContentTemplate="{TemplateBinding HeaderTemplate}"
                                                       ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
                                                       RecognizesAccessKey="True"
-                                                      TextElement.FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
-                                                      TextElement.FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
-                                                      TextElement.FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}" />
+                                                      TextElement.FontSize="{TemplateBinding Controls:TabControlHelper.HeaderFontSize}"
+                                                      TextElement.FontStretch="{TemplateBinding Controls:TabControlHelper.HeaderFontStretch}"
+                                                      TextElement.FontWeight="{TemplateBinding Controls:TabControlHelper.HeaderFontWeight}" />
                                 </DockPanel>
                             </Border>
                             <Border x:Name="ExpandSite"

--- a/MahApps.Metro/Styles/Controls.GroupBox.xaml
+++ b/MahApps.Metro/Styles/Controls.GroupBox.xaml
@@ -17,9 +17,9 @@
                 Value="{DynamicResource AccentColorBrush}" />
         <Setter Property="BorderBrush"
                 Value="{DynamicResource AccentColorBrush}" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize"
+        <Setter Property="Controls:TabControlHelper.HeaderFontSize"
                 Value="{DynamicResource ContentFontSize}" />
-        <Setter Property="Controls:ControlsHelper.GroupBoxHeaderForeground"
+        <Setter Property="Controls:GroupBoxHelper.HeaderForeground"
                 Value="{x:Null}" />
         <Setter Property="HeaderTemplate">
             <Setter.Value>
@@ -31,7 +31,7 @@
                                          Path="Background"
                                          Mode="OneWay" />
                                 <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type GroupBox}}"
-                                         Path="(Controls:ControlsHelper.GroupBoxHeaderForeground)"
+                                         Path="(Controls:GroupBoxHelper.HeaderForeground)"
                                          Mode="OneWay" />
                             </MultiBinding>
                         </TextElement.Foreground>
@@ -52,9 +52,9 @@
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="1">
                             <ContentPresenter Margin="{TemplateBinding Padding}"
-                                              TextElement.FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
-                                              TextElement.FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
-                                              TextElement.FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
+                                              TextElement.FontSize="{TemplateBinding Controls:TabControlHelper.HeaderFontSize}"
+                                              TextElement.FontStretch="{TemplateBinding Controls:TabControlHelper.HeaderFontStretch}"
+                                              TextElement.FontWeight="{TemplateBinding Controls:TabControlHelper.HeaderFontWeight}"
                                               ContentSource="Header"
                                               RecognizesAccessKey="True" />
                         </Border>

--- a/MahApps.Metro/Styles/Controls.Scrollbars.xaml
+++ b/MahApps.Metro/Styles/Controls.Scrollbars.xaml
@@ -572,7 +572,7 @@
 
     <Style x:Key="MetroScrollViewer"
            TargetType="{x:Type ScrollViewer}">
-        <Setter Property="Controls:ControlsHelper.VerticalScrollBarOnLeftSide"
+        <Setter Property="Controls:TabControlHelper.VerticalScrollBarOnLeftSide"
                 Value="False" />
         <Setter Property="Template">
             <Setter.Value>
@@ -621,7 +621,7 @@
                                    ViewportSize="{TemplateBinding ViewportWidth}" />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="Controls:ControlsHelper.VerticalScrollBarOnLeftSide"
+                        <Trigger Property="Controls:TabControlHelper.VerticalScrollBarOnLeftSide"
                                  Value="True">
                             <Setter TargetName="leftColumn"
                                     Property="Width"

--- a/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -156,7 +156,7 @@
         <Setter Property="SnapsToDevicePixels"
                 Value="True" />
         <!-- special property for header font size -->
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize"
+        <Setter Property="Controls:TabControlHelper.HeaderFontSize"
                 Value="{DynamicResource TabItemFontSize}" />
         <Setter Property="Template">
             <Setter.Value>
@@ -174,9 +174,9 @@
                                               Margin="{TemplateBinding Padding}"
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              TextElement.FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
-                                              TextElement.FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
-                                              TextElement.FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
+                                              TextElement.FontSize="{TemplateBinding Controls:TabControlHelper.HeaderFontSize}"
+                                              TextElement.FontStretch="{TemplateBinding Controls:TabControlHelper.HeaderFontStretch}"
+                                              TextElement.FontWeight="{TemplateBinding Controls:TabControlHelper.HeaderFontWeight}"
                                               TextElement.Foreground="{TemplateBinding Foreground}"
                                               ContentSource="Header"
                                               RecognizesAccessKey="True" />

--- a/MahApps.Metro/Themes/MetroAnimatedSingleRowTabControl.xaml
+++ b/MahApps.Metro/Themes/MetroAnimatedSingleRowTabControl.xaml
@@ -9,7 +9,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <Style TargetType="{x:Type Controls:MetroAnimatedSingleRowTabControl}">
-        <Setter Property="Controls:ControlsHelper.Transition"
+        <Setter Property="Controls:TabControlHelper.Transition"
                 Value="Left" />
         <Setter Property="Template">
             <Setter.Value>
@@ -39,7 +39,7 @@
                                       KeyboardNavigation.TabIndex="1" />
                         </ScrollViewer>
                         <Controls:TransitioningContentControl x:Name="ContentPanel"
-                                                              Transition="{TemplateBinding Controls:ControlsHelper.Transition}"
+                                                              Transition="{TemplateBinding Controls:TabControlHelper.Transition}"
                                                               Behaviours:ReloadBehavior.OnSelectedTabChanged="True"
                                                               RestartTransitionOnContentChange="True"
                                                               Grid.Column="0"
@@ -71,7 +71,7 @@
                         </Trigger>
                         <Trigger Property="TabStripPlacement"
                                  Value="Left">
-                            <Setter Property="Controls:ControlsHelper.Transition"
+                            <Setter Property="Controls:TabControlHelper.Transition"
                                     Value="Right" />
                             <Setter Property="Grid.Row"
                                     TargetName="HeaderPanelScroll"
@@ -136,7 +136,7 @@
                             <Setter Property="HorizontalScrollBarVisibility"
                                     TargetName="HeaderPanelScroll"
                                     Value="Disabled" />
-                            <Setter Property="Controls:ControlsHelper.VerticalScrollBarOnLeftSide"
+                            <Setter Property="Controls:TabControlHelper.VerticalScrollBarOnLeftSide"
                                     TargetName="HeaderPanelScroll"
                                     Value="True" />
                         </Trigger>

--- a/MahApps.Metro/Themes/MetroAnimatedTabControl.xaml
+++ b/MahApps.Metro/Themes/MetroAnimatedTabControl.xaml
@@ -4,7 +4,7 @@
                     xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours">
 
     <Style TargetType="{x:Type Controls:MetroAnimatedTabControl}">
-        <Setter Property="Controls:ControlsHelper.Transition"
+        <Setter Property="Controls:TabControlHelper.Transition"
                 Value="Left" />
         <Setter Property="Background"
                 Value="{x:Null}" />
@@ -43,7 +43,7 @@
                                 Grid.Row="1"
                                 KeyboardNavigation.TabIndex="2"
                                 KeyboardNavigation.TabNavigation="Local">
-                            <Controls:TransitioningContentControl Transition="{TemplateBinding Controls:ControlsHelper.Transition}"
+                            <Controls:TransitioningContentControl Transition="{TemplateBinding Controls:TabControlHelper.Transition}"
                                                                   Behaviours:ReloadBehavior.OnSelectedTabChanged="True"
                                                                   RestartTransitionOnContentChange="True">
                                 <ContentPresenter x:Name="PART_SelectedContentHost"
@@ -71,7 +71,7 @@
                         </Trigger>
                         <Trigger Property="TabStripPlacement"
                                  Value="Left">
-                            <Setter Property="Controls:ControlsHelper.Transition"
+                            <Setter Property="Controls:TabControlHelper.Transition"
                                     Value="Right" />
                             <Setter Property="Grid.Row"
                                     TargetName="HeaderPanel"

--- a/MahApps.Metro/Themes/MetroTabItem.xaml
+++ b/MahApps.Metro/Themes/MetroTabItem.xaml
@@ -32,7 +32,7 @@
         <Setter Property="SnapsToDevicePixels"
                 Value="True" />
         <!-- special property for header font size -->
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize"
+        <Setter Property="Controls:TabControlHelper.HeaderFontSize"
                 Value="{DynamicResource TabItemFontSize}" />
         <Setter Property="Template">
             <Setter.Value>
@@ -48,16 +48,16 @@
                                               Margin="2,1,2,1"
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              TextElement.FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
-                                              TextElement.FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
-                                              TextElement.FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
+                                              TextElement.FontSize="{TemplateBinding Controls:TabControlHelper.HeaderFontSize}"
+                                              TextElement.FontStretch="{TemplateBinding Controls:TabControlHelper.HeaderFontStretch}"
+                                              TextElement.FontWeight="{TemplateBinding Controls:TabControlHelper.HeaderFontWeight}"
                                               TextElement.Foreground="{TemplateBinding Foreground}"
                                               ContentSource="Header"
                                               RecognizesAccessKey="True" />
                             <Button x:Name="PART_CloseButton"
                                     Style="{DynamicResource ChromelessButtonStyle}"
                                     Background="{DynamicResource GrayNormalBrush}"
-                                    Width="{TemplateBinding Controls:ControlsHelper.HeaderFontSize, Converter={StaticResource MetroTabItemCloseButtonWidthConverter}}"
+                                    Width="{TemplateBinding Controls:TabControlHelper.HeaderFontSize, Converter={StaticResource MetroTabItemCloseButtonWidthConverter}}"
                                     Height="{Binding RelativeSource={RelativeSource Self}, Path=Width, Mode=OneWay}"
                                     HorizontalAlignment="Right"
                                     VerticalAlignment="Top"

--- a/samples/MetroDemo/ExampleViews/TabControlExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TabControlExamples.xaml
@@ -27,66 +27,66 @@
                            Style="{DynamicResource DescriptionHeaderStyle}" />
                     <TabControl>
                         <TabItem Header="item 1"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="Content" />
                         </TabItem>
                         <TabItem Header="item 2"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="More content" />
                         </TabItem>
                         <TabItem Header="item 3"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="More more content" />
                         </TabItem>
                         <TabItem Header="item 4"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="So much content!" />
                         </TabItem>
                         <TabItem Header="item 5"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="Content!" />
                         </TabItem>
                         <TabItem Header="item 6"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="This is not content (it is)" />
                         </TabItem>
                     </TabControl>
                     <Label Content="Default TabControl with underline"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
-                    <TabControl Controls:ControlsHelper.IsUnderlined="True">
+                    <TabControl Controls:TabControlHelper.IsUnderlined="True">
                         <TabItem Header="item 1"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="Content" />
                         </TabItem>
                         <TabItem Header="item 2"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="More content" />
                         </TabItem>
                         <TabItem Header="item 3"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="More more content" />
                         </TabItem>
                         <TabItem Header="item 4"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="So much content!" />
                         </TabItem>
                         <TabItem Header="item 5"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="Content!" />
                         </TabItem>
                         <TabItem Header="item 6"
-                                 Controls:ControlsHelper.HeaderFontSize="18">
+                                 Controls:TabControlHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="This is not content (it is)" />
                         </TabItem>
@@ -300,7 +300,7 @@
                            Style="{DynamicResource DescriptionHeaderStyle}" />
                     <Controls:MetroTabControl TabItemClosingEvent="MetroTabControl_TabItemClosingEvent">
                         <Controls:MetroTabItem Header="headers"
-                                               Controls:ControlsHelper.HeaderFontSize="20"
+                                               Controls:TabControlHelper.HeaderFontSize="20"
                                                CloseButtonEnabled="True"
                                                CloseTabCommand="{Binding SingleCloseTabCommand}"
                                                CloseTabCommandParameter="{Binding RelativeSource={RelativeSource Self}, Path=Header}">
@@ -308,7 +308,7 @@
                                        Text="you can bind to a command" />
                         </Controls:MetroTabItem>
                         <Controls:MetroTabItem Header="can"
-                                               Controls:ControlsHelper.HeaderFontSize="22"
+                                               Controls:TabControlHelper.HeaderFontSize="22"
                                                CloseButtonEnabled="True"
                                                CloseTabCommand="{Binding NeverCloseTabCommand}"
                                                CloseTabCommandParameter="{Binding RelativeSource={RelativeSource Self}, Path=Header}">
@@ -316,31 +316,31 @@
                                        Text="and ensure the command never closes" />
                         </Controls:MetroTabItem>
                         <Controls:MetroTabItem Header="have"
-                                               Controls:ControlsHelper.HeaderFontSize="24"
+                                               Controls:TabControlHelper.HeaderFontSize="24"
                                                CloseButtonEnabled="True">
                             <TextBlock FontSize="30"
                                        Text="More more content" />
                         </Controls:MetroTabItem>
                         <Controls:MetroTabItem Header="different"
-                                               Controls:ControlsHelper.HeaderFontSize="26"
+                                               Controls:TabControlHelper.HeaderFontSize="26"
                                                CloseButtonEnabled="True">
                             <TextBlock FontSize="30"
                                        Text="So much content!" />
                         </Controls:MetroTabItem>
                         <Controls:MetroTabItem Header="font"
-                                               Controls:ControlsHelper.HeaderFontSize="28"
+                                               Controls:TabControlHelper.HeaderFontSize="28"
                                                CloseButtonEnabled="True">
                             <TextBlock FontSize="30"
                                        Text="Content!" />
                         </Controls:MetroTabItem>
                         <Controls:MetroTabItem Header="sizes"
-                                               Controls:ControlsHelper.HeaderFontSize="30"
+                                               Controls:TabControlHelper.HeaderFontSize="30"
                                                CloseButtonEnabled="True">
                             <TextBlock FontSize="30"
                                        Text="This is not content (it is). This one won't close." />
                         </Controls:MetroTabItem>
                         <Controls:MetroTabItem Header="close button"
-                                               Controls:ControlsHelper.HeaderFontSize="36"
+                                               Controls:TabControlHelper.HeaderFontSize="36"
                                                CloseButtonEnabled="True">
                             <TextBlock FontSize="24"
                                        Text="The size of close button will be changed proportionately considering its header size." />

--- a/samples/MetroDemo/ExampleWindows/CleanWindowDemo.xaml
+++ b/samples/MetroDemo/ExampleWindows/CleanWindowDemo.xaml
@@ -124,7 +124,7 @@
                 <ColumnDefinition Width="300" />
             </Grid.ColumnDefinitions>
 
-            <GroupBox Grid.Column="0" Header="artists" Padding="5" Controls:ControlsHelper.HeaderFontSize="30">
+            <GroupBox Grid.Column="0" Header="artists" Padding="5" Controls:TabControlHelper.HeaderFontSize="30">
                 <ListBox Height="900"/>
             </GroupBox>
 
@@ -138,7 +138,7 @@
                 </Controls:MetroTabItem>
             </Controls:MetroTabControl>
 
-            <GroupBox Grid.Column="2" Header="playlists" Padding="5" Controls:ControlsHelper.HeaderFontSize="30">
+            <GroupBox Grid.Column="2" Header="playlists" Padding="5" Controls:TabControlHelper.HeaderFontSize="30">
                 <StackPanel Orientation="Horizontal">
                     <Button Content="Test"
                             Height="20"


### PR DESCRIPTION
Fixes #1520 

Two new classes `TabControlHelper` and `GroupBoxHelper`.

All properties here mentioned as had been moved had their dependencies moved too with the respective name changes (if applicable).
## GroupBox

`MahApps.Metro.Controls.ControlsHelper.GroupBoxHeaderForegroundProperty`
**moved to**
`MahApps.Metro.Controls.GroupBoxHelper.HeaderForegroundProperty`
## TabControl

`MahApps.Metro.Controls.ControlsHelper.IsUnderlinedProperty`
**moved to**
`MahApps.Metro.Controls.TabControlHelper.IsUnderlinedProperty`

`MahApps.Metro.Controls.ControlsHelper.HeaderFontSizeProperty`
**moved to**
`MahApps.Metro.Controls.TabControlHelper.HeaderFontSizeProperty`

`MahApps.Metro.Controls.ControlsHelper.HeaderFontStretchProperty`
**moved to**
`MahApps.Metro.Controls.TabControlHelper.HeaderFontStretchProperty`

`MahApps.Metro.Controls.ControlsHelper.HeaderFontWeightProperty`
**moved to**
`MahApps.Metro.Controls.TabControlHelper.HeaderFontWeightProperty`

`MahApps.Metro.Controls.ControlsHelper.VerticalScrollBarOnLeftSideProperty`
**moved to**
`MahApps.Metro.Controls.TabControlHelper.VerticalScrollBarOnLeftSideProperty`

`MahApps.Metro.Controls.ControlsHelper.TransitionProperty`
**moved to**
`MahApps.Metro.Controls.TabControlHelper.TransitionProperty`
