### PR TITLE
fix blurred arrows in TreeView

### DIFF
--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -295,10 +295,13 @@ namespace MahApps.Metro.Behaviours
             // handle size to content (thanks @lynnx)
             var sizeToContent = AssociatedObject.SizeToContent;
             var snapsToDevicePixels = AssociatedObject.SnapsToDevicePixels;
+            var useLayoutRounding = AssociatedObject.UseLayoutRounding;
             AssociatedObject.SnapsToDevicePixels = true;
+            AssociatedObject.UseLayoutRounding = true;
             AssociatedObject.SizeToContent = sizeToContent == SizeToContent.WidthAndHeight ? SizeToContent.Height : SizeToContent.Manual;
             AssociatedObject.SizeToContent = sizeToContent;
             AssociatedObject.SnapsToDevicePixels = snapsToDevicePixels;
+            AssociatedObject.UseLayoutRounding = useLayoutRounding;
         }
 
         private void AssociatedObject_Loaded(object sender, RoutedEventArgs e)

--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -295,13 +295,10 @@ namespace MahApps.Metro.Behaviours
             // handle size to content (thanks @lynnx)
             var sizeToContent = AssociatedObject.SizeToContent;
             var snapsToDevicePixels = AssociatedObject.SnapsToDevicePixels;
-            var useLayoutRounding = AssociatedObject.UseLayoutRounding;
             AssociatedObject.SnapsToDevicePixels = true;
-            AssociatedObject.UseLayoutRounding = true;
             AssociatedObject.SizeToContent = sizeToContent == SizeToContent.WidthAndHeight ? SizeToContent.Height : SizeToContent.Manual;
             AssociatedObject.SizeToContent = sizeToContent;
             AssociatedObject.SnapsToDevicePixels = snapsToDevicePixels;
-            AssociatedObject.UseLayoutRounding = useLayoutRounding;
         }
 
         private void AssociatedObject_Loaded(object sender, RoutedEventArgs e)

--- a/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -8,6 +8,8 @@
                 Value="{x:Null}" />
         <Setter Property="BorderBrush"
                 Value="{x:Null}" />
+        <Setter Property="SnapsToDevicePixels"
+                Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">
@@ -33,6 +35,7 @@
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Background="{TemplateBinding Background}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                 Grid.Column="0"
                                 KeyboardNavigation.DirectionalNavigation="Contained"
                                 Grid.Row="1"

--- a/MahApps.Metro/Styles/Controls.TreeView.xaml
+++ b/MahApps.Metro/Styles/Controls.TreeView.xaml
@@ -124,12 +124,13 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TreeViewItem}">
                     <StackPanel>
-                        <Border x:Name="Border"
+                        <Border x:Name="Bd"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Padding="{TemplateBinding Padding}"
                                 MinHeight="{TemplateBinding MinHeight}"
+                                UseLayoutRounding="True"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                             <Grid Margin="{Binding Converter={StaticResource LengthConverter}, RelativeSource={x:Static RelativeSource.TemplatedParent}}"
                                   Background="Transparent"
@@ -142,7 +143,6 @@
                                               Style="{StaticResource ExpandCollapseToggleStyle}"
                                               IsChecked="{Binding Path=IsExpanded, RelativeSource={x:Static RelativeSource.TemplatedParent}, Mode=TwoWay}"
                                               ClickMode="Press" />
-
                                 <ContentPresenter x:Name="PART_Header"
                                                   Grid.Column="1"
                                                   ContentSource="Header"
@@ -151,11 +151,8 @@
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                             </Grid>
                         </Border>
-                        <ItemsPresenter x:Name="ItemsHost">
-                            <ItemsPresenter.LayoutTransform>
-                                <ScaleTransform ScaleY="1" />
-                            </ItemsPresenter.LayoutTransform>
-                        </ItemsPresenter>
+                        <ItemsPresenter x:Name="ItemsHost"
+                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </StackPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsExpanded"
@@ -172,10 +169,10 @@
                                     Value="Hidden" />
                         </Trigger>
 
-                        <Trigger SourceName="Border"
+                        <Trigger SourceName="Bd"
                                  Property="IsMouseOver"
                                  Value="True">
-                            <Setter TargetName="Border"
+                            <Setter TargetName="Bd"
                                     Property="Background"
                                     Value="{DynamicResource AccentColorBrush3}" />
                             <Setter Property="Foreground"
