### PR TITLE
Setting for default focused button in MessageDialog

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -315,6 +315,7 @@ namespace MahApps.Metro.Controls.Dialogs
             MaximumBodyHeight = Double.NaN;
 
             DefaultText = "";
+            DefaultButtonFocus = MessageDialogResult.Negative;
         }
 
         /// <summary>
@@ -356,6 +357,11 @@ namespace MahApps.Metro.Controls.Dialogs
         /// Gets/sets the maximum height. (Default is unlimited height, <a href="http://msdn.microsoft.com/de-de/library/system.double.nan">Double.NaN</a>)
         /// </summary>
         public double MaximumBodyHeight { get; set; }
+
+        /// <summary>
+        /// Gets or sets which button should be focused by default
+        /// </summary>
+        public MessageDialogResult DefaultButtonFocus { get; set; }
     }
 
     /// <summary>

--- a/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
@@ -27,17 +27,30 @@ namespace MahApps.Metro.Controls.Dialogs
             Dispatcher.BeginInvoke(new Action(() => {
                 this.Focus();
 
-                //kind of acts like a selective 'IsDefault' mechanism.
-                switch (this.ButtonStyle)
+                var defaultButtonFocus = DialogSettings.DefaultButtonFocus;
+
+                //Ensure it's a valid option
+                if (!IsApplicable(defaultButtonFocus))
                 {
-                    case MessageDialogStyle.Affirmative:
+                    defaultButtonFocus = ButtonStyle == MessageDialogStyle.Affirmative
+                        ? MessageDialogResult.Affirmative
+                        : MessageDialogResult.Negative;
+                }
+
+                //kind of acts like a selective 'IsDefault' mechanism.
+                switch (defaultButtonFocus)
+                {
+                    case MessageDialogResult.Affirmative:
                         PART_AffirmativeButton.Focus();
                         break;
-
-                    case MessageDialogStyle.AffirmativeAndNegative:
-                    case MessageDialogStyle.AffirmativeAndNegativeAndDoubleAuxiliary:
-                    case MessageDialogStyle.AffirmativeAndNegativeAndSingleAuxiliary:
+                    case MessageDialogResult.Negative:
                         PART_NegativeButton.Focus();
+                        break;
+                    case MessageDialogResult.FirstAuxiliary:
+                        PART_FirstAuxiliaryButton.Focus();
+                        break;
+                    case MessageDialogResult.SecondAuxiliary:
+                        PART_SecondAuxiliaryButton.Focus();
                         break;
                 }
             }));
@@ -249,6 +262,23 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             get { return (string)GetValue(SecondAuxiliaryButtonTextProperty); }
             set { SetValue(SecondAuxiliaryButtonTextProperty, value); }
+        }
+
+        private bool IsApplicable(MessageDialogResult value)
+        {
+            switch (value)
+            {
+                case MessageDialogResult.Affirmative:
+                    return PART_AffirmativeButton.IsVisible;
+                case MessageDialogResult.Negative:
+                    return PART_NegativeButton.IsVisible;
+                case MessageDialogResult.FirstAuxiliary:
+                    return PART_FirstAuxiliaryButton.IsVisible;
+                case MessageDialogResult.SecondAuxiliary:
+                    return PART_SecondAuxiliaryButton.IsVisible;
+            }
+
+            return false;
         }
     }
 


### PR DESCRIPTION
Introduces new setting in MetroDialogSettings, to determine which button get focus by default in MetroDialog. Need this so user can hit enter when Affirmative is the default option.