### PR TITLE
Min, Restore/Max animation fix

### DIFF
--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -180,27 +180,31 @@ namespace MahApps.Metro.Behaviours
 
         private void HandleMaximize()
         {
-            var metroWindow = AssociatedObject as MetroWindow;
-            var ignoreTaskBar = metroWindow != null && metroWindow.IgnoreTaskbarOnMaximize;
-            if (AssociatedObject.WindowState == WindowState.Maximized && ignoreTaskBar)
+            if (AssociatedObject.WindowState == WindowState.Maximized)
             {
                 // remove resize border and window border, so we can move the window from top monitor position
                 windowChrome.ResizeBorderThickness = new Thickness(0);
                 AssociatedObject.BorderThickness = new Thickness(0);
 
-                // WindowChrome handles the size false if the main monitor is lesser the monitor where the window is maximized
-                // so set the window pos/size twice
-                IntPtr monitor = UnsafeNativeMethods.MonitorFromWindow(handle, Constants.MONITOR_DEFAULTTONEAREST);
-                if (monitor != IntPtr.Zero) {
-                    var monitorInfo = new MONITORINFO();
-                    UnsafeNativeMethods.GetMonitorInfo(monitor, monitorInfo);
+                var metroWindow = AssociatedObject as MetroWindow;
+                var ignoreTaskBar = metroWindow != null && metroWindow.IgnoreTaskbarOnMaximize;
+                if (ignoreTaskBar)
+                {
+                    // WindowChrome handles the size false if the main monitor is lesser the monitor where the window is maximized
+                    // so set the window pos/size twice
+                    IntPtr monitor = UnsafeNativeMethods.MonitorFromWindow(handle, Constants.MONITOR_DEFAULTTONEAREST);
+                    if (monitor != IntPtr.Zero)
+                    {
+                        var monitorInfo = new MONITORINFO();
+                        UnsafeNativeMethods.GetMonitorInfo(monitor, monitorInfo);
 
-                    ignoreTaskBar = metroWindow.IgnoreTaskbarOnMaximize || metroWindow.UseNoneWindowStyle;
-                    var x = ignoreTaskBar ? monitorInfo.rcMonitor.left : monitorInfo.rcWork.left;
-                    var y = ignoreTaskBar ? monitorInfo.rcMonitor.top : monitorInfo.rcWork.top;
-                    var cx = ignoreTaskBar ? Math.Abs(monitorInfo.rcMonitor.right - x) : Math.Abs(monitorInfo.rcWork.right - x);
-                    var cy = ignoreTaskBar ? Math.Abs(monitorInfo.rcMonitor.bottom - y) : Math.Abs(monitorInfo.rcWork.bottom - y);
-                    UnsafeNativeMethods.SetWindowPos(handle, new IntPtr(-2), x, y, cx, cy, 0x0040);
+                        //ignoreTaskBar = metroWindow.IgnoreTaskbarOnMaximize || metroWindow.UseNoneWindowStyle;
+                        var x = ignoreTaskBar ? monitorInfo.rcMonitor.left : monitorInfo.rcWork.left;
+                        var y = ignoreTaskBar ? monitorInfo.rcMonitor.top : monitorInfo.rcWork.top;
+                        var cx = ignoreTaskBar ? Math.Abs(monitorInfo.rcMonitor.right - x) : Math.Abs(monitorInfo.rcWork.right - x);
+                        var cy = ignoreTaskBar ? Math.Abs(monitorInfo.rcMonitor.bottom - y) : Math.Abs(monitorInfo.rcWork.bottom - y);
+                        UnsafeNativeMethods.SetWindowPos(handle, new IntPtr(-2), x, y, cx, cy, 0x0040);
+                    }
                 }
             }
             else

--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interactivity;
@@ -63,8 +62,7 @@ namespace MahApps.Metro.Behaviours
             AssociatedObject.Loaded += AssociatedObject_Loaded;
             AssociatedObject.Unloaded += AssociatedObject_Unloaded;
             AssociatedObject.SourceInitialized += AssociatedObject_SourceInitialized;
-            AssociatedObject.StateChanged += AssociatedObject_StateChanged;
-            AssociatedObject.Activated += AssociatedObject_Activated;
+            AssociatedObject.StateChanged += OnAssociatedObjectHandleMaximize;
 
             base.OnAttached();
         }
@@ -123,8 +121,7 @@ namespace MahApps.Metro.Behaviours
                 AssociatedObject.Loaded -= AssociatedObject_Loaded;
                 AssociatedObject.Unloaded -= AssociatedObject_Unloaded;
                 AssociatedObject.SourceInitialized -= AssociatedObject_SourceInitialized;
-                AssociatedObject.StateChanged -= AssociatedObject_StateChanged;
-                AssociatedObject.Activated -= AssociatedObject_Activated;
+                AssociatedObject.StateChanged -= OnAssociatedObjectHandleMaximize;
                 if (hwndSource != null)
                 {
                     hwndSource.RemoveHook(WindowProc);
@@ -171,25 +168,17 @@ namespace MahApps.Metro.Behaviours
                     returnval = UnsafeNativeMethods.DefWindowProc(hwnd, msg, wParam, new IntPtr(-1));
                     handled = true;
                     break;
-                /*case Constants.WM_MOVE:
-                    this.HandleMaximize(true);
-                    break;*/
             }
 
             return returnval;
         }
 
-        private void AssociatedObject_Activated(object sender, EventArgs e)
+        private void OnAssociatedObjectHandleMaximize(object sender, EventArgs e)
         {
             HandleMaximize();
         }
 
-        private void AssociatedObject_StateChanged(object sender, EventArgs e)
-        {
-            HandleMaximize();
-        }
-
-        private void HandleMaximize(bool handleOnlyMaximized = false)
+        private void HandleMaximize()
         {
             var metroWindow = AssociatedObject as MetroWindow;
             var ignoreTaskBar = metroWindow != null && metroWindow.IgnoreTaskbarOnMaximize;
@@ -214,7 +203,7 @@ namespace MahApps.Metro.Behaviours
                     UnsafeNativeMethods.SetWindowPos(handle, new IntPtr(-2), x, y, cx, cy, 0x0040);
                 }
             }
