### PR TITLE
Let the BaseMetroDialog inherit from ContentControl instead of Control

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -16,28 +16,9 @@ namespace MahApps.Metro.Controls.Dialogs
     /// You probably don't want to use this class, if you want to add arbitrary content to your dialog, 
     /// use the <see cref="SimpleDialog"/> class.
     /// </summary>
-    [System.Windows.Markup.ContentProperty("DialogBody")]
-    public abstract class BaseMetroDialog : Control
+    public abstract class BaseMetroDialog : ContentControl
     {
-        private const string PART_DialogBody_ContentPresenter = "PART_DialogBody_ContentPresenter";
-        protected ContentPresenter DialogBody_ContentPresenter = null;
-
         public static readonly DependencyProperty TitleProperty = DependencyProperty.Register("Title", typeof(string), typeof(BaseMetroDialog), new PropertyMetadata(default(string)));
-        public static readonly DependencyProperty DialogBodyProperty = DependencyProperty.Register("DialogBody", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null, (o, e) =>
-        {
-            var dialog = o as BaseMetroDialog;
-            if (dialog != null)
-            {
-                if (e.OldValue != null)
-                {
-                    dialog.RemoveLogicalChild(e.OldValue);
-                }
-                if (e.NewValue != null)
-                {
-                    dialog.AddLogicalChild(e.NewValue);
-                }
-            }
-        }));
         public static readonly DependencyProperty DialogTopProperty = DependencyProperty.Register("DialogTop", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
         public static readonly DependencyProperty DialogBottomProperty = DependencyProperty.Register("DialogBottom", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
 
@@ -50,15 +31,6 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             get { return (string)GetValue(TitleProperty); }
             set { SetValue(TitleProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets/sets arbitrary content in the "message" area in the dialog. 
-        /// </summary>
-        public object DialogBody
-        {
-            get { return GetValue(DialogBodyProperty); }
-            set { SetValue(DialogBodyProperty, value); }
         }
 
         /// <summary>
@@ -85,13 +57,6 @@ namespace MahApps.Metro.Controls.Dialogs
         static BaseMetroDialog()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(BaseMetroDialog), new FrameworkPropertyMetadata(typeof(BaseMetroDialog)));
-        }
-
-        public override void OnApplyTemplate()
-        {
-            DialogBody_ContentPresenter = GetTemplateChild(PART_DialogBody_ContentPresenter) as ContentPresenter;
-
-            base.OnApplyTemplate();
         }
 
         /// <summary>

--- a/MahApps.Metro/Controls/Dialogs/SimpleDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/SimpleDialog.cs
@@ -10,18 +10,6 @@ namespace MahApps.Metro.Controls.Dialogs
     /// <summary>
     /// A simple implementation of BaseMetroDialog allowing arbitrary content.
     /// </summary>
-    [ContentProperty("DialogBody")]
     public class SimpleDialog : BaseMetroDialog
-    {
-        public SimpleDialog()
-        {
-            this.Loaded += SimpleDialog_Loaded;
-        }
-
-        void SimpleDialog_Loaded(object sender, System.Windows.RoutedEventArgs e)
-        {
-            if (DialogBody_ContentPresenter.Content != null) //temp fix for #1238. it forces bindings to bind since for some reason, they won't when the dialog is shown.
-                ((FrameworkElement)DialogBody_ContentPresenter.Content).InvalidateProperty(FrameworkElement.DataContextProperty);
-        }
-    }
+    { }
 }

--- a/MahApps.Metro/Controls/TreeHelper.cs
+++ b/MahApps.Metro/Controls/TreeHelper.cs
@@ -35,6 +35,59 @@ namespace MahApps.Metro.Controls
         }
 
         /// <summary>
+        /// Finds a Child of a given item in the visual tree. 
+        /// </summary>
+        /// <param name="parent">A direct parent of the queried item.</param>
+        /// <typeparam name="T">The type of the queried item.</typeparam>
+        /// <param name="childName">x:Name or Name of child. </param>
+        /// <returns>The first parent item that matches the submitted type parameter. 
+        /// If not matching item can be found, 
+        /// a null parent is being returned.</returns>
+        public static T FindChild<T>(this DependencyObject parent, string childName)
+           where T : DependencyObject
+        {
+            // Confirm parent and childName are valid. 
+            if (parent == null) return null;
+
+            T foundChild = null;
+
+            int childrenCount = VisualTreeHelper.GetChildrenCount(parent);
+            for (int i = 0; i < childrenCount; i++)
+            {
+                var child = VisualTreeHelper.GetChild(parent, i);
+                // If the child is not of the request child type child
+                T childType = child as T;
+                if (childType == null)
+                {
+                    // recursively drill down the tree
+                    foundChild = FindChild<T>(child, childName);
+
+                    // If the child is found, break so we do not overwrite the found child. 
+                    if (foundChild != null) break;
+                }
+                else if (!string.IsNullOrEmpty(childName))
+                {
+                    var frameworkElement = child as FrameworkElement;
+                    // If the child's name is set for search
+                    if (frameworkElement != null && frameworkElement.Name == childName)
+                    {
+                        // if the child's name is of the request name
+                        foundChild = (T)child;
+                        break;
+                    }
+                }
+                else
+                {
+                    // child element found.
+                    foundChild = (T)child;
+                    break;
+                }
+            }
+
+            return foundChild;
+        }
+
+        /// <summary>
         /// This method is an alternative to WPF's
         /// <see cref="VisualTreeHelper.GetParent"/> method, which also
         /// supports content elements. Keep in mind that for content element,