@@ -183,7 +180,7 @@
                         </Trigger>
                         <Trigger Property="IsSelected"
                                  Value="True">
-                            <Setter TargetName="Border"
+                            <Setter TargetName="Bd"
                                     Property="Background"
                                     Value="{DynamicResource AccentColorBrush}" />
                             <Setter Property="Foreground"
@@ -202,7 +199,7 @@
                                            Value="True" />
                             </MultiTrigger.Conditions>
                             <MultiTrigger.Setters>
-                                <Setter TargetName="Border"
+                                <Setter TargetName="Bd"
                                         Property="Background"
                                         Value="{DynamicResource GrayBrush7}" />
                                 <Setter Property="Foreground"
@@ -216,7 +213,7 @@
                                 <Condition Property="Selector.IsSelectionActive"
                                            Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="Border"
+                            <Setter TargetName="Bd"
                                     Property="Background"
                                     Value="{DynamicResource AccentColorBrush2}" />
                         </MultiTrigger>
@@ -243,9 +240,10 @@
                     <Border Name="Border"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}">
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                         <ScrollViewer>
-                            <ItemsPresenter />
+                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </ScrollViewer>
                     </Border>
                     <ControlTemplate.Triggers>

--- a/MahApps.Metro/Styles/Controls.TreeView.xaml
+++ b/MahApps.Metro/Styles/Controls.TreeView.xaml
@@ -6,6 +6,9 @@
     <!-- Metro styled TreeView                                                           -->
     <!-- =============================================================================== -->
 
+    <PathGeometry x:Key="TreeArrow"
+                  Figures="M0,0 L0,6 L6,0 z" />
+
     <Style x:Key="ExpandCollapseToggleStyle"
            TargetType="{x:Type ToggleButton}">
         <Setter Property="Focusable"
@@ -23,10 +26,15 @@
                         <Path x:Name="ExpandPath"
                               HorizontalAlignment="Center"
                               VerticalAlignment="Center"
-                              Data="M 4 0 L 8 4 L 4 8 Z"
+                              Data="{StaticResource TreeArrow}"
                               Fill="Transparent"
-                              StrokeThickness="1"
-                              Stroke="{DynamicResource BlackBrush}" />
+                              Stroke="{DynamicResource BlackBrush}">
+                            <Path.RenderTransform>
+                                <RotateTransform Angle="135"
+                                                 CenterY="3"
+                                                 CenterX="3" />
+                            </Path.RenderTransform>
+                        </Path>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked"
@@ -34,14 +42,14 @@
                             <Setter Property="RenderTransform"
                                     TargetName="ExpandPath">
                                 <Setter.Value>
-                                    <RotateTransform Angle="45"
-                                                     CenterY="4"
-                                                     CenterX="4" />
+                                    <RotateTransform Angle="180"
+                                                     CenterY="3"
+                                                     CenterX="3" />
                                 </Setter.Value>
                             </Setter>
                             <Setter Property="Fill"
                                     TargetName="ExpandPath"
-                                    Value="{DynamicResource BlackBrush}" />
+                                    Value="{DynamicResource GrayBrush1}" />
                             <Setter Property="Stroke"
                                     TargetName="ExpandPath"
                                     Value="{DynamicResource BlackBrush}" />
@@ -124,9 +132,10 @@
                                 MinHeight="{TemplateBinding MinHeight}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                             <Grid Margin="{Binding Converter={StaticResource LengthConverter}, RelativeSource={x:Static RelativeSource.TemplatedParent}}"
+                                  Background="Transparent"
                                   VerticalAlignment="Stretch">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="19" />
+                                    <ColumnDefinition MinWidth="19" Width="Auto" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <ToggleButton x:Name="Expander"

--- a/MahApps.Metro/Themes/MetroContentControl.xaml
+++ b/MahApps.Metro/Themes/MetroContentControl.xaml
@@ -10,6 +10,8 @@
                 Value="Stretch" />
         <Setter Property="Focusable"
                 Value="False" />
+        <Setter Property="SnapsToDevicePixels"
+                Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Controls:MetroContentControl">
@@ -119,7 +121,8 @@
                                               Content="{TemplateBinding Content}"
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               Margin="{TemplateBinding Padding}"
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </AdornerDecorator>
                     </Grid>
                 </ControlTemplate>

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -256,8 +256,6 @@
                 Value="1" />
         <Setter Property="BorderBrush"
                 Value="Transparent" />
