### PR TITLE
Can now specify animation options when showing/hiding custom in-window metro dialogs

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -298,13 +298,13 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="dialog">The dialog instance itself.</param>
         /// <returns>A task representing the operation.</returns>
         /// <exception cref="InvalidOperationException">The <paramref name="dialog"/> is already visible in the window.</exception>
-        public static Task ShowMetroDialogAsync(this MetroWindow window, BaseMetroDialog dialog)
+        public static Task ShowMetroDialogAsync(this MetroWindow window, BaseMetroDialog dialog, MetroDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
             if (window.metroDialogContainer.Children.Contains(dialog))
                 throw new InvalidOperationException("The provided dialog is already visible in the specified window.");
 
-            return window.ShowOverlayAsync().ContinueWith(z =>
+            return HandleOverlayOnShow(settings,window).ContinueWith(z =>
                 {
                     dialog.Dispatcher.Invoke(new Action(() =>
                         {
@@ -334,7 +334,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// The <paramref name="dialog"/> is not visible in the window.
         /// This happens if <see cref="ShowMetroDialogAsync"/> hasn't been called before.
         /// </exception>
-        public static Task HideMetroDialogAsync(this MetroWindow window, BaseMetroDialog dialog)
+        public static Task HideMetroDialogAsync(this MetroWindow window, BaseMetroDialog dialog, MetroDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
             if (!window.metroDialogContainer.Children.Contains(dialog))
@@ -358,7 +358,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 {
                     window.metroDialogContainer.Children.Remove(dialog); //remove the dialog from the container
 
-                    return window.HideOverlayAsync();
+                    return HandleOverlayOnHide(settings,window);
                 }));
             }).Unwrap();
         }


### PR DESCRIPTION
Made a small addition so that animation options can now be specified for custom metro dialogs, similar to the other built in dialog options.
