### PR TITLE
ShowMetroDialogAsync - Dialog is awaitable

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -253,7 +253,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// Waits until this dialog gets unloaded.
         /// </summary>
         /// <returns></returns>
-        public Task WaitUnitlUnloaded()
+        public Task WaitUntilUnloadedAsync()
         {
             TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
 

--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -249,8 +249,11 @@ namespace MahApps.Metro.Controls.Dialogs
         /// </summary>
         protected internal MetroWindow OwningWindow { get; internal set; }
 
-
-        public Task WaitUnitlClosed()
+        /// <summary>
+        /// Waits until this dialog gets unloaded.
+        /// </summary>
+        /// <returns></returns>
+        public Task WaitUnitlUnloaded()
         {
             TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
 

--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -249,6 +249,20 @@ namespace MahApps.Metro.Controls.Dialogs
         /// </summary>
         protected internal MetroWindow OwningWindow { get; internal set; }
 
+
+        public Task WaitUnitlClosed()
+        {
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+
+            Unloaded += (s,e) =>
+            {
+                tcs.TrySetResult(null);
+            };
+
+            return tcs.Task;
+        }
+
+
         public Task _WaitForCloseAsync()
         {
             TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -288,14 +288,14 @@ namespace MahApps.Metro.Controls.Dialogs
         }
 
         /// <summary>
-        /// Adds a Metro Dialog instance to the specified window and makes it visible.
-        /// You can await until this dialog is removed/hidden by awaiting the returned task.
+        /// Adds a Metro Dialog instance to the specified window and makes it visible asynchronously.
+        /// You can wait until this dialog is closed (unloaded) by awaiting the returned task.
         /// <para>You have to close the resulting dialog yourself with <see cref="HideMetroDialogAsync"/>.</para>
         /// </summary>
         /// <param name="window">The owning window of the dialog.</param>
         /// <param name="dialog">The dialog instance itself.</param>
         /// <param name="settings">An optional pre-defined settings instance.</param>
-        /// <returns>A task representing the operation.</returns>
+        /// <returns>A task representing the life-time of this dialog.</returns>
         /// <exception cref="InvalidOperationException">The <paramref name="dialog"/> is already visible in the window.</exception>
         public static async Task ShowMetroDialogAsync(this MetroWindow window, BaseMetroDialog dialog,
             MetroDialogSettings settings = null)
@@ -320,7 +320,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 DialogOpened(window, new DialogStateChangedEventArgs());
             }
 
-            await dialog.WaitUnitlClosed();
+            await dialog.WaitUnitlUnloaded();
         }
 
         /// <summary>

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -297,6 +297,24 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="settings">An optional pre-defined settings instance.</param>
         /// <returns>A task representing the life-time of this dialog.</returns>
         /// <exception cref="InvalidOperationException">The <paramref name="dialog"/> is already visible in the window.</exception>
+        public static async Task ShowMetroDialogAsyncAwaitable(this MetroWindow window, BaseMetroDialog dialog,
+            MetroDialogSettings settings = null)
+        {
+            await ShowMetroDialogAsync(window, dialog, settings);
+
+            await dialog.WaitUnitlUnloaded();
+        }
+
+        /// <summary>
+        /// Adds a Metro Dialog instance to the specified window and makes it visible asynchronously.
+        /// If you want to wait until the user has closed the dialog, use <see cref="ShowMetroDialogAsyncAwaitable"/>
+        /// <para>You have to close the resulting dialog yourself with <see cref="HideMetroDialogAsync"/>.</para>
+        /// </summary>
+        /// <param name="window">The owning window of the dialog.</param>
+        /// <param name="dialog">The dialog instance itself.</param>
+        /// <param name="settings">An optional pre-defined settings instance.</param>
+        /// <returns>A task representing the operation.</returns>
+        /// <exception cref="InvalidOperationException">The <paramref name="dialog"/> is already visible in the window.</exception>
         public static async Task ShowMetroDialogAsync(this MetroWindow window, BaseMetroDialog dialog,
             MetroDialogSettings settings = null)
         {
@@ -319,9 +337,9 @@ namespace MahApps.Metro.Controls.Dialogs
             {
                 DialogOpened(window, new DialogStateChangedEventArgs());
             }
-
-            await dialog.WaitUnitlUnloaded();
         }
+
+
 
         /// <summary>
         /// Hides a visible Metro Dialog instance.

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -70,6 +70,19 @@
                 <TextBlock Height="30" Text="{Binding Artists[0].Name}" Foreground="{DynamicResource AccentBrush}" />
             </Dialog:CustomDialog>
 
+            <Dialog:CustomDialog x:Key="CustomCloseDialogTest"
+                                 Title="Custom Dialog which is awaitable"
+                                 x:Name="CustomCloseDialogTest">
+                
+                <StackPanel>
+                    <TextBlock Height="30" Text="This dialog allows arbitrary content. You have to close it yourself by clicking the close button below." 
+                               Foreground="{DynamicResource AccentBrush}" />
+                    <Button Content="Close Me!" Click="CloseCustomDialog"/>
+                </StackPanel>
+
+                
+            </Dialog:CustomDialog>
+
         </ResourceDictionary>
     </Window.Resources>
 
