### PR TITLE
Update FlyoutDemo.xaml

### DIFF
--- a/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
+++ b/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
@@ -153,7 +153,6 @@
                     <Button Content="cancel" />
                 </StackPanel>
             </Controls:Flyout>
-            <exampleWindows:CustomFlyout />
 
             <Controls:Flyout Header="Accented"
                              Position="Right"


### PR DESCRIPTION
Found a closing tab for exampleWindows:CustomFlyout that hasn't an opening tag, guessing it was left over from something... Also, demo runs fine without it.