### PR TITLE
RecognizesAccessKey in styles for CheckBox, RadioButton, and GroupBox

### DIFF
--- a/MahApps.Metro/Styles/Controls.CheckBox.xaml
+++ b/MahApps.Metro/Styles/Controls.CheckBox.xaml
@@ -103,6 +103,7 @@
                         <ContentPresenter x:Name="contentPresenter"
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
                                           Content="{TemplateBinding Content}"
+                                          RecognizesAccessKey="True"
                                           Grid.Column="1"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           Margin="{TemplateBinding Padding}"

--- a/MahApps.Metro/Styles/Controls.GroupBox.xaml
+++ b/MahApps.Metro/Styles/Controls.GroupBox.xaml
@@ -24,7 +24,7 @@
         <Setter Property="HeaderTemplate">
             <Setter.Value>
                 <DataTemplate>
-          <ContentPresenter Content="{Binding RelativeSource={RelativeSource AncestorType={x:Type GroupBox}}, Path=Header, Mode=OneWay, Converter={StaticResource ToUpperConverter}}" RecognizesAccessKey="True">
+                    <ContentPresenter Content="{Binding RelativeSource={RelativeSource AncestorType={x:Type GroupBox}}, Path=Header, Mode=OneWay, Converter={StaticResource ToUpperConverter}}" RecognizesAccessKey="True">
                         <TextElement.Foreground>
                             <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
                                 <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type GroupBox}}"

--- a/MahApps.Metro/Styles/Controls.GroupBox.xaml
+++ b/MahApps.Metro/Styles/Controls.GroupBox.xaml
@@ -24,7 +24,7 @@
         <Setter Property="HeaderTemplate">
             <Setter.Value>
                 <DataTemplate>
-                    <ContentPresenter Content="{Binding RelativeSource={RelativeSource AncestorType={x:Type GroupBox}}, Path=Header, Mode=OneWay, Converter={StaticResource ToUpperConverter}}">
+          <ContentPresenter Content="{Binding RelativeSource={RelativeSource AncestorType={x:Type GroupBox}}, Path=Header, Mode=OneWay, Converter={StaticResource ToUpperConverter}}" RecognizesAccessKey="True">
                         <TextElement.Foreground>
                             <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
                                 <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type GroupBox}}"

--- a/MahApps.Metro/Styles/Controls.RadioButton.xaml
+++ b/MahApps.Metro/Styles/Controls.RadioButton.xaml
@@ -86,6 +86,7 @@
                         <ContentPresenter x:Name="contentPresenter"
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
                                           Content="{TemplateBinding Content}"
+                                          RecognizesAccessKey="True"
                                           Grid.Column="1"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           Margin="{TemplateBinding Padding}"

--- a/docs/release-notes/1.2.0.md
+++ b/docs/release-notes/1.2.0.md
@@ -65,3 +65,4 @@ This is a bug fix and feature release of MahApps.Metro v1.2.0.
 - Fixed MVVM Binding for `OnLabel`/`OffLabel` at `ToggleSwitch` #1867 #1945
 - Fixed focus problem with `NumericUpDown` #1903 #1959
 - Fixed JIT Compiler encountered an internal limitation #1919 #1971
+- Fixed access keys in `CheckBox`, `RadioButton`, and `GroupBox` #1979

--- a/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
+++ b/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
@@ -209,7 +209,7 @@
             <Label Content="Checkbox"
                    Style="{DynamicResource DescriptionHeaderStyle}" />
             <CheckBox Margin="0, 10, 0, 0"
-                      Content="Enabled" />
+                      Content="_Enabled" />
             <CheckBox Margin="0, 10, 0, 0"
                       Content="Enabled"
                       IsChecked="True" />
@@ -236,7 +236,7 @@
             <Label Content="Radio button"
                    Style="{DynamicResource DescriptionHeaderStyle}" />
             <RadioButton Margin="0, 10, 0, 0"
-                         Content="Enabled"
+                         Content="E_nabled"
                          GroupName="1" />
             <RadioButton Margin="0, 10, 0, 0"
                          Content="Enabled"

--- a/samples/MetroDemo/ExampleViews/TabControlExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TabControlExamples.xaml
@@ -20,44 +20,44 @@
 
     <ScrollViewer>
         <StackPanel Margin="5, 10, 5, 0">
-            <GroupBox Header="Default TabControl"
+            <GroupBox Header="_Default TabControl"
                       Margin="0">
                 <StackPanel Margin="15, 5, 15, 5">
                     <Label Content="Default TabControl normal style"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
                     <TabControl>
-                        <TabItem Header="item 1"
+                        <TabItem Header="item _1"
                                  Controls:ControlsHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="Content" />
                         </TabItem>
-                        <TabItem Header="item 2"
+                        <TabItem Header="item _2"
                                  Controls:ControlsHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="More content" />
                         </TabItem>
-                        <TabItem Header="item 3"
+                        <TabItem Header="item _3"
                                  Controls:ControlsHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="More more content" />
                         </TabItem>
-                        <TabItem Header="item 4"
+                        <TabItem Header="item _4"
                                  Controls:ControlsHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="So much content!" />
                         </TabItem>
-                        <TabItem Header="item 5"
+                        <TabItem Header="item _5"
                                  Controls:ControlsHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="Content!" />
                         </TabItem>
-                        <TabItem Header="item 6"
+                        <TabItem Header="item _6"
                                  Controls:ControlsHelper.HeaderFontSize="18">
                             <TextBlock FontSize="30"
                                        Text="This is not content (it is)" />
                         </TabItem>
                     </TabControl>
-                    <Label Content="Default TabControl with underline"
+                    <Label Content="Default _TabControl with underline"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
                     <TabControl Controls:TabControlHelper.IsUnderlined="True">
                         <TabItem Header="item 1"
@@ -92,7 +92,7 @@
                         </TabItem>
                     </TabControl>
                     <Label Margin="0, 5, 0, 0"
-                           Content="Default TabControl with AnimatedTabControl style"
+                           Content="Default TabControl with _AnimatedTabControl style"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
                     <Grid>
                         <Grid.Resources>
@@ -114,7 +114,7 @@
                         </TabControl>
                     </Grid>
                     <Label Margin="0, 5, 0, 0"
-                           Content="Default TabControl with AnimatedSingleRowTabControl style"
+                           Content="Default TabControl with Animated_SingleRowTabControl style"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
                     <Grid>
                         <Grid.Resources>
@@ -140,7 +140,7 @@
                         </TabControl>
                     </Grid>
                     <Label Margin="0, 5, 0, 0"
-                           Content="Default TabControl left style"
+                           Content="Default TabControl _left style"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
                     <Grid>
                         <Grid.Resources>
@@ -186,7 +186,7 @@
                                     -->
                 </StackPanel>
             </GroupBox>
-            <GroupBox Header="Generic theme TabControls"
+            <GroupBox Header="_Generic theme TabControls"
                       Margin="0, 10, 0, 0">
                 <StackPanel Margin="15, 5, 15, 5">
                     <Label Content="MetroAnimatedTabControl"


### PR DESCRIPTION
The styles for CheckBox, RadioButton, and GroupBox are missing `RecognizesAccessKey="true"`, so keyboard navigation fails when using shortcuts (`_` in front of access keys)