### PR TITLE
Expander enhancements

### DIFF
--- a/MahApps.Metro/Controls/Helper/ControlsHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ControlsHelper.cs
@@ -10,7 +10,7 @@ namespace MahApps.Metro.Controls
     /// </summary>
     public static class ControlsHelper
     {
-        public static readonly DependencyProperty PreserveTextCaseProperty = DependencyProperty.RegisterAttached("PreserveTextCase", typeof(bool), typeof(ExpanderHelper), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
+        public static readonly DependencyProperty PreserveTextCaseProperty = DependencyProperty.RegisterAttached("PreserveTextCase", typeof(bool), typeof(ControlsHelper), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
 
         /// <summary>
         /// Gets the value to override the text case behavior for the header content.

--- a/MahApps.Metro/Controls/Helper/ControlsHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ControlsHelper.cs
@@ -10,6 +10,28 @@ namespace MahApps.Metro.Controls
     /// </summary>
     public static class ControlsHelper
     {
+        public static readonly DependencyProperty PreserveTextCaseProperty = DependencyProperty.RegisterAttached("PreserveTextCase", typeof(bool), typeof(ExpanderHelper), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
+
+        /// <summary>
+        /// Gets the value to override the text case behavior for the header content.
+        /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        [AttachedPropertyBrowsableForType(typeof(GroupBox))]
+        public static bool GetPreserveTextCase(UIElement element)
+        {
+            return (bool)element.GetValue(PreserveTextCaseProperty);
+        }
+
+        /// <summary>
+        /// Sets the value to override the text case behavior for the header content.
+        /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
+        /// </summary>
+        public static void SetPreserveTextCase(UIElement element, bool value)
+        {
+            element.SetValue(PreserveTextCaseProperty, value);
+        }
+
         public static readonly DependencyProperty HeaderFontSizeProperty =
             DependencyProperty.RegisterAttached("HeaderFontSize", typeof(double), typeof(ControlsHelper), new FrameworkPropertyMetadata(26.67, HeaderFontSizePropertyChangedCallback){ Inherits = true});
 

--- a/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
@@ -1,0 +1,89 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace MahApps.Metro.Controls
+{
+    /// <summary>
+    /// A helper class that provides various attached properties for the Expander control.
+    /// <see cref="Expander"/>
+    /// </summary>
+    public static class ExpanderHelper
+    {
+        public static readonly DependencyProperty HeaderUpStyleProperty = DependencyProperty.RegisterAttached("HeaderUpStyle", typeof(Style), typeof(ExpanderHelper), new FrameworkPropertyMetadata((Style)null, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.AffectsMeasure));
+
+        /// <summary>
+        /// Gets the toggle button style used for the ExpandDirection Up.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        public static Style GetHeaderUpStyle(UIElement element)
+        {
+            return (Style)element.GetValue(HeaderUpStyleProperty);
+        }
+
+        /// <summary>
+        /// Sets the toggle button style used for the ExpandDirection Up.
+        /// </summary>
+        public static void SetHeaderUpStyle(UIElement element, Style value)
+        {
+            element.SetValue(HeaderUpStyleProperty, value);
+        }
+
+        public static readonly DependencyProperty HeaderDownStyleProperty = DependencyProperty.RegisterAttached("HeaderDownStyle", typeof(Style), typeof(ExpanderHelper), new FrameworkPropertyMetadata((Style)null, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.AffectsMeasure));
+
+        /// <summary>
+        /// Gets the toggle button style used for the ExpandDirection Down.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        public static Style GetHeaderDownStyle(UIElement element)
+        {
+            return (Style)element.GetValue(HeaderDownStyleProperty);
+        }
+
+        /// <summary>
+        /// Sets the toggle button style used for the ExpandDirection Down.
+        /// </summary>
+        public static void SetHeaderDownStyle(UIElement element, Style value)
+        {
+            element.SetValue(HeaderDownStyleProperty, value);
+        }
+
+        public static readonly DependencyProperty HeaderLeftStyleProperty = DependencyProperty.RegisterAttached("HeaderLeftStyle", typeof(Style), typeof(ExpanderHelper), new FrameworkPropertyMetadata((Style)null, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.AffectsMeasure));
+
+        /// <summary>
+        /// Gets the toggle button style used for the ExpandDirection Left.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        public static Style GetHeaderLeftStyle(UIElement element)
+        {
+            return (Style)element.GetValue(HeaderLeftStyleProperty);
+        }
+
+        /// <summary>
+        /// Sets the toggle button style used for the ExpandDirection Left.
+        /// </summary>
+        public static void SetHeaderLeftStyle(UIElement element, Style value)
+        {
+            element.SetValue(HeaderLeftStyleProperty, value);
+        }
+
+        public static readonly DependencyProperty HeaderRightStyleProperty = DependencyProperty.RegisterAttached("HeaderRightStyle", typeof(Style), typeof(ExpanderHelper), new FrameworkPropertyMetadata((Style)null, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.AffectsMeasure));
+
+        /// <summary>
+        /// Gets the toggle button style used for the ExpandDirection Right.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        public static Style GetHeaderRightStyle(UIElement element)
+        {
+            return (Style)element.GetValue(HeaderRightStyleProperty);
+        }
+
+        /// <summary>
+        /// Sets the toggle button style used for the ExpandDirection Right.
+        /// </summary>
+        public static void SetHeaderRightStyle(UIElement element, Style value)
+        {
+            element.SetValue(HeaderRightStyleProperty, value);
+        }
+    }
+}

--- a/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
@@ -9,27 +9,6 @@ namespace MahApps.Metro.Controls
     /// </summary>
     public static class ExpanderHelper
     {
-        public static readonly DependencyProperty PreserveTextCaseProperty = DependencyProperty.RegisterAttached("PreserveTextCase", typeof(bool), typeof(ExpanderHelper), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
-
-        /// <summary>
-        /// Gets the value to override the text case behavior for the header content.
-        /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
-        /// </summary>
-        [AttachedPropertyBrowsableForType(typeof(Expander))]
-        public static bool GetPreserveTextCase(UIElement element)
-        {
-            return (bool)element.GetValue(PreserveTextCaseProperty);
-        }
-
-        /// <summary>
-        /// Sets the value to override the text case behavior for the header content.
-        /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
-        /// </summary>
-        public static void SetPreserveTextCase(UIElement element, bool value)
-        {
-            element.SetValue(PreserveTextCaseProperty, value);
-        }
-
         public static readonly DependencyProperty HeaderUpStyleProperty = DependencyProperty.RegisterAttached("HeaderUpStyle", typeof(Style), typeof(ExpanderHelper), new FrameworkPropertyMetadata((Style)null, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.AffectsMeasure));
 
         /// <summary>

--- a/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
@@ -10,6 +10,27 @@ namespace MahApps.Metro.Controls
     /// </summary>
     public static class ExpanderHelper
     {
+        public static readonly DependencyProperty PreserveTextCaseProperty = DependencyProperty.RegisterAttached("PreserveTextCase", typeof(bool), typeof(ExpanderHelper), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
+
+        /// <summary>
+        /// Gets the value to uverride the text case behavior for the header content.
+        /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        public static bool GetPreserveTextCase(UIElement element)
+        {
+            return (bool)element.GetValue(PreserveTextCaseProperty);
+        }
+
+        /// <summary>
+        /// Sets the value to uverride the text case behavior for the header content.
+        /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
+        /// </summary>
+        public static void SetPreserveTextCase(UIElement element, bool value)
+        {
+            element.SetValue(PreserveTextCaseProperty, value);
+        }
+
         public static readonly DependencyProperty HeaderUpStyleProperty = DependencyProperty.RegisterAttached("HeaderUpStyle", typeof(Style), typeof(ExpanderHelper), new FrameworkPropertyMetadata((Style)null, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.AffectsMeasure));
 
         /// <summary>

--- a/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
@@ -13,7 +13,7 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty PreserveTextCaseProperty = DependencyProperty.RegisterAttached("PreserveTextCase", typeof(bool), typeof(ExpanderHelper), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
 
         /// <summary>
-        /// Gets the value to uverride the text case behavior for the header content.
+        /// Gets the value to override the text case behavior for the header content.
         /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
         /// </summary>
         [AttachedPropertyBrowsableForType(typeof(Expander))]
@@ -23,10 +23,29 @@ namespace MahApps.Metro.Controls
         }
 
         /// <summary>
-        /// Sets the value to uverride the text case behavior for the header content.
+        /// Sets the value to override the text case behavior for the header content.
         /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
         /// </summary>
         public static void SetPreserveTextCase(UIElement element, bool value)
+        {
+            element.SetValue(PreserveTextCaseProperty, value);
+        }
+
+        public static readonly DependencyProperty HeaderTogglePartProperty = DependencyProperty.RegisterAttached("HeaderTogglePart", typeof(HeaderTogglePartType), typeof(ExpanderHelper), new FrameworkPropertyMetadata(HeaderTogglePartType.ToggleSite, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
+
+        /// <summary>
+        /// Gets the value which part toggles the Expander.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        public static HeaderTogglePartType GetHeaderTogglePart(UIElement element)
+        {
+            return (HeaderTogglePartType)element.GetValue(PreserveTextCaseProperty);
+        }
+
+        /// <summary>
+        /// Sets the value which part should toggle the Expander.
+        /// </summary>
+        public static void SetHeaderTogglePart(UIElement element, HeaderTogglePartType value)
         {
             element.SetValue(PreserveTextCaseProperty, value);
         }
@@ -106,5 +125,20 @@ namespace MahApps.Metro.Controls
         {
             element.SetValue(HeaderRightStyleProperty, value);
         }
+    }
+
+    /// <summary>
+    /// Enumeration to set which part should toggle the Expander.
+    /// </summary>
+    public enum HeaderTogglePartType
+    {
+        /// <summary>
+        /// Only the toggle button itself toggles the Expander.
+        /// </summary>
+        ToggleSite,
+        /// <summary>
+        /// The complete Header toggles the Expander.
+        /// </summary>
+        HeaderSite
     }
 }

--- a/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 
 namespace MahApps.Metro.Controls
 {
@@ -27,25 +26,6 @@ namespace MahApps.Metro.Controls
         /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
         /// </summary>
         public static void SetPreserveTextCase(UIElement element, bool value)
-        {
-            element.SetValue(PreserveTextCaseProperty, value);
-        }
-
-        public static readonly DependencyProperty HeaderTogglePartProperty = DependencyProperty.RegisterAttached("HeaderTogglePart", typeof(HeaderTogglePartType), typeof(ExpanderHelper), new FrameworkPropertyMetadata(HeaderTogglePartType.ToggleSite, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
-
-        /// <summary>
-        /// Gets the value which part toggles the Expander.
-        /// </summary>
-        [AttachedPropertyBrowsableForType(typeof(Expander))]
-        public static HeaderTogglePartType GetHeaderTogglePart(UIElement element)
-        {
-            return (HeaderTogglePartType)element.GetValue(PreserveTextCaseProperty);
-        }
-
-        /// <summary>
-        /// Sets the value which part should toggle the Expander.
-        /// </summary>
-        public static void SetHeaderTogglePart(UIElement element, HeaderTogglePartType value)
         {
             element.SetValue(PreserveTextCaseProperty, value);
         }
@@ -125,20 +105,5 @@ namespace MahApps.Metro.Controls
         {
             element.SetValue(HeaderRightStyleProperty, value);
         }
-    }
-
-    /// <summary>
-    /// Enumeration to set which part should toggle the Expander.
-    /// </summary>
-    public enum HeaderTogglePartType
-    {
-        /// <summary>
-        /// Only the toggle button itself toggles the Expander.
-        /// </summary>
-        ToggleSite,
-        /// <summary>
-        /// The complete Header toggles the Expander.
-        /// </summary>
-        HeaderSite
     }
 }

--- a/MahApps.Metro/Converters/ThicknessBindingConverter.cs
+++ b/MahApps.Metro/Converters/ThicknessBindingConverter.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace MahApps.Metro.Converters
+{
+    /// <summary>
+    /// Converts a Thickness to a new Thickness. It's possible to ignore a side With the IgnoreThicknessSide property.
+    /// </summary>
+    public class ThicknessBindingConverter : IValueConverter
+    {
+        public IgnoreThicknessSideType IgnoreThicknessSide { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Thickness)
+            {
+                // yes, we can override it with the parameter value
+                if (parameter is IgnoreThicknessSideType)
+                {
+                    this.IgnoreThicknessSide = (IgnoreThicknessSideType)parameter;
+                }
+                var orgThickness = (Thickness)value;
+                switch (this.IgnoreThicknessSide)
+                {
+                    case IgnoreThicknessSideType.Left:
+                        return new Thickness(0, orgThickness.Top, orgThickness.Right, orgThickness.Bottom);
+                    case IgnoreThicknessSideType.Top:
+                        return new Thickness(orgThickness.Left, 0, orgThickness.Right, orgThickness.Bottom);
+                    case IgnoreThicknessSideType.Right:
+                        return new Thickness(orgThickness.Left, orgThickness.Top, 0, orgThickness.Bottom);
+                    case IgnoreThicknessSideType.Bottom:
+                        return new Thickness(orgThickness.Left, orgThickness.Top, orgThickness.Right, 0);
+                    default:
+                        return orgThickness;
+                }
+            }
+            return default(Thickness);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            // for now no back converting
+            return DependencyProperty.UnsetValue;
+        }
+    }
+
+    public enum IgnoreThicknessSideType
+    {
+        /// <summary>
+        /// Use all sides.
+        /// </summary>
+        None,
+        /// <summary>
+        /// Ignore the left side.
+        /// </summary>
+        Left,
+        /// <summary>
+        /// Ignore the top side.
+        /// </summary>
+        Top,
+        /// <summary>
+        /// Ignore the right side.
+        /// </summary>
+        Right,
+        /// <summary>
+        /// Ignore the bottom side.
+        /// </summary>
+        Bottom
+    }
+}

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Controls\WindowCommands.cs" />
     <Compile Include="Converters\ResizeModeMinMaxButtonVisibilityConverter.cs" />
     <Compile Include="Converters\StringToVisibilityConverter.cs" />
+    <Compile Include="Converters\ThicknessBindingConverter.cs" />
     <Compile Include="Converters\ThicknessToDoubleConverter.cs" />
     <Compile Include="Converters\TreeViewMarginConverter.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\ComGuids.cs" />

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -159,6 +159,7 @@
       <DependentUpon>GlowWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\Helper\DataGridCellHelper.cs" />
+    <Compile Include="Controls\Helper\ExpanderHelper.cs" />
     <Compile Include="Controls\Helper\GroupBoxHelper.cs" />
     <Compile Include="Controls\MetroAnimatedSingleRowTabControl.cs" />
     <Compile Include="Controls\MetroAnimatedTabControl.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -151,6 +151,7 @@
     </Compile>
     <Compile Include="Controls\WindowCommandsOverlayBehavior.cs" />
     <Compile Include="Converters\BackgroundToForegroundConverter.cs" />
+    <Compile Include="Converters\ThicknessBindingConverter.cs" />
     <Compile Include="Converters\IsNullConverter.cs" />
     <Compile Include="Converters\FontSizeOffsetConverter.cs" />
     <Compile Include="Converters\MetroTabItemCloseButtonWidthConverter.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Controls\Helper\ComboBoxHelper.cs" />
     <Compile Include="Controls\Helper\ControlsHelper.cs" />
     <Compile Include="Controls\Helper\DataGridCellHelper.cs" />
+    <Compile Include="Controls\Helper\ExpanderHelper.cs" />
     <Compile Include="Controls\Helper\GroupBoxHelper.cs" />
     <Compile Include="Controls\Helper\PasswordBoxHelper.cs" />
     <Compile Include="Controls\Helper\ScrollBarHelper.cs" />

--- a/MahApps.Metro/Styles/Clean/CleanGroupBox.xaml
+++ b/MahApps.Metro/Styles/Clean/CleanGroupBox.xaml
@@ -1,12 +1,17 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
-                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
-    <Style TargetType="GroupBox" 
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
+
+    <Style TargetType="GroupBox"
            x:Key="CleanGroupBoxStyleKey">
-        <Setter Property="BorderThickness" Value="0.3" />
+        <Setter Property="BorderBrush"
+                Value="{DynamicResource GrayBrush7}" />
+        <Setter Property="BorderThickness"
+                Value="0.3" />
         <Setter Property="Controls:ControlsHelper.HeaderFontSize"
                 Value="16" />
+        <Setter Property="Controls:GroupBoxHelper.HeaderForeground"
+                Value="{DynamicResource TextBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="GroupBox">
@@ -17,40 +22,58 @@
                         </Grid.RowDefinitions>
 
                         <ContentPresenter Margin="{TemplateBinding Padding}"
+                                          Content="{TemplateBinding Header}"
+                                          ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                          ContentStringFormat="{TemplateBinding HeaderStringFormat}"
+                                          TextElement.Foreground="{TemplateBinding Controls:GroupBoxHelper.HeaderForeground}"
                                           TextElement.FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
                                           TextElement.FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
                                           TextElement.FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
-                                          ContentSource="Header"
-                                          ContentTemplate="{TemplateBinding HeaderTemplate}"
                                           RecognizesAccessKey="True"
-                                          Grid.Row="0">
-                        </ContentPresenter>
+                                          Grid.Row="0" />
 
-                        <Grid VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Grid.Row="1">
+                        <Grid VerticalAlignment="Stretch"
+                              HorizontalAlignment="Stretch"
+                              Grid.Row="1">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <Grid.Resources>
-                                <Style x:Key="InternalBorderStyle" TargetType="Border">
-                                    <Setter Property="VerticalAlignment" Value="Stretch" />
-                                    <Setter Property="BorderBrush" Value="{DynamicResource GrayBrush7}" />
-                                    <Setter Property="Background" Value="{DynamicResource GrayBrush7}" />
-                                    <Setter Property="Panel.ZIndex" Value="1" />
-                                    <Setter Property="Width" Value="Auto" />
+                                <Style x:Key="InternalBorderStyle"
+                                       TargetType="Border">
+                                    <Setter Property="VerticalAlignment"
+                                            Value="Stretch" />
+                                    <Setter Property="Panel.ZIndex"
+                                            Value="1" />
+                                    <Setter Property="Width"
+                                            Value="Auto" />
                                 </Style>
                             </Grid.Resources>
 
-                            <Border Grid.Column="0" Style="{StaticResource InternalBorderStyle}" BorderThickness="{TemplateBinding BorderThickness}" />
+                            <Border Grid.Column="0"
+                                    Style="{StaticResource InternalBorderStyle}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    Background="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}" />
 
-                            <ContentPresenter Grid.Column="1" />
+                            <ContentPresenter Grid.Column="1"
+                                              Content="{TemplateBinding Content}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              Cursor="{TemplateBinding Cursor}" />
 
-                            <Border Grid.Column="2" Style="{StaticResource InternalBorderStyle}" BorderThickness="{TemplateBinding BorderThickness}" />
+                            <Border Grid.Column="2"
+                                    Style="{StaticResource InternalBorderStyle}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    Background="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}" />
                         </Grid>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
+
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -420,6 +420,7 @@
                                               Content="{TemplateBinding Header}"
                                               ContentTemplate="{TemplateBinding HeaderTemplate}"
                                               ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                              ContentStringFormat="{TemplateBinding HeaderStringFormat}"
                                               FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
                                               FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
                                               FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"

--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -457,7 +457,7 @@
                         </DockPanel>
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="Controls:ExpanderHelper.PreserveTextCase"
+                        <Trigger Property="Controls:ControlsHelper.PreserveTextCase"
                                  Value="False">
                             <Setter TargetName="ToggleSite"
                                     Property="Content"

--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -36,6 +36,7 @@
                     <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                             Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent"
                               SnapsToDevicePixels="False">
@@ -354,6 +355,8 @@
                 Value="5" />
         <Setter Property="Padding"
                 Value="5" />
+        <Setter Property="SnapsToDevicePixels"
+                Value="True" />
         <Setter Property="Foreground"
                 Value="{DynamicResource BlackBrush}" />
         <Setter Property="Background"
@@ -427,16 +430,20 @@
                             <Border x:Name="HeaderSite"
                                     Background="{TemplateBinding Background}"
                                     BorderBrush="{TemplateBinding BorderBrush}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                    UseLayoutRounding="True"
                                     BorderThickness="1"
                                     DockPanel.Dock="Top">
                                 <DockPanel>
                                     <ToggleButton x:Name="ToggleSite"
                                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  UseLayoutRounding="False"
                                                   DockPanel.Dock="Left"
                                                   IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                                   Style="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderDownStyle)}" />
-                                    <ContentPresenter Margin="{TemplateBinding Padding}"
+                                    <ContentPresenter UseLayoutRounding="False"
+                                                      Margin="{TemplateBinding Padding}"
                                                       Content="{TemplateBinding Header}"
                                                       ContentTemplate="{TemplateBinding HeaderTemplate}"
                                                       ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
@@ -449,6 +456,8 @@
                             <Border x:Name="ExpandSite"
                                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                    UseLayoutRounding="True"
                                     Background="Transparent"
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     BorderThickness="1,0,1,1"
@@ -456,7 +465,8 @@
                                     Focusable="false"
                                     Opacity="0"
                                     Visibility="Collapsed">
-                                <ContentPresenter Margin="{TemplateBinding Padding}"
+                                <ContentPresenter UseLayoutRounding="False"
+                                                  Margin="{TemplateBinding Padding}"
                                                   Content="{TemplateBinding Content}"
                                                   ContentTemplate="{TemplateBinding ContentTemplate}"
                                                   Cursor="{TemplateBinding Cursor}" />

--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -364,6 +364,14 @@
                 Value="{DynamicResource ContentFontSize}" />
         <Setter Property="Controls:GroupBoxHelper.HeaderForeground"
                 Value="{x:Null}" />
+        <Setter Property="Controls:ExpanderHelper.HeaderUpStyle"
+                Value="{StaticResource ExpanderUpHeaderStyle}" />
+        <Setter Property="Controls:ExpanderHelper.HeaderDownStyle"
+                Value="{StaticResource ExpanderDownHeaderStyle}" />
+        <Setter Property="Controls:ExpanderHelper.HeaderLeftStyle"
+                Value="{StaticResource ExpanderLeftHeaderStyle}" />
+        <Setter Property="Controls:ExpanderHelper.HeaderRightStyle"
+                Value="{StaticResource ExpanderRightHeaderStyle}" />
         <Setter Property="HeaderTemplate">
             <Setter.Value>
                 <DataTemplate>
@@ -427,7 +435,7 @@
                                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                                   DockPanel.Dock="Left"
                                                   IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                                  Style="{StaticResource ExpanderDownHeaderStyle}" />
+                                                  Style="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderDownStyle)}" />
                                     <ContentPresenter Margin="{TemplateBinding Padding}"
                                                       Content="{TemplateBinding Header}"
                                                       ContentTemplate="{TemplateBinding HeaderTemplate}"
@@ -495,7 +503,7 @@
                                     Value="Left" />
                             <Setter TargetName="ToggleSite"
                                     Property="Style"
-                                    Value="{StaticResource ExpanderRightHeaderStyle}" />
+                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderRightStyle)}" />
                             <Setter TargetName="ToggleSite"
                                     Property="DockPanel.Dock"
                                     Value="Top" />
@@ -513,7 +521,7 @@
                                     Value="Bottom" />
                             <Setter TargetName="ToggleSite"
                                     Property="Style"
-                                    Value="{StaticResource ExpanderUpHeaderStyle}" />
+                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderUpStyle)}" />
                         </Trigger>
                         <Trigger Property="ExpandDirection"
                                  Value="Left">
@@ -528,7 +536,7 @@
                                     Value="Right" />
                             <Setter TargetName="ToggleSite"
                                     Property="Style"
-                                    Value="{StaticResource ExpanderLeftHeaderStyle}" />
+                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderLeftStyle)}" />
                             <Setter TargetName="ToggleSite"
                                     Property="DockPanel.Dock"
                                     Value="Top" />

--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -30,7 +30,7 @@
         <Setter Property="HorizontalContentAlignment"
                 Value="Center" />
         <Setter Property="VerticalContentAlignment"
-                Value="Top" />
+                Value="Stretch" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
@@ -115,7 +115,7 @@
            TargetType="{x:Type ToggleButton}"
            BasedOn="{StaticResource ExpanderBaseHeaderStyle}">
         <Setter Property="HorizontalContentAlignment"
-                Value="Left" />
+                Value="Stretch" />
         <Setter Property="VerticalContentAlignment"
                 Value="Center" />
         <Setter Property="Template">
@@ -414,47 +414,27 @@
                                     UseLayoutRounding="True"
                                     BorderThickness="{TemplateBinding BorderThickness}"
                                     DockPanel.Dock="Top">
-                                <DockPanel>
-                                    <ToggleButton x:Name="ToggleSite"
-                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  UseLayoutRounding="False"
-                                                  DockPanel.Dock="Left"
-                                                  IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                                  Style="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderDownStyle)}">
-                                        <ToggleButton.Foreground>
-                                            <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
-                                                <Binding Mode="OneWay"
-                                                         Path="Background"
-                                                         RelativeSource="{RelativeSource TemplatedParent}" />
-                                                <Binding Mode="OneWay"
-                                                         Path="(Controls:GroupBoxHelper.HeaderForeground)"
-                                                         RelativeSource="{RelativeSource TemplatedParent}" />
-                                            </MultiBinding>
-                                        </ToggleButton.Foreground>
-                                    </ToggleButton>
-                                    <ContentPresenter x:Name="HeaderContent"
-                                                      UseLayoutRounding="False"
-                                                      Margin="{TemplateBinding Padding}"
-                                                      Content="{TemplateBinding Header}"
-                                                      ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                                      ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
-                                                      RecognizesAccessKey="True"
-                                                      TextElement.FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
-                                                      TextElement.FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
-                                                      TextElement.FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}">
-                                        <TextElement.Foreground>
-                                            <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
-                                                <Binding Mode="OneWay"
-                                                         Path="Background"
-                                                         RelativeSource="{RelativeSource TemplatedParent}" />
-                                                <Binding Mode="OneWay"
-                                                         Path="(Controls:GroupBoxHelper.HeaderForeground)"
-                                                         RelativeSource="{RelativeSource TemplatedParent}" />
-                                            </MultiBinding>
-                                        </TextElement.Foreground>
-                                    </ContentPresenter>
-                                </DockPanel>
+                                <ToggleButton x:Name="ToggleSite"
+                                              UseLayoutRounding="False"
+                                              IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                              Content="{TemplateBinding Header}"
+                                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                              ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                              FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
+                                              FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
+                                              FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
+                                              Style="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderDownStyle)}">
+                                    <ToggleButton.Foreground>
+                                        <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
+                                            <Binding Mode="OneWay"
+                                                     Path="Background"
+                                                     RelativeSource="{RelativeSource TemplatedParent}" />
+                                            <Binding Mode="OneWay"
+                                                     Path="(Controls:GroupBoxHelper.HeaderForeground)"
+                                                     RelativeSource="{RelativeSource TemplatedParent}" />
+                                        </MultiBinding>
+                                    </ToggleButton.Foreground>
+                                </ToggleButton>
                             </Border>
                             <Border x:Name="ExpandSite"
                                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -479,7 +459,7 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="Controls:ExpanderHelper.PreserveTextCase"
                                  Value="False">
