### PR TITLE
IsReadOnly binding fix for NumericUpDown and more...

### DIFF
--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -187,6 +187,9 @@
                         </Trigger>
                         <Trigger Property="IsReadOnly"
                                  Value="True">
+                            <Setter TargetName="PART_ClearText"
+                                    Property="IsEnabled"
+                                    Value="False" />
                             <Setter TargetName="ReadOnlyVisualElement"
                                     Property="Opacity"
                                     Value="1" />

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -325,11 +325,6 @@
                                                Height="*" />
                             </Grid.RowDefinitions>
 
-                            <Border x:Name="ReadOnlyVisualElement"
-                                    Grid.ColumnSpan="2"
-                                    Grid.Row="1"
-                                    Background="{x:Null}"
-                                    Opacity="0" />
                             <ScrollViewer x:Name="PART_ContentHost"
                                           Grid.Column="0"
                                           Grid.Row="1"
@@ -573,11 +568,6 @@
                                                Height="*" />
                             </Grid.RowDefinitions>
 
-                            <Border x:Name="ReadOnlyVisualElement"
-                                    Grid.ColumnSpan="2"
-                                    Grid.Row="1"
-                                    Background="{x:Null}"
-                                    Opacity="0" />
                             <ScrollViewer x:Name="PART_ContentHost"
                                           Grid.Column="0"
                                           Grid.Row="1"
@@ -820,11 +810,6 @@
                                                Height="*" />
                             </Grid.RowDefinitions>
 
-                            <Border x:Name="ReadOnlyVisualElement"
-                                    Grid.ColumnSpan="2"
-                                    Grid.Row="1"
-                                    Background="{x:Null}"
-                                    Opacity="0" />
                             <ScrollViewer x:Name="PART_ContentHost"
                                           Grid.Column="0"
                                           Grid.Row="1"

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -234,6 +234,9 @@
                         </Trigger>
                         <Trigger Property="IsReadOnly"
                                  Value="True">
+                            <Setter TargetName="PART_ClearText"
+                                    Property="IsEnabled"
+                                    Value="False" />
                             <Setter TargetName="ReadOnlyVisualElement"
                                     Property="Opacity"
                                     Value="1" />
@@ -517,6 +520,9 @@
                         </Trigger>
                         <Trigger Property="IsReadOnly"
                                  Value="True">
+                            <Setter TargetName="PART_ClearText"
+                                    Property="IsEnabled"
+                                    Value="False" />
                             <Setter TargetName="ReadOnlyVisualElement"
                                     Property="Opacity"
                                     Value="1" />

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -520,9 +520,6 @@
                         </Trigger>
                         <Trigger Property="IsReadOnly"
                                  Value="True">
-                            <Setter TargetName="PART_ClearText"
-                                    Property="IsEnabled"
-                                    Value="False" />
                             <Setter TargetName="ReadOnlyVisualElement"
                                     Property="Opacity"
                                     Value="1" />

--- a/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -119,6 +119,12 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsReadOnly"
                                  Value="True">
+                            <Setter TargetName="PART_NumericUp"
+                                    Property="IsEnabled"
+                                    Value="False" />
+                            <Setter TargetName="PART_NumericDown"
+                                    Property="IsEnabled"
+                                    Value="False" />
                             <Setter Property="InterceptArrowKeys"
                                     Value="False" />
                             <Setter Property="InterceptMouseWheel"

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -209,25 +209,33 @@
                        Style="{DynamicResource DescriptionHeaderStyle}" />
 
                 <Label Content='Minimum="0", Maximum="10" TextAlignment="Left"' />
+                
+                <CheckBox x:Name="ReadOnlyCheck" Content="IsReadOnly" Margin="2" />
+                
                 <Controls:NumericUpDown Value="5"
+                                        x:Name="Test"
                                         TextAlignment="Left"
                                         Minimum="0"
-                                        IsReadOnly="True"
+                                        IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Maximum="10" />
 
                 <Label Content='Interval="2"' />
                 <Controls:NumericUpDown Value="5"
+                                        IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Interval="2" />
                 <Label Content='Interval="5"' />
                 <Controls:NumericUpDown Value="5"
+                                        IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Controls:TextBoxHelper.ClearTextButton="True"
                                         Interval="5" />
 
                 <Label Content="No Speedup when long pressed" />
                 <Controls:NumericUpDown Value="5"
+                                        IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Speedup="false" />
                 <Label Content="Speedup when long pressed but after 500ms" />
                 <Controls:NumericUpDown Controls:TextBoxHelper.Watermark="Test"
+                                        IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Delay="500"
                                         Speedup="true" />
 
@@ -235,9 +243,11 @@
                 <Label Content="{Binding ElementName=test, Path=Value}" />
                 <Controls:NumericUpDown Value="5"
                                         x:Name="test"
+                                        IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         StringFormat="pcs. {0:N2} pcs."
                                         Maximum="100" />
                 <Controls:NumericUpDown Value="5"
+                                        IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Interval=".1"
                                         StringFormat="0,000.00" />
             </StackPanel>


### PR DESCRIPTION
- fix binding usage of `IsReadOnly` for `NumericUpDown`
- PasswordBox has no read only flag
- handle `IsReadOnly` for clear text button too

Closes #1914 Binding to NumericUpDown.IsReadOnly does not work