-            else if (!handleOnlyMaximized)
+            else
             {
                 windowChrome.ResizeBorderThickness = SystemParameters2.Current.WindowResizeBorderThickness;
                 AssociatedObject.BorderThickness = savedBorderThickness.GetValueOrDefault(new Thickness(0));
@@ -229,20 +218,6 @@ namespace MahApps.Metro.Behaviours
                 AssociatedObject.Topmost = false;
                 AssociatedObject.Topmost = topMost;
             }
-        }
-
-        private static int GetEdge(RECT rc)
-        {
-            int uEdge;
-            if (rc.top == rc.left && rc.bottom > rc.right)
-                uEdge = (int)ABEdge.ABE_LEFT;
-            else if (rc.top == rc.left && rc.bottom < rc.right)
-                uEdge = (int)ABEdge.ABE_TOP;
-            else if (rc.top > rc.left)
-                uEdge = (int)ABEdge.ABE_BOTTOM;
-            else
-                uEdge = (int)ABEdge.ABE_RIGHT;
-            return uEdge;
         }
 
         private void AssociatedObject_SourceInitialized(object sender, EventArgs e)

--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -74,7 +74,11 @@ namespace MahApps.Metro.Behaviours
             var metroWindow = sender as MetroWindow;
             if (metroWindow != null && windowChrome != null)
             {
-                windowChrome.UseNoneWindowStyle = metroWindow.UseNoneWindowStyle;
+                if (!Equals(windowChrome.UseNoneWindowStyle, metroWindow.UseNoneWindowStyle))
+                {
+                    windowChrome.UseNoneWindowStyle = metroWindow.UseNoneWindowStyle;
+                    this.ForceRedrawWindowFromPropertyChanged();
+                }
             }
         }
 
@@ -83,7 +87,20 @@ namespace MahApps.Metro.Behaviours
             var metroWindow = sender as MetroWindow;
             if (metroWindow != null && windowChrome != null)
             {
-                windowChrome.IgnoreTaskbarOnMaximize = metroWindow.IgnoreTaskbarOnMaximize;
+                if (!Equals(windowChrome.IgnoreTaskbarOnMaximize, metroWindow.IgnoreTaskbarOnMaximize))
+                {
+                    windowChrome.IgnoreTaskbarOnMaximize = metroWindow.IgnoreTaskbarOnMaximize;
+                    this.ForceRedrawWindowFromPropertyChanged();
+                }
+            }
+        }
+
+        private void ForceRedrawWindowFromPropertyChanged()
+        {
+            this.HandleMaximize();
+            if (this.handle != IntPtr.Zero)
+            {
+                UnsafeNativeMethods.RedrawWindow(this.handle, IntPtr.Zero, IntPtr.Zero, Constants.RedrawWindowFlags.Invalidate | Constants.RedrawWindowFlags.Frame);
             }
         }
 

--- a/MahApps.Metro/Behaviours/GlowWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/GlowWindowBehavior.cs
@@ -33,12 +33,15 @@ namespace MahApps.Metro.Behaviours
             {
                 AssociatedObject.Topmost = prevTopmost;
             }
-            makeGlowVisibleTimer.Stop();
+            if (makeGlowVisibleTimer != null)
+            {
+                makeGlowVisibleTimer.Stop();
+            }
             if(AssociatedObject.WindowState != WindowState.Minimized)
             {
                 var metroWindow = this.AssociatedObject as MetroWindow;
                 var ignoreTaskBar = metroWindow != null && metroWindow.IgnoreTaskbarOnMaximize;
-                if (SystemParameters.MinimizeAnimation && !ignoreTaskBar)
+                if (makeGlowVisibleTimer != null && SystemParameters.MinimizeAnimation && !ignoreTaskBar)
                 {
                     makeGlowVisibleTimer.Start();
                 }

--- a/MahApps.Metro/Behaviours/GlowWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/GlowWindowBehavior.cs
@@ -36,13 +36,15 @@ namespace MahApps.Metro.Behaviours
             makeGlowVisibleTimer.Stop();
             if(AssociatedObject.WindowState != WindowState.Minimized)
             {
-                if(AssociatedObject.WindowStyle == WindowStyle.None || !SystemParameters.MinimizeAnimation)
+                var metroWindow = this.AssociatedObject as MetroWindow;
+                var ignoreTaskBar = metroWindow != null && metroWindow.IgnoreTaskbarOnMaximize;
+                if (SystemParameters.MinimizeAnimation && !ignoreTaskBar)
                 {
-                    RestoreGlow();
+                    makeGlowVisibleTimer.Start();
                 }
                 else
                 {
-                    makeGlowVisibleTimer.Start();
+                    RestoreGlow();
                 }
             }
             else

--- a/MahApps.Metro/Behaviours/GlowWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/GlowWindowBehavior.cs
@@ -92,20 +92,17 @@ namespace MahApps.Metro.Behaviours
 
         private void AssociatedObjectOnLoaded(object sender, RoutedEventArgs routedEventArgs)
         {
-            if(makeGlowVisibleTimer == null)
-            {
-                makeGlowVisibleTimer = new DispatcherTimer
-                {
-                    Interval = GlowTimerDelay
-                };
-                makeGlowVisibleTimer.Tick += makeGlowVisibleTimer_Tick;
-            }
-
             // No glow effect if UseNoneWindowStyle is true or GlowBrush not set.
             var metroWindow = this.AssociatedObject as MetroWindow;
             if (metroWindow != null && (metroWindow.UseNoneWindowStyle || metroWindow.GlowBrush == null))
             {
                 return;
+            }
+
+            if (makeGlowVisibleTimer == null)
+            {
+                makeGlowVisibleTimer = new DispatcherTimer { Interval = GlowTimerDelay };
+                makeGlowVisibleTimer.Tick += makeGlowVisibleTimer_Tick;
             }
 
             this.left = new GlowWindow(this.AssociatedObject, GlowDirection.Left);

--- a/MahApps.Metro/Controls/GlowWindow.xaml.cs
+++ b/MahApps.Metro/Controls/GlowWindow.xaml.cs
@@ -228,6 +228,7 @@ namespace MahApps.Metro.Controls
                 if (this.closing) return;
 
                 Visibility = IsGlowing ? Visibility.Visible : Visibility.Collapsed;
+                glow.Visibility = IsGlowing ? Visibility.Visible : Visibility.Collapsed;
 
                 UpdateCore();
             }

--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
@@ -1353,6 +1353,36 @@
         ALLOWDROPDESCRIPTIONTEXT = 1,
     }
 