-                            <Setter TargetName="HeaderContent"
+                            <Setter TargetName="ToggleSite"
                                     Property="Content"
                                     Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Mode=OneWay, Converter={StaticResource ToUpperConverter}}" />
                         </Trigger>
@@ -523,9 +503,6 @@
                             <Setter TargetName="ToggleSite"
                                     Property="Style"
                                     Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderRightStyle)}" />
-                            <Setter TargetName="ToggleSite"
-                                    Property="DockPanel.Dock"
-                                    Value="Top" />
                         </Trigger>
                         <Trigger Property="ExpandDirection"
                                  Value="Up">
@@ -556,9 +533,6 @@
                             <Setter TargetName="ToggleSite"
                                     Property="Style"
                                     Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderLeftStyle)}" />
-                            <Setter TargetName="ToggleSite"
-                                    Property="DockPanel.Dock"
-                                    Value="Top" />
                         </Trigger>
                         <Trigger Property="IsEnabled"
                                  Value="false">

--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -5,14 +5,37 @@
 
     <Converters:ToUpperConverter x:Key="ToUpperConverter" />
 
-    <Style x:Key="ExpanderRightHeaderStyle"
+    <Style x:Key="ExpanderBaseHeaderStyle"
            TargetType="{x:Type ToggleButton}">
+        <Setter Property="Background"
+                Value="Transparent" />
+        <Setter Property="BorderBrush"
+                Value="Transparent" />
+        <Setter Property="BorderThickness"
+                Value="0" />
+        <Setter Property="Margin"
+                Value="2" />
+        <Setter Property="Padding"
+                Value="0" />
+        <Setter Property="FocusVisualStyle"
+                Value="{x:Null}" />
+        <Setter Property="SnapsToDevicePixels"
+                Value="True" />
+    </Style>
+
+    <Style x:Key="ExpanderRightHeaderStyle"
+           TargetType="{x:Type ToggleButton}"
+           BasedOn="{StaticResource ExpanderBaseHeaderStyle}">
+        <Setter Property="HorizontalContentAlignment"
+                Value="Center" />
+        <Setter Property="VerticalContentAlignment"
+                Value="Top" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
                     <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="1"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent"
                               SnapsToDevicePixels="False">
