### PR TITLE
add mechanism for easy access of a dialog from a view model

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/DialogCoordinator.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogCoordinator.cs
@@ -11,7 +11,58 @@ namespace MahApps.Metro.Controls.Dialogs
         /// </summary>
         public static readonly DialogCoordinator Instance = new DialogCoordinator();
 
-        public Task<string> ShowInput(object context)
+        public Task<string> ShowInputAsync(object context, string title, string message, MetroDialogSettings metroDialogSettings = null)
+        {            
+            var metroWindow = GetMetroWindow(context);
+
+            return metroWindow.ShowInputAsync(title, message, metroDialogSettings);
+        }
+
+        public Task<LoginDialogData> ShowLoginAsync(object context, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, LoginDialogSettings settings = null)
+        {
+            var metroWindow = GetMetroWindow(context);
+
+            return metroWindow.ShowLoginAsync(title, message, settings);
+        }
+
+        public Task<MessageDialogResult> ShowMessageAsync(object context, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, MetroDialogSettings settings = null)
+        {
+            var metroWindow = GetMetroWindow(context);
+
+            return metroWindow.ShowMessageAsync(title, message, style, settings);
+        }
+
+        public Task<ProgressDialogController> ShowProgressAsync(object context, string title, string message,
+            bool isCancelable = false, MetroDialogSettings settings = null)
+        {
+            var metroWindow = GetMetroWindow(context);
+
+            return metroWindow.ShowProgressAsync(title, message, isCancelable, settings);
+        }
+
+        public Task ShowMetroDialogAsync(object context, BaseMetroDialog dialog,
+            MetroDialogSettings settings = null)
+        {
+            var metroWindow = GetMetroWindow(context);
+
+            return metroWindow.ShowMetroDialogAsync(dialog, settings);
+        }
+
+        public Task HideMetroDialogAsync(object context, BaseMetroDialog dialog, MetroDialogSettings settings = null)
+        {
+            var metroWindow = GetMetroWindow(context);
+
+            return metroWindow.HideMetroDialogAsync(dialog, settings);
+        }
+
+        public Task<TDialog> GetCurrentDialogAsync<TDialog>(object context) where TDialog : BaseMetroDialog
+        {
+            var metroWindow = GetMetroWindow(context);
+
+            return metroWindow.GetCurrentDialogAsync<TDialog>();
+        }
+
+        private static MetroWindow GetMetroWindow(object context)
         {
             if (context == null) throw new ArgumentNullException("context");
             if (!DialogParticipation.IsRegistered(context))
@@ -23,21 +74,7 @@ namespace MahApps.Metro.Controls.Dialogs
 
             if (metroWindow == null)
                 throw new InvalidOperationException("Control is not inside a MetroWindow.");
-
-            return metroWindow.ShowInputAsync("From a VM", "This dialog was shown from a VM, without knoweldge of Window");
+            return metroWindow;
         }
-    }
-
-    /// <summary>
-    /// Use the dialog coordinator to help you interfact with dialogs from a view model.
-    /// </summary>
-    public interface IDialogCoordinator
-    {
-        /// <summary>
-        /// Shows the input dialog.
-        /// </summary>
-        /// <param name="context">Typically this should be the view model, which you register in XAML using <see cref="DialogParticipation.Register"/>.</param>
-        /// <returns></returns>
-        Task<string> ShowInput(object context);
     }
 }

--- a/MahApps.Metro/Controls/Dialogs/DialogCoordinator.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogCoordinator.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace MahApps.Metro.Controls.Dialogs
+{
+    public class DialogCoordinator : IDialogCoordinator
+    {
+        /// <summary>
+        /// Gets the default instance if the dialog coordinator, which can be injected into a view model.
+        /// </summary>
+        public static readonly DialogCoordinator Instance = new DialogCoordinator();
+
+        public Task<string> ShowInput(object context)
+        {
+            if (context == null) throw new ArgumentNullException("context");
+            if (!DialogParticipation.IsRegistered(context))
+                throw new InvalidOperationException(
+                    "Context is not registered. Consider using DialogParticipation.Register in XAML to bind in the DataContext.");
+
+            var association = DialogParticipation.GetAssociation(context);
+            var metroWindow = Window.GetWindow(association) as MetroWindow;
+
+            if (metroWindow == null)
+                throw new InvalidOperationException("Control is not inside a MetroWindow.");
+
+            return metroWindow.ShowInputAsync("From a VM", "This dialog was shown from a VM, without knoweldge of Window");
+        }
+    }
+
+    /// <summary>
+    /// Use the dialog coordinator to help you interfact with dialogs from a view model.
+    /// </summary>
+    public interface IDialogCoordinator
+    {
+        /// <summary>
+        /// Shows the input dialog.
+        /// </summary>
+        /// <param name="context">Typically this should be the view model, which you register in XAML using <see cref="DialogParticipation.Register"/>.</param>
+        /// <returns></returns>
+        Task<string> ShowInput(object context);
+    }
+}

