### PR TITLE
Update FlyoutsControl.cs

### DIFF
--- a/MahApps.Metro/Controls/FlyoutsControl.cs
+++ b/MahApps.Metro/Controls/FlyoutsControl.cs
@@ -104,10 +104,13 @@ namespace MahApps.Metro.Controls
 
         private void DetachHandlers(Flyout item)
         {
-            var isOpenChanged = DependencyPropertyDescriptor.FromProperty(Flyout.IsOpenProperty, typeof(Flyout));
-            var themeChanged = DependencyPropertyDescriptor.FromProperty(Flyout.ThemeProperty, typeof(Flyout));
-            isOpenChanged.RemoveValueChanged(item, this.FlyoutStatusChanged);
-            themeChanged.RemoveValueChanged(item, this.FlyoutStatusChanged);
+            if (item != null)
+            {
+                var isOpenChanged = DependencyPropertyDescriptor.FromProperty(Flyout.IsOpenProperty, typeof(Flyout));
+                var themeChanged = DependencyPropertyDescriptor.FromProperty(Flyout.ThemeProperty, typeof(Flyout));
+                isOpenChanged.RemoveValueChanged(item, this.FlyoutStatusChanged);
+                themeChanged.RemoveValueChanged(item, this.FlyoutStatusChanged);
+            }
         }
 
         private void FlyoutStatusChanged(object sender, EventArgs e)


### PR DESCRIPTION
i'm using a `<Controls:FlyoutsControl ItemsSource="{Binding Flyouts}" />` binded to an `ObservableCollection<Flyout>` but when i remove items from Flyout Collection i get a Value can't be null error.

Following the recent conversation with thoemmi in Gitter i changed FlyoutControl to check for null before advancing
