### PR TITLE
Don't maximize over autohidden taskbar

### DIFF
--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -988,6 +988,17 @@ namespace Microsoft.Windows.Shell
 
             if (force || frameState != _isGlassEnabled)
             {
+                if (SystemParameters.MinimizeAnimation && _chromeInfo.IgnoreTaskbarOnMaximize == false/* && _chromeInfo.UseNoneWindowStyle == false*/)
+                {
+                    // allow animation
+                    _ModifyStyle(0, WS.CAPTION);
+                }
+                else
+                {
+                    // no animation
+                    _ModifyStyle(WS.CAPTION, 0);
+                }
+
                 _isGlassEnabled = frameState && _chromeInfo.GlassFrameThickness != default(Thickness);
 
                 if (!_isGlassEnabled)


### PR DESCRIPTION
Move AutoHidden taskbar handling code into WindowChromeWorker. 

GetMinMaxInfo hook shouldn't be needed in BorderlessWindowBehavior any longer.