--- a/MahApps.Metro/Controls/Dialogs/DialogParticipation.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogParticipation.cs
@@ -13,9 +13,11 @@ namespace MahApps.Metro.Controls.Dialogs
 
         private static void RegisterPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
-            //TODO tidy up old val?
+            if (dependencyPropertyChangedEventArgs.OldValue != null)
+                ContextRegistrationIndex.Remove(dependencyPropertyChangedEventArgs.OldValue);
 
-            ContextRegistrationIndex[dependencyPropertyChangedEventArgs.NewValue] = dependencyObject;
+            if (dependencyPropertyChangedEventArgs.NewValue != null)
+                ContextRegistrationIndex[dependencyPropertyChangedEventArgs.NewValue] = dependencyObject;
         }
 
         public static void SetRegister(DependencyObject element, object context)

--- a/MahApps.Metro/Controls/Dialogs/DialogParticipation.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogParticipation.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows;
+
+namespace MahApps.Metro.Controls.Dialogs
+{
+    public static class DialogParticipation
+    {
+        private static readonly IDictionary<object, DependencyObject> ContextRegistrationIndex = new Dictionary<object, DependencyObject>();
+
+        public static readonly DependencyProperty RegisterProperty = DependencyProperty.RegisterAttached(
+            "Register", typeof(object), typeof(DialogParticipation), new PropertyMetadata(default(object), RegisterPropertyChangedCallback));
+
+        private static void RegisterPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            //TODO tidy up old val?
+
+            ContextRegistrationIndex[dependencyPropertyChangedEventArgs.NewValue] = dependencyObject;
+        }
+
+        public static void SetRegister(DependencyObject element, object context)
+        {
+            element.SetValue(RegisterProperty, context);
+        }
+
+        public static object GetRegister(DependencyObject element)
+        {
+            return element.GetValue(RegisterProperty);
+        }
+
+        internal static bool IsRegistered(object context)
+        {
+            if (context == null) throw new ArgumentNullException("context");
+
+            return ContextRegistrationIndex.ContainsKey(context);
+        }
+
+        internal static DependencyObject GetAssociation(object context)
+        {
+            if (context == null) throw new ArgumentNullException("context");
+
+            return ContextRegistrationIndex[context];
+        }
+    }
+}