@@ -46,10 +69,10 @@
                             </Grid>
                             <ContentPresenter Grid.Row="1"
                                               Margin="0,4,0,0"
-                                              HorizontalAlignment="Center"
-                                              VerticalAlignment="Top"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                               RecognizesAccessKey="True"
-                                              SnapsToDevicePixels="True" />
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
@@ -87,13 +110,18 @@
     </Style>
 
     <Style x:Key="ExpanderUpHeaderStyle"
-           TargetType="{x:Type ToggleButton}">
+           TargetType="{x:Type ToggleButton}"
+           BasedOn="{StaticResource ExpanderBaseHeaderStyle}">
+        <Setter Property="HorizontalContentAlignment"
+                Value="Left" />
+        <Setter Property="VerticalContentAlignment"
+                Value="Center" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
                     <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="1"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent"
                               SnapsToDevicePixels="False">
@@ -127,10 +155,10 @@
                             </Grid>
                             <ContentPresenter Grid.Column="1"
                                               Margin="4,0,0,0"
-                                              HorizontalAlignment="Left"
-                                              VerticalAlignment="Center"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                               RecognizesAccessKey="True"
-                                              SnapsToDevicePixels="True" />
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
@@ -168,13 +196,14 @@
     </Style>
 
     <Style x:Key="ExpanderLeftHeaderStyle"
