### PR TITLE
Possiblity to define the UpDownButtons width

### DIFF
--- a/MahApps.Metro/Controls/DataGridNumericUpDownColumn.cs
+++ b/MahApps.Metro/Controls/DataGridNumericUpDownColumn.cs
@@ -14,6 +14,7 @@ namespace MahApps.Metro.Controls
         private double interval = (double)NumericUpDown.IntervalProperty.DefaultMetadata.DefaultValue;
         private string stringFormat = (string)NumericUpDown.StringFormatProperty.DefaultMetadata.DefaultValue;
         private bool hideUpDownButtons = (bool)NumericUpDown.HideUpDownButtonsProperty.DefaultMetadata.DefaultValue;
+        private double upDownButtonsWidth = (double)NumericUpDown.UpDownButtonsWidthProperty.DefaultMetadata.DefaultValue;
         private Binding foregroundBinding;
 
         static DataGridNumericUpDownColumn()
@@ -55,6 +56,7 @@ namespace MahApps.Metro.Controls
                     style.Setters.Add(new Setter(UIElement.IsHitTestVisibleProperty, false));
                     style.Setters.Add(new Setter(UIElement.FocusableProperty, false));
                     style.Setters.Add(new Setter(NumericUpDown.HideUpDownButtonsProperty, true));
+                    style.Setters.Add(new Setter(NumericUpDown.UpDownButtonsWidthProperty, 20d));
                     style.Setters.Add(new Setter(Control.BorderThicknessProperty, new Thickness(0d)));
                     style.Setters.Add(new Setter(Control.BackgroundProperty, Brushes.Transparent));
                     style.Setters.Add(new Setter(ScrollViewer.HorizontalScrollBarVisibilityProperty, ScrollBarVisibility.Disabled));
@@ -113,6 +115,7 @@ namespace MahApps.Metro.Controls
         {
             NumericUpDown generateNumericUpDown = GenerateNumericUpDown(false, cell);
             generateNumericUpDown.HideUpDownButtons = true;
+            generateNumericUpDown.UpDownButtonsWidth = 20d;
             return generateNumericUpDown;
         }
         
@@ -148,6 +151,7 @@ namespace MahApps.Metro.Controls
             numericUpDown.InterceptMouseWheel = true;
             numericUpDown.Speedup = true;
             numericUpDown.HideUpDownButtons = HideUpDownButtons;
+            numericUpDown.UpDownButtonsWidth = UpDownButtonsWidth;
 
             return numericUpDown;
         }
@@ -191,6 +195,12 @@ namespace MahApps.Metro.Controls
         {
             get { return hideUpDownButtons; }
             set { hideUpDownButtons = value; }
+        }
+
+        public double UpDownButtonsWidth
+        {
+            get { return upDownButtonsWidth; }
+            set { upDownButtonsWidth = value;  }
         }
     }
 }

--- a/MahApps.Metro/Controls/DataGridNumericUpDownColumn.cs
+++ b/MahApps.Metro/Controls/DataGridNumericUpDownColumn.cs
@@ -56,7 +56,6 @@ namespace MahApps.Metro.Controls
                     style.Setters.Add(new Setter(UIElement.IsHitTestVisibleProperty, false));
                     style.Setters.Add(new Setter(UIElement.FocusableProperty, false));
                     style.Setters.Add(new Setter(NumericUpDown.HideUpDownButtonsProperty, true));
-                    style.Setters.Add(new Setter(NumericUpDown.UpDownButtonsWidthProperty, 20d));
                     style.Setters.Add(new Setter(Control.BorderThicknessProperty, new Thickness(0d)));
                     style.Setters.Add(new Setter(Control.BackgroundProperty, Brushes.Transparent));
                     style.Setters.Add(new Setter(ScrollViewer.HorizontalScrollBarVisibilityProperty, ScrollBarVisibility.Disabled));
@@ -115,7 +114,6 @@ namespace MahApps.Metro.Controls
         {
             NumericUpDown generateNumericUpDown = GenerateNumericUpDown(false, cell);
             generateNumericUpDown.HideUpDownButtons = true;
-            generateNumericUpDown.UpDownButtonsWidth = 20d;
             return generateNumericUpDown;
         }
         