-        <Setter Property="UseLayoutRounding"
-                Value="True" />
         <Setter Property="WindowTitleBrush"
                 Value="{DynamicResource WindowTitleColorBrush}" />
         <Setter Property="TextElement.FontSize"

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -36,6 +36,7 @@
 
                     <Rectangle x:Name="PART_WindowTitleBackground"
                                Focusable="False"
+                               UseLayoutRounding="True"
                                Fill="{TemplateBinding WindowTitleBrush}"
                                Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}"
@@ -112,6 +113,7 @@
                                                    Grid.Column="4"
                                                    Grid.RowSpan="2"
                                                    VerticalAlignment="Top"
+                                                   UseLayoutRounding="True"
                                                    Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
 
                     <!-- the main window content -->
@@ -170,6 +172,7 @@
             </AdornerDecorator>
 
             <Border x:Name="PART_Border"
+                    Background="{x:Null}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
                     HorizontalAlignment="Stretch"

--- a/samples/MetroDemo/ExampleViews/SelectionExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/SelectionExamples.xaml
@@ -18,149 +18,105 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Grid Margin="1"
-          RenderOptions.ClearTypeHint="Enabled"
-          TextOptions.TextFormattingMode="Display">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition />
-            <ColumnDefinition />
-            <ColumnDefinition />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition />
-            <RowDefinition />
-        </Grid.RowDefinitions>
-        <StackPanel Grid.RowSpan="2"
-                    Grid.Column="0"
-                    Width="300">
-            <Label Content="List/GridView"
-                   Style="{DynamicResource DescriptionHeaderStyle}" />
-            <ListView Height="200"
-                      Margin="0, 10, 0, 0"
-                      BorderThickness="0"
-                      ItemsSource="{Binding Artists}"
-                      SelectedIndex="0">
-                <ListView.View>
-                    <GridView>
-                        <GridViewColumn DisplayMemberBinding="{Binding ArtistId}"
-                                        Header="ID" />
-                        <GridViewColumn DisplayMemberBinding="{Binding Name}"
-                                        Header="artist" />
-                    </GridView>
-                </ListView.View>
-            </ListView>
-            <ListView Height="200"
-                      Margin="0, 10, 0, 0"
-                      BorderThickness="0"
-                      IsEnabled="False"
-                      ItemsSource="{Binding Artists}"
-                      SelectedIndex="0">
-                <ListView.View>
-                    <GridView>
-                        <GridViewColumn DisplayMemberBinding="{Binding ArtistId}"
-                                        Header="ID" />
-                        <GridViewColumn DisplayMemberBinding="{Binding Name}"
-                                        Header="artist" />
-                    </GridView>
-                </ListView.View>
-            </ListView>
-        </StackPanel>
-        <Grid Grid.Column="1"
-              Grid.RowSpan="2">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
-
-            <Label Content="TreeView"
-                   Style="{DynamicResource DescriptionHeaderStyle}" />
-
-            <TreeView Grid.Row="1">
-                <TreeViewItem Header="Item 1">
-                    <TreeViewItem Header="Item 1.1">
-                        <TreeViewItem Header="Item 1.1.1" />
-                        <TreeViewItem Header="Item 1.1.2" />
+    <TabControl TabStripPlacement="Left"
+                Margin="10">
+        <TabItem Header="List/GridView">
+            <UniformGrid Rows="2">
+                <ListView Margin="5"
+                          BorderThickness="0"
+                          ItemsSource="{Binding Artists}"
+                          SelectedIndex="0">
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn DisplayMemberBinding="{Binding ArtistId}"
+                                            Header="ID" />
+                            <GridViewColumn DisplayMemberBinding="{Binding Name}"
+                                            Header="artist" />
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+                <ListView Margin="5"
+                          BorderThickness="0"
+                          IsEnabled="False"
+                          ItemsSource="{Binding Artists}"
+                          SelectedIndex="0">
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn DisplayMemberBinding="{Binding ArtistId}"
+                                            Header="ID" />
+                            <GridViewColumn DisplayMemberBinding="{Binding Name}"
+                                            Header="artist" />
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+            </UniformGrid>
+        </TabItem>
+        <TabItem Header="TreeView">
+            <UniformGrid Rows="2">
+                <TreeView>
+                    <TreeViewItem Header="Item 1">
+                        <TreeViewItem Header="Item 1.1">
+                            <TreeViewItem Header="Item 1.1.1" />
+                            <TreeViewItem Header="Item 1.1.2" />
+                        </TreeViewItem>
+                        <TreeViewItem Header="Item 1.2" />
+                        <TreeViewItem Header="Item 1.3" />
                     </TreeViewItem>
