### PR TITLE
Use correct size for window icon

### DIFF
--- a/MahApps.Metro/Controls/MultiFrameImage.cs
+++ b/MahApps.Metro/Controls/MultiFrameImage.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace MahApps.Metro.Controls
+{
+    public class MultiFrameImage : Image
+    {
+        static MultiFrameImage()
+        {
+            SourceProperty.OverrideMetadata(typeof(MultiFrameImage), new FrameworkPropertyMetadata(OnSourceChanged));
+        }
+
+        private static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var multiFrameImage = (MultiFrameImage) d;
+            multiFrameImage.UpdateFrameList();
+        }
+
+        private readonly List<BitmapSource> _frames = new List<BitmapSource>();
+
+        private void UpdateFrameList()
+        {
+            _frames.Clear();
+
+            var bitmapFrame = Source as BitmapFrame;
+            if (bitmapFrame == null)
+            {
+                return;
+            }
+
+            var decoder = bitmapFrame.Decoder;
+            if (decoder == null || decoder.Frames.Count == 0)
+            {
+                return;
+            }
+
+            // order all frames by size, take the frame with the highest color depth per size
+            _frames.AddRange(
+                decoder
+                    .Frames
+                    .GroupBy(f => f.PixelWidth * f.PixelHeight)
+                    .OrderBy(g => g.Key)
+                    .Select(g => g.OrderByDescending(f => f.Format.BitsPerPixel).First())
+                    );
+        }
+
+        protected override void OnRender(DrawingContext dc)
+        {
+            if (_frames.Count == 0)
+            {
+                base.OnRender(dc);
+                return;
+            }
+
+            var minSize = Math.Max(RenderSize.Width, RenderSize.Height);
+            var frame = _frames.FirstOrDefault(f => f.Width >= minSize && f.Height >= minSize) ?? _frames.Last();
+            dc.DrawImage(frame, new Rect(0, 0, RenderSize.Width, RenderSize.Height));
+        }
+    }
+}

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Controls\MetroTabControl.cs" />
     <Compile Include="Controls\MetroTabItem.cs" />
     <Compile Include="Controls\MetroWindowHelpers.cs" />
+    <Compile Include="Controls\MultiFrameImage.cs" />
     <Compile Include="Controls\NumericUpDown.cs" />
     <Compile Include="Controls\NumericUpDownChangedRoutedEventArgs.cs" />
     <Compile Include="Controls\NumericUpDownChangedRoutedEventHandler.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Controls\MetroTabControl.cs" />
     <Compile Include="Controls\MetroTabItem.cs" />
     <Compile Include="Controls\MetroWindowHelpers.cs" />
+    <Compile Include="Controls\MultiFrameImage.cs" />
     <Compile Include="Controls\NumericUpDown.cs" />
     <Compile Include="Controls\NumericUpDownChangedRoutedEventArgs.cs" />
     <Compile Include="Controls\NumericUpDownChangedRoutedEventHandler.cs" />

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -298,11 +298,11 @@
                 <Setter Property="IconTemplate">
                     <Setter.Value>
                         <DataTemplate>
-                            <Image Width="{TemplateBinding Width}"
-                                   Height="{TemplateBinding Height}"
-                                   Source="{TemplateBinding Content}"
-                                   RenderOptions.EdgeMode="{Binding IconEdgeMode, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}"
-                                   RenderOptions.BitmapScalingMode="{Binding IconBitmapScalingMode, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}" />
+                            <Controls:MultiFrameImage Width="{TemplateBinding Width}"
+                                                      Height="{TemplateBinding Height}"
+                                                      Source="{TemplateBinding Content}"
+                                                      RenderOptions.EdgeMode="{Binding IconEdgeMode, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}"
+                                                      RenderOptions.BitmapScalingMode="{Binding IconBitmapScalingMode, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}" />
                         </DataTemplate>
                     </Setter.Value>
                 </Setter>


### PR DESCRIPTION
This PR fixes #1242. A new control `MultiFrameImage` replaces the `Image` control in the `IconTemplate`, selecting the best matching icon frame from the provided icon source.

To reproduce the fix, remove all image formats from [`mahapps.metro.logo2.ico`](https://github.com/MahApps/MahApps.Metro/blob/master/samples/MetroDemo/mahapps.metro.logo2.ico) except 16x16 and 32x32 (I didn't want to include the modified icon file in this PR :wink:) and start the demo application.