-           TargetType="{x:Type ToggleButton}">
+           TargetType="{x:Type ToggleButton}"
+           BasedOn="{StaticResource ExpanderRightHeaderStyle}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
                     <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="1"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent"
                               SnapsToDevicePixels="False">
@@ -208,10 +237,10 @@
                             </Grid>
                             <ContentPresenter Grid.Row="1"
                                               Margin="0,4,0,0"
-                                              HorizontalAlignment="Center"
-                                              VerticalAlignment="Top"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                               RecognizesAccessKey="True"
-                                              SnapsToDevicePixels="True" />
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
@@ -249,13 +278,14 @@
     </Style>
 
     <Style x:Key="ExpanderDownHeaderStyle"
-           TargetType="{x:Type ToggleButton}">
+           TargetType="{x:Type ToggleButton}"
+           BasedOn="{StaticResource ExpanderUpHeaderStyle}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
                     <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="1"
+                            BorderThickness="{TemplateBinding BorderThickness}"
                             Padding="{TemplateBinding Padding}">
                         <Grid Background="Transparent"
                               SnapsToDevicePixels="False">
@@ -278,10 +308,10 @@
                                   StrokeThickness="2" />
                             <ContentPresenter Grid.Column="1"
                                               Margin="4,0,0,0"
-                                              HorizontalAlignment="Left"
-                                              VerticalAlignment="Center"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                               RecognizesAccessKey="True"
-                                              SnapsToDevicePixels="True" />
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
@@ -393,16 +423,10 @@
                                     DockPanel.Dock="Top">
                                 <DockPanel>
                                     <ToggleButton x:Name="ToggleSite"