--- a/MahApps.Metro/Controls/Dialogs/IDialogCoordinator.cs
+++ b/MahApps.Metro/Controls/Dialogs/IDialogCoordinator.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace MahApps.Metro.Controls.Dialogs
+{
+    /// <summary>
+    /// Use the dialog coordinator to help you interfact with dialogs from a view model.
+    /// </summary>
+    public interface IDialogCoordinator
+    {
+        /// <summary>
+        /// Shows the input dialog.
+        /// </summary>
+        /// <param name="context">Typically this should be the view model, which you register in XAML using <see cref="DialogParticipation.SetRegister"/>.</param>
+        /// <param name="title">The title of the MessageDialog.</param>
+        /// <param name="message">The message contained within the MessageDialog.</param>
+        /// <param name="settings">Optional settings that override the global metro dialog settings.</param>
+        /// <returns>The text that was entered or null (Nothing in Visual Basic) if the user cancelled the operation.</returns>
+        Task<string> ShowInputAsync(object context, string title, string message, MetroDialogSettings settings = null);
+
+        /// <summary>
+        /// Creates a LoginDialog inside of the current window.
+        /// </summary>
+        /// <param name="context">Typically this should be the view model, which you register in XAML using <see cref="DialogParticipation.SetRegister"/>.</param>
+        /// <param name="title">The title of the LoginDialog.</param>
+        /// <param name="message">The message contained within the LoginDialog.</param>
+        /// <param name="style"></param>
+        /// <param name="settings">Optional settings that override the global metro dialog settings.</param>
+        /// <returns>The text that was entered or null (Nothing in Visual Basic) if the user cancelled the operation.</returns>
+        Task<LoginDialogData> ShowLoginAsync(object context, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, LoginDialogSettings settings = null);
+
+        /// <summary>
+        /// Creates a MessageDialog inside of the current window.
+        /// </summary>
+        /// <param name="context">Typically this should be the view model, which you register in XAML using <see cref="DialogParticipation.SetRegister"/>.</param>
+        /// <param name="title">The title of the MessageDialog.</param>
+        /// <param name="message">The message contained within the MessageDialog.</param>
+        /// <param name="style">The type of buttons to use.</param>
+        /// <param name="settings">Optional settings that override the global metro dialog settings.</param>
+        /// <returns>A task promising the result of which button was pressed.</returns>
+        Task<MessageDialogResult> ShowMessageAsync(object context, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, MetroDialogSettings settings = null);
+
+        /// <summary>
+        /// Creates a ProgressDialog inside of the current window.
+        /// </summary>
+        /// <param name="context">Typically this should be the view model, which you register in XAML using <see cref="DialogParticipation.SetRegister"/>.</param>
+        /// <param name="title">The title of the ProgressDialog.</param>
+        /// <param name="message">The message within the ProgressDialog.</param>
+        /// <param name="isCancelable">Determines if the cancel button is visible.</param>
+        /// <param name="settings">Optional Settings that override the global metro dialog settings.</param>
+        /// <returns>A task promising the instance of ProgressDialogController for this operation.</returns>
+        Task<ProgressDialogController> ShowProgressAsync(object context, string title, string message,
+            bool isCancelable = false, MetroDialogSettings settings = null);
+
+        /// <summary>
+        /// Adds a Metro Dialog instance to the specified window and makes it visible asynchronously.        
+        /// <para>You have to close the resulting dialog yourself with <see cref="HideMetroDialogAsync"/>.</para>
+        /// </summary>
+        /// <param name="context">Typically this should be the view model, which you register in XAML using <see cref="DialogParticipation.SetRegister"/>.</param>
+        /// <param name="dialog">The dialog instance itself.</param>
+        /// <param name="settings">An optional pre-defined settings instance.</param>
+        /// <returns>A task representing the operation.</returns>
+        /// <exception cref="InvalidOperationException">The <paramref name="dialog"/> is already visible in the window.</exception>
+        Task ShowMetroDialogAsync(object context, BaseMetroDialog dialog,
+            MetroDialogSettings settings = null);
+
+        /// <summary>
+        /// Hides a visible Metro Dialog instance.
+        /// </summary>
+        /// <param name="context">Typically this should be the view model, which you register in XAML using <see cref="DialogParticipation.SetRegister"/>.</param>
+        /// <param name="dialog">The dialog instance to hide.</param>
+        /// <param name="settings">An optional pre-defined settings instance.</param>
+        /// <returns>A task representing the operation.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The <paramref name="dialog"/> is not visible in the window.
+        /// This happens if <see cref="ShowMetroDialogAsync"/> hasn't been called before.
+        /// </exception>
+        Task HideMetroDialogAsync(object context, BaseMetroDialog dialog, MetroDialogSettings settings = null);
+        
+        /// <summary>
+        /// Gets the current shown dialog.
+        /// </summary>
+        /// <param name="context">Typically this should be the view model, which you register in XAML using <see cref="DialogParticipation.SetRegister"/>.</param>
+        Task<TDialog> GetCurrentDialogAsync<TDialog>(object context) where TDialog : BaseMetroDialog;        
+    }
+}

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Behaviours\WindowsSettingBehaviour.cs" />
     <Compile Include="Controls\Dialogs\DialogCoordinator.cs" />
     <Compile Include="Controls\Dialogs\DialogParticipation.cs" />
+    <Compile Include="Controls\Dialogs\IDialogCoordinator.cs" />
     <Compile Include="Controls\Helper\ButtonHelper.cs" />
     <Compile Include="Controls\ClosingWindowEventHandlerArgs.cs" />
     <Compile Include="Controls\Helper\ComboBoxHelper.cs" />

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -130,6 +130,8 @@
     <Compile Include="Behaviours\StylizedBehaviorCollection.cs" />
     <Compile Include="Behaviours\TabControlSelectFirstVisibleTabBehavior.cs" />
     <Compile Include="Behaviours\WindowsSettingBehaviour.cs" />
+    <Compile Include="Controls\Dialogs\DialogCoordinator.cs" />
+    <Compile Include="Controls\Dialogs\DialogParticipation.cs" />
     <Compile Include="Controls\Helper\ButtonHelper.cs" />
     <Compile Include="Controls\ClosingWindowEventHandlerArgs.cs" />
     <Compile Include="Controls\Helper\ComboBoxHelper.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -85,6 +85,8 @@
     <Compile Include="Actions\SetFlyoutOpenAction.cs" />
     <Compile Include="Behaviours\BindableResourceBehavior.cs" />
     <Compile Include="Behaviours\BorderlessWindowBehavior.cs" />