+    internal enum MonitorOptions : uint
+    {
+        MONITOR_DEFAULTTONULL = 0x00000000,
+        MONITOR_DEFAULTTOPRIMARY = 0x00000001,
+        MONITOR_DEFAULTTONEAREST = 0x00000002
+    }
+
+    internal enum ABEdge
+    {
+        ABE_LEFT = 0,
+        ABE_TOP = 1,
+        ABE_RIGHT = 2,
+        ABE_BOTTOM = 3
+    }
+
+    internal enum ABMsg
+    {
+        ABM_NEW = 0,
+        ABM_REMOVE = 1,
+        ABM_QUERYPOS = 2,
+        ABM_SETPOS = 3,
+        ABM_GETSTATE = 4,
+        ABM_GETTASKBARPOS = 5,
+        ABM_ACTIVATE = 6,
+        ABM_GETAUTOHIDEBAR = 7,
+        ABM_SETAUTOHIDEBAR = 8,
+        ABM_WINDOWPOSCHANGED = 9,
+        ABM_SETSTATE = 10
+    }
+
     #endregion
 
     #region SafeHandles
@@ -2425,6 +2455,20 @@
         public string szMessage;
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
         public string szInsert;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct APPBARDATA
+    {
+        /// <summary>
+        /// initialize this field using: Marshal.SizeOf(typeof(APPBARDATA));
+        /// </summary>
+        public int cbSize;
+        public IntPtr hWnd;
+        public int uCallbackMessage;
+        public int uEdge;
+        public RECT rc;
+        public bool lParam;
     }
 
     #endregion
