### PR TITLE
Metro touchable thumb of Slider

### DIFF
--- a/MahApps.Metro/Controls/RangeSlider.cs
+++ b/MahApps.Metro/Controls/RangeSlider.cs
@@ -2158,8 +2158,15 @@ namespace MahApps.Metro.Controls
         //Get lower value for autotooltip
         private String GetLowerToolTipNumber()
         {
-            if (AutoToolTipTextConverter != null)
-                return AutoToolTipTextConverter.Convert(LowerValue, typeof(string), null, CultureInfo.InvariantCulture).ToString();
+            var converter = AutoToolTipTextConverter;
+            if (converter != null)
+            {
+                var convertedValue = converter.Convert(LowerValue, typeof(string), null, CultureInfo.InvariantCulture);
+                if (convertedValue != null)
+                {
+                    return convertedValue.ToString();
+                }
+            }
 
             NumberFormatInfo format = (NumberFormatInfo)(NumberFormatInfo.CurrentInfo.Clone());
             format.NumberDecimalDigits = AutoToolTipPrecision;
@@ -2169,8 +2176,15 @@ namespace MahApps.Metro.Controls
         //Get upper value for autotooltip
         private String GetUpperToolTipNumber()
         {
-            if (AutoToolTipTextConverter != null)
-                return AutoToolTipTextConverter.Convert(UpperValue, typeof(string), null, CultureInfo.InvariantCulture).ToString();
+            var converter = AutoToolTipTextConverter;
+            if (converter != null)
+            {
+                var convertedValue = converter.Convert(UpperValue, typeof(string), null, CultureInfo.InvariantCulture);
+                if (convertedValue != null)
+                {
+                    return convertedValue.ToString();
+                }
+            }
 
             NumberFormatInfo format = (NumberFormatInfo)(NumberFormatInfo.CurrentInfo.Clone());
             format.NumberDecimalDigits = AutoToolTipPrecision;

--- a/MahApps.Metro/MahApps.Metro.nuspec
+++ b/MahApps.Metro/MahApps.Metro.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>MahApps.Metro</id>
-    <version>1.1.1.0</version>
+    <version>1.1.2.0</version>
     <title>MahApps.Metro</title>
     <authors>Paul Jenkins; Jake Ginnivan; Brendan Forster (shiftkey); Alex Mitchell (Amrykid); Dennis Daume (flagbug); Jan Karger (punker76)</authors>
     <owners>Paul Jenkins; Jake Ginnivan</owners>

--- a/MahApps.Metro/Properties/AssemblyInfo.cs
+++ b/MahApps.Metro/Properties/AssemblyInfo.cs
@@ -13,8 +13,10 @@ using System.Windows.Markup;
 [assembly: XmlnsDefinition("http://metro.mahapps.com/winfx/xaml/shared", "MahApps.Metro.Converters")]
 [assembly: XmlnsDefinition("http://metro.mahapps.com/winfx/xaml/controls", "MahApps.Metro.Controls")]
 
-[assembly: AssemblyVersion("1.1.2.0")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyVersion("1.1.3.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]
 [assembly: AssemblyTitleAttribute("MahApps.Metro")]
 [assembly: AssemblyDescriptionAttribute("Toolkit for creating Metro styled WPF apps")]
-[assembly: AssemblyProductAttribute("MahApps.Metro 1.1.2")]
+[assembly: AssemblyProductAttribute("MahApps.Metro 1.1.3-ALPHA")]
+
+[assembly: InternalsVisibleTo("Mahapps.Metro.Tests")]

--- a/MahApps.Metro/Properties/AssemblyInfo.cs
+++ b/MahApps.Metro/Properties/AssemblyInfo.cs
@@ -17,6 +17,4 @@ using System.Windows.Markup;
 [assembly: AssemblyFileVersion("1.1.2.0")]
 [assembly: AssemblyTitleAttribute("MahApps.Metro")]
 [assembly: AssemblyDescriptionAttribute("Toolkit for creating Metro styled WPF apps")]
-[assembly: AssemblyProductAttribute("MahApps.Metro 1.1.2-ALPHA")]
-
-[assembly: InternalsVisibleTo("Mahapps.Metro.Tests")]
+[assembly: AssemblyProductAttribute("MahApps.Metro 1.1.2")]

--- a/docs/release-notes/1.1.2.md
+++ b/docs/release-notes/1.1.2.md
@@ -10,3 +10,4 @@ This is a bug fix release of MahApps.Metro.
 - Fixed upgrading the `WindowPlacementSettings` on version change #1787 #1736 (ada352b)
 - Fixed a painting issue of the entire window and the maximize action (5ae97f9)
 - Fixed another `Topmost` bug: Window is going behind other windows on program start #1251 (6b0a8fa)
+- Fixed brief flashing window when launched (e.g. from the explorer) #1781 (4b42fe0)

--- a/docs/release-notes/1.2.0.md
+++ b/docs/release-notes/1.2.0.md
@@ -1,0 +1,11 @@
+# Notes
+
+This is a bug fix and fetaure release of MahApps.Metro.
+
+# Features
+
+# Changes
+
+- The Glow (window) should not be clickable #1829
+
+# Bugfixes

--- a/docs/release-notes/1.2.0.md
+++ b/docs/release-notes/1.2.0.md
@@ -2,11 +2,10 @@
 
 This is a bug fix and fetaure release of MahApps.Metro.
 
-# Features
-
-# Changes
+# Features / Changes
 
 - The Glow (window) should not be clickable #1829
+- Add a tooltip text converter to RangeSlider for lower and upper value tooltip #1833
 
 # Bugfixes
 

--- a/docs/release-notes/1.2.0.md
+++ b/docs/release-notes/1.2.0.md
@@ -9,3 +9,5 @@ This is a bug fix and fetaure release of MahApps.Metro.
 - The Glow (window) should not be clickable #1829
 
 # Bugfixes
+
+- Fixed resizing cursors #1830


### PR DESCRIPTION
In touch environment, touching a slider won't make its thumb following user's finger, for another visual has capture the touch-device. In order to make the Thumb touchable, we have to capture the touch-device in himself. So here it is.