--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -106,6 +106,12 @@ namespace MahApps.Metro.Controls
             typeof(NumericUpDown),
             new PropertyMetadata(default(bool)));
 
+        public static readonly DependencyProperty UpDownButtonsWidthProperty = DependencyProperty.Register(
+            "UpDownButtonsWidth",
+            typeof(double),
+            typeof(NumericUpDown),
+            new PropertyMetadata(20d));
+
         public static readonly DependencyProperty InterceptManualEnterProperty = DependencyProperty.Register(
             "InterceptManualEnter",
             typeof(bool),
@@ -157,6 +163,7 @@ namespace MahApps.Metro.Controls
             HorizontalContentAlignmentProperty.OverrideMetadata(typeof(NumericUpDown), new FrameworkPropertyMetadata(HorizontalAlignment.Right));
 
             EventManager.RegisterClassHandler(typeof(NumericUpDown), UIElement.GotFocusEvent, new RoutedEventHandler(OnGotFocus));
+            
         }
 
         public event RoutedPropertyChangedEventHandler<double?> ValueChanged
@@ -302,6 +309,15 @@ namespace MahApps.Metro.Controls
         }
 
         [Bindable(true)]
+        [Category("Appearance")]
+        [DefaultValue(10)]
+        public double UpDownButtonsWidth
+        {
+            get { return (double)GetValue(UpDownButtonsWidthProperty); }
+            set { SetValue(UpDownButtonsWidthProperty, value); }
+        }
+
+        [Bindable(true)]
         [Category("Behavior")]
         [DefaultValue(DefaultInterval)]
         public double Interval
@@ -426,6 +442,7 @@ namespace MahApps.Metro.Controls
                     }
                 }
             }
+            
         }
 
         /// <summary>
@@ -438,7 +455,7 @@ namespace MahApps.Metro.Controls
 
             _repeatUp = GetTemplateChild(ElementNumericUp) as RepeatButton;
             _repeatDown = GetTemplateChild(ElementNumericDown) as RepeatButton;
-
+            
             _valueTextBox = GetTemplateChild(ElementTextBox) as TextBox;
 
             if (_repeatUp == null ||

--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -310,7 +310,7 @@ namespace MahApps.Metro.Controls
 
         [Bindable(true)]
         [Category("Appearance")]
-        [DefaultValue(10)]
+        [DefaultValue(20d)]
         public double UpDownButtonsWidth
         {
             get { return (double)GetValue(UpDownButtonsWidthProperty); }

--- a/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -62,9 +62,9 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition />
                                 <ColumnDefinition x:Name="PART_NumericUpColumn"
-                                                  Width="20" />
+                                                  Width="{TemplateBinding UpDownButtonsWidth}" />
                                 <ColumnDefinition x:Name="PART_NumericDownColumn"
-                                                  Width="20" />
+                                                  Width="{TemplateBinding UpDownButtonsWidth}" />
                             </Grid.ColumnDefinitions>
 
                             <TextBox x:Name="PART_TextBox"
@@ -91,7 +91,8 @@
                                           Delay="{TemplateBinding Delay}"
                                           Foreground="{TemplateBinding Foreground}"
                                           Style="{DynamicResource ChromelessButtonStyle}"
-                                          IsTabStop="False">
+                                          IsTabStop="False"
+                                          Width="{TemplateBinding UpDownButtonsWidth}">
                                 <Path x:Name="PolygonUp"
                                       Width="14"
                                       Height="14"
@@ -106,7 +107,8 @@
                                           Delay="{TemplateBinding Delay}"
                                           Style="{DynamicResource ChromelessButtonStyle}"
                                           Foreground="{TemplateBinding Foreground}"
-                                          IsTabStop="False">
+                                          IsTabStop="False"
+                                          Width="{TemplateBinding UpDownButtonsWidth}">
                                 <Path x:Name="PolygonDown"
                                       Width="14"
                                       Height="3"
@@ -201,6 +203,7 @@
                                     Property="Width"
                                     Value="0" />
                         </Trigger>
+                        
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
Add the possibility to define the UpDownButtons width in
DataGridNumericUpDownColumn. This can be usefull for a touch application
because by default, a width of 20 is not enough because the buttons are
too close