-                                                  Margin="2"
                                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  Background="Transparent"
-                                                  BorderBrush="Transparent"
                                                   DockPanel.Dock="Left"
-                                                  FocusVisualStyle="{x:Null}"
-                                                  IsChecked="{Binding IsExpanded,
-                                                                  Mode=TwoWay,
-                                                                  RelativeSource={RelativeSource TemplatedParent}}"
+                                                  IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                                   Style="{StaticResource ExpanderDownHeaderStyle}" />
                                     <ContentPresenter Margin="{TemplateBinding Padding}"
                                                       Content="{TemplateBinding Header}"

--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -60,13 +60,13 @@
                                          Height="19"
                                          HorizontalAlignment="Center"
                                          VerticalAlignment="Center"
-                                         Stroke="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=Background, Converter={x:Static Converters:BackgroundToForegroundConverter.Instance}}" />
+                                         Stroke="{TemplateBinding Foreground}" />
                                 <Path x:Name="Arrow"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Center"
                                       Data="M 1,1.5 L 4.5,5 L 8,1.5"
                                       SnapsToDevicePixels="false"
-                                      Stroke="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=Background, Converter={x:Static Converters:BackgroundToForegroundConverter.Instance}}"
+                                      Stroke="{TemplateBinding Foreground}"
                                       StrokeThickness="2" />
                             </Grid>
                             <ContentPresenter Grid.Row="1"
