### PR TITLE
NumericUpDown focusing fix

### DIFF
--- a/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
+++ b/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
@@ -248,15 +248,7 @@ namespace MahApps.Metro.Controls
             else if (d is NumericUpDown)
             {
                 var numericUpDown = d as NumericUpDown;
-
-                if ((bool)e.NewValue)
-                {
-                    numericUpDown.GotFocus += NumericUpDownGotFocus;
-                }
-                else
-                {
-                    numericUpDown.GotFocus -= NumericUpDownGotFocus;
-                }
+                numericUpDown.SelectAllOnFocus = (bool)e.NewValue;
             }
         }
 
@@ -295,17 +287,6 @@ namespace MahApps.Metro.Controls
             if (GetSelectAllOnFocus(passBox))
             {
                 passBox.Dispatcher.BeginInvoke((Action)(passBox.SelectAll));
-            }
-        }
-
-        static void NumericUpDownGotFocus(object sender, RoutedEventArgs e)
-        {
-            var numericUpDown = sender as NumericUpDown;
-            if (numericUpDown == null)
-                return;
-            if (GetSelectAllOnFocus(numericUpDown))
-            {
-                numericUpDown.Dispatcher.BeginInvoke((Action)(numericUpDown.SelectAll));
             }
         }
 

--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -149,6 +149,8 @@ namespace MahApps.Metro.Controls
 
             VerticalContentAlignmentProperty.OverrideMetadata(typeof(NumericUpDown), new FrameworkPropertyMetadata(VerticalAlignment.Center));
             HorizontalContentAlignmentProperty.OverrideMetadata(typeof(NumericUpDown), new FrameworkPropertyMetadata(HorizontalAlignment.Right));
+
+            EventManager.RegisterClassHandler(typeof(NumericUpDown), UIElement.GotFocusEvent, new RoutedEventHandler(OnGotFocus));
         }
 
         public event RoutedPropertyChangedEventHandler<double?> ValueChanged
@@ -383,6 +385,32 @@ namespace MahApps.Metro.Controls
         private CultureInfo SpecificCultureInfo
         {
             get { return Culture ?? Language.GetSpecificCulture(); }
+        }
+
+        /// <summary> 
+        ///     Called when this element or any below gets focus.
+        /// </summary>
+        private static void OnGotFocus(object sender, RoutedEventArgs e)
+        {
+            // When NumericUpDown gets logical focus, select the text inside us.
+            NumericUpDown numericUpDown = (NumericUpDown)sender;
+
+            // If we're an editable NumericUpDown, forward focus to the TextBox element
+            if (!e.Handled)
+            {
+                if ((numericUpDown.InterceptManualEnter || numericUpDown.IsReadOnly) && numericUpDown._valueTextBox != null)
+                {
+                    if (e.OriginalSource == numericUpDown)
+                    {
+                        numericUpDown._valueTextBox.Focus();
+                        e.Handled = true;
+                    }
+                    else if (e.OriginalSource == numericUpDown._valueTextBox)
+                    {
+                        numericUpDown._valueTextBox.SelectAll();
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -124,6 +124,12 @@ namespace MahApps.Metro.Controls
                                             }
                                         }));
 
+        public static readonly DependencyProperty SelectAllOnFocusProperty = DependencyProperty.Register(
+            "SelectAllOnFocus",
+            typeof(bool),
+            typeof(NumericUpDown),
+            new PropertyMetadata(true));
+
         private const double DefaultInterval = 1d;
         private const int DefaultDelay = 500;
         private const string ElementNumericDown = "PART_NumericDown";
@@ -304,6 +310,15 @@ namespace MahApps.Metro.Controls
             set { SetValue(IntervalProperty, value); }
         }
 
+        [Bindable(true)]
+        [Category("Behavior")]
+        [DefaultValue(true)]
+        public bool SelectAllOnFocus
+        {
+            get { return (bool)GetValue(SelectAllOnFocusProperty); }
+            set { SetValue(SelectAllOnFocusProperty, value); }
+        }
+
         /// <summary>
         ///     Gets or sets a value indicating whether the text can be changed by the use of the up or down buttons only.
         /// </summary>
@@ -405,7 +420,7 @@ namespace MahApps.Metro.Controls
                         numericUpDown._valueTextBox.Focus();
                         e.Handled = true;
                     }
-                    else if (e.OriginalSource == numericUpDown._valueTextBox)
+                    else if (e.OriginalSource == numericUpDown._valueTextBox && numericUpDown.SelectAllOnFocus)
                     {
                         numericUpDown._valueTextBox.SelectAll();
                     }

--- a/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -42,8 +42,8 @@
                 Value="{DynamicResource ControlBackgroundBrush}" />
         <Setter Property="Validation.ErrorTemplate"
                 Value="{DynamicResource ValidationErrorTemplate}" />
-        <Setter Property="Focusable"
-                Value="False" />
+        <Setter Property="FocusVisualStyle"
+                Value="{x:Null}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Controls:NumericUpDown}">
@@ -77,7 +77,7 @@
                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                      BorderThickness="0"
                                      Background="{x:Null}"
-                                     Focusable="True"
+                                     Focusable="{TemplateBinding Focusable}"
                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
                                      IsReadOnly="{TemplateBinding IsReadOnly}"


### PR DESCRIPTION
- fixed focus problem
- new `SelectAllOnFocus` dependency property (with default to true like ComboBox)

Closes #1903 NumericUpDown won't focus programatically