### PR TITLE
Move window when flyout is open

### DIFF
--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -487,7 +487,7 @@ namespace MahApps.Metro.Controls
 
             ApplyAnimation(Position, AnimateOpacity);
 
-            SetWindowEvents();
+            SetParentWindowEvents();
         }
 
         internal void ApplyAnimation(Position position, bool animateOpacity, bool resetShowFrame = true)
@@ -547,19 +547,19 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        private void SetWindowEvents()
+        private void SetParentWindowEvents()
         {
             var window = this.TryFindParent<MetroWindow>();
             if (window != null)
             {
-                this.ClearWindowEvents(window);
+                this.ClearParentWindowEvents(window);
 
                 PART_WindowTitle.MouseDown += window.TitleBarMouseDown;
                 PART_WindowTitle.MouseUp += window.TitleBarMouseUp;
             }
         }
 
-        private void ClearWindowEvents(MetroWindow window)
+        private void ClearParentWindowEvents(MetroWindow window)
         {
             PART_WindowTitle.MouseDown -= window.TitleBarMouseDown;
             PART_WindowTitle.MouseUp -= window.TitleBarMouseUp;

--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -15,6 +15,7 @@ namespace MahApps.Metro.Controls
     /// <seealso cref="FlyoutsControl"/>
     /// </summary>
     [TemplatePart(Name = "PART_BackButton", Type = typeof(Button))]
+    [TemplatePart(Name = "PART_WindowTitle", Type = typeof(UIElement))]
     [TemplatePart(Name = "PART_Header", Type = typeof(ContentPresenter))]
     [TemplatePart(Name = "PART_Content", Type = typeof(ContentPresenter))]
     public class Flyout : ContentControl
@@ -460,6 +461,7 @@ namespace MahApps.Metro.Controls
         SplineDoubleKeyFrame fadeOutFrame;
         ContentPresenter PART_Header;
         ContentPresenter PART_Content;
+        UIElement PART_WindowTitle;
 
         public override void OnApplyTemplate()
         {
@@ -471,7 +473,8 @@ namespace MahApps.Metro.Controls
 
             PART_Header = (ContentPresenter)GetTemplateChild("PART_Header");
             PART_Content = (ContentPresenter)GetTemplateChild("PART_Content");
-            
+            PART_WindowTitle = (UIElement)GetTemplateChild("PART_WindowTitle");
+
             hideStoryboard = (Storyboard)GetTemplateChild("HideStoryboard");
             hideFrame = (SplineDoubleKeyFrame)GetTemplateChild("hideFrame");
             hideFrameY = (SplineDoubleKeyFrame)GetTemplateChild("hideFrameY");
@@ -483,6 +486,8 @@ namespace MahApps.Metro.Controls
                 return;
 
             ApplyAnimation(Position, AnimateOpacity);
+
+            SetWindowEvents();
         }
 
         internal void ApplyAnimation(Position position, bool animateOpacity, bool resetShowFrame = true)
@@ -540,6 +545,24 @@ namespace MahApps.Metro.Controls
                         root.RenderTransform = new TranslateTransform(0, root.ActualHeight);
                     break;
             }
+        }
+
+        private void SetWindowEvents()
+        {
+            var window = this.TryFindParent<MetroWindow>();
+            if (window != null)
+            {
+                this.ClearWindowEvents(window);
+
+                PART_WindowTitle.MouseDown += window.TitleBarMouseDown;
+                PART_WindowTitle.MouseUp += window.TitleBarMouseUp;
+            }
+        }
+
+        private void ClearWindowEvents(MetroWindow window)
+        {
+            PART_WindowTitle.MouseDown -= window.TitleBarMouseDown;
+            PART_WindowTitle.MouseUp -= window.TitleBarMouseUp;
         }
 
         protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)

--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -559,7 +559,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        private void ClearParentWindowEvents(MetroWindow window)
+        protected internal void ClearParentWindowEvents(MetroWindow window)
         {
             PART_WindowTitle.MouseDown -= window.TitleBarMouseDown;
             PART_WindowTitle.MouseUp -= window.TitleBarMouseUp;

--- a/MahApps.Metro/Controls/FlyoutsControl.cs
+++ b/MahApps.Metro/Controls/FlyoutsControl.cs
@@ -58,6 +58,17 @@ namespace MahApps.Metro.Controls
             this.AttachHandlers((Flyout)element);
         }
 