@@ -162,6 +175,8 @@
                               Header="Show CustomDialog" />
                     <MenuItem Click="ShowDialogOutside"
                               Header="Show CustomDialog Externally" />
+                    <MenuItem Click="ShowAwaitCustomDialog"
+                              Header="Await CustomDialog" />
                 </MenuItem>
                 <MenuItem Header="Window">
                     <MenuItem IsCheckable="True" Header="Topmost"

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -180,7 +180,7 @@ namespace MetroDemo
 
             var dialog = (BaseMetroDialog)this.Resources["CustomDialogTest"];
 
-            await this.ShowMetroDialogAsync(dialog);
+            this.ShowMetroDialogAsync(dialog);
 
             await TaskEx.Delay(5000);
 
@@ -205,8 +205,6 @@ namespace MetroDemo
             await this.HideMetroDialogAsync(dialog);
         }
 
-        
-
          private async void ShowLoginDialogPasswordPreview(object sender, RoutedEventArgs e)
         {
             this.MetroDialogOptions.ColorScheme = UseAccentForDialogsMenuItem.IsChecked ? MetroDialogColorScheme.Accented : MetroDialogColorScheme.Theme;
@@ -220,7 +218,6 @@ namespace MetroDemo
                 MessageDialogResult messageResult = await this.ShowMessageAsync("Authentication Information", String.Format("Username: {0}\nPassword: {1}", result.Username, result.Password));
             }
         }
-
         private async void ShowProgressDialog(object sender, RoutedEventArgs e)
         {
             this.MetroDialogOptions.ColorScheme = UseAccentForDialogsMenuItem.IsChecked ? MetroDialogColorScheme.Accented : MetroDialogColorScheme.Theme;

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -193,7 +193,8 @@ namespace MetroDemo
 
             var dialog = (BaseMetroDialog)this.Resources["CustomCloseDialogTest"];
 
-            await this.ShowMetroDialogAsyncAwaitable(dialog);
+            await this.ShowMetroDialogAsync(dialog);
+            await dialog.WaitUnitlUnloaded();
 
             await this.ShowMessageAsync("Dialog gone", "The custom dialog has closed");
         }

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -187,6 +187,26 @@ namespace MetroDemo
             await this.HideMetroDialogAsync(dialog);
         }
 
+        private async void ShowAwaitCustomDialog(object sender, RoutedEventArgs e)
+        {
+            this.MetroDialogOptions.ColorScheme = UseAccentForDialogsMenuItem.IsChecked ? MetroDialogColorScheme.Accented : MetroDialogColorScheme.Theme;
+
+            var dialog = (BaseMetroDialog)this.Resources["CustomCloseDialogTest"];
+
+            await this.ShowMetroDialogAsync(dialog);
+
+            await this.ShowMessageAsync("Dialog gone", "The custom dialog has closed");
+        }
+
+        private async void CloseCustomDialog(object sender, RoutedEventArgs e)
+        {
+            var dialog = (BaseMetroDialog)this.Resources["CustomCloseDialogTest"];
+
+            await this.HideMetroDialogAsync(dialog);
+        }
+
+        
+
          private async void ShowLoginDialogPasswordPreview(object sender, RoutedEventArgs e)
         {
             this.MetroDialogOptions.ColorScheme = UseAccentForDialogsMenuItem.IsChecked ? MetroDialogColorScheme.Accented : MetroDialogColorScheme.Theme;
@@ -346,5 +366,7 @@ namespace MetroDemo
             w.EnableDWMDropShadow = true;
             w.Show();
         }
+
+
     }
 }

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -180,7 +180,7 @@ namespace MetroDemo
 
             var dialog = (BaseMetroDialog)this.Resources["CustomDialogTest"];
 
-            this.ShowMetroDialogAsync(dialog);
+            await this.ShowMetroDialogAsync(dialog);
 
             await TaskEx.Delay(5000);
 
@@ -193,7 +193,7 @@ namespace MetroDemo
 
             var dialog = (BaseMetroDialog)this.Resources["CustomCloseDialogTest"];
 
-            await this.ShowMetroDialogAsync(dialog);
+            await this.ShowMetroDialogAsyncAwaitable(dialog);
 
             await this.ShowMessageAsync("Dialog gone", "The custom dialog has closed");
         }

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -194,7 +194,7 @@ namespace MetroDemo
             var dialog = (BaseMetroDialog)this.Resources["CustomCloseDialogTest"];
 
             await this.ShowMetroDialogAsync(dialog);
-            await dialog.WaitUnitlUnloaded();
+            await dialog.WaitUntilUnloadedAsync();
 
             await this.ShowMessageAsync("Dialog gone", "The custom dialog has closed");
         }


### PR DESCRIPTION
As discussed in issue #1910, the ShowMetroDialogAsync method has now the same behaviour as the ShowMessageAsync has. If you await the returned task, it will wait until the dialog is gone.

This pull request contains the necessary changes and adds also a demo of this new capbability to the show case.

The now working code in the show-case pretty much sais all:

```csharp
await this.ShowMetroDialogAsync(dialog);

await dialog.WaitUntilUnloadedAsync(); // Just call await here to wait for the dialog to go away

// This message box is displayed after the dialog has been closed by the user
await this.ShowMessageAsync("Dialog gone", "The custom dialog has closed");
```
