### PR TITLE
Fixed GlowWindow InvalidOperationException

### DIFF
--- a/MahApps.Metro/Controls/GlowWindow.xaml.cs
+++ b/MahApps.Metro/Controls/GlowWindow.xaml.cs
@@ -217,6 +217,7 @@ namespace MahApps.Metro.Controls
 
         public void Update()
         {
+            if (!Owner.IsLoaded) return;
             if (Owner.Visibility == Visibility.Hidden)
             {
                 Visibility = Visibility.Hidden;


### PR DESCRIPTION
The application crashes sometimes because the glowwindow can't set the visibility of a closed window:

```
System.InvalidOperationException: Cannot set Visibility or call Show, ShowDialog, or WindowInteropHelper.EnsureHandle after a Window has closed.
 at System.Windows.Window.VerifyCanShow()
 at System.Windows.Window.CoerceVisibility(DependencyObject d, Object value)
 at System.Windows.DependencyObject.ProcessCoerceValue(DependencyProperty dp, PropertyMetadata metadata, EntryIndex& entryIndex, Int32& targetIndex, EffectiveValueEntry& newEntry, EffectiveValueEntry& oldEntry, Object& oldValue, Object baseValue, Object controlValue, CoerceValueCallback coerceValueCallback, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, Boolean skipBaseValueChecks)
 at System.Windows.DependencyObject.UpdateEffectiveValue(EntryIndex entryIndex, DependencyProperty dp, PropertyMetadata metadata, EffectiveValueEntry oldEntry, EffectiveValueEntry& newEntry, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType)
 at System.Windows.DependencyObject.SetValueCommon(DependencyProperty dp, Object value, PropertyMetadata metadata, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType, Boolean isInternal)
 at System.Windows.DependencyObject.SetValue(DependencyProperty dp, Object value)
 at MahApps.Metro.Controls.GlowWindow.Update()
 at MahApps.Metro.Controls.GlowWindow.<.ctor>b__1f(Object sender, DependencyPropertyChangedEventArgs e)
```