+        protected override void ClearContainerForItemOverride(DependencyObject element, object item)
+        {
+            var window = this.TryFindParent<MetroWindow>();
+            if (window != null)
+            {
+                // To avoid memory leaks (cause it's possible to have dynamic flyouts), clear parent window events.
+                ((Flyout)element).ClearParentWindowEvents(window);
+            }
+            base.ClearContainerForItemOverride(element, item);
+        }
+
         private void AttachHandlers(Flyout flyout)
         {
             var isOpenNotifier = new PropertyChangeNotifier(flyout, Flyout.IsOpenProperty);

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -931,7 +931,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        protected void TitleBarMouseDown(object sender, MouseButtonEventArgs e)
+        protected internal void TitleBarMouseDown(object sender, MouseButtonEventArgs e)
         {
             // if UseNoneWindowStyle = true no movement, no maximize please
             if (e.ChangedButton == MouseButton.Left && !this.UseNoneWindowStyle)
@@ -966,7 +966,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        protected void TitleBarMouseUp(object sender, MouseButtonEventArgs e)
+        protected internal void TitleBarMouseUp(object sender, MouseButtonEventArgs e)
         {
             if (ShowSystemMenuOnRightClick)
             {

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -110,10 +110,9 @@
 
     <ControlTemplate x:Key="FlyoutTemplate"
                      TargetType="{x:Type Controls:Flyout}">
-        <!--<AdornerDecorator>-->
-            <Grid x:Name="root"
-                  Margin="{TemplateBinding Margin}"
-                  Background="{TemplateBinding Background}">
+        <Grid x:Name="root"
+              Margin="{TemplateBinding Margin}"
+              Background="{TemplateBinding Background}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
@@ -121,116 +120,117 @@
             <Grid.RenderTransform>
                 <TranslateTransform />
             </Grid.RenderTransform>
-                <VisualStateManager.VisualStateGroups>
-                    <VisualStateGroup>
-                        <VisualState x:Name="Default" />
-                        <VisualState x:Name="Hide">
-                            <Storyboard x:Name="HideStoryboard">
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="Default" />
+                    <VisualState x:Name="Hide">
+                        <Storyboard x:Name="HideStoryboard">
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.X)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="0"
                                                       x:Name="hideFrame" />
-                                </DoubleAnimationUsingKeyFrames>
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="0"
                                                       x:Name="hideFrameY" />
-                                </DoubleAnimationUsingKeyFrames>
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.Opacity)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="0"
                                                       x:Name="fadeOutFrame" />
-                                </DoubleAnimationUsingKeyFrames>
-                            </Storyboard>
-                        </VisualState>
-                        <VisualState x:Name="Show">
-                            <Storyboard>
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                            </DoubleAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="Show">
+                        <Storyboard>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.X)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="0"
                                                       x:Name="showFrame" />
-                                </DoubleAnimationUsingKeyFrames>
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="0"
                                                       x:Name="showFrameY" />
-                                </DoubleAnimationUsingKeyFrames>
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.Opacity)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="1" />
-                                </DoubleAnimationUsingKeyFrames>
-                            </Storyboard>
-                        </VisualState>
-                        <VisualState x:Name="HideDirect">
-                            <Storyboard>
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                            </DoubleAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="HideDirect">
+                        <Storyboard>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.X)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="0"
+                                <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="0" />
-                                </DoubleAnimationUsingKeyFrames>
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="0"
+                                <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="0" />
-                                </DoubleAnimationUsingKeyFrames>
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.Opacity)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="0"
+                                <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="0" />
-                                </DoubleAnimationUsingKeyFrames>
-                            </Storyboard>
-                        </VisualState>
-                        <VisualState x:Name="ShowDirect">
-                            <Storyboard>
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                            </DoubleAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                    <VisualState x:Name="ShowDirect">
+                        <Storyboard>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.X)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="0"
+                                <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="0" />
-                                </DoubleAnimationUsingKeyFrames>
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="0"
+                                <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="0" />
-                                </DoubleAnimationUsingKeyFrames>
-                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.Opacity)"
                                                            Storyboard.TargetName="root">
-                                    <SplineDoubleKeyFrame KeyTime="0"
+                                <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="1" />
-                                </DoubleAnimationUsingKeyFrames>
-                            </Storyboard>
-                        </VisualState>
-                    </VisualStateGroup>
-                </VisualStateManager.VisualStateGroups>
-                <Rectangle x:Name="PART_WindowTitle"
-                           Grid.Row="0"
-                           Height="{Binding TitlebarHeight, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type Controls:MetroWindow}}}"
-                           HorizontalAlignment="Stretch"
-                           StrokeThickness="0"
-                           Fill="Transparent"/>
+                            </DoubleAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Rectangle x:Name="PART_WindowTitle"
+                       Grid.Row="0"
+                       Height="{Binding TitlebarHeight, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type Controls:MetroWindow}}}"
+                       HorizontalAlignment="Stretch"
+                       StrokeThickness="0"
+                       Fill="Transparent"/>
+            <AdornerDecorator Grid.Row="1">
                 <DockPanel FocusVisualStyle="{x:Null}"
                            Focusable="False"
                            Grid.Row="1">
