### PR TITLE
Use the specified ItemTemplate in the WindowCommands control

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -462,7 +462,8 @@
 
                     <ItemsControl IsTabStop="False"
                                   Height="{Binding TitlebarHeight, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}"
-                                  ItemsSource="{Binding Items, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommands}}}">
+                                  ItemsSource="{Binding Items, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommands}}}"
+                                  ItemTemplate="{TemplateBinding ItemTemplate}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <StackPanel Orientation="Horizontal" />


### PR DESCRIPTION
Also fixes an issue with using a colour resource where a brush is expected.

This is useful when using the control's ItemsSource property in a MVVM scenario where one would want to manipulate what/how the child controls are rendered.