-                    <TreeViewItem Header="Item 1.2" />
-                    <TreeViewItem Header="Item 1.3" />
-                </TreeViewItem>
-                <TreeViewItem Header="Item 22" />
-                <TreeViewItem Header="Item 3">
-                    <TreeViewItem Header="Item 3.1">
-                        <TreeViewItem Header="Item 3.1.1" />
-                        <TreeViewItem Header="Item 3.1.2" />
+                    <TreeViewItem Header="Item 22" />
+                    <TreeViewItem Header="Item 3">
+                        <TreeViewItem Header="Item 3.1">
+                            <TreeViewItem Header="Item 3.1.1" />
+                            <TreeViewItem Header="Item 3.1.2" />
+                        </TreeViewItem>
+                        <TreeViewItem Header="Item 3.2" />
+                        <TreeViewItem Header="Item 3.3" />
                     </TreeViewItem>
-                    <TreeViewItem Header="Item 3.2" />
-                    <TreeViewItem Header="Item 3.3" />
-                </TreeViewItem>
-            </TreeView>
-            <TreeView IsEnabled="False"
-                      Grid.Row="2">
-                <TreeViewItem Header="Item 1">
-                    <TreeViewItem Header="Item 1.1">
-                        <TreeViewItem Header="Item 1.1.1" />
-                        <TreeViewItem Header="Item 1.1.2" />
+                </TreeView>
+                <TreeView IsEnabled="False">
+                    <TreeViewItem Header="Item 1">
+                        <TreeViewItem Header="Item 1.1">
+                            <TreeViewItem Header="Item 1.1.1" />
+                            <TreeViewItem Header="Item 1.1.2" />
+                        </TreeViewItem>
+                        <TreeViewItem Header="Item 1.2" />
+                        <TreeViewItem Header="Item 1.3" />
                     </TreeViewItem>
-                    <TreeViewItem Header="Item 1.2" />
-                    <TreeViewItem Header="Item 1.3" />
-                </TreeViewItem>
-                <TreeViewItem Header="Item 22" />
-                <TreeViewItem Header="Item 3"
-                              IsExpanded="True"
-                              IsSelected="True">
-                    <TreeViewItem Header="Item 3.1"
-                                  IsExpanded="True">
-                        <TreeViewItem Header="Item 3.1.1"
-                                      IsExpanded="True" />
-                        <TreeViewItem Header="Item 3.1.2" />
+                    <TreeViewItem Header="Item 22" />
+                    <TreeViewItem Header="Item 3"
+                                  IsExpanded="True"
+                                  IsSelected="True">
+                        <TreeViewItem Header="Item 3.1"
+                                      IsExpanded="True">
+                            <TreeViewItem Header="Item 3.1.1"
+                                          IsExpanded="True" />
+                            <TreeViewItem Header="Item 3.1.2" />
+                        </TreeViewItem>
+                        <TreeViewItem Header="Item 3.2" />
+                        <TreeViewItem Header="Item 3.3" />
                     </TreeViewItem>
-                    <TreeViewItem Header="Item 3.2" />
-                    <TreeViewItem Header="Item 3.3" />
-                </TreeViewItem>
-            </TreeView>
-        </Grid>
-        <StackPanel Grid.Column="2"
-                    Width="300">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <Label Grid.ColumnSpan="2"
-                       Content="ListBox"
-                       Style="{DynamicResource DescriptionHeaderStyle}" />
-                <ListBox Grid.Row="1"
-                         Grid.Column="0"
-                         Height="100"
-                         ItemsSource="{Binding Artists}"
+                </TreeView>
+            </UniformGrid>
+        </TabItem>
+        <TabItem Header="ListBox">
+            <UniformGrid Columns="2"
+                         Rows="2">
+                <ListBox ItemsSource="{Binding Artists}"
                          DisplayMemberPath="Name"
                          Margin="1"
                          SelectedIndex="0" />
