### PR TITLE
Update MetroProgressBar.cs

### DIFF
--- a/MahApps.Metro/Controls/MetroProgressBar.cs
+++ b/MahApps.Metro/Controls/MetroProgressBar.cs
@@ -141,7 +141,7 @@ namespace MahApps.Metro.Controls
                             doubleAnimParent.InvalidateProperty(Storyboard.TargetNameProperty);
                         }
 
-                        indeterminate.Storyboard.Remove();
+                        //indeterminate.Storyboard.Remove();
                         indeterminate.Storyboard = newStoryboard;
 
                         if (!IsIndeterminate)


### PR DESCRIPTION
Occur Warning 6 in MetroProgressBar

If excute MetroProgressBar, as below, ouput debug.

System.Windows.Media.Animation Warning: 6 : Unable to perform action because the specified Storyboard was never applied to this object for interactive control.; Action='Remove'; Storyboard='System.Windows.Media.Animation.Storyboard'; Storyboard.HashCode='12083158'; Storyboard.Type='System.Windows.Media.Animation.Storyboard'; TargetElement='System.Windows.Media.Animation.Storyboard'; TargetElement.HashCode='12083158'; TargetElement.Type='System.Windows.Media.Animation.Storyboard'

Solution, delete "indeterminate.Storyboard.Remove();"