+    <Compile Include="Controls\Dialogs\DialogCoordinator.cs" />
+    <Compile Include="Controls\Dialogs\DialogParticipation.cs" />
     <Compile Include="Behaviours\GlowWindowBehavior.cs" />
     <Compile Include="Behaviours\PasswordBoxBindingBehavior.cs" />
     <Compile Include="Behaviours\StylizedBehaviorCollection.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Controls\Dialogs\BaseMetroDialog.cs" />
     <Compile Include="Controls\Dialogs\DialogManager.cs" />
     <Compile Include="Controls\Dialogs\DialogStateChangedEventArgs.cs" />
+    <Compile Include="Controls\Dialogs\IDialogCoordinator.cs" />
     <Compile Include="Controls\Dialogs\InputDialog.cs" />
     <Compile Include="Controls\Dialogs\LoginDialog.cs" />
     <Compile Include="Controls\Dialogs\ProgressDialog.cs" />

--- a/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml.cs
+++ b/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Input;
 using MahApps.Metro.Controls;
+using MahApps.Metro.Controls.Dialogs;
 using MetroDemo.Models;
 
 namespace MetroDemo.ExampleWindows
@@ -13,7 +14,7 @@ namespace MetroDemo.ExampleWindows
         
         public FlyoutDemo()
         {
-            this.DataContext = new MainWindowViewModel();
+            this.DataContext = new MainWindowViewModel(DialogCoordinator.Instance);
             this.InitializeComponent();
             this.Closing += (s, e) =>
                 {

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -20,7 +20,9 @@
                       d:DesignHeight="600"
                       d:DesignWidth="800"
                       d:DataContext="{d:DesignInstance MetroDemo:MainWindowViewModel}"
-                      Closing="MetroWindow_Closing">
+                      Closing="MetroWindow_Closing"
+                      Dialog:DialogParticipation.Register="{Binding}"
+                      >
 
     <Window.Resources>
         <ResourceDictionary>
@@ -178,6 +180,9 @@
                               Header="Show CustomDialog Externally" />
                     <MenuItem Click="ShowAwaitCustomDialog"
                               Header="Await CustomDialog" />
+                    <Separator />
+                    <MenuItem Command="{Binding ShowInputDialogCommand}"
+                              Header="Show InputDialog via VM" />
                 </MenuItem>
                 <MenuItem Header="Window">
                     <MenuItem IsCheckable="True" Header="ShowInTaskbar"

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -183,6 +183,14 @@
                     <Separator />
                     <MenuItem Command="{Binding ShowInputDialogCommand}"
                               Header="Show InputDialog via VM" />
+                    <MenuItem Command="{Binding ShowLoginDialogCommand}"
+                              Header="Show LoginDialog via VM" />
+                    <MenuItem Command="{Binding ShowMessageDialogCommand}"
+                              Header="Show MessageDialog via VM" />
+                    <MenuItem Command="{Binding ShowProgressDialogCommand}"
+                              Header="Show ProgressDialog via VM" />
+                    <MenuItem Command="{Binding ShowCustomDialogCommand}"
+                              Header="Show CustomDialog via VM" />
                 </MenuItem>
                 <MenuItem Header="Window">
                     <MenuItem IsCheckable="True" Header="ShowInTaskbar"

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -17,7 +17,7 @@ namespace MetroDemo
 
         public MainWindow()
         {
-            _viewModel = new MainWindowViewModel();
+            _viewModel = new MainWindowViewModel(DialogCoordinator.Instance);
             DataContext = _viewModel;
             
             InitializeComponent();

--- a/samples/MetroDemo/MainWindowViewModel.cs
+++ b/samples/MetroDemo/MainWindowViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.ComponentModel;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -271,10 +272,93 @@ namespace MetroDemo
                     CanExecuteDelegate = x => true,
                     ExecuteDelegate = x =>
                     {
-                        _dialogCoordinator.ShowInput(this).ContinueWith(t => Console.WriteLine(t.Result));
+                        _dialogCoordinator.ShowInputAsync(this, "From a VM", "This dialog was shown from a VM, without knowledge of Window").ContinueWith(t => Console.WriteLine(t.Result));
                     }
                 });
             }
