### PR TITLE
Remove redundant ItemsControl inside our ItemsControl

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -470,9 +470,7 @@
                             </Style>
                         </ResourceDictionary>
                     </ControlTemplate.Resources>
-                    <Border>
-                        <ItemsPresenter />
-                    </Border>
+                    <ItemsPresenter />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -321,6 +321,13 @@
                 Value="Center" />
         <Setter Property="FocusVisualStyle"
                 Value="{x:Null}" />
+        <Setter Property="ItemsPanel">
+            <Setter.Value>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" />
+                </ItemsPanelTemplate>
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Controls:WindowCommands">
@@ -463,16 +470,9 @@
                             </Style>
                         </ResourceDictionary>
                     </ControlTemplate.Resources>
-
-                    <ItemsControl IsTabStop="False"
-                                  ItemsSource="{Binding Items, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommands}}}"
-                                  ItemTemplate="{TemplateBinding ItemTemplate}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <StackPanel Orientation="Horizontal" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                    </ItemsControl>
+                    <Border>
+                        <ItemsPresenter />
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
We were using an ItemsControl inside our ItemsControl and binding the
nested ItemsControl's source to our ItemsControl's source. Wut?