### PR TITLE
GlowWindow closing fix

### DIFF
--- a/MahApps.Metro/Controls/GlowWindow.xaml.cs
+++ b/MahApps.Metro/Controls/GlowWindow.xaml.cs
@@ -31,6 +31,7 @@ namespace MahApps.Metro.Controls
 
             this.IsGlowing = true;
             this.AllowsTransparency = true;
+            this.Closing += (sender, e) => e.Cancel = !closing;
 
             this.Owner = owner;
             glow.Visibility = Visibility.Collapsed;


### PR DESCRIPTION
I'm currently working on an application where a user needs to login. After the login, a user can open several windows. When a user logs off, all these child windows need to be closed. This is done using `Application.Current.Windows`. However, all the GlowWindows are also part of this list and are closed, causing errors on the following GlowWindow.Update() call.

This can be fixed by only allowing a GlowWindow to be closed when its owner has been closed.