@@ -3616,6 +3660,13 @@
         [DllImport("urlmon.dll")]
         public static extern HRESULT CopyStgMedium(ref STGMEDIUM pcstgmedSrc, ref STGMEDIUM pstgmedDest);
 
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [DllImport("shell32.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern uint SHAppBarMessage(int dwMessage, ref APPBARDATA pData);
 
         #region Win7 declarations
 

--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
@@ -3104,6 +3104,22 @@
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [DllImport("user32.dll", EntryPoint = "GetMonitorInfoW", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool _GetMonitorInfoW([In] IntPtr hMonitor, [Out] MONITORINFO lpmi);
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        public static MONITORINFO GetMonitorInfoW(IntPtr hMonitor)
+        {
+            var mi = new MONITORINFO();
+            if (!_GetMonitorInfoW(hMonitor, mi))
+            {
+                throw new Win32Exception();
+            }
+            return mi;
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         [DllImport("gdi32.dll", EntryPoint = "GetStockObject", SetLastError = true)]
         private static extern IntPtr _GetStockObject(StockObject fnObject);
 

--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
@@ -3300,6 +3300,10 @@
         public static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [DllImport("user32.dll")]
+        public static extern IntPtr MonitorFromPoint(POINT pt, MonitorOptions dwFlags);
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         [DllImport("user32.dll", EntryPoint = "PostMessage", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool _PostMessage(IntPtr hWnd, WM Msg, IntPtr wParam, IntPtr lParam);

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChrome.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChrome.cs
@@ -246,12 +246,24 @@ namespace Microsoft.Windows.Shell
             "IgnoreTaskbarOnMaximize",
             typeof(bool),
             typeof(WindowChrome),
-            new FrameworkPropertyMetadata(false));
+            new FrameworkPropertyMetadata(false, (d, e) => ((WindowChrome)d)._OnPropertyChangedThatRequiresRepaint()));
 
         public bool IgnoreTaskbarOnMaximize
         {
             get { return (bool)GetValue(IgnoreTaskbarOnMaximizeProperty); }
             set { SetValue(IgnoreTaskbarOnMaximizeProperty, value); }
+        }
+
+        public static readonly DependencyProperty UseNoneWindowStyleProperty = DependencyProperty.Register(
+            "UseNoneWindowStyle",
+            typeof(bool),
+            typeof(WindowChrome),
+            new FrameworkPropertyMetadata(false, (d, e) => ((WindowChrome)d)._OnPropertyChangedThatRequiresRepaint()));
+
+        public bool UseNoneWindowStyle
+        {
+            get { return (bool)GetValue(UseNoneWindowStyleProperty); }
+            set { SetValue(UseNoneWindowStyleProperty, value); }
         }
 
         public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -1063,17 +1063,6 @@ namespace Microsoft.Windows.Shell
 
             if (force || frameState != _isGlassEnabled)
             {
-                if (_MinimizeAnimation)
-                {
-                    // allow animation
-                    _ModifyStyle(0, WS.CAPTION);
-                }
-                else
-                {
-                    // no animation
-                    _ModifyStyle(WS.CAPTION, 0);
-                }
-
                 _isGlassEnabled = frameState && _chromeInfo.GlassFrameThickness != default(Thickness);
 
                 if (!_isGlassEnabled)
@@ -1083,6 +1072,17 @@ namespace Microsoft.Windows.Shell
                 else
                 {
                     _ClearRoundingRegion();
+                }
+
+                if (_MinimizeAnimation)
+                {
+                    // allow animation
+                    _ModifyStyle(0, WS.CAPTION);
+                }
+                else
+                {
+                    // no animation
+                    _ModifyStyle(WS.CAPTION, 0);
                 }
 
                 // update the glass frame too, if the user sets the glass frame thickness to 0 at run time

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -990,7 +990,6 @@ namespace Microsoft.Windows.Shell
 
             if (force || frameState != _isGlassEnabled)
             {
-                bool modified = _ModifyStyle(WS.VISIBLE, 0);
                 if (SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false/* && _chromeInfo.UseNoneWindowStyle == false*/)
                 {
                     // allow animation
@@ -1015,11 +1014,6 @@ namespace Microsoft.Windows.Shell
 
                 // update the glass frame too, if the user sets the glass frame thickness to 0 at run time
                 _ExtendGlassFrame();
-
-                if (modified)
-                {
-                    _ModifyStyle(0, WS.VISIBLE);
-                }
 
                 NativeMethods.SetWindowPos(_hwnd, IntPtr.Zero, 0, 0, 0, 0, _SwpFlags);
             }

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -572,6 +572,8 @@ namespace Microsoft.Windows.Shell
             // Since the first field of NCCALCSIZE_PARAMS is a RECT and is the only field we care about
             // we can unconditionally treat it as a RECT.
 
+            var redraw = false;
+
             if (NativeMethods.GetWindowPlacement(_hwnd).showCmd == SW.MAXIMIZE)
             {
                 if (_MinimizeAnimation)
@@ -585,9 +587,13 @@ namespace Microsoft.Windows.Shell
                     def.Top = (int) (rc.Top + NativeMethods.GetWindowInfo(_hwnd).cyWindowBorders);
 
                     // monitor an work area will be equal if taskbar is hidden
-                    if(mi.rcMonitor.Height == mi.rcWork.Height && mi.rcMonitor.Width == mi.rcWork.Width)
+                    if (mi.rcMonitor.Height == mi.rcWork.Height && mi.rcMonitor.Width == mi.rcWork.Width)
+                    {
                         def = AdjustWorkingAreaForAutoHide(mon, def);
+                    }
                     Marshal.StructureToPtr(def, lParam, true);
+
+                    redraw = true;
                 }
             }
 
@@ -614,12 +620,11 @@ namespace Microsoft.Windows.Shell
 
                 Marshal.StructureToPtr(rcClientArea, lParam, false);
 
-                handled = true;
-                return new IntPtr((int)WVR.REDRAW);
+                redraw = true;
             }
 
             handled = true;
-            return IntPtr.Zero;
+            return redraw ? new IntPtr((int)WVR.REDRAW) : IntPtr.Zero;
         }
 
         private HT _GetHTFromResizeGripDirection(ResizeGripDirection direction)

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -432,6 +432,15 @@ namespace Microsoft.Windows.Shell
             }
         }
 
+        /// A borderless window lost his animation, with this we bring it back.
+        private bool _MinimizeAnimation
+        {
+            get
+            {
+                return SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false; /* && _chromeInfo.UseNoneWindowStyle == false*/
+            }
+        }
+
         #region WindowProc and Message Handlers
 
         private IntPtr _WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
@@ -471,7 +480,7 @@ namespace Microsoft.Windows.Shell
         private IntPtr _HandleRestoreWindow(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled)
         {
             WINDOWPLACEMENT wpl = NativeMethods.GetWindowPlacement(_hwnd);
-            if (SC.RESTORE == (SC)wParam.ToInt32() && wpl.showCmd == SW.SHOWMAXIMIZED && SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false /* && _chromeInfo.UseNoneWindowStyle == false*/)
+            if (SC.RESTORE == (SC)wParam.ToInt32() && wpl.showCmd == SW.SHOWMAXIMIZED && _MinimizeAnimation)
             {
                 bool modified = _ModifyStyle(WS.DLGFRAME, 0);
 
@@ -563,7 +572,7 @@ namespace Microsoft.Windows.Shell
 
             if (NativeMethods.GetWindowPlacement(_hwnd).showCmd == SW.MAXIMIZE)
             {
-                if (SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false/* && _chromeInfo.UseNoneWindowStyle == false*/)
+                if (_MinimizeAnimation)
                 {
                     IntPtr mon = NativeMethods.MonitorFromWindow(_hwnd, (uint)MonitorOptions.MONITOR_DEFAULTTONEAREST);
                     MONITORINFO mi = NativeMethods.GetMonitorInfo(mon);
@@ -810,7 +819,8 @@ namespace Microsoft.Windows.Shell
 
         private IntPtr _HandleEnterSizeMove2(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled)
         {
-            if (SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false /* && _chromeInfo.UseNoneWindowStyle == false*/) {
+            if (_MinimizeAnimation)
+            {
                 /* we only need to remove DLGFRAME ( CAPTION = BORDER | DLGFRAME )
                  * to prevent nasty drawing
                  * removing border will cause a 1 off error on the client rect size
@@ -826,7 +836,7 @@ namespace Microsoft.Windows.Shell
 
         private IntPtr _HandleExitSizeMove2(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled)
         {
-            if (SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false /* && _chromeInfo.UseNoneWindowStyle == false*/)
+            if (_MinimizeAnimation)
             {
                 // restore DLGFRAME
                 if (_ModifyStyle(0, WS.DLGFRAME))
@@ -987,7 +997,7 @@ namespace Microsoft.Windows.Shell
 
             if (force || frameState != _isGlassEnabled)
             {
-                if (SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false/* && _chromeInfo.UseNoneWindowStyle == false*/)
+                if (_MinimizeAnimation)
                 {
                     // allow animation
                     _ModifyStyle(0, WS.CAPTION);
@@ -1045,7 +1055,7 @@ namespace Microsoft.Windows.Shell
             if (wpl.showCmd == SW.SHOWMAXIMIZED)
             {
                 RECT rcMax;
-                if (SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false/* && _chromeInfo.UseNoneWindowStyle == false*/)
+                if (_MinimizeAnimation)
                 {
                     rcMax = _GetClientRectRelativeToWindowRect(_hwnd);
                 }

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -439,7 +439,7 @@ namespace Microsoft.Windows.Shell
         {
             get
             {
-                return SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false; /* && _chromeInfo.UseNoneWindowStyle == false*/
+                return SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false;// && _chromeInfo.UseNoneWindowStyle == false;
             }
         }
 
@@ -787,7 +787,7 @@ namespace Microsoft.Windows.Shell
              * This fix is not really a full fix. Moving the Window back gives us the wrong size, because
              * MonitorFromWindow gives us the wrong (old) monitor!
              */
-            var ignoreTaskBar = _chromeInfo.IgnoreTaskbarOnMaximize || _chromeInfo.UseNoneWindowStyle;
+            var ignoreTaskBar = _chromeInfo.IgnoreTaskbarOnMaximize;// || _chromeInfo.UseNoneWindowStyle;
             WindowState state = _GetHwndState();
             if (ignoreTaskBar && state == WindowState.Maximized)
             {
@@ -884,22 +884,15 @@ namespace Microsoft.Windows.Shell
 
         private IntPtr _HandleMove2(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled)
         {
-            var ignoreTaskBar = _chromeInfo.IgnoreTaskbarOnMaximize || _chromeInfo.UseNoneWindowStyle;
             WindowState state = _GetHwndState();
-            if (ignoreTaskBar && state == WindowState.Maximized) {
+            if (state == WindowState.Maximized) {
                 IntPtr monitorFromWindow = NativeMethods.MonitorFromWindow(_hwnd, (uint)MonitorOptions.MONITOR_DEFAULTTONEAREST);
                 if (monitorFromWindow != IntPtr.Zero)
                 {
-                    //RECT windowRect = NativeMethods.GetWindowRect(_hwnd);
-                    //POINT screenPoint = new POINT() { x = windowRect.Left + windowRect.Width / 2, y = windowRect.Top + windowRect.Height / 2 };
-                    //IntPtr monitor = NativeMethods.MonitorFromPoint(screenPoint, MonitorOptions.MONITOR_DEFAULTTONEAREST);
-                    //if (monitor != IntPtr.Zero)
-                    {
-                        //MONITORINFO monitorInfo = NativeMethods.GetMonitorInfoW(monitor);
-                        MONITORINFO monitorInfo = NativeMethods.GetMonitorInfoW(monitorFromWindow);
-                        RECT rcMonitorArea = monitorInfo.rcMonitor;
-                        NativeMethods.SetWindowPos(_hwnd, IntPtr.Zero, rcMonitorArea.Left, rcMonitorArea.Top, rcMonitorArea.Width, rcMonitorArea.Height, SWP.ASYNCWINDOWPOS | SWP.FRAMECHANGED);
-                    }
+                    var ignoreTaskBar = _chromeInfo.IgnoreTaskbarOnMaximize;// || _chromeInfo.UseNoneWindowStyle;
+                    MONITORINFO monitorInfo = NativeMethods.GetMonitorInfoW(monitorFromWindow);
+                    RECT rcMonitorArea = ignoreTaskBar ? monitorInfo.rcMonitor : monitorInfo.rcWork;
+                    NativeMethods.SetWindowPos(_hwnd, IntPtr.Zero, rcMonitorArea.Left, rcMonitorArea.Top, rcMonitorArea.Width, rcMonitorArea.Height, SWP.ASYNCWINDOWPOS | SWP.FRAMECHANGED);
                 }
             }
 

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -526,7 +526,7 @@ namespace Microsoft.Windows.Shell
             bool autoHide = Convert.ToBoolean(
                 MahApps.Metro.Native.UnsafeNativeMethods.SHAppBarMessage((int)MahApps.Metro.Native.ABMsg.ABM_GETSTATE, ref abd));
 
-            if (!autoHide)
+            if (!autoHide || !Equals(monitorContainingApplication, monitorWithTaskbarOnIt))
             {
                 return area;
             }

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -882,7 +882,7 @@ namespace Microsoft.Windows.Shell
 
         private IntPtr _HandleEnterSizeMoveForAnimation(WM uMsg, IntPtr wParam, IntPtr lParam, out bool handled)
         {
-            if (_MinimizeAnimation)
+            if (_MinimizeAnimation && _GetHwndState() == WindowState.Maximized)
             {
                 /* we only need to remove DLGFRAME ( CAPTION = BORDER | DLGFRAME )
                  * to prevent nasty drawing

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -913,7 +913,23 @@ namespace Microsoft.Windows.Shell
                     var ignoreTaskBar = _chromeInfo.IgnoreTaskbarOnMaximize;// || _chromeInfo.UseNoneWindowStyle;
                     MONITORINFO monitorInfo = NativeMethods.GetMonitorInfoW(monitorFromWindow);
                     RECT rcMonitorArea = ignoreTaskBar ? monitorInfo.rcMonitor : monitorInfo.rcWork;
-                    NativeMethods.SetWindowPos(_hwnd, IntPtr.Zero, rcMonitorArea.Left, rcMonitorArea.Top, rcMonitorArea.Width, rcMonitorArea.Height, SWP.ASYNCWINDOWPOS | SWP.FRAMECHANGED);
+                    /*
+                     * ASYNCWINDOWPOS
+                     * If the calling thread and the thread that owns the window are attached to different input queues,
+                     * the system posts the request to the thread that owns the window. This prevents the calling thread
+                     * from blocking its execution while other threads process the request.
+                     * 
+                     * FRAMECHANGED
+                     * Applies new frame styles set using the SetWindowLong function. Sends a WM_NCCALCSIZE message to the window,
+                     * even if the window's size is not being changed. If this flag is not specified, WM_NCCALCSIZE is sent only
+                     * when the window's size is being changed.
+                     * 
+                     * NOCOPYBITS
+                     * Discards the entire contents of the client area. If this flag is not specified, the valid contents of the client
+                     * area are saved and copied back into the client area after the window is sized or repositioned.
+                     * 
+                     */
+                    NativeMethods.SetWindowPos(_hwnd, IntPtr.Zero, rcMonitorArea.Left, rcMonitorArea.Top, rcMonitorArea.Width, rcMonitorArea.Height, SWP.ASYNCWINDOWPOS | SWP.FRAMECHANGED | SWP.NOCOPYBITS);
                 }
             }
 

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -625,8 +625,7 @@ namespace Microsoft.Windows.Shell
             }
 
             handled = true;
-            // revert VALIDRECTS for now
-            return redraw ? new IntPtr((int)WVR.REDRAW/* | (int)WVR.VALIDRECTS*/) : IntPtr.Zero;
+            return redraw ? new IntPtr((int)WVR.REDRAW | (int)WVR.VALIDRECTS) : IntPtr.Zero;
         }
 
         private HT _GetHTFromResizeGripDirection(ResizeGripDirection direction)

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -512,19 +512,17 @@ namespace Microsoft.Windows.Shell
         /// <summary>
         /// This method handles the window size if the taskbar is set to auto-hide.
         /// </summary>
-        private static Standard.RECT AdjustWorkingAreaForAutoHide(IntPtr monitorContainingApplication, Standard.RECT area )
+        private static RECT AdjustWorkingAreaForAutoHide(IntPtr monitorContainingApplication, RECT area )
         {
+            // maybe we can use ReBarWindow32 isntead Shell_TrayWnd
             IntPtr hwnd =  MahApps.Metro.Native.UnsafeNativeMethods.FindWindow("Shell_TrayWnd", null);
-            IntPtr monitorWithTaskbarOnIt = MahApps.Metro.Native.UnsafeNativeMethods.MonitorFromWindow(hwnd, 
-                                                MahApps.Metro.Native.Constants.MONITOR_DEFAULTTONEAREST);
-
+            IntPtr monitorWithTaskbarOnIt = MahApps.Metro.Native.UnsafeNativeMethods.MonitorFromWindow(hwnd, MahApps.Metro.Native.Constants.MONITOR_DEFAULTTONEAREST);
 
             var abd = new MahApps.Metro.Native.APPBARDATA();
             abd.cbSize = Marshal.SizeOf(abd);
             abd.hWnd = hwnd;
             MahApps.Metro.Native.UnsafeNativeMethods.SHAppBarMessage((int)MahApps.Metro.Native.ABMsg.ABM_GETTASKBARPOS, ref abd);
-            bool autoHide = Convert.ToBoolean(
-                MahApps.Metro.Native.UnsafeNativeMethods.SHAppBarMessage((int)MahApps.Metro.Native.ABMsg.ABM_GETSTATE, ref abd));
+            bool autoHide = Convert.ToBoolean(MahApps.Metro.Native.UnsafeNativeMethods.SHAppBarMessage((int)MahApps.Metro.Native.ABMsg.ABM_GETSTATE, ref abd));
 
             if (!autoHide || !Equals(monitorContainingApplication, monitorWithTaskbarOnIt))
             {

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -625,7 +625,8 @@ namespace Microsoft.Windows.Shell
             }
 
             handled = true;
-            return redraw ? new IntPtr((int)WVR.REDRAW | (int)WVR.VALIDRECTS) : IntPtr.Zero;
+            // revert VALIDRECTS for now
+            return redraw ? new IntPtr((int)WVR.REDRAW/* | (int)WVR.VALIDRECTS*/) : IntPtr.Zero;
         }
 
         private HT _GetHTFromResizeGripDirection(ResizeGripDirection direction)

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -515,14 +515,14 @@ namespace Microsoft.Windows.Shell
         private static RECT AdjustWorkingAreaForAutoHide(IntPtr monitorContainingApplication, RECT area )
         {
             // maybe we can use ReBarWindow32 isntead Shell_TrayWnd
-            IntPtr hwnd =  MahApps.Metro.Native.UnsafeNativeMethods.FindWindow("Shell_TrayWnd", null);
-            IntPtr monitorWithTaskbarOnIt = MahApps.Metro.Native.UnsafeNativeMethods.MonitorFromWindow(hwnd, MahApps.Metro.Native.Constants.MONITOR_DEFAULTTONEAREST);
+            IntPtr hwnd = NativeMethods.FindWindow("Shell_TrayWnd", null);
+            IntPtr monitorWithTaskbarOnIt = NativeMethods.MonitorFromWindow(hwnd, (uint)MonitorOptions.MONITOR_DEFAULTTONEAREST);
 
-            var abd = new MahApps.Metro.Native.APPBARDATA();
+            var abd = new APPBARDATA();
             abd.cbSize = Marshal.SizeOf(abd);
             abd.hWnd = hwnd;
-            MahApps.Metro.Native.UnsafeNativeMethods.SHAppBarMessage((int)MahApps.Metro.Native.ABMsg.ABM_GETTASKBARPOS, ref abd);
-            bool autoHide = Convert.ToBoolean(MahApps.Metro.Native.UnsafeNativeMethods.SHAppBarMessage((int)MahApps.Metro.Native.ABMsg.ABM_GETSTATE, ref abd));
+            NativeMethods.SHAppBarMessage((int)ABMsg.ABM_GETTASKBARPOS, ref abd);
+            bool autoHide = Convert.ToBoolean(NativeMethods.SHAppBarMessage((int)ABMsg.ABM_GETSTATE, ref abd));
 
             if (!autoHide || !Equals(monitorContainingApplication, monitorWithTaskbarOnIt))
             {
@@ -531,16 +531,16 @@ namespace Microsoft.Windows.Shell
 
             switch (abd.uEdge)
             {
-                case (int)MahApps.Metro.Native.ABEdge.ABE_LEFT:
+                case (int)ABEdge.ABE_LEFT:
                     area.Left += 2;
                     break;
-                case (int)MahApps.Metro.Native.ABEdge.ABE_RIGHT:
+                case (int)ABEdge.ABE_RIGHT:
                     area.Right -= 2;
                     break;
-                case (int)MahApps.Metro.Native.ABEdge.ABE_TOP:
+                case (int)ABEdge.ABE_TOP:
                     area.Top += 2;
                     break;
-                case (int)MahApps.Metro.Native.ABEdge.ABE_BOTTOM:
+                case (int)ABEdge.ABE_BOTTOM:
                     area.Bottom -= 2;
                     break;
                 default:
@@ -565,8 +565,7 @@ namespace Microsoft.Windows.Shell
             {
                 if (SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false/* && _chromeInfo.UseNoneWindowStyle == false*/)
                 {
-                    const int MONITOR_DEFAULTTONEAREST = 0x00000002;
-                    IntPtr mon = NativeMethods.MonitorFromWindow(_hwnd, MONITOR_DEFAULTTONEAREST);
+                    IntPtr mon = NativeMethods.MonitorFromWindow(_hwnd, (uint)MonitorOptions.MONITOR_DEFAULTTONEAREST);
                     MONITORINFO mi = NativeMethods.GetMonitorInfo(mon);
 
                     RECT rc = (RECT) Marshal.PtrToStructure(lParam, typeof(RECT));
@@ -1039,8 +1038,6 @@ namespace Microsoft.Windows.Shell
 
         private void _SetRoundingRegion(WINDOWPOS? wp)
         {
-            const int MONITOR_DEFAULTTONEAREST = 0x00000002;
-
             // We're early - WPF hasn't necessarily updated the state of the window.
             // Need to query it ourselves.
             WINDOWPLACEMENT wpl = NativeMethods.GetWindowPlacement(_hwnd);
@@ -1069,7 +1066,7 @@ namespace Microsoft.Windows.Shell
                         top = (int)r.Top;
                     }
 
-                    IntPtr hMon = NativeMethods.MonitorFromWindow(_hwnd, MONITOR_DEFAULTTONEAREST);
+                    IntPtr hMon = NativeMethods.MonitorFromWindow(_hwnd, (uint)MonitorOptions.MONITOR_DEFAULTTONEAREST);
 
                     MONITORINFO mi = NativeMethods.GetMonitorInfo(hMon);
                     rcMax = _chromeInfo.IgnoreTaskbarOnMaximize ? mi.rcMonitor : mi.rcWork;

--- a/MahApps.Metro/Native/ABEdge.cs
+++ b/MahApps.Metro/Native/ABEdge.cs
@@ -1,5 +1,8 @@
-﻿namespace MahApps.Metro.Native
+﻿using System;
+
+namespace MahApps.Metro.Native
 {
+    [Obsolete("Use Standard.ABEdge instead.")]
     internal enum ABEdge
     {
         ABE_LEFT = 0,

--- a/MahApps.Metro/Native/ABMsg.cs
+++ b/MahApps.Metro/Native/ABMsg.cs
@@ -1,5 +1,8 @@
-﻿namespace MahApps.Metro.Native
+﻿using System;
+
+namespace MahApps.Metro.Native
 {
+    [Obsolete("Use Standard.ABMsg instead.")]
     internal enum ABMsg
     {
         ABM_NEW = 0,

--- a/MahApps.Metro/Native/APPBARDATA.cs
+++ b/MahApps.Metro/Native/APPBARDATA.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace MahApps.Metro.Native
 {
+    [Obsolete("Use Standard.APPBARDATA instead.")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct APPBARDATA
     {

--- a/MahApps.Metro/Native/Constants.cs
+++ b/MahApps.Metro/Native/Constants.cs
@@ -1,4 +1,6 @@
-﻿namespace MahApps.Metro.Native
+﻿using System;
+
+namespace MahApps.Metro.Native
 {
     internal static class Constants
     {
@@ -63,6 +65,56 @@
             ///        Activates and displays the window. If the window is minimized or maximized, the system restores it to its original size and position. An application should specify this flag when restoring a minimized window.
             /// </summary>
             SW_RESTORE = 9
+        }
+
+        [Flags()]
+        public enum RedrawWindowFlags : uint
+        {
+            /// <summary>
+            /// Invalidates the rectangle or region that you specify in lprcUpdate or hrgnUpdate.
+            /// You can set only one of these parameters to a non-NULL value. If both are NULL, RDW_INVALIDATE invalidates the entire window.
+            /// </summary>
+            Invalidate = 0x1,
+
+            /// <summary>Causes the OS to post a WM_PAINT message to the window regardless of whether a portion of the window is invalid.</summary>
+            InternalPaint = 0x2,
+
+            /// <summary>
+            /// Causes the window to receive a WM_ERASEBKGND message when the window is repainted.
+            /// Specify this value in combination with the RDW_INVALIDATE value; otherwise, RDW_ERASE has no effect.
+            /// </summary>
+            Erase = 0x4,
+
+            /// <summary>
+            /// Validates the rectangle or region that you specify in lprcUpdate or hrgnUpdate.
+            /// You can set only one of these parameters to a non-NULL value. If both are NULL, RDW_VALIDATE validates the entire window.
+            /// This value does not affect internal WM_PAINT messages.
+            /// </summary>
+            Validate = 0x8,
+
+            NoInternalPaint = 0x10,
+
+            /// <summary>Suppresses any pending WM_ERASEBKGND messages.</summary>
+            NoErase = 0x20,
+
+            /// <summary>Excludes child windows, if any, from the repainting operation.</summary>
+            NoChildren = 0x40,
+
+            /// <summary>Includes child windows, if any, in the repainting operation.</summary>
+            AllChildren = 0x80,
+
+            /// <summary>Causes the affected windows, which you specify by setting the RDW_ALLCHILDREN and RDW_NOCHILDREN values, to receive WM_ERASEBKGND and WM_PAINT messages before the RedrawWindow returns, if necessary.</summary>
+            UpdateNow = 0x100,
+
+            /// <summary>
+            /// Causes the affected windows, which you specify by setting the RDW_ALLCHILDREN and RDW_NOCHILDREN values, to receive WM_ERASEBKGND messages before RedrawWindow returns, if necessary.
+            /// The affected windows receive WM_PAINT messages at the ordinary time.
+            /// </summary>
+            EraseNow = 0x200,
+
+            Frame = 0x400,
+
+            NoFrame = 0x800
         }
 
         public const int MONITOR_DEFAULTTONEAREST = 0x00000002;

--- a/MahApps.Metro/Native/UnsafeNativeMethods.cs
+++ b/MahApps.Metro/Native/UnsafeNativeMethods.cs
@@ -209,9 +209,11 @@ namespace MahApps.Metro.Native
         [DllImport("user32.dll")]
         internal static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
 
+        [Obsolete("Use NativeMethods.FindWindow instead.")]
         [DllImport("user32.dll", SetLastError = true)]
         internal static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
 
+        [Obsolete("Use NativeMethods.SHAppBarMessage instead.")]
         [DllImport("shell32.dll", CallingConvention = CallingConvention.StdCall)]
         public static extern int SHAppBarMessage(int dwMessage, ref APPBARDATA pData);
 

--- a/MahApps.Metro/Native/UnsafeNativeMethods.cs
+++ b/MahApps.Metro/Native/UnsafeNativeMethods.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -217,5 +218,13 @@ namespace MahApps.Metro.Native
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern bool RedrawWindow(IntPtr hWnd, [In] ref RECT lprcUpdate, IntPtr hrgnUpdate, Constants.RedrawWindowFlags flags);
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern bool RedrawWindow(IntPtr hWnd, IntPtr lprcUpdate, IntPtr hrgnUpdate, Constants.RedrawWindowFlags flags); 
     }
 }

--- a/docs/release-notes/1.1.0.md
+++ b/docs/release-notes/1.1.0.md
@@ -1,6 +1,6 @@
 # Notes
 
-This is a bug fix and minor fetaure release of MahApps.Metro.
+This is a bug fix and fetaure release of MahApps.Metro.
 
 # Features
 
@@ -13,6 +13,7 @@ This is a bug fix and minor fetaure release of MahApps.Metro.
 - `MaximumBodyHeight` for `MetroDialogSettings`, so we can get a `ScrollViewer` for tall dialog content
 - `IsMinButtonEnabled`, `IsMaxRestoreButtonEnabled` and `IsCloseButtonEnabled` to enable/disable the window buttons at `WindowButtonCommands` @romerod #1562
 - `IdealForegroundDisabledBrush` to set the foreground for disabled window buttons at `WindowButtonCommands` #1581
+- `MetroWindow` animates now on minimize/maximize/restore window action (limited by ignoring the taskbar) #1756 
 
 # Bugfixes
 
@@ -23,3 +24,4 @@ This is a bug fix and minor fetaure release of MahApps.Metro.
 ![](https://camo.githubusercontent.com/9df3efb07f02b8d95a471a493762433fa8eb442c/687474703a2f2f6673312e64697265637475706c6f61642e6e65742f696d616765732f3135303131312f79766a356e3333352e706e67)
 - Fixed disabled window buttons foreground (and add `IdealForegroundDisabledBrush` to handle this) #1581
 - Fixed wrong max/restore button tool tip when maximized [SHA](https://github.com/MahApps/MahApps.Metro/commit/4a1a8f91c6588c034a6e5ef3fac64e4eacce6845)
+- Fixed wrong window size while moving maximized window between monitors #1275  

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -9,7 +9,7 @@
                       xmlns:exampleViews="clr-namespace:MetroDemo.ExampleViews"
                       Title="MahApps.Metro - Demo Application"
                       Width="960"
-                      Height="600"
+                      Height="600" UseNoneWindowStyle="True" WindowState="Maximized"
                       Icon="mahapps.metro.logo2.ico"
                       ShowIconOnTitleBar="True"
                       ShowTitleBar="True"

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -164,6 +164,8 @@
                 <MenuItem Header="Window">
                     <MenuItem IsCheckable="True" Header="Ignore taskbar on maximize"
                               IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=IgnoreTaskbarOnMaximize}" />
+                    <MenuItem IsCheckable="True" Header="Toggle FullScreen"
+                              IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=ToggleFullScreen}" />
                 </MenuItem>
             </Menu>
 

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -9,7 +9,7 @@
                       xmlns:exampleViews="clr-namespace:MetroDemo.ExampleViews"
                       Title="MahApps.Metro - Demo Application"
                       Width="960"
-                      Height="600" UseNoneWindowStyle="True" WindowState="Maximized"
+                      Height="600"
                       Icon="mahapps.metro.logo2.ico"
                       ShowIconOnTitleBar="True"
                       ShowTitleBar="True"

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -162,7 +162,8 @@
                               Header="Show CustomDialog Externally" />
                 </MenuItem>
                 <MenuItem Header="Window">
-                    <MenuItem IsCheckable="True" Header="Ignore taskbar on maximize" Click="IgnoreTaskBar_Click"/>
+                    <MenuItem IsCheckable="True" Header="Ignore taskbar on maximize"
+                              IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=IgnoreTaskbarOnMaximize}" />
                 </MenuItem>
             </Menu>
 

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -29,6 +29,46 @@ namespace MetroDemo
                 };
         }
 
+        public static readonly DependencyProperty ToggleFullScreenProperty =
+            DependencyProperty.Register("ToggleFullScreen",
+                                        typeof(bool),
+                                        typeof(MainWindow),
+                                        new PropertyMetadata(default(bool), ToggleFullScreenPropertyChangedCallback));
+
+        private static void ToggleFullScreenPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            var metroWindow = (MetroWindow)dependencyObject;
+            if (e.OldValue != e.NewValue)
+            {
+                var fullScreen = (bool)e.NewValue;
+                if (fullScreen)
+                {
+                    metroWindow.UseNoneWindowStyle = true;
+                    metroWindow.IgnoreTaskbarOnMaximize = true;
+                    metroWindow.ShowMinButton = false;
+                    metroWindow.ShowMaxRestoreButton = false;
+                    metroWindow.ShowCloseButton = false;
+                    metroWindow.WindowState = WindowState.Maximized;
+                }
+                else
+                {
+                    metroWindow.UseNoneWindowStyle = false;
+                    metroWindow.ShowTitleBar = true; // <-- this must be set to true
+                    metroWindow.IgnoreTaskbarOnMaximize = false;
+                    metroWindow.ShowMinButton = true;
+                    metroWindow.ShowMaxRestoreButton = true;
+                    metroWindow.ShowCloseButton = true;
+                    metroWindow.WindowState = WindowState.Normal;
+                }
+            }
+        }
+
+        public bool ToggleFullScreen
+        {
+            get { return (bool)GetValue(ToggleFullScreenProperty); }
+            set { SetValue(ToggleFullScreenProperty, value); }
+        }
+
         private void LaunchMahAppsOnGitHub(object sender, RoutedEventArgs e)
         {
             System.Diagnostics.Process.Start("https://github.com/MahApps/MahApps.Metro");

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -250,10 +250,5 @@ namespace MetroDemo
             if (_shutdown)
                 Application.Current.Shutdown();
         }
-
-        private void IgnoreTaskBar_Click(object sender, RoutedEventArgs e)
-        {
-            this.IgnoreTaskbarOnMaximize = !this.IgnoreTaskbarOnMaximize;
-        }
     }
 }


### PR DESCRIPTION
this pr should fix the missing minimize and maximize/restore animations.
thx to @AdditionalPylons for the inspiration and work to solve this issue (hopefully).

limitations goes to a window that ignores the taskbar (no animation)

Closes #1539 

this closes #1275 too (Issues when switching MetroWindow between monitors while maximized)