### PR TITLE
Add support for initial password in login dialog

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
@@ -23,6 +23,8 @@ namespace MahApps.Metro.Controls.Dialogs
 
         public string InitialUsername { get; set; }
 
+        public string InitialPassword { get; set; }
+
         public string UsernameWatermark { get; set; }
 
         public string PasswordWatermark { get; set; }
@@ -50,6 +52,7 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             InitializeComponent();
             Username = settings.InitialUsername;
+            Password = settings.InitialPassword;
             UsernameWatermark = settings.UsernameWatermark;
             PasswordWatermark = settings.PasswordWatermark;
             NegativeButtonButtonVisibility = settings.NegativeButtonVisibility;


### PR DESCRIPTION
Adds the ability to set an initial password in the login dialog.  Use case is if a password is stored  it can be retrieved "displayed" in the login dialog the next time it is opened.