### PR TITLE
Add tooltip text converter to RangeSlider

### DIFF
--- a/MahApps.Metro/Controls/RangeSlider.cs
+++ b/MahApps.Metro/Controls/RangeSlider.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
 
@@ -233,6 +234,10 @@ namespace MahApps.Metro.Controls
             DependencyProperty.Register("AutoToolTipPrecision", typeof (Int32), typeof (RangeSlider),
                 new FrameworkPropertyMetadata(0), IsValidPrecision);
 
+        public static readonly DependencyProperty AutoToolTipTextConverterProperty =
+            DependencyProperty.Register("AutoToolTipTextConverter", typeof (IValueConverter), typeof (RangeSlider),
+                new FrameworkPropertyMetadata(null));
+
         public static readonly DependencyProperty IntervalProperty =
             DependencyProperty.Register("Interval", typeof(Int32), typeof(RangeSlider),
                 new FrameworkPropertyMetadata(100, IntervalChangedCallback), IsValidPrecision);
@@ -256,6 +261,16 @@ namespace MahApps.Metro.Controls
         {
             get { return (Int32)GetValue(AutoToolTipPrecisionProperty); }
             set { SetValue(AutoToolTipPrecisionProperty, value); }
+        }
+
+        /// <summary>
+        /// Get/sets the converter for the tooltip text
+        /// </summary>
+        [Bindable(true), Category("Behavior")]
+        public IValueConverter AutoToolTipTextConverter
+        {
+            get { return (IValueConverter)GetValue(AutoToolTipTextConverterProperty); }
+            set { SetValue(AutoToolTipTextConverterProperty, value); }
         }
 
         /// <summary>
@@ -2143,7 +2158,10 @@ namespace MahApps.Metro.Controls
         //Get lower value for autotooltip
         private String GetLowerToolTipNumber()
         {
-            NumberFormatInfo format = (NumberFormatInfo) (NumberFormatInfo.CurrentInfo.Clone());
+            if (AutoToolTipTextConverter != null)
+                return AutoToolTipTextConverter.Convert(LowerValue, typeof(string), null, CultureInfo.InvariantCulture).ToString();
+
+            NumberFormatInfo format = (NumberFormatInfo)(NumberFormatInfo.CurrentInfo.Clone());
             format.NumberDecimalDigits = AutoToolTipPrecision;
             return LowerValue.ToString("N", format);
         }
@@ -2151,7 +2169,10 @@ namespace MahApps.Metro.Controls
         //Get upper value for autotooltip
         private String GetUpperToolTipNumber()
         {
-            NumberFormatInfo format = (NumberFormatInfo) (NumberFormatInfo.CurrentInfo.Clone());
+            if (AutoToolTipTextConverter != null)
+                return AutoToolTipTextConverter.Convert(UpperValue, typeof(string), null, CultureInfo.InvariantCulture).ToString();
+
+            NumberFormatInfo format = (NumberFormatInfo)(NumberFormatInfo.CurrentInfo.Clone());
             format.NumberDecimalDigits = AutoToolTipPrecision;
             return UpperValue.ToString("N", format);
         }


### PR DESCRIPTION
The changes allow to use a custom format for the tooltip. For example, I
want that the user can choose a timespan (ms). The tooltip just shows
large numbers. With a converter, the tooltip can display the value in a
time format (mm:ss) which is much better to read for the user.
![Preview](http://fs2.directupload.net/images/150311/o6gkdxqc.png)