### PR TITLE
Deferred MetroWindow Resizing

### DIFF
--- a/MahApps.Metro/Controls/MetroResizeGrip.cs
+++ b/MahApps.Metro/Controls/MetroResizeGrip.cs
@@ -1,0 +1,189 @@
+﻿using MahApps.Metro.Native;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Forms;
+using System.Windows.Input;
+using System.Windows.Interop;
+using System.Windows.Media;
+
+namespace MahApps.Metro.Controls
+{
+    public class MetroResizeGrip : System.Windows.Controls.Primitives.ResizeGrip
+    {
+        public static readonly DependencyProperty DeferResizeProperty =
+            DependencyProperty.RegisterAttached("DeferResize", typeof(bool), typeof(MetroResizeGrip), new PropertyMetadata(false));
+
+        private bool _IsDragging;
+        private MetroWindow _ParentWindow;
+        private IntPtr _ParentWindowHandle;
+        private ResizerWindow _ResizerWindow;
+        private IntPtr _ResizerWindowHandle;
+        private int _XOffset;
+        private int _YOffset;
+        private bool _DeferResize;
+        private Point _MousePosition;
+
+        public MetroResizeGrip()
+        {
+            this.Loaded += (sender, e) =>
+            {
+                _FindParentWindow();
+                InvalidateDeferResizeProperty();
+                _ResizerWindow = new ResizerWindow(_ParentWindow);
+                _ResizerWindow.SourceInitialized += (sender2, e2) =>
+                {
+                    _ResizerWindowHandle = ((HwndSource)HwndSource.FromVisual(_ResizerWindow)).Handle;
+                };
+                _ResizerWindow.Show();
+                _ResizerWindow.Visibility = System.Windows.Visibility.Collapsed;
+                _ResizerWindow.HideStoryboard.Completed += (sender2, e2) =>
+                {
+                    if (_ResizerWindow.Opacity == 0)
+                        _ResizerWindow.Visibility = System.Windows.Visibility.Collapsed;
+                };
+            };
+            this.MouseLeftButtonDown += ResizeGrip_MouseLeftButtonDown;
+            this.MouseLeftButtonUp += ResizeGrip_MouseLeftButtonUp;
+            this.MouseMove += ResizeGrip_MouseMove;
+        }
+
+        public static bool GetDeferResize(DependencyObject obj)
+        {
+            return (bool)obj.GetValue(DeferResizeProperty);
+        }
+
+        public static void SetDeferResize(DependencyObject obj, bool value)
+        {
+            obj.SetValue(DeferResizeProperty, value);
+        }
+
+        public void InvalidateDeferResizeProperty()
+        {
+            _DeferResize = MetroResizeGrip.GetDeferResize(_ParentWindow);
+        }
+
+        private void _DetermineNewSize(out int cx, out int cy)
+        {
+            Point pt = _GetRelativePoint();
+
+            cx = (int)pt.X + _XOffset;
+            cy = (int)pt.Y + _YOffset;
+
+            if (pt.X <= _ParentWindow.MinWidth)
+                cx = (int)_ParentWindow.MinWidth;
+            if (pt.Y <= _ParentWindow.MinHeight)
+                cy = (int)_ParentWindow.MinHeight;
+
+            // This is to guard against the user dragging the resize grip under the taskbar, since he won't be able to get a
+            // grip on it again.
+            Int32Rect r = _GetScreenWorkingAreaBoundsFromPoint(_MousePosition);
+            if (_MousePosition.Y + _YOffset >= r.Height)
+            {
+                cy = r.Height - (int)_ParentWindow.Top;
+            }
+        }
+
+        private void _FindParentWindow()
+        {
+            DependencyObject DO = this;
+            while (true)
+            {
+                DO = VisualTreeHelper.GetParent(DO);
+                if (DO is Window)
+                {
+                    _ParentWindow = (MetroWindow)DO;
+                    _ParentWindowHandle = ((HwndSource)(HwndSource.FromVisual(_ParentWindow))).Handle;
+                    _ParentWindow.Closed += (sender, e) => _ResizerWindow.Close();
+                    break;
+                }
+            }
+        }
+
+        private Point _GetRelativePoint()
+        {
+            POINT p; UnsafeNativeMethods.GetCursorPos(out p);
+            Point point = _MousePosition = new Point(p.X, p.Y);
+            Point point2 = _ParentWindow.PointFromScreen(point);
+            return point2;
+        }
+
+        private void _Process()
+        {
+            int cx, cy;
+            _DetermineNewSize(out cx, out cy);
+
+            UnsafeNativeMethods.SetWindowPos(_ParentWindowHandle, IntPtr.Zero, 0, 0, cx, cy, (uint)0x2 /* SWP_NOMOVE */);
+        }
+
+        private void _UpdateResizer()
+        {
+            int cx, cy;
+            _DetermineNewSize(out cx, out cy);
+
+            UnsafeNativeMethods.SetWindowPos(_ResizerWindowHandle, new IntPtr((int)-1 /* HWND_TOPMOST */), (int)_ParentWindow.Left - 10, (int)_ParentWindow.Top - 10, cx + 20, cy + 20, (uint)0x10 /* SWP_NOACTIVE */);
+        }
+
+        private void ResizeGrip_MouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            Debug.Assert(_ParentWindow != null);
+
+            e.Handled = true;
+            _IsDragging = true;
+            Point basePoint = _GetRelativePoint();
+            _XOffset = (int)_ParentWindow.ActualWidth - (int)basePoint.X;
+            _YOffset = (int)_ParentWindow.ActualHeight - (int)basePoint.Y;
+
+            if (MetroResizeGrip.GetDeferResize(_ParentWindow))
+            {
+                _ResizerWindow.Visibility = System.Windows.Visibility.Visible;
+                _ResizerWindow.ShowStoryboard.Begin();
+            }
+            Mouse.Capture(this);
+        }
+
+        private void ResizeGrip_MouseLeftButtonUp(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            Debug.Assert(_ParentWindow != null);
+
+            e.Handled = true;
+            if (MetroResizeGrip.GetDeferResize(_ParentWindow))
+            {
+                _Process();
+                _ResizerWindow.HideStoryboard.Begin();
+            }
+            _IsDragging = false;
+            this.ReleaseMouseCapture();
+        }
+
+        private void ResizeGrip_MouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            Debug.Assert(_ParentWindow != null);
+            Debug.Assert(_ParentWindowHandle != null);
+
+            e.Handled = true;
+            if (!_IsDragging)
+                return;
+
+            if (_DeferResize)
+            {
+                _UpdateResizer();
+            }
+            else
+            {
+                _Process();
+            }
+        }
+
+        private Int32Rect _GetScreenWorkingAreaBoundsFromPoint(System.Windows.Point point)
+        {
+            Screen screen = Screen.FromPoint(new System.Drawing.Point((int)point.X, (int)point.Y));
+            System.Drawing.Rectangle r = screen.WorkingArea;
+            return new Int32Rect(r.X, r.Y, r.Width, r.Height);
+        }
+    }
+}

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -36,6 +36,7 @@ namespace MahApps.Metro.Controls
         private const string PART_OverlayBox = "PART_OverlayBox";
         private const string PART_MetroDialogContainer = "PART_MetroDialogContainer";
         private const string PART_FlyoutModal = "PART_FlyoutModal";
