### PR TITLE
Metro frame style

### DIFF
--- a/MahApps.Metro/Controls/MetroWindowNavigationHelpers.cs
+++ b/MahApps.Metro/Controls/MetroWindowNavigationHelpers.cs
@@ -48,7 +48,7 @@ namespace MahApps.Metro.Controls
             Application.Current.Navigated += navigated;
         }
 
-#if !NET_4
+#if NET4_5
     /// <summary>
     ///     Provides an oppurtunity to execute an asynchronous action when a content is being navigated to.
     /// </summary>

--- a/MahApps.Metro/Controls/MetroWindowNavigationHelpers.cs
+++ b/MahApps.Metro/Controls/MetroWindowNavigationHelpers.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Navigation;
+
+namespace MahApps.Metro.Controls
+{
+    /// <summary>
+    ///     Helper methods related to navigation.
+    /// </summary>
+    public static class MetroWindowNavigationHelpers
+    {
+        /* NOTE : these members have not been put in MetroWindowHelpers
+         * because we need a public class so that users can consume them. */
+
+        /// <summary>
+        ///     Gets if the specified object is being navigated to.
+        /// </summary>
+        /// <param name="o"></param>
+        /// <param name="e"></param>
+        /// <returns></returns>
+        private static bool IsNavigatedTo(object o, NavigationEventArgs e)
+        {
+            if (o == null) throw new ArgumentNullException("o");
+            if (e == null) throw new ArgumentNullException("e");
+            return e.Content != null && ReferenceEquals(e.Content, o);
+        }
+
+        /// <summary>
+        ///     Provides an oppurtunity to execute an action when a content is being navigated to.
+        /// </summary>
+        /// <param name="content">Content object being navigated to.</param>
+        /// <param name="action">Action to execute.</param>
+        public static void OnNavigated(this object content, Action<NavigationEventArgs> action)
+        {
+            if (content == null) throw new ArgumentNullException("content");
+            if (action == null) throw new ArgumentNullException("action");
+            NavigatedEventHandler navigated = null;
+            navigated = (sender, e) =>
+            {
+                if (IsNavigatedTo(content, e))
+                {
+                    action(e);
+                }
+
+                Application.Current.Navigated -= navigated;
+            };
+            Application.Current.Navigated += navigated;
+        }
+
+#if NET4_5
+    /// <summary>
+    ///     Provides an oppurtunity to execute an asynchronous action when a content is being navigated to.
+    /// </summary>
+    /// <param name="content">Content object being navigated to.</param>
+    /// <param name="function">Asynchronous action to execute.</param>
+        public static void OnNavigated(this object content, Func<NavigationEventArgs, Task> function)
+        {
+            if (content == null) throw new ArgumentNullException("content");
+            if (function == null) throw new ArgumentNullException("function");
+            NavigatedEventHandler navigated = null;
+            navigated = async (sender, e) =>
+            {
+                if (IsNavigatedTo(content, e))
+                {
+                    await function(e);
+                }
+
+                Application.Current.Navigated -= navigated;
+            };
+            Application.Current.Navigated += navigated;
+        }
+#endif
+    }
+}

--- a/MahApps.Metro/Controls/MetroWindowNavigationHelpers.cs
+++ b/MahApps.Metro/Controls/MetroWindowNavigationHelpers.cs
@@ -48,7 +48,7 @@ namespace MahApps.Metro.Controls
             Application.Current.Navigated += navigated;
         }
 
-#if NET4_5
+#if !NET_4
     /// <summary>
     ///     Provides an oppurtunity to execute an asynchronous action when a content is being navigated to.
     /// </summary>

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Controls\MetroTabControl.cs" />
     <Compile Include="Controls\MetroTabItem.cs" />
     <Compile Include="Controls\MetroWindowHelpers.cs" />
+    <Compile Include="Controls\MetroWindowNavigationHelpers.cs" />
     <Compile Include="Controls\NumericUpDown.cs" />
     <Compile Include="Controls\NumericUpDownChangedRoutedEventArgs.cs" />
     <Compile Include="Controls\NumericUpDownChangedRoutedEventHandler.cs" />

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -341,6 +341,11 @@
       <SubType>Designer</SubType>
       <DependentUpon>Controls.xaml</DependentUpon>
     </Page>