@@ -146,13 +146,13 @@
                                          Height="19"
                                          HorizontalAlignment="Center"
                                          VerticalAlignment="Center"
-                                         Stroke="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=Background, Converter={x:Static Converters:BackgroundToForegroundConverter.Instance}}" />
+                                         Stroke="{TemplateBinding Foreground}" />
                                 <Path x:Name="Arrow"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Center"
                                       Data="M 1,1.5 L 4.5,5 L 8,1.5"
                                       SnapsToDevicePixels="false"
-                                      Stroke="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=Background, Converter={x:Static Converters:BackgroundToForegroundConverter.Instance}}"
+                                      Stroke="{TemplateBinding Foreground}"
                                       StrokeThickness="2" />
                             </Grid>
                             <ContentPresenter Grid.Column="1"
@@ -228,13 +228,13 @@
                                          Height="19"
                                          HorizontalAlignment="Center"
                                          VerticalAlignment="Center"
-                                         Stroke="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=Background, Converter={x:Static Converters:BackgroundToForegroundConverter.Instance}}" />
+                                         Stroke="{TemplateBinding Foreground}" />
                                 <Path x:Name="Arrow"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Center"
                                       Data="M 1,1.5 L 4.5,5 L 8,1.5"
                                       SnapsToDevicePixels="false"
-                                      Stroke="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=Background, Converter={x:Static Converters:BackgroundToForegroundConverter.Instance}}"
+                                      Stroke="{TemplateBinding Foreground}"
                                       StrokeThickness="2" />
                             </Grid>
                             <ContentPresenter Grid.Row="1"
@@ -300,13 +300,13 @@
                                      Height="19"
                                      HorizontalAlignment="Center"
                                      VerticalAlignment="Center"
-                                     Stroke="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=Background, Converter={x:Static Converters:BackgroundToForegroundConverter.Instance}}" />
+                                     Stroke="{TemplateBinding Foreground}" />
                             <Path x:Name="Arrow"
                                   HorizontalAlignment="Center"
                                   VerticalAlignment="Center"
                                   Data="M 1,1.5 L 4.5,5 L 8,1.5"
                                   SnapsToDevicePixels="false"
-                                  Stroke="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=Background, Converter={x:Static Converters:BackgroundToForegroundConverter.Instance}}"
+                                  Stroke="{TemplateBinding Foreground}"
                                   StrokeThickness="2" />
                             <ContentPresenter Grid.Column="1"
                                               Margin="4,0,0,0"
@@ -378,29 +378,6 @@
                 Value="{StaticResource ExpanderLeftHeaderStyle}" />
         <Setter Property="Controls:ExpanderHelper.HeaderRightStyle"
                 Value="{StaticResource ExpanderRightHeaderStyle}" />
