### PR TITLE
use IdealForegroundColorBrush in title bar elements

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -262,7 +262,7 @@
             </Setter.Value>
         </Setter>
         <Setter Property="TitleForeground"
-                Value="White" />
+                Value="{DynamicResource IdealForegroundColor}" />
         <Setter Property="Template"
                 Value="{StaticResource WindowTemplateKey}" />
         <Setter Property="TitleTemplate">
@@ -325,6 +325,8 @@
                     <ControlTemplate.Resources>
                         <ResourceDictionary>
                             <Style TargetType="{x:Type Button}">
+                                <Setter Property="Foreground" 
+                                        Value="{DynamicResource IdealForegroundColor}"/>
                                 <Setter Property="Background"
                                         Value="{DynamicResource TransparentWhiteBrush}" />
                                 <Setter Property="HorizontalContentAlignment"
@@ -376,7 +378,7 @@
                                                 <Trigger Property="IsEnabled"
                                                          Value="false">
                                                     <Setter Property="Foreground"
-                                                            Value="#ADADAD" />
+                                                            Value="{DynamicResource IdealForegroundColorBrush}" />
                                                 </Trigger>
                                             </ControlTemplate.Triggers>
                                         </ControlTemplate>
@@ -386,7 +388,7 @@
                                     <DataTrigger Binding="{Binding ShowTitleBar, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}"
                                                  Value="True">
                                         <Setter Property="Foreground"
-                                                Value="White" />
+                                                Value="{DynamicResource IdealForegroundColorBrush}" />
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
@@ -448,7 +450,7 @@
                                                 <DataTrigger Binding="{Binding ShowTitleBar, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}"
                                                              Value="True">
                                                     <Setter Property="Foreground"
-                                                            Value="White" />
+                                                            Value="{DynamicResource IdealForegroundColorBrush}" />
                                                 </DataTrigger>
                                             </ControlTemplate.Triggers>
                                         </ControlTemplate>
@@ -502,7 +504,7 @@
                                 Focusable="False"
                                 Height="{Binding TitlebarHeight, Mode=OneWay, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"
                                 Style="{Binding WindowMinButtonStyle, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}"
-                                Foreground="{TemplateBinding Foreground}"
+                                Foreground="{DynamicResource IdealForegroundColorBrush}"
                                 ToolTip="{Binding Minimize, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowButtonCommands}}}">
                             <Button.Visibility>
                                 <MultiBinding Converter="{x:Static conv:ResizeModeMinMaxButtonVisibilityConverter.Instance}"
@@ -517,14 +519,14 @@
                             </Button.Visibility>
                             <Path Data="F1M0,6L0,9 9,9 9,6 0,6z"
                                   SnapsToDevicePixels="True"
-                                  Fill="{TemplateBinding Foreground}" />
+                                  Fill="{DynamicResource IdealForegroundColorBrush}" />
                         </Button>
 
                         <Button x:Name="PART_Max"
                                 Focusable="False"
                                 Height="{Binding TitlebarHeight, Mode=OneWay, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"
                                 Style="{Binding WindowMaxButtonStyle, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}"
-                                Foreground="{TemplateBinding Foreground}"
+                                Foreground="{DynamicResource IdealForegroundColorBrush}"
                                 ToolTip="{Binding Maximize, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowButtonCommands}}}">
                             <Button.Visibility>
                                 <MultiBinding Converter="{x:Static conv:ResizeModeMinMaxButtonVisibilityConverter.Instance}"
@@ -538,7 +540,7 @@
                                 </MultiBinding>
                             </Button.Visibility>
                             <Path x:Name="MaxPath" SnapsToDevicePixels="True"
-                                  Fill="{TemplateBinding Foreground}" >
+                                  Fill="{DynamicResource IdealForegroundColorBrush}" >
                             </Path>
                         </Button>
 
@@ -546,12 +548,12 @@
                                 Focusable="False"
                                 Height="{Binding TitlebarHeight, Mode=OneWay, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"
                                 Style="{Binding WindowCloseButtonStyle, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}"
-                                Foreground="{TemplateBinding Foreground}"
+                                Foreground="{DynamicResource IdealForegroundColorBrush}"
                                 ToolTip="{Binding Close, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowButtonCommands}}}"
                                 Visibility="{Binding ShowCloseButton, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <Path Data="F1M0,0L2,0 5,3 8,0 10,0 6,4 10,8 8,8 5,5 2,8 0,8 4,4 0,0z"
                                   SnapsToDevicePixels="True"
-                                  Fill="{TemplateBinding Foreground}" />
+                                  Fill="{DynamicResource IdealForegroundColorBrush}" />
                         </Button>
                     </StackPanel>
                     <ControlTemplate.Triggers>


### PR DESCRIPTION
When using a bright theme (such as yellow), you can hardly read the elements in the title bar. With this PR I suggest to use `IdealForegroundColor` where appropriate.

I'm not sure whether I've changed the correct elements. Please review my changes carefully. :worried: 

**Before:**
![image](https://cloud.githubusercontent.com/assets/73690/4781313/75ae5c50-5c97-11e4-8d3f-a0138e778971.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/73690/4781312/42cdf624-5c97-11e4-9fe0-7a31bb537017.png)
