### PR TITLE
Message Dialog receiving MinHeight and MaxHeight in MetroDialogSettings

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -330,12 +330,12 @@ namespace MahApps.Metro.Controls.Dialogs
         public string DefaultText { get; set; }
 
         /// <summary>
-        /// Gets/sets the Minimum Height Percent of the Dialog
+        /// Gets/sets the Minimum Height Percent of the Dialog. Default value is 0.25
         /// </summary>
         public double MinHeightPercent { get; set; }
 
         /// <summary>
-        /// Gets/sets the Maximum Height Percent of the Dialog
+        /// Gets/sets the Maximum Height Percent of the Dialog. Default value is 1.0
         /// </summary>
         public double MaxHeightPercent { get; set; }
     }

--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -329,12 +329,12 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <summary>
         /// Gets/sets the Minimum Height Percent of the Dialog
         /// </summary>
-        public int MinHeightPercent { get; set; }
+        public double MinHeightPercent { get; set; }
 
         /// <summary>
         /// Gets/sets the Maximum Height Percent of the Dialog
         /// </summary>
-        public int MaxHeightPercent { get; set; }
+        public double MaxHeightPercent { get; set; }
     }
 
     /// <summary>

--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -41,7 +41,7 @@ namespace MahApps.Metro.Controls.Dialogs
         public static readonly DependencyProperty DialogTopProperty = DependencyProperty.Register("DialogTop", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
         public static readonly DependencyProperty DialogBottomProperty = DependencyProperty.Register("DialogBottom", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
 
-        protected MetroDialogSettings DialogSettings { get; private set; }
+        public MetroDialogSettings DialogSettings { get; private set; }
 
         /// <summary>
         /// Gets/sets the dialog's title.
@@ -289,6 +289,9 @@ namespace MahApps.Metro.Controls.Dialogs
             AnimateShow = AnimateHide = true;
 
             DefaultText = "";
+
+            MinHeightPercent = 0.25;
+            MaxHeightPercent = 1;
         }
 
         /// <summary>

--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -325,6 +325,16 @@ namespace MahApps.Metro.Controls.Dialogs
         /// Gets/sets the default text( just the inputdialog needed)
         /// </summary>
         public string DefaultText { get; set; }
+
+        /// <summary>
+        /// Gets/sets the Minimum Height Percent of the Dialog
+        /// </summary>
+        public int MinHeightPercent { get; set; }
+
+        /// <summary>
+        /// Gets/sets the Maximum Height Percent of the Dialog
+        /// </summary>
+        public int MaxHeightPercent { get; set; }
     }
 
     /// <summary>

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -228,7 +228,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 return ((Task<ProgressDialogController>)window.Dispatcher.Invoke(new Func<Task<ProgressDialogController>>(() =>
                     {
                         //create the dialog control
-                        ProgressDialog dialog = new ProgressDialog(window);
+                        ProgressDialog dialog = new ProgressDialog(window, settings);
                         dialog.Message = message;
                         dialog.Title = title;
                         dialog.IsCancelable = isCancelable;

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -366,14 +366,14 @@ namespace MahApps.Metro.Controls.Dialogs
         private static SizeChangedEventHandler SetupAndOpenDialog(MetroWindow window, BaseMetroDialog dialog)
         {
             dialog.SetValue(Panel.ZIndexProperty, (int)window.overlayBox.GetValue(Panel.ZIndexProperty) + 1);
-            dialog.MinHeight = window.ActualHeight / 4.0;
-            dialog.MaxHeight = window.ActualHeight;
+            dialog.MinHeight = window.ActualHeight * window.MetroDialogOptions.MinHeightPercent;
+            dialog.MaxHeight = window.ActualHeight * window.MetroDialogOptions.MaxHeightPercent;
 
             SizeChangedEventHandler sizeHandler = null; //an event handler for auto resizing an open dialog.
             sizeHandler = new SizeChangedEventHandler((sender, args) =>
             {
-                dialog.MinHeight = window.ActualHeight / 4.0;
-                dialog.MaxHeight = window.ActualHeight;
+                dialog.MinHeight = window.ActualHeight * window.MetroDialogOptions.MinHeightPercent;
+                dialog.MaxHeight = window.ActualHeight * window.MetroDialogOptions.MaxHeightPercent;
             });
 
             window.SizeChanged += sizeHandler;

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -366,14 +366,14 @@ namespace MahApps.Metro.Controls.Dialogs
         private static SizeChangedEventHandler SetupAndOpenDialog(MetroWindow window, BaseMetroDialog dialog)
         {
             dialog.SetValue(Panel.ZIndexProperty, (int)window.overlayBox.GetValue(Panel.ZIndexProperty) + 1);
-            dialog.MinHeight = window.ActualHeight * window.MetroDialogOptions.MinHeightPercent;
-            dialog.MaxHeight = window.ActualHeight * window.MetroDialogOptions.MaxHeightPercent;
+            dialog.MinHeight = window.ActualHeight * dialog.DialogSettings.MinHeightPercent;
+            dialog.MaxHeight = window.ActualHeight * dialog.DialogSettings.MaxHeightPercent;
 
             SizeChangedEventHandler sizeHandler = null; //an event handler for auto resizing an open dialog.
             sizeHandler = new SizeChangedEventHandler((sender, args) =>
             {
-                dialog.MinHeight = window.ActualHeight * window.MetroDialogOptions.MinHeightPercent;
-                dialog.MaxHeight = window.ActualHeight * window.MetroDialogOptions.MaxHeightPercent;
+                dialog.MinHeight = window.ActualHeight * dialog.DialogSettings.MinHeightPercent;
+                dialog.MaxHeight = window.ActualHeight * dialog.DialogSettings.MaxHeightPercent;
             });
 
             window.SizeChanged += sizeHandler;

--- a/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
@@ -9,13 +9,12 @@
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
-            <TextBlock Grid.Row="0"
-                       Margin="0 5 0 0"
-                       FontSize="{StaticResource DialogMessageFontSize}"
+            <ScrollViewer Margin="0 5 0 0" VerticalScrollBarVisibility="Auto" Grid.Row="0">
+                <TextBlock FontSize="{StaticResource DialogMessageFontSize}"
                        Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                        TextWrapping="Wrap"
                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
-
+            </ScrollViewer>
             <StackPanel Grid.Row="1"
                         Orientation="Horizontal"
                         HorizontalAlignment="Right"


### PR DESCRIPTION
Currently when a message is too long, bigger than the window, the content of the messsage is lost.
This message has 61 lines and you can only see the first 20 or so.
![image](https://cloud.githubusercontent.com/assets/1263856/4686241/2d682c00-5643-11e4-9189-a5d29961d2c2.png)

With this pull request, if the message is too long, an scrollbar will appear.
![image](https://cloud.githubusercontent.com/assets/1263856/4686267/860aba9e-5643-11e4-8157-921c4370ed7d.png)

If the message is short, it will not appear
![image](https://cloud.githubusercontent.com/assets/1263856/4686276/9a1a2f38-5643-11e4-81cc-b6d647ec2724.png)

Optionally you can pass MinHeightPercent and MaxHeightPercent as parameters of **MetroDialogSettings**:
```
var settings = new MetroDialogSettings
            {
                ColorScheme = MetroDialogColorScheme.Theme,
                AnimateShow = false,
                AnimateHide = false,
                MinHeightPercent = 0.25,
                MaxHeightPercent = 0.75
            };

var result = await _metroWindow.ShowMessageAsync("Title", "Message", style, settings);
```

With this you can have an scrollbar even if the text's size is not bigger than the window's size. 
Min and Max values are received as percents of the Windows Size instead of Pixels
![image](https://cloud.githubusercontent.com/assets/1263856/4709094/ef320184-589c-11e4-9c49-c4168a8a310f.png)

Fixes #1451 