### PR TITLE
Use Shape instead of Rectangle

### DIFF
--- a/MahApps.Metro/Controls/ToggleSwitchButton.cs
+++ b/MahApps.Metro/Controls/ToggleSwitchButton.cs
@@ -15,7 +15,7 @@ namespace MahApps.Metro.Controls
     [TemplatePart(Name = PART_BackgroundTranslate, Type = typeof(TranslateTransform))]
     [TemplatePart(Name = PART_DraggingThumb, Type = typeof(Thumb))]
     [TemplatePart(Name = PART_SwitchTrack, Type = typeof(Grid))]
-    [TemplatePart(Name = PART_ThumbIndicator, Type = typeof(Rectangle))]
+    [TemplatePart(Name = PART_ThumbIndicator, Type = typeof(Shape))]
     [TemplatePart(Name = PART_ThumbTranslate, Type = typeof(TranslateTransform))]
     public class ToggleSwitchButton : ToggleButton
     {
@@ -28,7 +28,7 @@ namespace MahApps.Metro.Controls
         private TranslateTransform _BackgroundTranslate;
         private Thumb _DraggingThumb;
         private Grid _SwitchTrack;
-        private Rectangle _ThumbIndicator;
+        private Shape _ThumbIndicator;
         private TranslateTransform _ThumbTranslate;
 
         [Obsolete(@"This property will be deleted in the next release. You should use OnSwitchBrush and OffSwitchBrush to change the switch's brushes.")]
@@ -144,7 +144,7 @@ namespace MahApps.Metro.Controls
             _BackgroundTranslate = GetTemplateChild(PART_BackgroundTranslate) as TranslateTransform;
             _DraggingThumb = GetTemplateChild(PART_DraggingThumb) as Thumb;
             _SwitchTrack = GetTemplateChild(PART_SwitchTrack) as Grid;
-            _ThumbIndicator = GetTemplateChild(PART_ThumbIndicator) as Rectangle;
+            _ThumbIndicator = GetTemplateChild(PART_ThumbIndicator) as Shape;
             _ThumbTranslate = GetTemplateChild(PART_ThumbTranslate) as TranslateTransform;
 
             if (_ThumbIndicator != null && _BackgroundTranslate != null)


### PR DESCRIPTION
Use Shape is more generic and allows to use for indicator different shapes in ControlTepmlate.