+    <Page Include="Styles\Controls.Frame.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <DependentUpon>Controls.xaml</DependentUpon>
+    </Page>
     <Page Include="Styles\Controls.GroupBox.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Controls\MetroTabControl.cs" />
     <Compile Include="Controls\MetroTabItem.cs" />
     <Compile Include="Controls\MetroWindowHelpers.cs" />
+    <Compile Include="Controls\MetroWindowNavigationHelpers.cs" />
     <Compile Include="Controls\NumericUpDown.cs" />
     <Compile Include="Controls\NumericUpDownChangedRoutedEventArgs.cs" />
     <Compile Include="Controls\NumericUpDownChangedRoutedEventHandler.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -334,6 +334,11 @@
       <SubType>Designer</SubType>
       <DependentUpon>Controls.xaml</DependentUpon>
     </Page>
+    <Page Include="Styles\Controls.Frame.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <DependentUpon>Controls.xaml</DependentUpon>
+    </Page>
     <Page Include="Styles\Controls.GroupBox.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/MahApps.Metro/Styles/Controls.Frame.xaml
+++ b/MahApps.Metro/Styles/Controls.Frame.xaml
@@ -1,0 +1,155 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style x:Key="MetroFrame" TargetType="{x:Type Frame}">
+        <!--  NOTE: original style taken from MetroNavigationWindow and adjusted as needed  -->
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Frame}">
+                    <!--  NOTE: border taken from original Frame template  -->
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Padding="{TemplateBinding Padding}">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+
+                            <StackPanel x:Name="PART_Navigation"
+                                        Grid.Row="0"
+                                        Orientation="Horizontal">
+                                <Button x:Name="PART_BackButton"
+                                        Width="40"
+                                        Height="40"
+                                        VerticalAlignment="Bottom"
+                                        Command="NavigationCommands.BrowseBack"
+                                        DockPanel.Dock="Left"
+                                        FontFamily="Segoe UI Symbol"
+                                        FontSize="16"
+                                        Style="{DynamicResource MetroCircleButtonStyle}"
+                                        Visibility="Hidden">
+                                    <Button.LayoutTransform>
+                                        <ScaleTransform ScaleX="-1" />
+                                    </Button.LayoutTransform>
+                                    <Rectangle Width="20" Height="15">
+                                        <Rectangle.Fill>
+                                            <VisualBrush Stretch="Fill">
+                                                <VisualBrush.Visual>
+                                                    <Canvas Width="48"
+                                                            Height="48"
+                                                            Clip="F1 M 0,0L 48,0L 48,48L 0,48L 0,0"
+                                                            UseLayoutRounding="False">
+                                                        <Path Canvas.Left="12"
+                                                              Canvas.Top="15"
+                                                              Width="25"
+                                                              Height="18"
+                                                              Data="F1 M 12,22L 12,26L 28.25,26L 21,33L 27.5,33L 37,24L 27.5,15L 21,15L 28.25,22L 12,22 Z "
+                                                              Fill="{DynamicResource BlackBrush}"
+                                                              Stretch="Fill" />
+                                                    </Canvas>
+                                                </VisualBrush.Visual>
+                                            </VisualBrush>
+                                        </Rectangle.Fill>
+                                    </Rectangle>
+                                </Button>
+                                <Label x:Name="PART_Title"
+                                       Margin="0 5 0 0"
+                                       Content="{Binding Content.(Page.Title),
+                                                         ElementName=PART_FrameCP}"
+                                       FontSize="25" />
+                                <Button x:Name="PART_ForwardButton"
+                                        Width="40"
+                                        Height="40"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Bottom"
+                                        Command="NavigationCommands.BrowseForward"
+                                        DockPanel.Dock="Right"
+                                        FontFamily="Segoe UI Symbol"
+                                        FontSize="16"
+                                        Style="{DynamicResource MetroCircleButtonStyle}"
+                                        Visibility="Collapsed">
+                                    <Rectangle Width="20" Height="15">
+                                        <Rectangle.Fill>
+                                            <VisualBrush Stretch="Fill">
+                                                <VisualBrush.Visual>
+                                                    <Canvas Width="48"
+                                                            Height="48"
+                                                            Clip="F1 M 0,0L 48,0L 48,48L 0,48L 0,0"
+                                                            UseLayoutRounding="False">
+                                                        <Path Canvas.Left="12"
+                                                              Canvas.Top="15"
+                                                              Width="25"
+                                                              Height="18"
+                                                              Data="F1 M 12,22L 12,26L 28.25,26L 21,33L 27.5,33L 37,24L 27.5,15L 21,15L 28.25,22L 12,22 Z "
+                                                              Fill="{DynamicResource BlackBrush}"
+                                                              Stretch="Fill" />
+                                                    </Canvas>
+                                                </VisualBrush.Visual>
+                                            </VisualBrush>
+                                        </Rectangle.Fill>
+                                    </Rectangle>
+                                </Button>
+                            </StackPanel>
+
+                            <ContentPresenter x:Name="PART_FrameCP"
+                                              Grid.Row="1"
+                                              Margin="3,0,3,0" />
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="CanGoBack" Value="True">
+                            <Setter TargetName="PART_BackButton" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="CanGoBack" Value="False">
+                            <Setter TargetName="PART_BackButton" Property="Visibility" Value="Hidden" />
+                        </Trigger>
+                        <Trigger Property="CanGoForward" Value="True">
+                            <Setter TargetName="PART_ForwardButton" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="CanGoForward" Value="False">
+                            <Setter TargetName="PART_ForwardButton" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="NavigationUIVisibility" Value="Visible">
+                            <Setter TargetName="PART_Navigation" Property="Visibility" Value="Visible" />
+                        </Trigger>
+                        <Trigger Property="NavigationUIVisibility" Value="Hidden">
+                            <Setter TargetName="PART_Navigation" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <!--
+                            NOTE NavigationUIVisibility-Automatic triggers below are disabled
+                            because we always want to see page title even if it should be collapsed.
+                            It could be further enhanced by checking whether title is null and collapse if so.
+                        -->
+                        <!--
+                            <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                            <Condition Property="NavigationUIVisibility" Value="Automatic" />
+                            <Condition Property="CanGoBack" Value="False" />
+                            <Condition Property="CanGoForward" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_Navigation" Property="Visibility" Value="Collapsed" />
+                            </MultiTrigger>
+                            <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                            <Condition Property="NavigationUIVisibility" Value="Automatic" />
+                            <Condition Property="CanGoBack" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_Navigation" Property="Visibility" Value="Visible" />
+                            </MultiTrigger>
+                            
+                            <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                            <Condition Property="NavigationUIVisibility" Value="Automatic" />
+                            <Condition Property="CanGoForward" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_Navigation" Property="Visibility" Value="Visible" />
+                            </MultiTrigger>
+                        -->
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.xaml
+++ b/MahApps.Metro/Styles/Controls.xaml
@@ -18,6 +18,7 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.DatePicker.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.DataGrid.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Expander.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Frame.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.GroupBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.ListBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.PasswordBox.xaml" />
@@ -61,6 +62,7 @@
     <Style TargetType="Menu" BasedOn="{StaticResource MetroMenu}" />
     <Style TargetType="ContextMenu" BasedOn="{StaticResource MetroContextMenu}" />
     <Style TargetType="Expander" BasedOn="{StaticResource MetroExpander}" />
