### PR TITLE
add the buttons resource to window style resources

### DIFF
--- a/MahApps.Metro/Styles/Clean/CleanWindow.xaml
+++ b/MahApps.Metro/Styles/Clean/CleanWindow.xaml
@@ -6,6 +6,10 @@
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     mc:Ignorable="options">
 
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Buttons.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="#ADADAD" options:Freeze="True" />
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />

--- a/MahApps.Metro/Styles/VS/Window.xaml
+++ b/MahApps.Metro/Styles/VS/Window.xaml
@@ -2,6 +2,10 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Buttons.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
     <Style TargetType="{x:Type Controls:MetroWindow}"
            BasedOn="{StaticResource {x:Type Controls:MetroWindow}}"
            x:Key="VSWindowStyleKey">

--- a/docs/release-notes/1.1.0.md
+++ b/docs/release-notes/1.1.0.md
@@ -13,7 +13,8 @@ This is a bug fix and fetaure release of MahApps.Metro.
 - `MaximumBodyHeight` for `MetroDialogSettings`, so we can get a `ScrollViewer` for tall dialog content
 - `IsMinButtonEnabled`, `IsMaxRestoreButtonEnabled` and `IsCloseButtonEnabled` to enable/disable the window buttons at `WindowButtonCommands` @romerod #1562
 - `IdealForegroundDisabledBrush` to set the foreground for disabled window buttons at `WindowButtonCommands` #1581
-- `MetroWindow` animates now on minimize/maximize/restore window action (limited by ignoring the taskbar) #1756 
+- `MetroWindow` animates now on minimize/maximize/restore window action (limited by ignoring the taskbar) #1756
+- It's now possible to put the MahApps styles only in a window and the main app will remain unaffected (all buttons and commands will be styled as good as well.) #1777
 
 # Bugfixes
 


### PR DESCRIPTION
with this we can put the complete MahApps styles only in a window.
and only this window gets MahApps themed.

![2015-01-29_21h56_34](https://cloud.githubusercontent.com/assets/658431/5966108/c0f47ae0-a801-11e4-98cf-63da05b4b5ac.png)