+        private const string PART_MetroResizeGrip = "PART_MetroResizeGrip";
 
         public static readonly DependencyProperty ShowIconOnTitleBarProperty = DependencyProperty.Register("ShowIconOnTitleBar", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
         public static readonly DependencyProperty IconEdgeModeProperty = DependencyProperty.Register("IconEdgeMode", typeof(EdgeMode), typeof(MetroWindow), new PropertyMetadata(EdgeMode.Aliased));
@@ -95,6 +96,7 @@ namespace MahApps.Metro.Controls
         internal ContentPresenter LeftWindowCommandsPresenter;
         internal ContentPresenter RightWindowCommandsPresenter;
         internal WindowButtonCommands WindowButtonCommands;
+        internal MetroResizeGrip metroResizeGrip;
         
         internal Grid overlayBox;
         internal Grid metroDialogContainer;
@@ -813,6 +815,7 @@ namespace MahApps.Metro.Controls
             icon = GetTemplateChild(PART_Icon) as UIElement;
             titleBar = GetTemplateChild(PART_TitleBar) as UIElement;
             titleBarBackground = GetTemplateChild(PART_WindowTitleBackground) as UIElement;
+            metroResizeGrip = GetTemplateChild(PART_MetroResizeGrip) as MetroResizeGrip;
 
             this.SetVisibiltyForAllTitleElements(this.TitlebarHeight > 0);
         }
@@ -1011,6 +1014,11 @@ namespace MahApps.Metro.Controls
             { }
 
             public Flyout ChangedFlyout { get; internal set; }
+        }
+
+        public void InvalidateDeferResizeProperty()
+        {
+            metroResizeGrip.InvalidateDeferResizeProperty();
         }
     }
 }

