### PR TITLE
Dynamic fontsize for dialogs

### DIFF
--- a/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -5,7 +5,6 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Buttons.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style BasedOn="{StaticResource SquareButtonStyle}"
@@ -71,7 +70,7 @@
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0"
-                                       FontSize="{StaticResource DialogTitleFontSize}"
+                                       FontSize="{DynamicResource DialogTitleFontSize}"
                                        Foreground="{TemplateBinding Foreground}"
                                        Text="{TemplateBinding Title}"
                                        TextWrapping="Wrap" />

--- a/MahApps.Metro/Themes/Dialogs/InputDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/InputDialog.xaml
@@ -7,24 +7,24 @@
     <Grid Margin="0 10 0 0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"
-                            MinHeight="20" />
+                           MinHeight="20" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0"
-                    Margin="0 5 0 0"
-                    FontSize="{StaticResource DialogMessageFontSize}"
-                    Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                    TextWrapping="Wrap"
-                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+                   Margin="0 5 0 0"
+                   FontSize="{DynamicResource DialogMessageFontSize}"
+                   Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                   TextWrapping="Wrap"
+                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         <TextBox Grid.Row="1"
-                    Margin="0 5 0 0"
-                    FontSize="{StaticResource DialogMessageFontSize}"
-                    controls:ControlsHelper.FocusBorderBrush="{DynamicResource AccentColorBrush}"
-                    x:Name="PART_TextBox"
-                    Text="{Binding Input, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                    TextWrapping="Wrap"
-                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+                 Margin="0 5 0 0"
+                 FontSize="{DynamicResource DialogMessageFontSize}"
+                 controls:ControlsHelper.FocusBorderBrush="{DynamicResource AccentColorBrush}"
+                 x:Name="PART_TextBox"
+                 Text="{Binding Input, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                 TextWrapping="Wrap"
+                 Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
 
         <StackPanel Grid.Row="2"
                     Orientation="Horizontal"

--- a/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
@@ -8,32 +8,32 @@
     <Grid Margin="0 10 0 0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"
-                            MinHeight="20" />
+                           MinHeight="20" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0"
-                    Margin="0 5 0 0"
-                    FontSize="{StaticResource DialogMessageFontSize}"
-                    Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                    TextWrapping="Wrap"
-                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+                   Margin="0 5 0 0"
+                   FontSize="{DynamicResource DialogMessageFontSize}"
+                   Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                   TextWrapping="Wrap"
+                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         <TextBox Grid.Row="1"
-                    Margin="0 5 0 0"
-                    FontSize="{StaticResource DialogMessageFontSize}"
-                    x:Name="PART_TextBox"
-                    Controls:TextBoxHelper.Watermark="{Binding UsernameWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                    Text="{Binding Username, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                    TextWrapping="Wrap"
-                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+                 Margin="0 5 0 0"
+                 FontSize="{DynamicResource DialogMessageFontSize}"
+                 x:Name="PART_TextBox"
+                 Controls:TextBoxHelper.Watermark="{Binding UsernameWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                 Text="{Binding Username, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                 TextWrapping="Wrap"
+                 Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         <PasswordBox Grid.Row="2"
-                        Margin="0 5 0 0"
-                        FontSize="{StaticResource DialogMessageFontSize}"
-                        x:Name="PART_TextBox2"
-                        Behaviors:PasswordBoxBindingBehavior.Password="{Binding Password, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                        Controls:TextBoxHelper.Watermark="{Binding PasswordWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+                     Margin="0 5 0 0"
+                     FontSize="{DynamicResource DialogMessageFontSize}"
+                     x:Name="PART_TextBox2"
+                     Behaviors:PasswordBoxBindingBehavior.Password="{Binding Password, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                     Controls:TextBoxHelper.Watermark="{Binding PasswordWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                     Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         <StackPanel Grid.Row="3"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"

--- a/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
@@ -14,7 +14,7 @@
             <TextBlock x:Name="PART_MessageTextBlock"
                        Margin="0 5 0 0"
                        TextWrapping="Wrap"
-                       FontSize="{StaticResource DialogMessageFontSize}"
+                       FontSize="{DynamicResource DialogMessageFontSize}"
                        Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         </ScrollViewer>

--- a/MahApps.Metro/Themes/Dialogs/ProgressDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/ProgressDialog.xaml
@@ -11,7 +11,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <TextBlock Margin="0 5 0 0"
-                       FontSize="{StaticResource DialogMessageFontSize}"
+                       FontSize="{DynamicResource DialogMessageFontSize}"
                        Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:ProgressDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                        TextWrapping="Wrap"
                        Grid.Row="0"

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -67,7 +67,7 @@
             <Dialog:CustomDialog x:Key="CustomDialogTest"
                                  Title="This dialog allows arbitrary content. It will close in 5 seconds."
                                  x:Name="CustomTestDialog">
-                <TextBlock Height="30" Text="{Binding Artists[0].Name}" Foreground="{DynamicResource AccentBrush}" />
+                <TextBlock Height="30" Text="{Binding Artists[0].Name}" Foreground="{DynamicResource AccentColorBrush}" />
             </Dialog:CustomDialog>
 
             <Dialog:CustomDialog x:Key="CustomCloseDialogTest"
@@ -76,7 +76,8 @@
                 
                 <StackPanel>
                     <TextBlock Height="30" Text="This dialog allows arbitrary content. You have to close it yourself by clicking the close button below." 
-                               Foreground="{DynamicResource AccentBrush}" />
+                               TextWrapping="Wrap"
+                               Foreground="{DynamicResource AccentColorBrush}" />
                     <Button Content="Close Me!" Click="CloseCustomDialog"/>
                 </StackPanel>
 


### PR DESCRIPTION
fix the static usage of font size in dialogs
so it's now possible to override these values
```xaml
    <System:Double x:Key="DialogTitleFontSize">26</System:Double>
    <System:Double x:Key="DialogMessageFontSize">15</System:Double>
```