-                <ListBox Grid.Row="2"
-                         Grid.Column="0"
-                         ItemsSource="{Binding Albums}"
+                <ListBox ItemsSource="{Binding Albums}"
                          DisplayMemberPath="Title"
                          Margin="1"
                          IsEnabled="False"
                          SelectedIndex="0" />
-                <ListBox Grid.Row="1"
-                         Grid.Column="1"
-                         BorderThickness="1"
+                <ListBox BorderThickness="1"
                          Margin="1"
                          SelectedIndex="0">
                     <ListBoxItem Content="Item 1" />
                     <ListBoxItem Content="Item 2" />
                     <ListBoxItem Content="Item 3" />
                 </ListBox>
-                <ListBox Grid.Row="2"
-                         Grid.Column="1"
-                         BorderThickness="1"
+                <ListBox BorderThickness="1"
                          Margin="1"
                          IsEnabled="False"
                          SelectedIndex="0">
@@ -168,79 +124,79 @@
                     <ListBoxItem Content="Item 2" />
                     <ListBoxItem Content="Item 3" />
                 </ListBox>
-            </Grid>
-        </StackPanel>
-        <StackPanel Grid.Row="1"
-                    Grid.Column="2">
-            <Label Content="ComboBox"
-                   Style="{DynamicResource DescriptionHeaderStyle}" />
-            <ComboBox Width="200"
-                      Controls:TextBoxHelper.ClearTextButton="True"
-                      Margin="0, 10, 0, 0"
-                      SelectedIndex="0">
-                <ComboBoxItem Content="Item 1" />
-                <ComboBoxItem Content="Item 2" />
-                <ComboBoxItem Content="Very long Item 3 for MahApps.Metro" />
-                <ComboBoxItem Content="Item 4" />
-            </ComboBox>
-            <ComboBox Width="200"
-                      Controls:TextBoxHelper.ClearTextButton="True"
-                      Margin="0, 10, 0, 0"
-                      SelectedIndex="0"
-                      IsEditable="True">
-                <ComboBoxItem Content="Item 1" />
-                <ComboBoxItem Content="Item 2" />
-                <ComboBoxItem Content="Very long Item 3 for MahApps.Metro" />
-                <ComboBoxItem Content="Item 4" />
-            </ComboBox>
-            <ComboBox Width="200"
-                      Margin="0, 10, 0, 0"
-                      Style="{DynamicResource VirtualisedMetroComboBox}"
-                      Controls:TextBoxHelper.Watermark="Autocompletion"
-                      DisplayMemberPath="Title"
-                      IsEditable="True"
-                      ItemsSource="{Binding Albums}"
-                      MaxDropDownHeight="125"
-                      Text="{Binding Path=Title}" />
-            <ComboBox Width="200"
-                      Margin="0, 10, 0, 0"
-                      Controls:TextBoxHelper.Watermark="Autocompletion with grouping/virtualization"
-                      ToolTip="grouping/virtualization works only with .NET 4.5"
-                      DisplayMemberPath="Title"
-                      IsEditable="True"
-                      IsEnabled="True"
-                      ItemsSource="{Binding Albums}"
-                      Text="{Binding Path=Title}"
-                      Controls:ComboBoxHelper.EnableVirtualizationWithGrouping="True"
-                      x:Name="groupingComboBox">
-                <ComboBox.GroupStyle>
-                    <GroupStyle>
-                        <GroupStyle.HeaderTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding Path=Name.Name}" />
-                            </DataTemplate>
-                        </GroupStyle.HeaderTemplate>
-                    </GroupStyle>
-                </ComboBox.GroupStyle>
-            </ComboBox>
-            <ComboBox Width="200"
-                      Margin="0, 10, 0, 0"
-                      IsEnabled="False"
-                      SelectedIndex="0">
-                <ComboBoxItem Content="Item 1" />
-                <ComboBoxItem Content="Item 2" />
-                <ComboBoxItem Content="Item 3" />
-                <ComboBoxItem Content="Item 4" />
-            </ComboBox>
-            <ComboBox Width="200"
-                      Margin="0, 10, 0, 0"
-                      Controls:TextBoxHelper.Watermark="Autocompletion"
-                      DisplayMemberPath="Title"
-                      IsEditable="True"
-                      IsEnabled="False"
-                      ItemsSource="{Binding Albums}"
-                      Text="{Binding Path=Title, Mode=TwoWay}" />
-        </StackPanel>
-    </Grid>
+            </UniformGrid>
+        </TabItem>
+        <TabItem Header="ComboBox">
+            <StackPanel Orientation="Vertical"
+                        HorizontalAlignment="Left">
+                <ComboBox Width="200"
+                          Controls:TextBoxHelper.ClearTextButton="True"
+                          Margin="0, 10, 0, 0"
+                          SelectedIndex="0">
+                    <ComboBoxItem Content="Item 1" />
+                    <ComboBoxItem Content="Item 2" />
+                    <ComboBoxItem Content="Very long Item 3 for MahApps.Metro" />
+                    <ComboBoxItem Content="Item 4" />
+                </ComboBox>
+                <ComboBox Width="200"
+                          Controls:TextBoxHelper.ClearTextButton="True"
+                          Margin="0, 10, 0, 0"
+                          SelectedIndex="0"
+                          IsEditable="True">
+                    <ComboBoxItem Content="Item 1" />
+                    <ComboBoxItem Content="Item 2" />
+                    <ComboBoxItem Content="Very long Item 3 for MahApps.Metro" />
+                    <ComboBoxItem Content="Item 4" />
+                </ComboBox>
+                <ComboBox Width="200"
+                          Margin="0, 10, 0, 0"
+                          Style="{DynamicResource VirtualisedMetroComboBox}"
+                          Controls:TextBoxHelper.Watermark="Autocompletion"
+                          DisplayMemberPath="Title"
+                          IsEditable="True"
+                          ItemsSource="{Binding Albums}"
+                          MaxDropDownHeight="125"
+                          Text="{Binding Path=Title}" />
+                <ComboBox Width="200"
+                          Margin="0, 10, 0, 0"
+                          Controls:TextBoxHelper.Watermark="Autocompletion with grouping/virtualization"
+                          ToolTip="grouping/virtualization works only with .NET 4.5"
+                          DisplayMemberPath="Title"
+                          IsEditable="True"
+                          IsEnabled="True"
+                          ItemsSource="{Binding Albums}"
+                          Text="{Binding Path=Title}"
+                          Controls:ComboBoxHelper.EnableVirtualizationWithGrouping="True"
+                          x:Name="groupingComboBox">
+                    <ComboBox.GroupStyle>
+                        <GroupStyle>
+                            <GroupStyle.HeaderTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Path=Name.Name}" />
+                                </DataTemplate>
+                            </GroupStyle.HeaderTemplate>
+                        </GroupStyle>
+                    </ComboBox.GroupStyle>
+                </ComboBox>
+                <ComboBox Width="200"
+                          Margin="0, 10, 0, 0"
+                          IsEnabled="False"
+                          SelectedIndex="0">
+                    <ComboBoxItem Content="Item 1" />
+                    <ComboBoxItem Content="Item 2" />
+                    <ComboBoxItem Content="Item 3" />
+                    <ComboBoxItem Content="Item 4" />
+                </ComboBox>
+                <ComboBox Width="200"
+                          Margin="0, 10, 0, 0"
+                          Controls:TextBoxHelper.Watermark="Autocompletion"
+                          DisplayMemberPath="Title"
+                          IsEditable="True"
+                          IsEnabled="False"
+                          ItemsSource="{Binding Albums}"
+                          Text="{Binding Path=Title, Mode=TwoWay}" />
+            </StackPanel>
+        </TabItem>
+    </TabControl>
 
 </UserControl>


### PR DESCRIPTION
this pr fixes a nasty behavior using the `UseLayoutRounding`. using this with the `MetroWindow` style produces blurred paths, e.g. the arrows in a `TreeView`.
omg WPF, lessons learned...

**before**
![image](https://cloud.githubusercontent.com/assets/658431/7760632/97d91fb6-001d-11e5-9a78-a1886019696e.png)

**after**
![image](https://cloud.githubusercontent.com/assets/658431/7760575/290d6cd6-001d-11e5-9051-a01c965a5d26.png)

Closes #1907 Blurred arrows in TreeView