### PR TITLE
Fix the chrome for when there is no enough space

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -32,6 +32,7 @@
                                StrokeThickness="0" />
 
                     <DockPanel LastChildFill="True"
+                               Panel.ZIndex="3"
                                Grid.Row="0"
                                Grid.RowSpan="2"
                                Grid.Column="0">

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -17,23 +17,11 @@
         <Grid>
             <AdornerDecorator>
                 <Grid Background="{TemplateBinding Background}">
-                    <Grid.ColumnDefinitions>
-                        <!-- icon -->
-                        <ColumnDefinition Width="Auto" />
-                        <!-- left window commands -->
-                        <ColumnDefinition Width="Auto" />
-                        <!-- title -->
-                        <ColumnDefinition Width="*" />
-                        <!-- right window commands -->
-                        <ColumnDefinition Width="Auto" />
-                        <!-- min,max,close buttons -->
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
-
+                    
                     <Rectangle x:Name="PART_WindowTitleBackground"
                                Focusable="False"
                                Fill="{TemplateBinding WindowTitleBrush}"
@@ -42,77 +30,77 @@
                                Grid.Column="0"
                                Grid.ColumnSpan="5"
                                StrokeThickness="0" />
+                    
+                    <DockPanel LastChildFill="True"
+                               Grid.Row="0"
+                               Grid.Column="0">
+                        <!-- the window button commands -->
+                        <Controls:WindowButtonCommands x:Name="PART_WindowButtonCommands"
+                                                       DockPanel.Dock="Right"
+                                                       Focusable="False"
+                                                       Panel.ZIndex="1"
+                                                       Grid.Column="4"
+                                                       Grid.RowSpan="2"
+                                                       VerticalAlignment="Top"
+                                                       Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
 
