### PR TITLE
fix ResizeGrip usage by setting the WindowChrome ResizeGripDirection

### DIFF
--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -314,6 +314,8 @@ namespace MahApps.Metro.Behaviours
             window.SetIsHitTestVisibleInChromeProperty<ContentPresenter>("PART_LeftWindowCommands");
             window.SetIsHitTestVisibleInChromeProperty<ContentPresenter>("PART_RightWindowCommands");
             window.SetIsHitTestVisibleInChromeProperty<ContentControl>("PART_WindowButtonCommands");
+
+            window.SetWindowChromeResizeGripDirection("WindowResizeGrip", ResizeGripDirection.BottomRight);
         }
 
         [Obsolete(@"This property will be deleted in the next release. You should use BorderThickness=""0"" and a GlowBrush=""Black"" properties in your Window to get a drop shadow around it.")]

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -977,9 +977,23 @@ namespace MahApps.Metro.Controls
             }
         }
 
+        /// <summary>
+        /// Gets the template child with the given name.
+        /// </summary>
+        /// <typeparam name="T">The interface type inheirted from DependencyObject.</typeparam>
+        /// <param name="name">The name of the template child.</param>
         internal T GetPart<T>(string name) where T : DependencyObject
         {
             return GetTemplateChild(name) as T;
+        }
+
+        /// <summary>
+        /// Gets the template child with the given name.
+        /// </summary>
+        /// <param name="name">The name of the template child.</param>
+        internal DependencyObject GetPart(string name)
+        {
+            return GetTemplateChild(name);
         }
 
         private static void ShowSystemMenuPhysicalCoordinates(Window window, Point physicalScreenLocation)

--- a/MahApps.Metro/Controls/MetroWindowHelpers.cs
+++ b/MahApps.Metro/Controls/MetroWindowHelpers.cs
@@ -17,8 +17,8 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Sets the IsHitTestVisibleInChromeProperty to a MetroWindow template child
         /// </summary>
-        /// <param name="window">The MetroWindow</param>
-        /// <param name="name">The name of the template child</param>
+        /// <param name="window">The MetroWindow.</param>
+        /// <param name="name">The name of the template child.</param>
         public static void SetIsHitTestVisibleInChromeProperty<T>(this MetroWindow window, string name) where T : DependencyObject
         {
             if (window == null)
@@ -29,6 +29,25 @@ namespace MahApps.Metro.Controls
             if (elementPart != null)
             {
                 elementPart.SetValue(WindowChrome.IsHitTestVisibleInChromeProperty, true);
+            }
+        }
+
+        /// <summary>
+        /// Sets the WindowChrome ResizeGripDirection to a MetroWindow template child.
+        /// </summary>
+        /// <param name="window">The MetroWindow.</param>
+        /// <param name="name">The name of the template child.</param>
+        /// <param name="direction">The direction.</param>
+        public static void SetWindowChromeResizeGripDirection(this MetroWindow window, string name, ResizeGripDirection direction)
+        {
+            if (window == null)
+            {
+                return;
+            }
+            var inputElement = window.GetPart(name) as IInputElement;
+            if (inputElement != null)
+            {
+                WindowChrome.SetResizeGripDirection(inputElement, direction);
             }
         }
 


### PR DESCRIPTION
...the title says...
Closes #1832 Corner resize doesn't work with glow border or drop shadow