+    <Style TargetType="Frame" BasedOn="{StaticResource MetroFrame}" />
     <Style TargetType="GroupBox" BasedOn="{StaticResource MetroGroupBox}" />
     <Style TargetType="ListBox" BasedOn="{StaticResource MetroListBox}" />
     <Style TargetType="ListBoxItem" BasedOn="{StaticResource MetroListBoxItem}" />

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -189,17 +189,46 @@ namespace MetroDemo
 
         }
 
-        private void LaunchNavigationDemo(object sender, RoutedEventArgs e)
+        private async void LaunchNavigationDemo(object sender, RoutedEventArgs e)
         {
-            var navWin = new MetroNavigationWindow();
-            navWin.Title = "Navigation Demo";
+            MetroDialogOptions.ColorScheme = UseAccentForDialogsMenuItem.IsChecked ? MetroDialogColorScheme.Accented : MetroDialogColorScheme.Theme;
+            var mySettings = new MetroDialogSettings()
+            {
+                AffirmativeButtonText = "MetroNavigationWindow",
+                NegativeButtonText = "MetroWindow + Frame",
+                FirstAuxiliaryButtonText = "Cancel",
+                ColorScheme = UseAccentForDialogsMenuItem.IsChecked ? MetroDialogColorScheme.Accented : MetroDialogColorScheme.Theme
+            };
 
-            //uncomment the next two lines if you want the clean style.
-            //navWin.Resources.MergedDictionaries.Add(new ResourceDictionary() { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Clean/CleanWindow.xaml", UriKind.Absolute) });
-            //navWin.SetResourceReference(StyleProperty, "CleanWindowStyleKey");
+            MessageDialogResult result = await this.ShowMessageAsync("Navigation demo", "Choose a navigation demo: ",
+                MessageDialogStyle.AffirmativeAndNegativeAndSingleAuxiliary, mySettings);
+            switch (result)
+            {
+                case MessageDialogResult.Negative:
+                    var frameWin = new Navigation.NavigationFrameWindow();
+                    frameWin.Title = "Navigation Demo (MetroWindow + Frame)";
+                    frameWin.NavigateTo(new Navigation.HomePage());
+                    frameWin.Show();
+                    break;
+                case MessageDialogResult.Affirmative:
+                    var navWin = new MetroNavigationWindow();
+                    navWin.Title = "Navigation Demo (MetroNavigationWindow)";
 
-            navWin.Show();
-            navWin.Navigate(new Navigation.HomePage());
+                    //uncomment the next two lines if you want the clean style.
+                    //navWin.Resources.MergedDictionaries.Add(new ResourceDictionary() { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Clean/CleanWindow.xaml", UriKind.Absolute) });
+                    //navWin.SetResourceReference(StyleProperty, "CleanWindowStyleKey");
+
+                    navWin.Show();
+                    navWin.Navigate(new Navigation.HomePage());
+                    break;
+                case MessageDialogResult.FirstAuxiliary:
+                    // canceled
+                    break;
+                case MessageDialogResult.SecondAuxiliary:
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
 
         private async void MetroWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)

--- a/samples/MetroDemo/MetroDemo.NET45.csproj
+++ b/samples/MetroDemo/MetroDemo.NET45.csproj
@@ -234,6 +234,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Navigation\NavigationFrameWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Properties\DesignTimeResources.xaml" Condition="'$(DesignTime)'=='true' OR ('$(SolutionPath)'!='' AND Exists('$(SolutionPath)') AND '$(BuildingInsideVisualStudio)'!='true' AND '$(BuildingInsideExpressionBlend)'!='true')">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -241,6 +245,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Navigation\NavigationFrameWindow.xaml.cs">
+      <DependentUpon>NavigationFrameWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/samples/MetroDemo/MetroDemo.csproj
+++ b/samples/MetroDemo/MetroDemo.csproj
@@ -159,6 +159,9 @@
     <Compile Include="Navigation\InterestingPage.xaml.cs">
       <DependentUpon>InterestingPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Navigation\NavigationFrameWindow.xaml.cs">
+      <DependentUpon>NavigationFrameWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ExampleWindows\VSDemo.xaml.cs">
       <DependentUpon>VSDemo.xaml</DependentUpon>
     </Compile>
@@ -239,6 +242,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Navigation\InterestingPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Navigation\NavigationFrameWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/samples/MetroDemo/Navigation/HomePage.xaml.cs
+++ b/samples/MetroDemo/Navigation/HomePage.xaml.cs
@@ -23,7 +23,7 @@ namespace MetroDemo.Navigation
                 Console.WriteLine(format);
             });
 
