### PR TITLE
yes, we need a really good HitTest control

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -254,6 +254,8 @@
     <Style TargetType="{x:Type Controls:MetroWindow}">
         <Setter Property="BorderThickness"
                 Value="1" />
+        <Setter Property="BorderBrush"
+                Value="Transparent" />
         <Setter Property="UseLayoutRounding"
                 Value="True" />
         <Setter Property="WindowTitleBrush"


### PR DESCRIPTION
if you ever wondered why you can't resize a `MetroWindow` on the right top or left top (if there is a icon), this pr fix this issue :-P

![](http://gifs.joelglovier.com/excited/yes-excited-kids.gif)
