### PR TITLE
InputDialog - select default text

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/InputDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/InputDialog.cs
@@ -23,6 +23,7 @@ namespace MahApps.Metro.Controls.Dialogs
             {
                 this.Focus();
                 PART_TextBox.Focus();
+                PART_TextBox.SelectAll();
             }));
 
             var tcs = new TaskCompletionSource<string>();


### PR DESCRIPTION
If the dialog opens with default text, the text is automatically selected. For example, if the dialog is opened for rename something, it makes it much easier to override all.