-#if NET_4_5
+#if NET4_5
             // Example of an asynchronous operation when OnNavigated to here.
             this.OnNavigated(async e =>
             {

--- a/samples/MetroDemo/Navigation/HomePage.xaml.cs
+++ b/samples/MetroDemo/Navigation/HomePage.xaml.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Navigation;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Controls.Dialogs;
 
@@ -17,19 +14,18 @@ namespace MetroDemo.Navigation
         {
             InitializeComponent();
 
-
             // Example of a synchronous operation when OnNavigated to here.
-            OnNavigated(this, e =>
+            this.OnNavigated(e =>
             {
                 // Print some text on the console
-                string format = string.Format("MetroWindow.OnNavigated example, extra data received: {0}",
+                string format = String.Format("MetroWindow.OnNavigated example, extra data received: '{0}'",
                     e.ExtraData);
                 Console.WriteLine(format);
             });
 
 #if NET_4_5
             // Example of an asynchronous operation when OnNavigated to here.
-            OnNavigated(this, async e =>
+            this.OnNavigated(async e =>
             {
                 // Show a message dialog to the user
                 var frame = (Frame) e.Navigator;
@@ -37,70 +33,10 @@ namespace MetroDemo.Navigation
                 if (window != null)
                 {
                     string message = String.Format("Extra data received: {0}", e.ExtraData);
-                    await window.ShowMessageAsync("MetroWindow.OnNavigated async example", message);
+                    await window.ShowMessageAsync("MetroWindow.OnNavigated async action example", message);
                 }
             });
 #endif
         }
-
-
-        /// <summary>
-        ///     Gets if the specified object is being navigated to.
-        /// </summary>
-        /// <param name="o"></param>
-        /// <param name="e"></param>
-        /// <returns></returns>
-        private static bool IsNavigatedTo(object o, NavigationEventArgs e)
-        {
-            if (o == null) throw new ArgumentNullException("o");
-            if (e == null) throw new ArgumentNullException("e");
-            return e.Content != null && Equals(e.Content, o);
-        }
-
-        /// <summary>
-        ///     Provides an oppurtunity to execute an action when a content is being navigated to.
-        /// </summary>
-        /// <param name="content">Content object being navigated to.</param>
-        /// <param name="action">Action to execute.</param>
-        public static void OnNavigated(object content, Action<NavigationEventArgs> action)
-        {
-            if (content == null) throw new ArgumentNullException("content");
-            if (action == null) throw new ArgumentNullException("action");
-            NavigatedEventHandler navigated = null;
-            navigated = (sender, e) =>
-            {
-                if (IsNavigatedTo(content, e))
-                {
-                    action(e);
-                }
-
-                Application.Current.Navigated -= navigated;
-            };
-            Application.Current.Navigated += navigated;
-        }
-
-#if NET_4_5
-        /// <summary>
-        ///     Provides an oppurtunity to execute an asynchronous action when a content is being navigated to.
-        /// </summary>
-        /// <param name="content">Content object being navigated to.</param>
-        /// <param name="function">Asynchronous action to execute.</param>
-        public static void OnNavigated(object content, Func<NavigationEventArgs, Task> function)
-        {
-            if (content == null) throw new ArgumentNullException("content");
-            if (function == null) throw new ArgumentNullException("function");
-            NavigatedEventHandler navigated = null;
-            navigated = async (sender, e) =>
-            {
-                if (IsNavigatedTo(content, e))
-                {
-                    await function(e);
-                }
-
-                Application.Current.Navigated -= navigated;
-            };
-            Application.Current.Navigated += navigated;
-        }
-#endif
     }
 }

--- a/samples/MetroDemo/Navigation/HomePage.xaml.cs
+++ b/samples/MetroDemo/Navigation/HomePage.xaml.cs
@@ -6,7 +6,7 @@ using MahApps.Metro.Controls.Dialogs;
 namespace MetroDemo.Navigation
 {
     /// <summary>
-    /// Interaction logic for HomePage.xaml
+    ///     Interaction logic for HomePage.xaml
     /// </summary>
     public partial class HomePage : Page
     {
@@ -28,12 +28,20 @@ namespace MetroDemo.Navigation
             this.OnNavigated(async e =>
             {
                 // Show a message dialog to the user
-                var frame = (Frame) e.Navigator;
+                var frame = (Frame)e.Navigator;
                 var window = frame.TryFindParent<MetroWindow>();
                 if (window != null)
                 {
-                    string message = String.Format("Extra data received: {0}", e.ExtraData);
-                    await window.ShowMessageAsync("MetroWindow.OnNavigated async action example", message);
+                    if (window is MetroNavigationWindow)
+                    {
+                        // NOTE : actually OnNavigated is useful only for MetroWindow so
+                        // we do not show this example for MetroNavigationWindow 
+                    }
+                    else
+                    {
+                        string message = String.Format("Extra data received: {0}", e.ExtraData);
+                        await window.ShowMessageAsync("MetroWindow.OnNavigated async action example", message);
+                    }
                 }
             });
 #endif

--- a/samples/MetroDemo/Navigation/HomePage.xaml.cs
+++ b/samples/MetroDemo/Navigation/HomePage.xaml.cs
@@ -1,16 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
-using System.Windows.Shapes;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Controls.Dialogs;
 
 namespace MetroDemo.Navigation
 {
@@ -22,6 +16,91 @@ namespace MetroDemo.Navigation
         public HomePage()
         {
             InitializeComponent();
+
+
+            // Example of a synchronous operation when OnNavigated to here.
+            OnNavigated(this, e =>
+            {
+                // Print some text on the console
+                string format = string.Format("MetroWindow.OnNavigated example, extra data received: {0}",
+                    e.ExtraData);
+                Console.WriteLine(format);
+            });
+
+#if NET_4_5
+            // Example of an asynchronous operation when OnNavigated to here.
+            OnNavigated(this, async e =>
+            {
+                // Show a message dialog to the user
+                var frame = (Frame) e.Navigator;
+                var window = frame.TryFindParent<MetroWindow>();
+                if (window != null)
+                {
+                    string message = String.Format("Extra data received: {0}", e.ExtraData);
+                    await window.ShowMessageAsync("MetroWindow.OnNavigated async example", message);
+                }
+            });
+#endif
         }
+
+
+        /// <summary>
+        ///     Gets if the specified object is being navigated to.
+        /// </summary>
+        /// <param name="o"></param>
+        /// <param name="e"></param>
+        /// <returns></returns>
+        private static bool IsNavigatedTo(object o, NavigationEventArgs e)
+        {
+            if (o == null) throw new ArgumentNullException("o");
+            if (e == null) throw new ArgumentNullException("e");
+            return e.Content != null && Equals(e.Content, o);
+        }
+
+        /// <summary>
+        ///     Provides an oppurtunity to execute an action when a content is being navigated to.
+        /// </summary>
+        /// <param name="content">Content object being navigated to.</param>
+        /// <param name="action">Action to execute.</param>
+        public static void OnNavigated(object content, Action<NavigationEventArgs> action)
+        {
+            if (content == null) throw new ArgumentNullException("content");
+            if (action == null) throw new ArgumentNullException("action");
+            NavigatedEventHandler navigated = null;
+            navigated = (sender, e) =>
+            {
+                if (IsNavigatedTo(content, e))
+                {
+                    action(e);
+                }
+
+                Application.Current.Navigated -= navigated;
+            };
+            Application.Current.Navigated += navigated;
+        }
+
+#if NET_4_5
+        /// <summary>
+        ///     Provides an oppurtunity to execute an asynchronous action when a content is being navigated to.
+        /// </summary>
+        /// <param name="content">Content object being navigated to.</param>
+        /// <param name="function">Asynchronous action to execute.</param>
+        public static void OnNavigated(object content, Func<NavigationEventArgs, Task> function)
+        {
+            if (content == null) throw new ArgumentNullException("content");
+            if (function == null) throw new ArgumentNullException("function");
+            NavigatedEventHandler navigated = null;
+            navigated = async (sender, e) =>
+            {
+                if (IsNavigatedTo(content, e))
+                {
+                    await function(e);
+                }
+
+                Application.Current.Navigated -= navigated;
+            };
+            Application.Current.Navigated += navigated;
+        }
+#endif
     }
 }

--- a/samples/MetroDemo/Navigation/NavigationFrameWindow.xaml
+++ b/samples/MetroDemo/Navigation/NavigationFrameWindow.xaml
@@ -1,0 +1,9 @@
+﻿<controls:MetroWindow x:Class="MetroDemo.Navigation.NavigationFrameWindow"
+                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                      xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
+                      Title="NavigationFrameWindow">
+    <Grid>
+        <Frame x:Name="Frame1" />
+    </Grid>
+</controls:MetroWindow>

--- a/samples/MetroDemo/Navigation/NavigationFrameWindow.xaml.cs
+++ b/samples/MetroDemo/Navigation/NavigationFrameWindow.xaml.cs
@@ -1,0 +1,17 @@
+﻿using MahApps.Metro.Controls;
+
+namespace MetroDemo.Navigation
+{
+    public partial class NavigationFrameWindow : MetroWindow
+    {
+        public NavigationFrameWindow()
+        {
+            InitializeComponent();
+        }
+
+        public void NavigateTo(object o)
+        {
+            Frame1.Navigate(o);
+        }
+    }
+}


### PR DESCRIPTION
**Description**

Allows users to use a `MetroWindow` + a `Frame` against a `MetroNavigationWindow` which cannot be instantiated in XAML (bit annoying but there's no fix : http://support.microsoft.com/kb/957231). The style has been taken from the one in `MetroNavigationWindow`, it's a 1:1 replica.

Now since `MetroWindow` is based on `Window` it does not receive navigation events, I've added an extension method that offers this feature, currently for OnNavigated and later for other types of navigations events.

Demo project has been updated to show the functionality: https://github.com/aybe/MahApps.Metro/blob/master/samples/MetroDemo/Navigation/HomePage.xaml.cs#L18
