### PR TITLE
removing superfluous finalization code, as per Issue #1591

### DIFF
--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -125,14 +125,6 @@ namespace MahApps.Metro.Controls
             HorizontalContentAlignmentProperty.OverrideMetadata(typeof(NumericUpDown), new FrameworkPropertyMetadata(HorizontalAlignment.Right));
         }
 
-        ~NumericUpDown()
-        {
-            if (_valueTextBox != null)
-            {
-                DataObject.RemovePastingHandler(_valueTextBox, OnValueTextBoxPaste);
-            }
-        }
-
         public event RoutedPropertyChangedEventHandler<double?> ValueChanged
         {
             add { AddHandler(ValueChangedEvent, value); }


### PR DESCRIPTION
Removed the finalizer.
See Issue #1591 

In order to support dynamic template switching, event de-registration may be done in `OnApplyTemplate`. (Note: this change does not alter the behavior or support of dynamic template switching).
