### PR TITLE
Fix #1845 External dialog flickering

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -443,9 +443,6 @@ namespace MahApps.Metro.Controls.Dialogs
             win.MinHeight = SystemParameters.PrimaryScreenHeight / 4.0;
             win.SizeToContent = SizeToContent.Height;
 
-            var glowWindow = new GlowWindowBehavior();
-            glowWindow.Attach(win);
-
             dialog.ParentDialogWindow = win; //THIS IS ONLY, I REPEAT, ONLY SET FOR EXTERNAL DIALOGS!
 
             win.Content = dialog;


### PR DESCRIPTION
Root cause: The GlowWindowBehavior was added twice.
Please note that when content is added to the window (e.g. "win.Content = dialog;") the Glow Behavior is automatically added.