--- a/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -67,10 +67,8 @@
                                        Foreground="{TemplateBinding Foreground}"
                                        Text="{TemplateBinding Title}"
                                        TextWrapping="Wrap" />
-                            <ContentPresenter x:Name="PART_DialogBody_ContentPresenter"
-                                              Grid.Row="1"
-                                              Content="{TemplateBinding DialogBody}"
-                                              DataContext="{TemplateBinding DataContext}" />
+                            <ContentPresenter Grid.Row="1"
+                                              Content="{TemplateBinding Content}" />
                         </Grid>
                     </Grid>
                     <ContentPresenter Grid.Row="2"

--- a/MahApps.Metro/Themes/Dialogs/InputDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/InputDialog.xaml
@@ -4,45 +4,43 @@
                          xmlns:controls="clr-namespace:MahApps.Metro.Controls"
                          x:Class="MahApps.Metro.Controls.Dialogs.InputDialog"
                          Loaded="Dialog_Loaded">
-    <Dialogs:BaseMetroDialog.DialogBody>
-        <Grid Margin="0 10 0 0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"
-                               MinHeight="20" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <TextBlock Grid.Row="0"
-                       Margin="0 5 0 0"
-                       FontSize="{StaticResource DialogMessageFontSize}"
-                       Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                       TextWrapping="Wrap"
-                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBox Grid.Row="1"
-                     Margin="0 5 0 0"
-                     FontSize="{StaticResource DialogMessageFontSize}"
-                     controls:TextboxHelper.FocusBorderBrush="{DynamicResource AccentColorBrush}"
-                     x:Name="PART_TextBox"
-                     Text="{Binding Input, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                     TextWrapping="Wrap"
-                     Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+    <Grid Margin="0 10 0 0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"
+                            MinHeight="20" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0"
+                    Margin="0 5 0 0"
+                    FontSize="{StaticResource DialogMessageFontSize}"
+                    Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    TextWrapping="Wrap"
+                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Grid.Row="1"
+                    Margin="0 5 0 0"
+                    FontSize="{StaticResource DialogMessageFontSize}"
+                    controls:TextboxHelper.FocusBorderBrush="{DynamicResource AccentColorBrush}"
+                    x:Name="PART_TextBox"
+                    Text="{Binding Input, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    TextWrapping="Wrap"
+                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
 
-            <StackPanel Grid.Row="2"
-                        Orientation="Horizontal"
-                        HorizontalAlignment="Right"
-                        Height="85">
-                <Button x:Name="PART_AffirmativeButton"
-                        Height="35"
-                        MinWidth="80"
-                        Style="{DynamicResource AccentedDialogSquareButton}"
-                        Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                        Margin="0 0 5 0" />
-                <Button x:Name="PART_NegativeButton"
-                        Height="35"
-                        MinWidth="80"
-                        Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                        Margin="5 0 5 0" />
-            </StackPanel>
-        </Grid>
-    </Dialogs:BaseMetroDialog.DialogBody>
+        <StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Height="85">
+            <Button x:Name="PART_AffirmativeButton"
+                    Height="35"
+                    MinWidth="80"
+                    Style="{DynamicResource AccentedDialogSquareButton}"
+                    Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Margin="0 0 5 0" />
+            <Button x:Name="PART_NegativeButton"
+                    Height="35"
+                    MinWidth="80"
+                    Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Margin="5 0 5 0" />
+        </StackPanel>
+    </Grid>
 </Dialogs:BaseMetroDialog>

--- a/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
@@ -4,54 +4,50 @@
                          xmlns:Dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs"
                          x:Class="MahApps.Metro.Controls.Dialogs.LoginDialog"
                          Loaded="Dialog_Loaded">
