### PR TITLE
apply SnapsToDevicePixels="true" to NumericUpDown

### DIFF
--- a/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -12,6 +12,8 @@
     <Style TargetType="{x:Type Controls:NumericUpDown}">
         <Setter Property="BorderThickness"
                 Value="1" />
+        <Setter Property="SnapsToDevicePixels"
+                Value="true" />
         <Setter Property="Foreground"
                 Value="{DynamicResource TextBrush}" />
         <Setter Property="BorderBrush"


### PR DESCRIPTION
Most controls but `NumericUpDown` have `SnapsToDevicePixels` set to `true` in their template. This PR corrects this.
