### PR TITLE
Fixed background of ComboBox

### DIFF
--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -11,7 +11,7 @@
         <Setter Property="Foreground"
                 Value="{DynamicResource TextBrush}" />
         <Setter Property="Background"
-                Value="{DynamicResource GrayBrush10}" />
+                Value="{DynamicResource ControlBackgroundBrush}" />
         <Setter Property="HorizontalContentAlignment"
                 Value="Left" />
         <Setter Property="VerticalContentAlignment"
@@ -49,7 +49,7 @@
                                 <Setter Property="Foreground"
                                         Value="{DynamicResource TextBrush}" />
                                 <Setter Property="Background"
-                                        Value="{DynamicResource GrayBrush10}" />
+                                        Value="{DynamicResource ControlBackgroundBrush}" />
                                 <Setter Property="BorderBrush"
                                         Value="{DynamicResource TextBoxBorderBrush}" />
                                 <Setter Property="BorderThickness"


### PR DESCRIPTION
The `ComboBox` styled used a gray brush as background instead of the
control background brush as `TextBox` do.

This was not an issue when using the default themes. When creating a new theme where the background is dark blue this became an issue since the background of a `ComboBox` was gray and not dark blue.

This is my first contribution on GitHub ever, so I decided to do something simple.
