### PR TITLE
Project Settings: Treat warnings as errors

### DIFF
--- a/MahApps.Metro.Resources/MahApps.Metro.Resources.csproj
+++ b/MahApps.Metro.Resources/MahApps.Metro.Resources.csproj
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -292,6 +292,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// </summary>
         /// <param name="window">The owning window of the dialog.</param>
         /// <param name="dialog">The dialog instance itself.</param>
+        /// <param name="settings">Optional Settings that override the global metro dialog settings.</param>
         /// <returns>A task representing the operation.</returns>
         /// <exception cref="InvalidOperationException">The <paramref name="dialog"/> is already visible in the window.</exception>
         public static Task ShowMetroDialogAsync(this MetroWindow window, BaseMetroDialog dialog, MetroDialogSettings settings = null)
@@ -323,6 +324,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// </summary>
         /// <param name="window">The window with the dialog that is visible.</param>
         /// <param name="dialog">The dialog instance to hide.</param>
+        /// <param name="settings">Optional Settings that override the global metro dialog settings.</param>
         /// <returns>A task representing the operation.</returns>
         /// <exception cref="InvalidOperationException">
         /// The <paramref name="dialog"/> is not visible in the window.

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -87,6 +87,7 @@
     <CodeContractsRuntimeCheckingLevel>Full</CodeContractsRuntimeCheckingLevel>
     <CodeContractsReferenceAssembly>DoNotBuild</CodeContractsReferenceAssembly>
     <CodeContractsAnalysisWarningLevel>0</CodeContractsAnalysisWarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -48,6 +48,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\MahApps.Metro.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>


### PR DESCRIPTION
I think it would be a good style to enable this option to force anybody to follow some basic rules of code style defined by Microsoft.