### PR TITLE
Hotfix DataGrid row conditional foreground

### DIFF
--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -307,6 +307,8 @@
            TargetType="{x:Type DataGridCell}">
         <Setter Property="Controls:DataGridCellHelper.SaveDataGrid"
                 Value="True" />
+        <Setter Property="OverridesDefaultStyle" 
+                Value="True" />
         <Setter Property="BorderBrush"
                 Value="Transparent" />
         <Setter Property="HorizontalContentAlignment"

--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -307,8 +307,6 @@
            TargetType="{x:Type DataGridCell}">
         <Setter Property="Controls:DataGridCellHelper.SaveDataGrid"
                 Value="True" />
-        <Setter Property="Background"
-                Value="Transparent" />
         <Setter Property="BorderBrush"
                 Value="Transparent" />
         <Setter Property="HorizontalContentAlignment"

--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -307,8 +307,6 @@
            TargetType="{x:Type DataGridCell}">
         <Setter Property="Controls:DataGridCellHelper.SaveDataGrid"
                 Value="True" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource BlackBrush}" />
         <Setter Property="Background"
                 Value="Transparent" />
         <Setter Property="BorderBrush"


### PR DESCRIPTION
if you used style like this:

```XAML
        <Style x:Key="WareTypeRow"
               BasedOn="{StaticResource MetroDataGridRow}"
               TargetType="DataGridRow">
            <Style.Triggers>
                <DataTrigger Binding="{Binding Expelled}" Value="True">
                    <Setter Property="Foreground" Value="Red" />
                </DataTrigger>
            </Style.Triggers>
            <Setter Property="Control.Foreground" Value="{DynamicResource BlackBrush}" />
            <Setter Property="FrameworkElement.Margin" Value="0" />
        </Style>
...
       <DataGrid RowStyle="{StaticResource WareTypeRow}" ...>
          ...
       </DataGrid/>
```
the style is not applied.