### PR TITLE
Closing a tab doesn't work under specific circumstances

### DIFF
--- a/MahApps.Metro/Controls/MetroTabControl.cs
+++ b/MahApps.Metro/Controls/MetroTabControl.cs
@@ -171,7 +171,7 @@ namespace MahApps.Metro.Controls
                                 if (collection == null) return;
 
                                 // find the item and kill it (I mean, remove it)
-                                foreach (var item in owner.ItemsSource.Cast<object>().Where(item => tabItem.DataContext == item))
+                                foreach (var item in owner.ItemsSource.Cast<object>().Where(item => tabItem == item || tabItem.DataContext == item))
                                 {
                                     collection.Remove(item);
                                     break;


### PR DESCRIPTION
When `MetroTabControl.ItemsSource` is bound to a list of `MetroTabItem`s, then closing a tab doesn't work. Currently the code requires that the bound items are not their own container.