-        <Setter Property="HeaderTemplate">
-            <Setter.Value>
-                <DataTemplate>
-                    <ContentPresenter Content="{Binding RelativeSource={RelativeSource AncestorType={x:Type Expander}},
-                                              Path=Header,
-                                              Mode=OneWay,
-                                              Converter={StaticResource ToUpperConverter}}">
-                        <TextElement.Foreground>
-                            <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
-                                <Binding Mode="OneWay"
-                                         Path="Background"
-                                         RelativeSource="{RelativeSource FindAncestor,
-                                                                         AncestorType={x:Type Expander}}" />
-                                <Binding Mode="OneWay"
-                                         Path="(Controls:GroupBoxHelper.HeaderForeground)"
-                                         RelativeSource="{RelativeSource FindAncestor,
-                                                                         AncestorType={x:Type Expander}}" />
-                            </MultiBinding>
-                        </TextElement.Foreground>
-                    </ContentPresenter>
-                </DataTemplate>
-            </Setter.Value>
-        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Expander}">
@@ -444,8 +421,20 @@
                                                   UseLayoutRounding="False"
                                                   DockPanel.Dock="Left"
                                                   IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                                  Style="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderDownStyle)}" />
-                                    <ContentPresenter UseLayoutRounding="False"
+                                                  Style="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderDownStyle)}">
+                                        <ToggleButton.Foreground>
+                                            <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
+                                                <Binding Mode="OneWay"
+                                                         Path="Background"
+                                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                                                <Binding Mode="OneWay"
+                                                         Path="(Controls:GroupBoxHelper.HeaderForeground)"
+                                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                                            </MultiBinding>
+                                        </ToggleButton.Foreground>
+                                    </ToggleButton>
+                                    <ContentPresenter x:Name="HeaderContent"
+                                                      UseLayoutRounding="False"
                                                       Margin="{TemplateBinding Padding}"
                                                       Content="{TemplateBinding Header}"
                                                       ContentTemplate="{TemplateBinding HeaderTemplate}"
@@ -453,7 +442,18 @@
                                                       RecognizesAccessKey="True"
                                                       TextElement.FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
                                                       TextElement.FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
-                                                      TextElement.FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}" />
+                                                      TextElement.FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}">
+                                        <TextElement.Foreground>
+                                            <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
+                                                <Binding Mode="OneWay"
+                                                         Path="Background"
+                                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                                                <Binding Mode="OneWay"
+                                                         Path="(Controls:GroupBoxHelper.HeaderForeground)"
+                                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                                            </MultiBinding>
+                                        </TextElement.Foreground>
+                                    </ContentPresenter>
                                 </DockPanel>
                             </Border>
                             <Border x:Name="ExpandSite"
@@ -477,6 +477,12 @@
                         </DockPanel>
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:ExpanderHelper.PreserveTextCase"
+                                 Value="False">
+                            <Setter TargetName="HeaderContent"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Mode=OneWay, Converter={StaticResource ToUpperConverter}}" />
+                        </Trigger>
                         <Trigger Property="IsExpanded"
                                  Value="true">
                             <Setter TargetName="ExpandSite"

--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -4,6 +4,7 @@
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
     <Converters:ToUpperConverter x:Key="ToUpperConverter" />
+    <Converters:ThicknessBindingConverter x:Key="ThicknessBindingConverter" />
 
     <Style x:Key="ExpanderBaseHeaderStyle"
            TargetType="{x:Type ToggleButton}">
@@ -363,6 +364,8 @@
                 Value="{DynamicResource AccentColorBrush}" />
         <Setter Property="BorderBrush"
                 Value="{DynamicResource AccentColorBrush}" />
+        <Setter Property="BorderThickness"
+                Value="1" />
         <Setter Property="Controls:ControlsHelper.HeaderFontSize"
                 Value="{DynamicResource ContentFontSize}" />
         <Setter Property="Controls:GroupBoxHelper.HeaderForeground"
@@ -432,7 +435,7 @@
                                     BorderBrush="{TemplateBinding BorderBrush}"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                     UseLayoutRounding="True"
-                                    BorderThickness="1"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
                                     DockPanel.Dock="Top">
                                 <DockPanel>
                                     <ToggleButton x:Name="ToggleSite"
@@ -460,7 +463,7 @@
                                     UseLayoutRounding="True"
                                     Background="Transparent"
                                     BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="1,0,1,1"
+                                    BorderThickness="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:IgnoreThicknessSideType.Top}}"
                                     DockPanel.Dock="Bottom"
                                     Focusable="false"
                                     Opacity="0"
@@ -507,7 +510,7 @@
                                     Value="Right" />
                             <Setter TargetName="ExpandSite"
                                     Property="BorderThickness"
-                                    Value="0,1,1,1" />
+                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:IgnoreThicknessSideType.Left}}" />
                             <Setter TargetName="HeaderSite"
                                     Property="DockPanel.Dock"
                                     Value="Left" />
@@ -525,7 +528,7 @@
                                     Value="Top" />
                             <Setter TargetName="ExpandSite"
                                     Property="BorderThickness"
-                                    Value="1,1,1,0" />
+                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:IgnoreThicknessSideType.Bottom}}" />
                             <Setter TargetName="HeaderSite"
                                     Property="DockPanel.Dock"
                                     Value="Bottom" />
@@ -540,7 +543,7 @@
                                     Value="Left" />
                             <Setter TargetName="ExpandSite"
                                     Property="BorderThickness"
-                                    Value="1,1,0,1" />
+                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:IgnoreThicknessSideType.Right}}" />
                             <Setter TargetName="HeaderSite"
                                     Property="DockPanel.Dock"
                                     Value="Right" />

--- a/MahApps.Metro/Styles/Controls.GroupBox.xaml
+++ b/MahApps.Metro/Styles/Controls.GroupBox.xaml
@@ -4,6 +4,7 @@
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
     <Converters:ToUpperConverter x:Key="ToUpperConverter" />
+    <Converters:ThicknessBindingConverter x:Key="ThicknessBindingConverter" />
 
     <Style x:Key="MetroGroupBox"
            TargetType="{x:Type GroupBox}">
@@ -11,34 +12,20 @@
                 Value="5" />
         <Setter Property="Padding"
                 Value="5" />
+        <Setter Property="SnapsToDevicePixels"
+                Value="True" />
         <Setter Property="Foreground"
                 Value="{DynamicResource BlackBrush}" />
         <Setter Property="Background"
                 Value="{DynamicResource AccentColorBrush}" />
         <Setter Property="BorderBrush"
                 Value="{DynamicResource AccentColorBrush}" />