--- a/MahApps.Metro/Controls/ResizerWindow.xaml
+++ b/MahApps.Metro/Controls/ResizerWindow.xaml
@@ -1,0 +1,56 @@
+﻿<Window x:Class="MahApps.Metro.Controls.ResizerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="ResizerWindow" Height="300" Width="300"
+        ResizeMode="NoResize"
+        x:ClassModifier="internal"
+        AllowsTransparency="True"
+        WindowStyle="None"
+        Background="Transparent"
+        x:Name="resizerWindow"
+        Opacity="0"
+        ShowActivated="False"
+        ShowInTaskbar="False"
+        IsHitTestVisible="False">
+    <Window.Resources>
+        <Storyboard x:Key="ShowStoryboard">
+            <DoubleAnimation
+                Storyboard.TargetProperty="(UIElement.Opacity)"
+                Storyboard.TargetName="resizerWindow"
+                To="1"
+                Duration="00:00:.2" />
+        </Storyboard>
+        <Storyboard x:Key="HideStoryboard">
+            <DoubleAnimation
+                Storyboard.TargetProperty="(UIElement.Opacity)"
+                Storyboard.TargetName="resizerWindow"
+                To="0"
+                Duration="00:00:.1" />
+        </Storyboard>
+    </Window.Resources>
+    <Grid Name="RootGrid" Margin="10">
+        <Grid.Resources>
+            <Style x:Key="VerticalBorderStyle" TargetType="Border">
+                <Setter Property="SnapsToDevicePixels" Value="True" />
+                <Setter Property="UseLayoutRounding" Value="True" />
+                <Setter Property="Width" Value="6" />
+                <Setter Property="BorderBrush" Value="#66666666" />
+                <Setter Property="BorderThickness" Value="6" />
+                <Setter Property="VerticalAlignment" Value="Stretch" />
+                <Setter Property="Margin" Value="0,6" />
+            </Style>
+            <Style x:Key="HorizontalBorderStyle" TargetType="Border">
+                <Setter Property="SnapsToDevicePixels" Value="True" />
+                <Setter Property="UseLayoutRounding" Value="True" />
+                <Setter Property="Height" Value="6" />
+                <Setter Property="BorderBrush" Value="#66666666" />
+                <Setter Property="BorderThickness" Value="6" />
+                <Setter Property="HorizontalAlignment" Value="Stretch" />
+            </Style>
+        </Grid.Resources>
+        <Border Style="{StaticResource VerticalBorderStyle}" HorizontalAlignment="Left" />
+        <Border Style="{StaticResource HorizontalBorderStyle}" VerticalAlignment="Top" />
+        <Border Style="{StaticResource VerticalBorderStyle}" HorizontalAlignment="Right" />
+        <Border Style="{StaticResource HorizontalBorderStyle}" VerticalAlignment="Bottom" />
+    </Grid>
+</Window>

--- a/MahApps.Metro/Controls/ResizerWindow.xaml.cs
+++ b/MahApps.Metro/Controls/ResizerWindow.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace MahApps.Metro.Controls
+{
+    internal partial class ResizerWindow : Window
+    {
+        public ResizerWindow(MetroWindow window)
+        {
+            InitializeComponent();
+            this.Owner = window;
+            this.ShowStoryboard = this.TryFindResource("ShowStoryboard") as Storyboard;
+            this.HideStoryboard = this.TryFindResource("HideStoryboard") as Storyboard;
+        }
+
+        public Storyboard ShowStoryboard { get; set; }
+
+        public Storyboard HideStoryboard { get; set; }
+    }
+}

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -105,6 +105,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Lib\NET45\System.Windows.Interactivity.dll</HintPath>
@@ -160,6 +162,7 @@
     <Compile Include="Controls\MetroAnimatedTabControl.cs" />
     <Compile Include="Controls\MetroNavigationWindow.cs" />
     <Compile Include="Controls\MetroProgressBar.cs" />
+    <Compile Include="Controls\MetroResizeGrip.cs" />
     <Compile Include="Controls\MetroTabControl.cs" />
     <Compile Include="Controls\MetroTabItem.cs" />
     <Compile Include="Controls\MetroWindowHelpers.cs" />
@@ -173,6 +176,9 @@
     <Compile Include="Controls\Position.cs" />
     <Compile Include="Controls\PropertyChangeNotifier.cs" />
     <Compile Include="Controls\RangeParameterChangedEventArgs.cs" />
+    <Compile Include="Controls\ResizerWindow.xaml.cs">
+      <DependentUpon>ResizerWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\SafeRaise.cs" />
     <Compile Include="Controls\Helper\ScrollBarHelper.cs" />
     <Compile Include="Controls\ScrollViewerOffsetMediator.cs" />
@@ -259,6 +265,10 @@
     <Page Include="Controls\GlowWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Controls\ResizerWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Styles\Accents\Amber.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -66,6 +66,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Lib\NET40\System.Windows.Interactivity.dll</HintPath>
@@ -125,6 +127,7 @@
     <Compile Include="Controls\MetroAnimatedTabControl.cs" />
     <Compile Include="Controls\MetroNavigationWindow.cs" />
     <Compile Include="Controls\MetroProgressBar.cs" />
