### PR TITLE
fix wrong overlapping window button commands with ShowInTaskbar=False

### DIFF
--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
@@ -838,6 +838,17 @@
         COMMAND = 0x0111,
         SYSCOMMAND = 0x0112,
 
+        // These two messages aren't defined in winuser.h, but they are sent to windows
+        // with captions. They appear to paint the window caption and frame.
+        // Unfortunately if you override the standard non-client rendering as we do
+        // with CustomFrameWindow, sometimes Windows (not deterministically
+        // reproducibly but definitely frequently) will send these messages to the
+        // window and paint the standard caption/title over the top of the custom one.
+        // So we need to handle these messages in CustomFrameWindow to prevent this
+        // from happening.
+        NCUAHDRAWCAPTION = 0xAE,
+        NCUAHDRAWFRAME = 0xAF,
+
         MOUSEMOVE = 0x0200,
         LBUTTONDOWN = 0x0201,
         LBUTTONUP = 0x0202,

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -179,6 +179,8 @@
                               Header="Await CustomDialog" />
                 </MenuItem>
                 <MenuItem Header="Window">
+                    <MenuItem IsCheckable="True" Header="ShowInTaskbar"
+                              IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=ShowInTaskbar}" />
                     <MenuItem IsCheckable="True" Header="Topmost"
                               IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=Topmost}" />
                     <MenuItem IsCheckable="True" Header="Ignore taskbar on maximize"


### PR DESCRIPTION
... the title says...
Closes #1912 Minimized and not ShowInTaskbar shows windows buttons command

**before**
![image](https://cloud.githubusercontent.com/assets/658431/7860567/772384aa-054a-11e5-8abc-a2e2bd1d673d.png)

**after**
![image](https://cloud.githubusercontent.com/assets/658431/7860570/799edac2-054a-11e5-9614-b4f1b4234225.png)

(the not showing right MahApps window button commands will be fixed in another pr)