+        <Setter Property="BorderThickness"
+                Value="1" />
         <Setter Property="Controls:ControlsHelper.HeaderFontSize"
                 Value="{DynamicResource ContentFontSize}" />
         <Setter Property="Controls:GroupBoxHelper.HeaderForeground"
                 Value="{x:Null}" />
-        <Setter Property="HeaderTemplate">
-            <Setter.Value>
-                <DataTemplate>
-                    <ContentPresenter Content="{Binding RelativeSource={RelativeSource AncestorType={x:Type GroupBox}}, Path=Header, Mode=OneWay, Converter={StaticResource ToUpperConverter}}" RecognizesAccessKey="True">
-                        <TextElement.Foreground>
-                            <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
-                                <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type GroupBox}}"
-                                         Path="Background"
-                                         Mode="OneWay" />
-                                <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType={x:Type GroupBox}}"
-                                         Path="(Controls:GroupBoxHelper.HeaderForeground)"
-                                         Mode="OneWay" />
-                            </MultiBinding>
-                        </TextElement.Foreground>
-                    </ContentPresenter>
-                </DataTemplate>
-            </Setter.Value>
-        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type GroupBox}">
@@ -47,27 +34,57 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
-                        <Border Grid.Row="0"
+                        <Border x:Name="HeaderSite"
+                                Grid.Row="0"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="1">
-                            <ContentPresenter Margin="{TemplateBinding Padding}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                UseLayoutRounding="True"
+                                BorderThickness="{TemplateBinding BorderThickness}">
+                            <ContentPresenter x:Name="HeaderContent"
+                                              Margin="{TemplateBinding Padding}"
+                                              UseLayoutRounding="False"
+                                              Content="{TemplateBinding Header}"
+                                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                              ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                              ContentStringFormat="{TemplateBinding HeaderStringFormat}"
                                               TextElement.FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
                                               TextElement.FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
                                               TextElement.FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
-                                              ContentSource="Header"
-                                              RecognizesAccessKey="True" />
+                                              RecognizesAccessKey="True">
+                                <TextElement.Foreground>
+                                    <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
+                                        <Binding Mode="OneWay"
+                                                 Path="Background"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                        <Binding Mode="OneWay"
+                                                 Path="(Controls:GroupBoxHelper.HeaderForeground)"
+                                                 RelativeSource="{RelativeSource TemplatedParent}" />
+                                    </MultiBinding>
+                                </TextElement.Foreground>
+                            </ContentPresenter>
                         </Border>
                         <Border Grid.Row="1"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                UseLayoutRounding="True"
                                 Background="Transparent"
                                 BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="1,0,1,1">
-                            <ContentPresenter Margin="{TemplateBinding Padding}"
+                                BorderThickness="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:IgnoreThicknessSideType.Top}}">
+                            <ContentPresenter UseLayoutRounding="False"
+                                              Margin="{TemplateBinding Padding}"
                                               Content="{TemplateBinding Content}"
                                               ContentTemplate="{TemplateBinding ContentTemplate}"
                                               Cursor="{TemplateBinding Cursor}" />
                         </Border>
                     </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:ControlsHelper.PreserveTextCase"
+                                 Value="False">
+                            <Setter TargetName="HeaderContent"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Mode=OneWay, Converter={StaticResource ToUpperConverter}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/samples/MetroDemo/ExampleWindows/CleanWindowDemo.xaml
+++ b/samples/MetroDemo/ExampleWindows/CleanWindowDemo.xaml
@@ -4,6 +4,7 @@
                       xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
                       xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                       xmlns:behaviours="clr-namespace:MahApps.Metro.Behaviours;assembly=MahApps.Metro"
+                      xmlns:models="clr-namespace:MetroDemo.Models"
                       Icon="..\mahapps.metro.logo2.ico"
                       ShowIconOnTitleBar="True"
                       GlowBrush="{DynamicResource AccentColorBrush}"
@@ -125,7 +126,20 @@
             </Grid.ColumnDefinitions>
 
             <GroupBox Grid.Column="0" Header="artists" Padding="5" Controls:ControlsHelper.HeaderFontSize="30">
-                <ListBox Height="900"/>
+                <ListBox ItemsSource="{x:Static models:SampleData.Artists}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock>
+                                <TextBlock.Text>
+                                    <MultiBinding StringFormat="{}{0} - {1}">
+                                        <Binding Path="ArtistId" Mode="OneWay" />
+                                        <Binding Path="Name" Mode="OneWay" />
+                                    </MultiBinding>
+                                </TextBlock.Text>
+                            </TextBlock>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
             </GroupBox>
 
             <Controls:MetroTabControl x:Name="TC" Grid.Column="1">


### PR DESCRIPTION
- [x] some styling fixes (margin, padding, border thickness)
- [x] add `ExpanderHelper` with
  + 4 new attached dependency properties `HeaderUpStyle`, `HeaderDownStyle` and `HeaderLeftStyle`, `HeaderRightStyle`. so it's now possible to create your own header toggle styles without rewriting the `Expander` style
- [x] better handling for `BorderThickness`
  + the `Expander` uses now the new value converter `ThicknessBindingConverter`, so setting the `BorderThickness` is much better than before
- [x] Click on Expander header support #1291 (just do the default expander behavior)
- [x] new `PreserveTextCase` attached property

and for `GroupBox`
- [x] some styling fixes (margin, padding, border thickness)
- [x] `PreserveTextCase` attached property
- [x] `ThicknessBindingConverter`, so setting the `BorderThickness` is much better than before

![image](https://cloud.githubusercontent.com/assets/658431/8240498/43015cbe-1603-11e5-8987-848550c2f7a5.png)

![image](https://cloud.githubusercontent.com/assets/658431/8240501/464a4b92-1603-11e5-9935-d198c6ea0c58.png)

![image](https://cloud.githubusercontent.com/assets/658431/8252375/c65a77da-1685-11e5-9b4e-2f8736d46b45.png)

![image](https://cloud.githubusercontent.com/assets/658431/8252378/c98ade5e-1685-11e5-9120-6d1a7c257c0b.png)