### PR TITLE
fix for HandleTheme getting possible System.NullReferenceException

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -82,10 +82,9 @@ namespace MahApps.Metro.Controls.Dialogs
 
         private void Initialize()
         {
+            this.Loaded += (sender, args) => HandleTheme();
             ThemeManager.IsThemeChanged += ThemeManager_IsThemeChanged;
             this.Unloaded += BaseMetroDialog_Unloaded;
-
-            HandleTheme();
 
             this.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Themes/Dialogs/BaseMetroDialog.xaml") });
         }


### PR DESCRIPTION
fixed by handle theme in the loaded event

![image](https://cloud.githubusercontent.com/assets/658431/7733274/58cbeca8-ff2e-11e4-8cba-81aad9b07a95.png)

Closes #1931 Modal dialogs not showing in Visual Studio plugin