+    <Compile Include="Controls\MetroResizeGrip.cs" />
     <Compile Include="Controls\MetroTabControl.cs" />
     <Compile Include="Controls\MetroTabItem.cs" />
     <Compile Include="Controls\MetroWindowHelpers.cs" />
@@ -137,6 +140,9 @@
     <Compile Include="Controls\Position.cs" />
     <Compile Include="Controls\PropertyChangeNotifier.cs" />
     <Compile Include="Controls\RangeParameterChangedEventArgs.cs" />
+    <Compile Include="Controls\ResizerWindow.xaml.cs">
+      <DependentUpon>ResizerWindow.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\SafeRaise.cs" />
     <Compile Include="Controls\ScrollViewerOffsetMediator.cs" />
     <Compile Include="Controls\SplitButton.cs" />
@@ -217,6 +223,10 @@
     <Compile Include="ThemeManager.cs" />
     <AppDesigner Include="Properties\" />
     <Page Include="Controls\GlowWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Controls\ResizerWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -174,7 +174,7 @@
                     BorderThickness="{TemplateBinding BorderThickness}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch" />
-			<Controls:MetroResizeGrip x:Name="PART_MetroResizeGrip"
+            <Controls:MetroResizeGrip x:Name="PART_MetroResizeGrip"
                                       Cursor="SizeNWSE"
                                       HorizontalAlignment="Right"
                                       VerticalAlignment="Bottom"

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -174,11 +174,12 @@
                     BorderThickness="{TemplateBinding BorderThickness}"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch" />
-            <ResizeGrip x:Name="WindowResizeGrip"
-                        HorizontalAlignment="Right"
-                        IsTabStop="false"
-                        Visibility="Collapsed"
-                        VerticalAlignment="Bottom" />
+			<Controls:MetroResizeGrip x:Name="PART_MetroResizeGrip"
+                                      Cursor="SizeNWSE"
+                                      HorizontalAlignment="Right"
+                                      VerticalAlignment="Bottom"
+                                      Visibility="Collapsed"
+                                      IsTabStop="false" />
         </Grid>
 
         <ControlTemplate.Resources>
@@ -231,7 +232,7 @@
                                Value="Normal" />
                 </MultiTrigger.Conditions>
                 <Setter Property="Visibility"
-                        TargetName="WindowResizeGrip"
+                        TargetName="PART_MetroResizeGrip"
                         Value="Visible" />
             </MultiTrigger>
         </ControlTemplate.Triggers>

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -14,6 +14,8 @@
                       ShowIconOnTitleBar="True"
                       ShowTitleBar="True"
                       WindowStartupLocation="CenterScreen"
+                      ResizeMode="CanResizeWithGrip"
+                      Controls:MetroResizeGrip.DeferResize="False"
                       GlowBrush="{DynamicResource AccentColorBrush}"
                       NonActiveGlowBrush="Red"
                       mc:Ignorable="d"
@@ -166,6 +168,7 @@
                               IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=IgnoreTaskbarOnMaximize}" />
                     <MenuItem IsCheckable="True" Header="Toggle FullScreen (no taskbar, window style = none)"
                               IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=ToggleFullScreen}" />
+                    <MenuItem IsCheckable="True" Header="Defer Resize" Click="DeferResize_Click" />
                 </MenuItem>
             </Menu>
 

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -288,5 +288,11 @@ namespace MetroDemo
             if (_shutdown)
                 Application.Current.Shutdown();
         }
+
+        private void DeferResize_Click(object sender, RoutedEventArgs e)
+        {
+            MetroResizeGrip.SetDeferResize(this, !MetroResizeGrip.GetDeferResize(this));
+            this.InvalidateDeferResizeProperty();
+        }
     }
 }


### PR DESCRIPTION
This PR creates a resizer that works with the MetroResizeGrip to defer the resizing of the MetroWindow.
Two classes are added, `WindowResizer` and `MetroResizeGrip`. The `MetroResizeGrip` is added to the MetroWindow's template instead of the normal `ResizeGrip`.

You can enable this feature by setting the attached property `MetroResizeGrip.DeferResize`.

For now, this only works with the resize grip, I have a feeling that for this to work with the window chrome resizers a lot of things will need to be radically changed.

Usage:
![capture](https://cloud.githubusercontent.com/assets/4404199/5791550/4b2200b8-9ee6-11e4-8dbc-83c1d9f8c76b.PNG)


Enable this from the demo:
![mahssp](https://cloud.githubusercontent.com/assets/4404199/5791543/655034ec-9ee5-11e4-8763-f97f03dfbafb.png)

![mahapps23r](https://cloud.githubusercontent.com/assets/4404199/5791544/6e80220c-9ee5-11e4-8495-bfcfba4d9c19.gif)

Closes #1534 