### PR TITLE
Added alignment properties for MetroDataGridRowHeader

### DIFF
--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -250,6 +250,10 @@
 
     <Style x:Key="MetroDataGridRowHeader"
            TargetType="{x:Type DataGridRowHeader}">
+        <Setter Property="HorizontalContentAlignment"
+                Value="Left" />
+        <Setter Property="VerticalContentAlignment"
+                Value="Center" />
         <Setter Property="Background"
                 Value="Transparent" />
         <Setter Property="BorderBrush"
@@ -268,10 +272,9 @@
                                 Padding="{TemplateBinding Padding}"
                                 Margin="{TemplateBinding Margin}"
                                 SnapsToDevicePixels="True">
-                            <StackPanel Orientation="Horizontal">
-                                <ContentPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                  VerticalAlignment="Center" />
-                            </StackPanel>
+                            <ContentPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
                         </Border>
                         <Thumb x:Name="PART_TopHeaderGripper"
                                VerticalAlignment="Top"

--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -251,7 +251,7 @@
     <Style x:Key="MetroDataGridRowHeader"
            TargetType="{x:Type DataGridRowHeader}">
         <Setter Property="HorizontalContentAlignment"
-                Value="Left" />
+                Value="Stretch" />
         <Setter Property="VerticalContentAlignment"
                 Value="Center" />
         <Setter Property="Background"


### PR DESCRIPTION
Now we can use style like this
```csharp
<Style x:Key="RowHeaderStyle" TargetType="DataGridRowHeader"
       BasedOn="{StaticResource MetroDataGridRowHeader}">
    <Setter Property="HorizontalContentAlignment" Value="Center" />
</Style>
```
```csharp
<DataGrid RowHeaderStyle="{StaticResource RowHeaderStyle}" />
```
![screenshot_1](https://cloud.githubusercontent.com/assets/526086/6387818/c6b0e338-bdaa-11e4-8bb0-923400a5ad94.png)
