### PR TITLE
fix preservetext for buttons in dialogs

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -18,7 +18,7 @@ namespace MahApps.Metro.Controls.Dialogs
         public static readonly DependencyProperty DialogTopProperty = DependencyProperty.Register("DialogTop", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
         public static readonly DependencyProperty DialogBottomProperty = DependencyProperty.Register("DialogBottom", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
 
-        protected MetroDialogSettings DialogSettings { get; private set; }
+        public MetroDialogSettings DialogSettings { get; private set; }
 
         /// <summary>
         /// Gets/sets the dialog's title.
@@ -284,6 +284,8 @@ namespace MahApps.Metro.Controls.Dialogs
     {
         public MetroDialogSettings()
         {
+            PreserveTextCase = true;
+            
             AffirmativeButtonText = "OK";
             NegativeButtonText = "Cancel";
 
@@ -334,6 +336,12 @@ namespace MahApps.Metro.Controls.Dialogs
         /// Gets/sets the maximum height. (Default is unlimited height, <a href="http://msdn.microsoft.com/de-de/library/system.double.nan">Double.NaN</a>)
         /// </summary>
         public double MaximumBodyHeight { get; set; }
+
+        /// <summary>
+        /// Overrides the text case behavior for certain buttons.
+        /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
+        /// </summary>
+        public bool PreserveTextCase { get; set; }
     }
 
     /// <summary>

--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -18,7 +18,7 @@ namespace MahApps.Metro.Controls.Dialogs
         public static readonly DependencyProperty DialogTopProperty = DependencyProperty.Register("DialogTop", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
         public static readonly DependencyProperty DialogBottomProperty = DependencyProperty.Register("DialogBottom", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
 
-        public MetroDialogSettings DialogSettings { get; private set; }
+        protected MetroDialogSettings DialogSettings { get; private set; }
 
         /// <summary>
         /// Gets/sets the dialog's title.
@@ -284,8 +284,6 @@ namespace MahApps.Metro.Controls.Dialogs
     {
         public MetroDialogSettings()
         {
-            PreserveTextCase = true;
-            
             AffirmativeButtonText = "OK";
             NegativeButtonText = "Cancel";
 
@@ -336,12 +334,6 @@ namespace MahApps.Metro.Controls.Dialogs
         /// Gets/sets the maximum height. (Default is unlimited height, <a href="http://msdn.microsoft.com/de-de/library/system.double.nan">Double.NaN</a>)
         /// </summary>
         public double MaximumBodyHeight { get; set; }
-
-        /// <summary>
-        /// Overrides the text case behavior for certain buttons.
-        /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
-        /// </summary>
-        public bool PreserveTextCase { get; set; }
     }
 
     /// <summary>

--- a/MahApps.Metro/Controls/Dialogs/InputDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/InputDialog.cs
@@ -117,7 +117,7 @@ namespace MahApps.Metro.Controls.Dialogs
             switch (this.DialogSettings.ColorScheme)
             {
                 case MetroDialogColorScheme.Accented:
-                    this.PART_NegativeButton.Style = this.FindResource("HighlightedSquareButtonStyle") as Style;
+                    this.PART_NegativeButton.Style = this.FindResource("AccentedDialogHighlightedSquareButton") as Style;
                     PART_TextBox.SetResourceReference(ForegroundProperty, "BlackColorBrush");
                     break;
             }

--- a/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
@@ -158,7 +158,7 @@ namespace MahApps.Metro.Controls.Dialogs
             switch (this.DialogSettings.ColorScheme)
             {
                 case MetroDialogColorScheme.Accented:
-                    this.PART_NegativeButton.Style = this.FindResource("HighlightedSquareButtonStyle") as Style;
+                    this.PART_NegativeButton.Style = this.FindResource("AccentedDialogHighlightedSquareButton") as Style;
                     PART_TextBox.SetResourceReference(ForegroundProperty, "BlackColorBrush");
                     PART_TextBox2.SetResourceReference(ForegroundProperty, "BlackColorBrush");
                     break;

--- a/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
@@ -203,9 +203,9 @@ namespace MahApps.Metro.Controls.Dialogs
             switch (md.DialogSettings.ColorScheme)
             {
                 case MetroDialogColorScheme.Accented:
-                    md.PART_NegativeButton.Style = md.FindResource("HighlightedSquareButtonStyle") as Style;
-                    md.PART_FirstAuxiliaryButton.Style = md.FindResource("HighlightedSquareButtonStyle") as Style;
-                    md.PART_SecondAuxiliaryButton.Style = md.FindResource("HighlightedSquareButtonStyle") as Style;
+                    md.PART_NegativeButton.Style = md.FindResource("AccentedDialogHighlightedSquareButton") as Style;
+                    md.PART_FirstAuxiliaryButton.Style = md.FindResource("AccentedDialogHighlightedSquareButton") as Style;
+                    md.PART_SecondAuxiliaryButton.Style = md.FindResource("AccentedDialogHighlightedSquareButton") as Style;
                     break;
             }
         }

--- a/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -10,15 +10,22 @@
 
     <Style BasedOn="{StaticResource SquareButtonStyle}"
            TargetType="{x:Type Button}">
-        <Setter Property="controls:ButtonHelper.PreserveTextCase" 
-                Value="True" />
+        <Setter Property="controls:ButtonHelper.PreserveTextCase"
+                Value="{Binding Path=DialogSettings.PreserveTextCase, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Dialogs:BaseMetroDialog}}}" />
     </Style>
 
     <Style x:Key="AccentedDialogSquareButton"
            BasedOn="{StaticResource AccentedSquareButtonStyle}"
            TargetType="{x:Type Button}">
-        <Setter Property="controls:ButtonHelper.PreserveTextCase" 
-                Value="True" />
+        <Setter Property="controls:ButtonHelper.PreserveTextCase"
+                Value="{Binding Path=DialogSettings.PreserveTextCase, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Dialogs:BaseMetroDialog}}}" />
+    </Style>
+
+    <Style x:Key="AccentedDialogHighlightedSquareButton"
+           BasedOn="{StaticResource HighlightedSquareButtonStyle}"
+           TargetType="{x:Type Button}">
+        <Setter Property="controls:ButtonHelper.PreserveTextCase"
+                Value="{Binding Path=DialogSettings.PreserveTextCase, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Dialogs:BaseMetroDialog}}}" />
     </Style>
 
     <Storyboard x:Key="DialogShownStoryboard">

--- a/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -11,21 +11,21 @@
     <Style BasedOn="{StaticResource SquareButtonStyle}"
            TargetType="{x:Type Button}">
         <Setter Property="controls:ButtonHelper.PreserveTextCase"
-                Value="{Binding Path=DialogSettings.PreserveTextCase, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Dialogs:BaseMetroDialog}}}" />
+                Value="True" />
     </Style>
 
     <Style x:Key="AccentedDialogSquareButton"
            BasedOn="{StaticResource AccentedSquareButtonStyle}"
            TargetType="{x:Type Button}">
         <Setter Property="controls:ButtonHelper.PreserveTextCase"
-                Value="{Binding Path=DialogSettings.PreserveTextCase, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Dialogs:BaseMetroDialog}}}" />
+                Value="True" />
     </Style>
 
     <Style x:Key="AccentedDialogHighlightedSquareButton"
            BasedOn="{StaticResource HighlightedSquareButtonStyle}"
            TargetType="{x:Type Button}">
         <Setter Property="controls:ButtonHelper.PreserveTextCase"
-                Value="{Binding Path=DialogSettings.PreserveTextCase, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Dialogs:BaseMetroDialog}}}" />
+                Value="True" />
     </Style>
 
     <Storyboard x:Key="DialogShownStoryboard">


### PR DESCRIPTION
there is a little bug with accented dialogs and the text of the buttons, so this should fix it...

Closes #1755 