### PR TITLE
fix Gripper for MetroDataGridRowHeader

### DIFF
--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -94,18 +94,21 @@
 
     <Style x:Key="MetroRowHeaderGripperStyle"
            TargetType="{x:Type Thumb}">
-        <Setter Property="Width"
-                Value="8" />
+        <Setter Property="Height"
+                Value="6" />
         <Setter Property="Background"
-                Value="Transparent" />
+                Value="{DynamicResource GrayBrush5}" />
         <Setter Property="Cursor"
                 Value="SizeNS" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Thumb}">
-                    <Border Background="{TemplateBinding Background}"
-                            Padding="{TemplateBinding Padding}"
-                            SnapsToDevicePixels="True" />
+                    <Border Padding="{TemplateBinding Padding}"
+                            Background="Transparent">
+                        <Rectangle VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                   Height="1"
+                                   Fill="{TemplateBinding Background}" />
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -241,7 +244,7 @@
         <Setter Property="ContentTemplate">
             <Setter.Value>
                 <DataTemplate>
-                    <TextBlock TextBlock.FontWeight="SemiBold"
+                    <TextBlock FontWeight="SemiBold"
                                Text="{Binding Converter={StaticResource ToUpperConverter}}" />
                 </DataTemplate>
             </Setter.Value>
@@ -277,12 +280,13 @@
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
                         </Border>
                         <Thumb x:Name="PART_TopHeaderGripper"
+                               VerticalContentAlignment="Top"
                                VerticalAlignment="Top"
-                               Height="3"
+                               Background="Transparent"
                                Style="{StaticResource MetroRowHeaderGripperStyle}" />
                         <Thumb x:Name="PART_BottomHeaderGripper"
+                               VerticalContentAlignment="Bottom"
                                VerticalAlignment="Bottom"
-                               Height="3"
                                Style="{StaticResource MetroRowHeaderGripperStyle}" />
                     </Grid>
 


### PR DESCRIPTION
Now grippers displayed in rowheaders.
![image](https://cloud.githubusercontent.com/assets/526086/6407830/e9575400-be61-11e4-9f16-2dcd09e0f348.png)