-    
-    <Dialogs:BaseMetroDialog.DialogBody>
-        <Grid Margin="0 10 0 0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"
-                               MinHeight="20" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <TextBlock Grid.Row="0"
-                       Margin="0 5 0 0"
-                       FontSize="{StaticResource DialogMessageFontSize}"
-                       Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                       TextWrapping="Wrap"
-                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBox Grid.Row="1"
-                     Margin="0 5 0 0"
-                     FontSize="{StaticResource DialogMessageFontSize}"
-                     x:Name="PART_TextBox"
-                     Controls:TextboxHelper.Watermark="{Binding UsernameWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                     Text="{Binding Username, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                     TextWrapping="Wrap"
-                     Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
-            <PasswordBox Grid.Row="2"
-                         Margin="0 5 0 0"
-                         FontSize="{StaticResource DialogMessageFontSize}"
-                         x:Name="PART_TextBox2"
-                         Controls:TextboxHelper.Watermark="{Binding PasswordWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                         Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
-            <StackPanel Grid.Row="3"
-                        Orientation="Horizontal"
-                        HorizontalAlignment="Right"
-                        Height="85">
-                <Button x:Name="PART_AffirmativeButton"
-                        Height="35"
-                        MinWidth="80"
-                        Style="{DynamicResource AccentedDialogSquareButton}"
-                        Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                        Margin="0 0 5 0" />
-                <Button x:Name="PART_NegativeButton"
-                        Height="35"
-                        MinWidth="80"
-                        Visibility="{Binding NegativeButtonButtonVisibility, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                        Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                        Margin="5 0 5 0" />
-            </StackPanel>
-        </Grid>
-    </Dialogs:BaseMetroDialog.DialogBody>
-
+    <Grid Margin="0 10 0 0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"
+                            MinHeight="20" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0"
+                    Margin="0 5 0 0"
+                    FontSize="{StaticResource DialogMessageFontSize}"
+                    Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    TextWrapping="Wrap"
+                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox Grid.Row="1"
+                    Margin="0 5 0 0"
+                    FontSize="{StaticResource DialogMessageFontSize}"
+                    x:Name="PART_TextBox"
+                    Controls:TextboxHelper.Watermark="{Binding UsernameWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Text="{Binding Username, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    TextWrapping="Wrap"
+                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+        <PasswordBox Grid.Row="2"
+                        Margin="0 5 0 0"
+                        FontSize="{StaticResource DialogMessageFontSize}"
+                        x:Name="PART_TextBox2"
+                        Controls:TextboxHelper.Watermark="{Binding PasswordWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+        <StackPanel Grid.Row="3"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Height="85">
+            <Button x:Name="PART_AffirmativeButton"
+                    Height="35"
+                    MinWidth="80"
+                    Style="{DynamicResource AccentedDialogSquareButton}"
+                    Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Margin="0 0 5 0" />
+            <Button x:Name="PART_NegativeButton"
+                    Height="35"
+                    MinWidth="80"
+                    Visibility="{Binding NegativeButtonButtonVisibility, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Margin="5 0 5 0" />
+        </StackPanel>
+    </Grid>
 </Dialogs:BaseMetroDialog>

--- a/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
@@ -3,47 +3,45 @@
                          xmlns:Dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs"
                          x:Class="MahApps.Metro.Controls.Dialogs.MessageDialog"
                          Loaded="Dialog_Loaded">
-    <Dialogs:BaseMetroDialog.DialogBody>
-        <Grid Margin="0 10 0 0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <TextBlock Grid.Row="0"
-                       Margin="0 5 0 0"
-                       FontSize="{StaticResource DialogMessageFontSize}"
-                       Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                       TextWrapping="Wrap"
-                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+    <Grid Margin="0 10 0 0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0"
+                    Margin="0 5 0 0"
+                    FontSize="{StaticResource DialogMessageFontSize}"
+                    Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    TextWrapping="Wrap"
+                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
 
-            <StackPanel Grid.Row="1"
-                        Orientation="Horizontal"
-                        HorizontalAlignment="Right"
-                        Height="85">
-                <Button x:Name="PART_AffirmativeButton"
-                        Height="35"
-                        MinWidth="80"
-                        Style="{DynamicResource AccentedDialogSquareButton}"
-                        Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                        Margin="0 0 5 0" />
-                <Button x:Name="PART_NegativeButton"
-                        Height="35"
-                        MinWidth="80"
-                        Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                        Margin="5 0 5 0" />
-                <Button x:Name="PART_FirstAuxiliaryButton"
-                        Height="35"
-                        MinWidth="80"
-                        Visibility="Collapsed"
-                        Content="{Binding FirstAuxiliaryButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                        Margin="5 0 5 0" />
-                <Button x:Name="PART_SecondAuxiliaryButton"
-                        Height="35"
-                        MinWidth="80"
-                        Visibility="Collapsed"
-                        Content="{Binding SecondAuxiliaryButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                        Margin="5 0 0 0" />
-            </StackPanel>
-        </Grid>
-    </Dialogs:BaseMetroDialog.DialogBody>
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Height="85">
+            <Button x:Name="PART_AffirmativeButton"
+                    Height="35"
+                    MinWidth="80"
+                    Style="{DynamicResource AccentedDialogSquareButton}"
+                    Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Margin="0 0 5 0" />
+            <Button x:Name="PART_NegativeButton"
+                    Height="35"
+                    MinWidth="80"
+                    Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Margin="5 0 5 0" />
+            <Button x:Name="PART_FirstAuxiliaryButton"
+                    Height="35"
+                    MinWidth="80"
+                    Visibility="Collapsed"
+                    Content="{Binding FirstAuxiliaryButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Margin="5 0 5 0" />
+            <Button x:Name="PART_SecondAuxiliaryButton"
+                    Height="35"
+                    MinWidth="80"
+                    Visibility="Collapsed"
+                    Content="{Binding SecondAuxiliaryButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Margin="5 0 0 0" />
+        </StackPanel>
+    </Grid>
 </Dialogs:BaseMetroDialog>

--- a/MahApps.Metro/Themes/Dialogs/ProgressDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/ProgressDialog.xaml
@@ -4,7 +4,7 @@
                          xmlns:Dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs"
                          x:Class="MahApps.Metro.Controls.Dialogs.ProgressDialog"
                          Cursor="Wait">
-    <Dialogs:BaseMetroDialog.DialogBody>
+    <Dialogs:BaseMetroDialog.Content>
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
@@ -30,7 +30,7 @@
                         Visibility="Hidden" />
             </StackPanel>
         </Grid>
-    </Dialogs:BaseMetroDialog.DialogBody>
+    </Dialogs:BaseMetroDialog.Content>
     <Dialogs:BaseMetroDialog.DialogBottom>
         <Controls:MetroProgressBar HorizontalAlignment="Stretch"
                                    VerticalAlignment="Bottom"

--- a/Mahapps.Metro.Tests/CustomDialogTest.cs
+++ b/Mahapps.Metro.Tests/CustomDialogTest.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading.Tasks;
+using System.Windows.Controls;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Controls.Dialogs;
+using Mahapps.Metro.Tests.TestHelpers;
+using Xunit;
+
+namespace Mahapps.Metro.Tests
+{
+    public class CustomDialogTest : AutomationTestBase
+    {
+        [Fact]
+        public async Task ReceivesDataContext()
+        {
+            await TestHost.SwitchToAppThread();
+
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            var vm = new TheViewModel();
+            var dialog = (SimpleDialog) window.Resources["CustomDialog"];
+
+            await window.ShowMetroDialogAsync(dialog);
+
+            await TestHost.SwitchToAppThread(); // No idea why we have to do this again
+
+            dialog.DataContext = vm;
+            var textBlock = dialog.FindChild<TextBlock>("TheDialogBody");
+
+            Assert.Equal(vm.Text, textBlock.Text);
+        }
+
+        private class TheViewModel
+        {
+            public string Text
+            {
+                get { return "TheText"; }
+            }
+        }
+    }
+}

--- a/Mahapps.Metro.Tests/DialogWindow.xaml
+++ b/Mahapps.Metro.Tests/DialogWindow.xaml
@@ -1,0 +1,15 @@
+﻿<controls:MetroWindow x:Class="Mahapps.Metro.Tests.DialogWindow"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs;assembly=MahApps.Metro"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="300">
+    <controls:MetroWindow.Resources>
+        <dialogs:SimpleDialog x:Key="CustomDialog">
+            <TextBlock x:Name="TheDialogBody" Text="{Binding Path=Text}" />
+        </dialogs:SimpleDialog>
+    </controls:MetroWindow.Resources>
+</controls:MetroWindow>

--- a/Mahapps.Metro.Tests/DialogWindow.xaml.cs
+++ b/Mahapps.Metro.Tests/DialogWindow.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Mahapps.Metro.Tests
+{
+    public partial class DialogWindow 
+    {
+        public DialogWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Mahapps.Metro.Tests/Mahapps.Metro.Tests.csproj
+++ b/Mahapps.Metro.Tests/Mahapps.Metro.Tests.csproj
@@ -87,6 +87,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CleanWindowTest.cs" />
+    <Compile Include="CustomDialogTest.cs" />
+    <Compile Include="DialogWindow.xaml.cs">
+      <DependentUpon>DialogWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="FlyoutTest.cs" />
     <Compile Include="CleanWindow.xaml.cs">
       <DependentUpon>CleanWindow.xaml</DependentUpon>
@@ -122,6 +126,10 @@
     <Page Include="CleanWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="DialogWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="HiddenMinMaxCloseButtonsWindow.xaml">
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
This way we don't have to duplicate the logic that a ContentControl already provides for us
