### PR TITLE
Double focus in NumericUpDown control

### DIFF
--- a/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -40,6 +40,8 @@
                 Value="{DynamicResource ControlBackgroundBrush}" />
         <Setter Property="Validation.ErrorTemplate"
                 Value="{DynamicResource ValidationErrorTemplate}" />
+        <Setter Property="Focusable"
+                Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Controls:NumericUpDown}">


### PR DESCRIPTION
If you use the keyboard to navigate through the controls, `NumericUpDown` will receice the focus twice: first the entire control, and the second focus goes to the actual text box. I fixed it by applying `Focusable="false"` in `NumericUpDown`'s control template.