-                    <!-- icon -->
-                    <ContentControl x:Name="PART_Icon"
-                                    Focusable="False"
-                                    Grid.Row="0"
-                                    Grid.Column="0"
-                                    Panel.ZIndex="1"
-                                    Content="{TemplateBinding Icon}"
-                                    ContentTemplate="{TemplateBinding IconTemplate}"
-                                    HorizontalContentAlignment="Stretch"
-                                    VerticalContentAlignment="Stretch"
-                                    MinWidth="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                    Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                    Visibility="{TemplateBinding ShowIconOnTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        <!-- icon -->
+                        <ContentControl x:Name="PART_Icon"
+                                        Focusable="False"
+                                        DockPanel.Dock="Left"
+                                        Panel.ZIndex="1"
+                                        Content="{TemplateBinding Icon}"
+                                        ContentTemplate="{TemplateBinding IconTemplate}"
+                                        HorizontalContentAlignment="Stretch"
+                                        VerticalContentAlignment="Stretch"
+                                        MinWidth="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                        Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                        Visibility="{TemplateBinding ShowIconOnTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-                    <!-- the left window commands -->
-                    <ContentPresenter x:Name="PART_LeftWindowCommands"
-                                      Focusable="False"
-                                      Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      Panel.ZIndex="1"
-                                      Grid.Row="0"
-                                      Grid.Column="1"
-                                      Grid.RowSpan="2"
-                                      VerticalAlignment="Top"
-                                      Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        <!-- the left window commands -->
+                        <ContentPresenter x:Name="PART_LeftWindowCommands"
+                                          DockPanel.Dock="Left"
+                                          Focusable="False"
+                                          Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          Panel.ZIndex="1"
+                                          VerticalAlignment="Top"
+                                          Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-                    <!-- the title bar -->
-                    <ContentControl x:Name="PART_TitleBar"
-                                    Focusable="False"
-                                    Grid.Row="0"
-                                    Grid.Column="2"
-                                    Content="{TemplateBinding Title}"
-                                    ContentTemplate="{TemplateBinding TitleTemplate}"
-                                    HorizontalContentAlignment="Stretch"
-                                    VerticalContentAlignment="Stretch"
-                                    Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                    Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <ContentControl.Foreground>
-                            <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
-                                <Binding ElementName="PART_WindowTitleBackground"
+                        <!-- the right window commands -->
+                        <ContentPresenter x:Name="PART_RightWindowCommands"
+                                          DockPanel.Dock="Right"
+                                          HorizontalAlignment="Right"
+                                          Focusable="False"
+                                          Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          Panel.ZIndex="1"
+                                          VerticalAlignment="Top"
+                                          Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+                        <!-- the title bar -->
+                        <ContentControl x:Name="PART_TitleBar"
+                                        DockPanel.Dock="Left"
+                                        Focusable="False"
+                                        Content="{TemplateBinding Title}"
+                                        ContentTemplate="{TemplateBinding TitleTemplate}"
+                                        HorizontalContentAlignment="Left"
+                                        VerticalContentAlignment="Stretch"
+                                        Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                        Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <ContentControl.Foreground>
+                                <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
+                                    <Binding ElementName="PART_WindowTitleBackground"
                                          Path="Fill"
                                          Mode="OneWay" />
-                                <Binding RelativeSource="{RelativeSource TemplatedParent}"
+                                    <Binding RelativeSource="{RelativeSource TemplatedParent}"
                                          Path="TitleForeground"
                                          Mode="OneWay" />
-                            </MultiBinding>
-                        </ContentControl.Foreground>
-                    </ContentControl>
+                                </MultiBinding>
+                            </ContentControl.Foreground>
+                        </ContentControl>
 
-                    <!-- the right window commands -->
-                    <ContentPresenter x:Name="PART_RightWindowCommands"
-                                      Focusable="False"
-                                      Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      Panel.ZIndex="1"
-                                      Grid.Row="0"
-                                      Grid.Column="3"
-                                      Grid.RowSpan="2"
-                                      VerticalAlignment="Top"
-                                      Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
-
-                    <!-- the window button commands -->
-                    <Controls:WindowButtonCommands x:Name="PART_WindowButtonCommands"
-                                                   Focusable="False"
-                                                   Panel.ZIndex="1"
-                                                   Grid.Row="0"
-                                                   Grid.Column="4"
-                                                   Grid.RowSpan="2"
-                                                   VerticalAlignment="Top"
-                                                   Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+                    </DockPanel>
 
                     <!-- the main window content -->
                     <Controls:MetroContentControl Grid.Row="1"

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -21,7 +21,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
-                    
+
                     <Rectangle x:Name="PART_WindowTitleBackground"
                                Focusable="False"
                                Fill="{TemplateBinding WindowTitleBrush}"
@@ -30,15 +30,15 @@
                                Grid.Column="0"
                                Grid.ColumnSpan="5"
                                StrokeThickness="0" />
-                    
+
                     <DockPanel LastChildFill="True"
                                Grid.Row="0"
+                               Grid.RowSpan="2"
                                Grid.Column="0">
                         <!-- the window button commands -->
                         <Controls:WindowButtonCommands x:Name="PART_WindowButtonCommands"
                                                        DockPanel.Dock="Right"
                                                        Focusable="False"
-                                                       Panel.ZIndex="1"
                                                        Grid.Column="4"
                                                        Grid.RowSpan="2"
                                                        VerticalAlignment="Top"
@@ -48,11 +48,11 @@
                         <ContentControl x:Name="PART_Icon"
                                         Focusable="False"
                                         DockPanel.Dock="Left"
-                                        Panel.ZIndex="1"
                                         Content="{TemplateBinding Icon}"
                                         ContentTemplate="{TemplateBinding IconTemplate}"
                                         HorizontalContentAlignment="Stretch"
                                         VerticalContentAlignment="Stretch"
+                                        VerticalAlignment="Top"
                                         MinWidth="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                         Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                         Visibility="{TemplateBinding ShowIconOnTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
@@ -62,7 +62,6 @@
                                           DockPanel.Dock="Left"
                                           Focusable="False"
                                           Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                          Panel.ZIndex="1"
                                           VerticalAlignment="Top"
                                           Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                           Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
@@ -73,7 +72,6 @@
                                           HorizontalAlignment="Right"
                                           Focusable="False"
                                           Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                          Panel.ZIndex="1"
                                           VerticalAlignment="Top"
                                           Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                           Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
@@ -85,6 +83,7 @@
                                         Content="{TemplateBinding Title}"
                                         ContentTemplate="{TemplateBinding TitleTemplate}"
                                         HorizontalContentAlignment="Left"
+                                        VerticalAlignment="Top"
                                         VerticalContentAlignment="Stretch"
                                         Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                         Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -99,7 +98,6 @@
                                 </MultiBinding>
                             </ContentControl.Foreground>
                         </ContentControl>
-
                     </DockPanel>
 
                     <!-- the main window content -->
@@ -116,8 +114,6 @@
                     <!-- disables the main content when a modal flyout is shown -->
                     <Rectangle Grid.Row="0"
                                Grid.RowSpan="2"
-                               Grid.ColumnSpan="5"
-                               Grid.Column="0"
                                Name="PART_FlyoutModal"
                                Fill="{DynamicResource BlackColorBrush}"
                                Opacity="0.5"
@@ -125,8 +121,6 @@
 
                     <!-- flyouts -->
                     <ContentControl Grid.Row="0"
-                                    Grid.Column="0"
-                                    Grid.ColumnSpan="5"
                                     Grid.RowSpan="2"
                                     Panel.ZIndex="2"
                                     Focusable="False"
@@ -136,8 +130,6 @@
 
                     <!-- Used to create that overlay effect. Can be used for anything. -->
                     <Grid Grid.Row="0"
-                          Grid.Column="0"
-                          Grid.ColumnSpan="5"
                           Grid.RowSpan="2"
                           Panel.ZIndex="3"
                           Focusable="False"
@@ -148,8 +140,6 @@
                           Visibility="Hidden" />
 
                     <Grid Grid.Row="0"
-                          Grid.Column="0"
-                          Grid.ColumnSpan="5"
                           Grid.RowSpan="2"
                           Panel.ZIndex="4"
                           FocusVisualStyle="{x:Null}"


### PR DESCRIPTION
This PR will correct the behavior of the chrome bar when there is no enough space to render all components (icon, title, window commands, window buttons...).

Old:
![capture_old](https://cloud.githubusercontent.com/assets/4404199/5937395/be1a9e9a-a6f7-11e4-9d6f-15dc3e59a58f.JPG)

The new chrome bar will now handle this correctly:
![capture1](https://cloud.githubusercontent.com/assets/4404199/5937411/daa8d6d0-a6f7-11e4-929a-845f6a314db2.JPG)

This works no matter how much you decide to shrink the window's width, the window buttons are our first priority.

Closes #1773