@@ -241,8 +241,8 @@
                     <ContentPresenter x:Name="PART_Content"
                                       DockPanel.Dock="Bottom" />
                 </DockPanel>
-            </Grid>
-        <!--</AdornerDecorator>-->
+            </AdornerDecorator>
+        </Grid>
         <ControlTemplate.Triggers>
             <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource Self}}"
                          Value="Top">

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -110,119 +110,130 @@
 
     <ControlTemplate x:Key="FlyoutTemplate"
                      TargetType="{x:Type Controls:Flyout}">
-        <Grid x:Name="root"
-              Margin="{TemplateBinding Margin}"
-              Background="{TemplateBinding Background}">
+        <!--<AdornerDecorator>-->
+            <Grid x:Name="root"
+                  Margin="{TemplateBinding Margin}"
+                  Background="{TemplateBinding Background}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
             <Grid.RenderTransform>
                 <TranslateTransform />
             </Grid.RenderTransform>
-            <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup>
-                    <VisualState x:Name="Default" />
-                    <VisualState x:Name="Hide">
-                        <Storyboard x:Name="HideStoryboard">
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroup>
+                        <VisualState x:Name="Default" />
+                        <VisualState x:Name="Hide">
+                            <Storyboard x:Name="HideStoryboard">
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.X)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="0"
                                                       x:Name="hideFrame" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="0"
                                                       x:Name="hideFrameY" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.Opacity)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="0"
                                                       x:Name="fadeOutFrame" />
-                            </DoubleAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualState>
-                    <VisualState x:Name="Show">
-                        <Storyboard>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                </DoubleAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </VisualState>
+                        <VisualState x:Name="Show">
+                            <Storyboard>
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.X)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="0"
                                                       x:Name="showFrame" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="0"
                                                       x:Name="showFrameY" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.Opacity)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="00:00:00.750"
+                                    <SplineDoubleKeyFrame KeyTime="00:00:00.750"
                                                       KeySpline="0.25,1,0.05,1"
                                                       Value="1" />
-                            </DoubleAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualState>
-                    <VisualState x:Name="HideDirect">
-                        <Storyboard>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                </DoubleAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </VisualState>
+                        <VisualState x:Name="HideDirect">
+                            <Storyboard>
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.X)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="0"
+                                    <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="0"
+                                    <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.Opacity)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="0"
+                                    <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualState>
-                    <VisualState x:Name="ShowDirect">
-                        <Storyboard>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                </DoubleAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </VisualState>
+                        <VisualState x:Name="ShowDirect">
+                            <Storyboard>
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.X)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="0"
+                                    <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="0"
+                                    <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                </DoubleAnimationUsingKeyFrames>
+                                <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetProperty="(UIElement.Opacity)"
                                                            Storyboard.TargetName="root">
-                                <SplineDoubleKeyFrame KeyTime="0"
+                                    <SplineDoubleKeyFrame KeyTime="0"
                                                       Value="1" />
-                            </DoubleAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateManager.VisualStateGroups>
-            <AdornerDecorator>
+                                </DoubleAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateManager.VisualStateGroups>
+                <Rectangle x:Name="PART_WindowTitle"
+                           Grid.Row="0"
+                           Height="{Binding TitlebarHeight, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type Controls:MetroWindow}}}"
+                           HorizontalAlignment="Stretch"
+                           StrokeThickness="0"
+                           Fill="Transparent"/>
                 <DockPanel FocusVisualStyle="{x:Null}"
-                           Focusable="False">
+                           Focusable="False"
+                           Grid.Row="1">
                     <ContentPresenter x:Name="PART_Header"
                                       DockPanel.Dock="Top"
                                       ContentSource="Header"
@@ -230,8 +241,8 @@
                     <ContentPresenter x:Name="PART_Content"
                                       DockPanel.Dock="Bottom" />
                 </DockPanel>
-            </AdornerDecorator>
-        </Grid>
+            </Grid>
+        <!--</AdornerDecorator>-->
         <ControlTemplate.Triggers>
             <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource Self}}"
                          Value="Top">


### PR DESCRIPTION
When a flyout was open you weren't able to move the window where the flyout was over the title bar. This was particularly anoying if you wished to move the window while a flyout was opened as a modal flyout or covered the entire area of the window.

I've implemented a change that enables the window to be moved when a flyout is opened and the mouse cursor is within the windows title bar area. 

If the default behaviour was intended by design perhaps this feature could be optional with a property. 

I hope this is ok. 