+        }
+
+        private ICommand showLoginDialogCommand;
+
+        public ICommand ShowLoginDialogCommand
+        {
+            get
+            {
+                return this.showLoginDialogCommand ?? (this.showLoginDialogCommand = new SimpleCommand
+                {
+                    CanExecuteDelegate = x => true,
+                    ExecuteDelegate = x =>
+                    {
+                        _dialogCoordinator.ShowLoginAsync(this, "Login from a VM", "This login dialog was shown from a VM, so you can be all MVVM.").ContinueWith(t => Console.WriteLine(t.Result));
+                    }
+                });
+            }
+        }
+
+        private ICommand showMessageDialogCommand;
+
+        public ICommand ShowMessageDialogCommand
+        {
+            get
+            {
+                return this.showMessageDialogCommand ?? (this.showMessageDialogCommand = new SimpleCommand
+                {
+                    CanExecuteDelegate = x => true,
+                    ExecuteDelegate = x =>
+                    {
+                        _dialogCoordinator.ShowMessageAsync(this, "Message from VM", "MVVM based messages!").ContinueWith(t => Console.WriteLine(t.Result));
+                    }
+                });
+            }
+        }
+
+        private ICommand showProgressDialogCommand;
+
+        public ICommand ShowProgressDialogCommand
+        {
+            get
+            {
+                return this.showProgressDialogCommand ?? (this.showProgressDialogCommand = new SimpleCommand
+                {
+                    CanExecuteDelegate = x => true,
+                    ExecuteDelegate = x => RunProgressFromVm()
+                });
+            }
+        }
+
+        private async void RunProgressFromVm()
+        {
+            var controller = await _dialogCoordinator.ShowProgressAsync(this, "Progress from VM", "Progressing all the things, wait 3 seconds");
+
+            await TaskEx.Delay(3000);
+
+            await controller.CloseAsync();
+        }
+        
+
+        private ICommand showCustomDialogCommand;
+
+        public ICommand ShowCustomDialogCommand
+        {
+            get
+            {
+                return this.showCustomDialogCommand ?? (this.showCustomDialogCommand = new SimpleCommand
+                {
+                    CanExecuteDelegate = x => true,
+                    ExecuteDelegate = x => RunCustomFromVm()                    
+                });
+            }
+        }
+
+        private async void RunCustomFromVm()
+        {
+            var customDialog = new CustomDialog() { Title = "Custom, wait 3 seconds" };
+
+            await _dialogCoordinator.ShowMetroDialogAsync(this, customDialog);
+
+            await TaskEx.Delay(3000);
+
+            await _dialogCoordinator.HideMetroDialogAsync(this, customDialog);
         }
 
         public IEnumerable<string> BrushResources { get; private set; }

--- a/samples/MetroDemo/MainWindowViewModel.cs
+++ b/samples/MetroDemo/MainWindowViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -46,11 +47,13 @@ namespace MetroDemo
 
     public class MainWindowViewModel : INotifyPropertyChanged, IDataErrorInfo
     {
+        private readonly IDialogCoordinator _dialogCoordinator;
         int? _integerGreater10Property;
         private bool _animateOnPositionChange = true;
 
-        public MainWindowViewModel()
+        public MainWindowViewModel(IDialogCoordinator dialogCoordinator)
         {
+            _dialogCoordinator = dialogCoordinator;
             SampleData.Seed();
 
             // create accent color menu items for the demo
@@ -254,6 +257,24 @@ namespace MetroDemo
         public ICommand NeverCloseTabCommand
         {
             get { return this.neverCloseTabCommand ?? (this.neverCloseTabCommand = new SimpleCommand { CanExecuteDelegate = x => false }); }
+        }
+
+
+        private ICommand showInputDialogCommand;
+
+        public ICommand ShowInputDialogCommand
+        {
+            get
+            {
+                return this.showInputDialogCommand ?? (this.showInputDialogCommand = new SimpleCommand
+                {
+                    CanExecuteDelegate = x => true,
+                    ExecuteDelegate = x =>
+                    {
+                        _dialogCoordinator.ShowInput(this).ContinueWith(t => Console.WriteLine(t.Result));
+                    }
+                });
+            }
         }
 
         public IEnumerable<string> BrushResources { get; private set; }


### PR DESCRIPTION
Using this mechanism you can easily use the MahApps dialogs from a view model.  It is agbostic to whatever DI framework you may or may not be using.

To use you add an attached property in your XAML, which will tie the Binding (your view model) to the Window:

```
Dialog:DialogParticipation.Register="{Binding}"
```

Then the DialogCoordinator can be called from your view model, providing it with a context (your view model), it will know which Window to use to show the dialog.

```
_dialogCoordinator.ShowInput(this).ContinueWith(t => Console.WriteLine(t.Result));
```

__outstanding:__ I've added to the demo app, but only a single dialog type right now.  If you accept this PR I will build out the interface for the other dialog types.

