### PR TITLE
WindowCommands layout fix

### DIFF
--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -490,7 +490,7 @@
                             </Style>
                         </ResourceDictionary>
                     </ControlTemplate.Resources>
-                    <ItemsPresenter />
+                    <ItemsPresenter Height="{Binding TitlebarHeight, RelativeSource={RelativeSource AncestorType=Controls:MetroWindow}}" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
Noticed a tiny annoyance: the WindowCommands' height did not span the entire height of the title bar, which makes the buttons harder to reach (which is my opinion as I just throw the cursor to the top of the screen to click). I'm sure this behavior used be there a while ago.

From this
![inactive](https://cloud.githubusercontent.com/assets/6247359/7337655/ff50cc5c-ec31-11e4-98d3-abf94a79c684.png)
to this
![active](https://cloud.githubusercontent.com/assets/6247359/7337656/058ff962-ec32-11e4-9b85-ea67f89f18ac.png)
