### PR TITLE
DataGrid Fixes/Changes

### DIFF
--- a/MahApps.Metro/Controls/DataGridNumericUpDownColumn.cs
+++ b/MahApps.Metro/Controls/DataGridNumericUpDownColumn.cs
@@ -62,6 +62,7 @@ namespace MahApps.Metro.Controls
                     style.Setters.Add(new Setter(ScrollViewer.VerticalScrollBarVisibilityProperty, ScrollBarVisibility.Disabled));
                     style.Setters.Add(new Setter(Control.VerticalContentAlignmentProperty, VerticalAlignment.Center));
                     style.Setters.Add(new Setter(FrameworkElement.MinHeightProperty, 0d));
+                    style.Setters.Add(new Setter(ControlsHelper.DisabledVisualElementVisibilityProperty, Visibility.Collapsed));
 
                     style.Seal();
                     _defaultElementStyle = style;
@@ -116,7 +117,7 @@ namespace MahApps.Metro.Controls
             generateNumericUpDown.HideUpDownButtons = true;
             return generateNumericUpDown;
         }
-        
+
         private NumericUpDown GenerateNumericUpDown(bool isEditing, DataGridCell cell)
         {
             NumericUpDown numericUpDown = (cell != null) ? (cell.Content as NumericUpDown) : null;
@@ -187,8 +188,8 @@ namespace MahApps.Metro.Controls
         {
             get { return stringFormat; }
             set { stringFormat = value; }
-        } 
-        
+        }
+
         public bool HideUpDownButtons
         {
             get { return hideUpDownButtons; }
@@ -198,7 +199,7 @@ namespace MahApps.Metro.Controls
         public double UpDownButtonsWidth
         {
             get { return upDownButtonsWidth; }
-            set { upDownButtonsWidth = value;  }
+            set { upDownButtonsWidth = value; }
         }
     }
 }

--- a/MahApps.Metro/Controls/Helper/ControlsHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ControlsHelper.cs
@@ -10,6 +10,28 @@ namespace MahApps.Metro.Controls
     /// </summary>
     public static class ControlsHelper
     {
+        public static readonly DependencyProperty DisabledVisualElementVisibilityProperty = DependencyProperty.RegisterAttached("DisabledVisualElementVisibility", typeof(Visibility), typeof(ControlsHelper), new FrameworkPropertyMetadata(Visibility.Visible, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
+
+        /// <summary>
+        /// Gets the value to handle the visibility of the DisabledVisualElement in the template.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(TextBox))]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
+        [AttachedPropertyBrowsableForType(typeof(RichTextBox))]
+        [AttachedPropertyBrowsableForType(typeof(NumericUpDown))]
+        public static Visibility GetDisabledVisualElementVisibility(UIElement element)
+        {
+            return (Visibility)element.GetValue(DisabledVisualElementVisibilityProperty);
+        }
+
+        /// <summary>
+        /// Sets the value to handle the visibility of the DisabledVisualElement in the template.
+        /// </summary>
+        public static void SetDisabledVisualElementVisibility(UIElement element, Visibility value)
+        {
+            element.SetValue(DisabledVisualElementVisibilityProperty, value);
+        }
+
         public static readonly DependencyProperty PreserveTextCaseProperty = DependencyProperty.RegisterAttached("PreserveTextCase", typeof(bool), typeof(ControlsHelper), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
 
         /// <summary>

--- a/MahApps.Metro/Controls/Helper/DataGridRowHelper.cs
+++ b/MahApps.Metro/Controls/Helper/DataGridRowHelper.cs
@@ -1,0 +1,28 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace MahApps.Metro.Controls
+{
+    public static class DataGridRowHelper
+    {
+        public static readonly DependencyProperty SelectionUnitProperty = DependencyProperty.RegisterAttached("SelectionUnit", typeof(DataGridSelectionUnit), typeof(DataGridRowHelper), new FrameworkPropertyMetadata(DataGridSelectionUnit.FullRow));
+
+        /// <summary>
+        /// Gets the value to define the DataGridRow selection behavior.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(DataGridRow))]
+        public static DataGridSelectionUnit GetSelectionUnit(UIElement element)
+        {
+            return (DataGridSelectionUnit)element.GetValue(SelectionUnitProperty);
+        }
+
+        /// <summary>
+        /// Sets the value to define the DataGridRow selection behavior.
+        /// </summary>
+        public static void SetSelectionUnit(UIElement element, DataGridSelectionUnit value)
+        {
+            element.SetValue(SelectionUnitProperty, value);
+        }
+
+    }
+}

--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -474,6 +474,7 @@ namespace MahApps.Metro.Controls
             _repeatDown.PreviewMouseUp += (o, e) => ResetInternal();
             
             OnValueChanged(Value, Value);
+
             _scrollViewer = TryFindScrollViewer();
         }
 
@@ -891,14 +892,12 @@ namespace MahApps.Metro.Controls
         private ScrollViewer TryFindScrollViewer()
         {
             _valueTextBox.ApplyTemplate();
-            var style = _valueTextBox.Template.FindName("PART_ContentHost", _valueTextBox) as ScrollViewer;
-
-            if (style != null)
+            var scrollViewer = _valueTextBox.Template.FindName("PART_ContentHost", _valueTextBox) as ScrollViewer;
+            if (scrollViewer != null)
             {
                 _handlesMouseWheelScrolling = new Lazy<PropertyInfo>(() => _scrollViewer.GetType().GetProperties(BindingFlags.NonPublic | BindingFlags.Instance).SingleOrDefault(i => i.Name == "HandlesMouseWheelScrolling"));
             }
-
-            return style;
+            return scrollViewer;
         }
 
         private void ChangeValueWithSpeedUp(bool toPositive)

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -718,7 +718,6 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -159,6 +159,7 @@
       <DependentUpon>GlowWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\Helper\DataGridCellHelper.cs" />
+    <Compile Include="Controls\Helper\DataGridRowHelper.cs" />
     <Compile Include="Controls\Helper\ExpanderHelper.cs" />
     <Compile Include="Controls\Helper\GroupBoxHelper.cs" />
     <Compile Include="Controls\MetroAnimatedSingleRowTabControl.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Controls\Helper\ComboBoxHelper.cs" />
     <Compile Include="Controls\Helper\ControlsHelper.cs" />
     <Compile Include="Controls\Helper\DataGridCellHelper.cs" />
+    <Compile Include="Controls\Helper\DataGridRowHelper.cs" />
     <Compile Include="Controls\Helper\ExpanderHelper.cs" />
     <Compile Include="Controls\Helper\GroupBoxHelper.cs" />
     <Compile Include="Controls\Helper\PasswordBoxHelper.cs" />

--- a/MahApps.Metro/Styles/Accents/Amber.xaml
+++ b/MahApps.Metro/Styles/Accents/Amber.xaml
@@ -34,4 +34,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/BaseDark.xaml
+++ b/MahApps.Metro/Styles/Accents/BaseDark.xaml
@@ -83,4 +83,6 @@
 
     <Color x:Key="MenuShadowColor">#FFFFFFFF</Color>
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.DisabledHighlightBrush" Color="{StaticResource Gray7}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/BaseLight.xaml
+++ b/MahApps.Metro/Styles/Accents/BaseLight.xaml
@@ -83,4 +83,6 @@
 
     <Color x:Key="MenuShadowColor">#FF000000</Color>
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.DisabledHighlightBrush" Color="{StaticResource Gray7}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Blue.xaml
+++ b/MahApps.Metro/Styles/Accents/Blue.xaml
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Brown.xaml
+++ b/MahApps.Metro/Styles/Accents/Brown.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -35,4 +35,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Cobalt.xaml
+++ b/MahApps.Metro/Styles/Accents/Cobalt.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Crimson.xaml
+++ b/MahApps.Metro/Styles/Accents/Crimson.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
     
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Cyan.xaml
+++ b/MahApps.Metro/Styles/Accents/Cyan.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Emerald.xaml
+++ b/MahApps.Metro/Styles/Accents/Emerald.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Green.xaml
+++ b/MahApps.Metro/Styles/Accents/Green.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Indigo.xaml
+++ b/MahApps.Metro/Styles/Accents/Indigo.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Lime.xaml
+++ b/MahApps.Metro/Styles/Accents/Lime.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Magenta.xaml
+++ b/MahApps.Metro/Styles/Accents/Magenta.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Mauve.xaml
+++ b/MahApps.Metro/Styles/Accents/Mauve.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Olive.xaml
+++ b/MahApps.Metro/Styles/Accents/Olive.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
     
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Orange.xaml
+++ b/MahApps.Metro/Styles/Accents/Orange.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
     
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Pink.xaml
+++ b/MahApps.Metro/Styles/Accents/Pink.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
     
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Purple.xaml
+++ b/MahApps.Metro/Styles/Accents/Purple.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
     
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Red.xaml
+++ b/MahApps.Metro/Styles/Accents/Red.xaml
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Sienna.xaml
+++ b/MahApps.Metro/Styles/Accents/Sienna.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Steel.xaml
+++ b/MahApps.Metro/Styles/Accents/Steel.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Taupe.xaml
+++ b/MahApps.Metro/Styles/Accents/Taupe.xaml
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Teal.xaml
+++ b/MahApps.Metro/Styles/Accents/Teal.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Violet.xaml
+++ b/MahApps.Metro/Styles/Accents/Violet.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Yellow.xaml
+++ b/MahApps.Metro/Styles/Accents/Yellow.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -36,4 +36,11 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{StaticResource IdealForegroundColor}" Opacity="0.4" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Colors.xaml
+++ b/MahApps.Metro/Styles/Colors.xaml
@@ -163,4 +163,14 @@
 
     <Color x:Key="MenuShadowColor">#FF000000</Color>
 
+    <Color x:Key="IdealForegroundColor">Black</Color>
+
+    <!-- DataGrid brushes -->
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.DisabledHighlightBrush" Color="{StaticResource Gray7}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -535,8 +535,6 @@
            TargetType="{x:Type DataGridRow}">
         <Setter Property="Controls:DataGridRowHelper.SelectionUnit"
                 Value="{Binding Path=SelectionUnit, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
-        <Setter Property="Background"
-                Value="Transparent" />
         <Setter Property="Margin"
                 Value="0,0,0,0" />
         <Setter Property="Validation.ErrorTemplate"

--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -526,6 +526,8 @@
     <!-- Don't set the MinHeight or Height property, use the MinRowHeight or RowHeight property on DataGrid style! -->
     <Style x:Key="MetroDataGridRow"
            TargetType="{x:Type DataGridRow}">
+        <Setter Property="Controls:DataGridRowHelper.SelectionUnit"
+                Value="{Binding Path=SelectionUnit, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
         <Setter Property="Background"
                 Value="Transparent" />
         <Setter Property="Margin"
@@ -535,7 +537,7 @@
             <!-- IsSelected -->
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=SelectionUnit, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
+                    <Condition Binding="{Binding Path=(Controls:DataGridRowHelper.SelectionUnit), RelativeSource={RelativeSource Self}}"
                                Value="FullRow" />
                     <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
                                Value="true" />
@@ -551,7 +553,7 @@
             <!-- IsSelected and Selector.IsSelectionActive -->
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=SelectionUnit, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
+                    <Condition Binding="{Binding Path=(Controls:DataGridRowHelper.SelectionUnit), RelativeSource={RelativeSource Self}}"
                                Value="FullRow" />
                     <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
                                Value="true" />
@@ -569,7 +571,7 @@
             <!-- IsMouseOver -->
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=SelectionUnit, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
+                    <Condition Binding="{Binding Path=(Controls:DataGridRowHelper.SelectionUnit), RelativeSource={RelativeSource Self}}"
                                Value="FullRow" />
                     <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}"
                                Value="true" />
@@ -583,7 +585,7 @@
             <!-- IsEnabled -->
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=SelectionUnit, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
+                    <Condition Binding="{Binding Path=(Controls:DataGridRowHelper.SelectionUnit), RelativeSource={RelativeSource Self}}"
                                Value="FullRow" />
                     <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}"
                                Value="false" />
@@ -595,7 +597,7 @@
             <!-- IsEnabled and IsSelected -->
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=SelectionUnit, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
+                    <Condition Binding="{Binding Path=(Controls:DataGridRowHelper.SelectionUnit), RelativeSource={RelativeSource Self}}"
                                Value="FullRow" />
                     <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}"
                                Value="false" />

--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -8,6 +8,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <Converters:ToUpperConverter x:Key="ToUpperConverter" />
+    <BooleanToVisibilityConverter x:Key="bool2VisibilityConverter" />
 
     <Style x:Key="MetroDataGridCheckBox"
            TargetType="CheckBox"
@@ -275,9 +276,15 @@
                                 Padding="{TemplateBinding Padding}"
                                 Margin="{TemplateBinding Margin}"
                                 SnapsToDevicePixels="True">
-                            <ContentPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
+                            <StackPanel Orientation="Horizontal">
+                                <ContentPresenter RecognizesAccessKey="True"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
+                                <Control SnapsToDevicePixels="false"
+                                         Template="{Binding ValidationErrorTemplate, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}"
+                                         Visibility="{Binding (Validation.HasError), Converter={StaticResource bool2VisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}" />
+                            </StackPanel>
                         </Border>
                         <Thumb x:Name="PART_TopHeaderGripper"
                                VerticalContentAlignment="Top"
@@ -532,6 +539,30 @@
                 Value="Transparent" />
         <Setter Property="Margin"
                 Value="0,0,0,0" />
+        <Setter Property="Validation.ErrorTemplate"
+                Value="{x:Null}" />
+        <Setter Property="ValidationErrorTemplate">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid VerticalAlignment="Center"
+                          DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type DataGridRow}}, Path=(Validation.Errors).CurrentItem}"
+                          ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=DataContext.ErrorContent}">
+                        <Path Height="20"
+                              Width="20"
+                              Stretch="Uniform"
+                              Fill="{DynamicResource ControlsValidationBrush}"
+                              Data="m 31.630585,39.233818 24.6309,-24.6308 c 0.6183,-0.6184 1.6208,-0.6184 2.2392,0 l 24.6308,24.6308 c 0.6184,0.6184 0.6184,1.6209 0,2.2392 l -24.6308,24.6309 c -0.6183,0.6183 -1.6209,0.6183 -2.2392,0 l -24.6309,-24.6309 c -0.6183,-0.6183 -0.6183,-1.6208 0,-2.2392 z" />
+                        <Path Height="10"
+                              Width="10"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center"
+                              Stretch="Uniform"
+                              Fill="{DynamicResource ValidationTextBrush}"
+                              Data="m 53.781741,31.196677 c -2.237724,0 -4.0625,1.824776 -4.0625,4.0625 0,2.237724 1.824776,4.0625 4.0625,4.0625 2.237724,0 4.0625,-1.824776 4.0625,-4.0625 0,-2.237724 -1.824776,-4.0625 -4.0625,-4.0625 z m -4.09375,-21.375 0.03125,0.53125 1.21875,19.46875 5.6875,0 1.25,-20 -8.1875,0 z" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
         <Style.Triggers>
 
             <!-- IsSelected -->

--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -529,6 +529,26 @@
         </Style.Triggers>
     </Style>
 
+    <ControlTemplate x:Key="DefaultRowValidationErrorTemplate">
+        <Grid VerticalAlignment="Center"
+              Margin="2 0 2 0"
+              DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type DataGridRow}}, Path=(Validation.Errors).CurrentItem}"
+              ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=DataContext.ErrorContent}">
+            <Path Height="20"
+                  Width="20"
+                  Stretch="Uniform"
+                  Fill="{DynamicResource ControlsValidationBrush}"
+                  Data="m 31.630585,39.233818 24.6309,-24.6308 c 0.6183,-0.6184 1.6208,-0.6184 2.2392,0 l 24.6308,24.6308 c 0.6184,0.6184 0.6184,1.6209 0,2.2392 l -24.6308,24.6309 c -0.6183,0.6183 -1.6209,0.6183 -2.2392,0 l -24.6309,-24.6309 c -0.6183,-0.6183 -0.6183,-1.6208 0,-2.2392 z" />
+            <Path Height="10"
+                  Width="10"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center"
+                  Stretch="Uniform"
+                  Fill="{DynamicResource ValidationTextBrush}"
+                  Data="m 53.781741,31.196677 c -2.237724,0 -4.0625,1.824776 -4.0625,4.0625 0,2.237724 1.824776,4.0625 4.0625,4.0625 2.237724,0 4.0625,-1.824776 4.0625,-4.0625 0,-2.237724 -1.824776,-4.0625 -4.0625,-4.0625 z m -4.09375,-21.375 0.03125,0.53125 1.21875,19.46875 5.6875,0 1.25,-20 -8.1875,0 z" />
+        </Grid>
+    </ControlTemplate>
+
     <!--____________________ Metro RowStyle ____________________-->
     <!-- Don't set the MinHeight or Height property, use the MinRowHeight or RowHeight property on DataGrid style! -->
     <Style x:Key="MetroDataGridRow"
@@ -539,28 +559,8 @@
                 Value="0,0,0,0" />
         <Setter Property="Validation.ErrorTemplate"
                 Value="{x:Null}" />
-        <Setter Property="ValidationErrorTemplate">
-            <Setter.Value>
-                <ControlTemplate>
-                    <Grid VerticalAlignment="Center"
-                          DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type DataGridRow}}, Path=(Validation.Errors).CurrentItem}"
-                          ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=DataContext.ErrorContent}">
-                        <Path Height="20"
-                              Width="20"
-                              Stretch="Uniform"
-                              Fill="{DynamicResource ControlsValidationBrush}"
-                              Data="m 31.630585,39.233818 24.6309,-24.6308 c 0.6183,-0.6184 1.6208,-0.6184 2.2392,0 l 24.6308,24.6308 c 0.6184,0.6184 0.6184,1.6209 0,2.2392 l -24.6308,24.6309 c -0.6183,0.6183 -1.6209,0.6183 -2.2392,0 l -24.6309,-24.6309 c -0.6183,-0.6183 -0.6183,-1.6208 0,-2.2392 z" />
-                        <Path Height="10"
-                              Width="10"
-                              HorizontalAlignment="Center"
-                              VerticalAlignment="Center"
-                              Stretch="Uniform"
-                              Fill="{DynamicResource ValidationTextBrush}"
-                              Data="m 53.781741,31.196677 c -2.237724,0 -4.0625,1.824776 -4.0625,4.0625 0,2.237724 1.824776,4.0625 4.0625,4.0625 2.237724,0 4.0625,-1.824776 4.0625,-4.0625 0,-2.237724 -1.824776,-4.0625 -4.0625,-4.0625 z m -4.09375,-21.375 0.03125,0.53125 1.21875,19.46875 5.6875,0 1.25,-20 -8.1875,0 z" />
-                    </Grid>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="ValidationErrorTemplate"
+                Value="{StaticResource DefaultRowValidationErrorTemplate}" />
         <Style.Triggers>
 
             <!-- IsSelected -->

--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -277,7 +277,7 @@
                                 SnapsToDevicePixels="True">
                             <ContentPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
                         </Border>
                         <Thumb x:Name="PART_TopHeaderGripper"
                                VerticalContentAlignment="Top"
@@ -338,70 +338,187 @@
             </Setter.Value>
         </Setter>
         <Style.Triggers>
-            <Trigger Property="IsSelected"
-                     Value="True">
-                <Setter Property="Foreground"
-                        Value="{DynamicResource AccentSelectedColorBrush}" />
-            </Trigger>
+
+            <!-- IsSelected -->
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
-                               Value="True" />
                     <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
                                Value="Cell" />
+                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
                 </MultiDataTrigger.Conditions>
                 <Setter Property="Background"
-                        Value="{DynamicResource AccentColorBrush}" />
+                        Value="{DynamicResource MetroDataGrid.HighlightBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource MetroDataGrid.HighlightTextBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.HighlightBrush}" />
             </MultiDataTrigger>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
-                               Value="True" />
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}"
-                               Value="False" />
                     <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
                                Value="CellOrRowHeader" />
+                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
                 </MultiDataTrigger.Conditions>
                 <Setter Property="Background"
-                        Value="{DynamicResource AccentColorBrush}" />
+                        Value="{DynamicResource MetroDataGrid.HighlightBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource MetroDataGrid.HighlightTextBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.HighlightBrush}" />
             </MultiDataTrigger>
+
+            <!-- IsKeyboardFocusWithin -->
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}"
-                               Value="True" />
                     <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
                                Value="Cell" />
+                    <Condition Binding="{Binding Path=IsKeyboardFocusWithin, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
                 </MultiDataTrigger.Conditions>
-                <Setter Property="Background"
-                        Value="{DynamicResource AccentColorBrush3}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.FocusBorderBrush}" />
             </MultiDataTrigger>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}"
-                               Value="True" />
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}"
-                               Value="False" />
                     <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
                                Value="CellOrRowHeader" />
+                    <Condition Binding="{Binding Path=IsKeyboardFocusWithin, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
+                </MultiDataTrigger.Conditions>
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.FocusBorderBrush}" />
+            </MultiDataTrigger>
+
+            <!-- IsSelected and Selector.IsSelectionActive -->
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
+                               Value="Cell" />
+                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
+                    <Condition Binding="{Binding Path=(Selector.IsSelectionActive), RelativeSource={RelativeSource Self}}"
+                               Value="false" />
                 </MultiDataTrigger.Conditions>
                 <Setter Property="Background"
-                        Value="{DynamicResource AccentColorBrush3}" />
+                        Value="{DynamicResource MetroDataGrid.InactiveSelectionHighlightBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.InactiveSelectionHighlightBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource MetroDataGrid.InactiveSelectionHighlightTextBrush}" />
             </MultiDataTrigger>
-            <Trigger Property="IsEnabled"
-                     Value="False">
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
+                               Value="CellOrRowHeader" />
+                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
+                    <Condition Binding="{Binding Path=(Selector.IsSelectionActive), RelativeSource={RelativeSource Self}}"
+                               Value="false" />
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Background"
+                        Value="{DynamicResource MetroDataGrid.InactiveSelectionHighlightBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.InactiveSelectionHighlightBrush}" />
                 <Setter Property="Foreground"
-                        Value="{DynamicResource GrayBrush7}" />
-            </Trigger>
-            <MultiTrigger>
-                <MultiTrigger.Conditions>
-                    <Condition Property="IsEnabled"
-                               Value="False" />
-                    <Condition Property="IsSelected"
-                               Value="True" />
-                </MultiTrigger.Conditions>
+                        Value="{DynamicResource MetroDataGrid.InactiveSelectionHighlightTextBrush}" />
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
+                               Value="FullRow" />
+                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
+                    <Condition Binding="{Binding Path=(Selector.IsSelectionActive), RelativeSource={RelativeSource Self}}"
+                               Value="false" />
+                </MultiDataTrigger.Conditions>
                 <Setter Property="Foreground"
-                        Value="{DynamicResource AccentSelectedColorBrush}" />
-            </MultiTrigger>
+                        Value="{DynamicResource MetroDataGrid.InactiveSelectionHighlightTextBrush}" />
+            </MultiDataTrigger>
+
+            <!-- IsMouseOver -->
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
+                               Value="Cell" />
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Background"
+                        Value="{DynamicResource MetroDataGrid.MouseOverHighlightBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.MouseOverHighlightBrush}" />
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
+                               Value="CellOrRowHeader" />
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Background"
+                        Value="{DynamicResource MetroDataGrid.MouseOverHighlightBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.MouseOverHighlightBrush}" />
+            </MultiDataTrigger>
+
+            <!-- IsEnabled -->
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
+                               Value="Cell" />
+                    <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}"
+                               Value="false" />
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground"
+                        Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
+                               Value="CellOrRowHeader" />
+                    <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}"
+                               Value="false" />
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground"
+                        Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+            </MultiDataTrigger>
+
+            <!-- IsEnabled and IsSelected -->
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
+                               Value="Cell" />
+                    <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}"
+                               Value="false" />
+                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground"
+                        Value="{DynamicResource MetroDataGrid.HighlightTextBrush}" />
+                <Setter Property="Background"
+                        Value="{DynamicResource MetroDataGrid.DisabledHighlightBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.DisabledHighlightBrush}" />
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=(Controls:DataGridCellHelper.DataGrid).SelectionUnit, RelativeSource={RelativeSource Self}}"
+                               Value="CellOrRowHeader" />
+                    <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}"
+                               Value="false" />
+                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground"
+                        Value="{DynamicResource MetroDataGrid.HighlightTextBrush}" />
+                <Setter Property="Background"
+                        Value="{DynamicResource MetroDataGrid.DisabledHighlightBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.DisabledHighlightBrush}" />
+            </MultiDataTrigger>
+
         </Style.Triggers>
     </Style>
 
@@ -409,67 +526,90 @@
     <!-- Don't set the MinHeight or Height property, use the MinRowHeight or RowHeight property on DataGrid style! -->
     <Style x:Key="MetroDataGridRow"
            TargetType="{x:Type DataGridRow}">
-        <Setter Property="Foreground"
-                Value="{DynamicResource BlackBrush}" />
+        <Setter Property="Background"
+                Value="Transparent" />
         <Setter Property="Margin"
                 Value="0,0,0,0" />
         <Style.Triggers>
-            <Trigger Property="IsSelected"
-                     Value="True">
-                <Setter Property="Background"
-                        Value="{DynamicResource AccentColorBrush}" />
-                <Setter Property="Foreground"
-                        Value="{DynamicResource AccentSelectedColorBrush}" />
-            </Trigger>
-            <MultiTrigger>
-                <MultiTrigger.Conditions>
-                    <Condition Property="IsSelected"
-                               Value="True" />
-                    <Condition Property="Selector.IsSelectionActive"
-                               Value="True" />
-                </MultiTrigger.Conditions>
-                <Setter Property="Background"
-                        Value="{DynamicResource AccentColorBrush2}" />
-            </MultiTrigger>
+
+            <!-- IsSelected -->
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}"
-                               Value="True" />
                     <Condition Binding="{Binding Path=SelectionUnit, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
                                Value="FullRow" />
+                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
                 </MultiDataTrigger.Conditions>
                 <Setter Property="Background"
-                        Value="{DynamicResource AccentColorBrush3}" />
+                        Value="{DynamicResource MetroDataGrid.HighlightBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource MetroDataGrid.HighlightTextBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.HighlightBrush}" />
             </MultiDataTrigger>
+
+            <!-- IsSelected and Selector.IsSelectionActive -->
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}"
-                               Value="True" />
-                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
-                               Value="True" />
                     <Condition Binding="{Binding Path=SelectionUnit, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
-                               Value="CellOrRowHeader" />
+                               Value="FullRow" />
+                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
+                    <Condition Binding="{Binding Path=(Selector.IsSelectionActive), RelativeSource={RelativeSource Self}}"
+                               Value="false" />
                 </MultiDataTrigger.Conditions>
                 <Setter Property="Background"
-                        Value="{DynamicResource AccentColorBrush3}" />
+                        Value="{DynamicResource MetroDataGrid.InactiveSelectionHighlightBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.InactiveSelectionHighlightBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource MetroDataGrid.InactiveSelectionHighlightTextBrush}" />
             </MultiDataTrigger>
-            <Trigger Property="IsEnabled"
-                     Value="False">
-                <Setter Property="Foreground"
-                        Value="{DynamicResource GrayBrush7}" />
-            </Trigger>
-            <MultiTrigger>
-                <MultiTrigger.Conditions>
-                    <Condition Property="IsEnabled"
-                               Value="False" />
-                    <Condition Property="IsSelected"
-                               Value="True" />
-                </MultiTrigger.Conditions>
+
+            <!-- IsMouseOver -->
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=SelectionUnit, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
+                               Value="FullRow" />
+                    <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
+                </MultiDataTrigger.Conditions>
                 <Setter Property="Background"
-                        Value="{DynamicResource GrayBrush7}" />
+                        Value="{DynamicResource MetroDataGrid.MouseOverHighlightBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.MouseOverHighlightBrush}" />
+            </MultiDataTrigger>
+
+            <!-- IsEnabled -->
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=SelectionUnit, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
+                               Value="FullRow" />
+                    <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}"
+                               Value="false" />
+                </MultiDataTrigger.Conditions>
                 <Setter Property="Foreground"
-                        Value="{DynamicResource AccentSelectedColorBrush}" />
-            </MultiTrigger>
+                        Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+            </MultiDataTrigger>
+
+            <!-- IsEnabled and IsSelected -->
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding Path=SelectionUnit, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}"
+                               Value="FullRow" />
+                    <Condition Binding="{Binding Path=IsEnabled, RelativeSource={RelativeSource Self}}"
+                               Value="false" />
+                    <Condition Binding="{Binding Path=IsSelected, RelativeSource={RelativeSource Self}}"
+                               Value="true" />
+                </MultiDataTrigger.Conditions>
+                <Setter Property="Foreground"
+                        Value="{DynamicResource MetroDataGrid.HighlightTextBrush}" />
+                <Setter Property="Background"
+                        Value="{DynamicResource MetroDataGrid.DisabledHighlightBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource MetroDataGrid.DisabledHighlightBrush}" />
+            </MultiDataTrigger>
+
         </Style.Triggers>
     </Style>
 
@@ -649,26 +789,6 @@
                 <Setter Property="Background"
                         Value="{DynamicResource AccentColorBrush2}" />
             </MultiDataTrigger>
-            <Trigger Property="IsSelected"
-                     Value="True">
-                <Setter Property="Foreground"
-                        Value="{DynamicResource AccentSelectedColorBrush}" />
-            </Trigger>
-            <Trigger Property="IsEnabled"
-                     Value="False">
-                <Setter Property="Foreground"
-                        Value="{DynamicResource GrayBrush7}" />
-            </Trigger>
-            <MultiTrigger>
-                <MultiTrigger.Conditions>
-                    <Condition Property="IsEnabled"
-                               Value="False" />
-                    <Condition Property="IsSelected"
-                               Value="True" />
-                </MultiTrigger.Conditions>
-                <Setter Property="Foreground"
-                        Value="{DynamicResource AccentSelectedColorBrush}" />
-            </MultiTrigger>
         </Style.Triggers>
     </Style>
 

--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -307,8 +307,6 @@
            TargetType="{x:Type DataGridCell}">
         <Setter Property="Controls:DataGridCellHelper.SaveDataGrid"
                 Value="True" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource BlackBrush}" />
         <Setter Property="Background"
                 Value="Transparent" />
         <Setter Property="BorderBrush"

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -149,11 +149,12 @@
                             </Button>
                         </Grid>
                         <Rectangle x:Name="DisabledVisualElement"
-                                Stroke="{DynamicResource ControlsDisabledBrush}"
-                                StrokeThickness="{TemplateBinding BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}}"
-                                Fill="{DynamicResource ControlsDisabledBrush}"
-                                IsHitTestVisible="False"
-                                Opacity="0" />
+                                   Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}"
+                                   Stroke="{DynamicResource ControlsDisabledBrush}"
+                                   StrokeThickness="{TemplateBinding BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}}"
+                                   Fill="{DynamicResource ControlsDisabledBrush}"
+                                   IsHitTestVisible="False"
+                                   Opacity="0" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="false">
@@ -389,6 +390,7 @@
                                               Visibility="Collapsed" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
+                                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                 BorderBrush="{DynamicResource ControlsDisabledBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
@@ -631,6 +633,7 @@
                                               Visibility="Collapsed" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
+                                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                 BorderBrush="{DynamicResource ControlsDisabledBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
@@ -876,6 +879,7 @@
                                               Visibility="Collapsed" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
+                                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                 BorderBrush="{DynamicResource ControlsDisabledBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -152,6 +152,7 @@
                                     IsTabStop="False" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
+                                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                 BorderBrush="{DynamicResource ControlsDisabledBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
@@ -447,6 +448,7 @@
                                     IsTabStop="False" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
+                                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                 BorderBrush="{DynamicResource ControlsDisabledBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
@@ -687,13 +689,13 @@
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
                         <Border x:Name="DisabledVisualElement"
+                                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                 BorderBrush="{DynamicResource ControlsDisabledBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 Background="{DynamicResource ControlsDisabledBrush}"
-                                Opacity="0.6"
                                 IsHitTestVisible="False"
-                                Visibility="Collapsed" />
+                                Opacity="0" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver"
@@ -711,8 +713,8 @@
                         <Trigger Property="IsEnabled"
                                  Value="False">
                             <Setter TargetName="DisabledVisualElement"
-                                    Property="Visibility"
-                                    Value="Visible" />
+                                    Property="Opacity"
+                                    Value="0.6" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -68,6 +68,7 @@
                             </Grid.ColumnDefinitions>
 
                             <TextBox x:Name="PART_TextBox"
+                                     Controls:ControlsHelper.DisabledVisualElementVisibility="Collapsed"
                                      MinWidth="20"
                                      MinHeight="{TemplateBinding MinHeight}"
                                      Foreground="{TemplateBinding Foreground}"
@@ -117,8 +118,22 @@
                                       Data="F1 M 19,38L 57,38L 57,44L 19,44L 19,38 Z " />
                             </RepeatButton>
                         </Grid>
+                        <Border x:Name="DisabledVisualElement"
+                                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                BorderBrush="{DynamicResource ControlsDisabledBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Background="{DynamicResource ControlsDisabledBrush}"
+                                IsHitTestVisible="False"
+                                Opacity="0" />
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled"
+                                 Value="False">
+                            <Setter TargetName="DisabledVisualElement"
+                                    Property="Opacity"
+                                    Value="0.6" />
+                        </Trigger>
                         <Trigger Property="IsReadOnly"
                                  Value="True">
                             <Setter TargetName="PART_NumericUp"
@@ -203,7 +218,6 @@
                                     Property="Width"
                                     Value="0" />
                         </Trigger>
-                        
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>

--- a/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
@@ -174,10 +174,21 @@
                         <DataTrigger Binding="{Binding Price, Mode=OneWay, Converter={StaticResource AlbumPriceIsTooMuchConverter}}"
                                      Value="True">
                             <Setter Property="Background"
-                                    Value="#FFE2E2" />
+                                    Value="#FF8B8B" />
                             <Setter Property="Foreground"
                                     Value="Red" />
                         </DataTrigger>
+                        <!-- IsMouseOver -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Price, Mode=OneWay, Converter={StaticResource AlbumPriceIsTooMuchConverter}}"
+                                           Value="True" />
+                                <Condition Binding="{Binding Path=IsMouseOver, RelativeSource={RelativeSource Self}}"
+                                           Value="true" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Background"
+                                    Value="#FFBDBD" />
+                        </MultiDataTrigger>
                     </Style.Triggers>
                 </Style>
             </DataGrid.RowStyle>

--- a/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:MetroDemo="clr-namespace:MetroDemo"
              xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:ValueConverter="clr-namespace:MetroDemo.ValueConverter"
              mc:Ignorable="d"
              d:DesignHeight="600"
              d:DesignWidth="800"
@@ -105,6 +106,8 @@
                 </Grid>
             </ControlTemplate>
 
+            <ValueConverter:AlbumPriceIsTooMuchConverter x:Key="AlbumPriceIsTooMuchConverter" />
+
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -157,6 +160,24 @@
                                                       StringFormat="C"
                                                       Minimum="0" />
             </DataGrid.Columns>
+            <DataGrid.RowStyle>
+                <Style BasedOn="{StaticResource MetroDataGridRow}"
+                       TargetType="{x:Type DataGridRow}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Price, Mode=OneWay, Converter={StaticResource AlbumPriceIsTooMuchConverter}}"
+                                     Value="True">
+                            <Setter Property="Background"
+                                    Value="#FFE2E2" />
+                            <Setter Property="Foreground"
+                                    Value="Red" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                    <Setter Property="Control.Foreground"
+                            Value="{DynamicResource BlackBrush}" />
+                    <Setter Property="FrameworkElement.Margin"
+                            Value="0" />
+                </Style>
+            </DataGrid.RowStyle>
         </DataGrid>
 
         <ContentControl Grid.Column="0"

--- a/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
@@ -140,6 +140,7 @@
                   Grid.Row="1"
                   RenderOptions.ClearTypeHint="Enabled"
                   TextOptions.TextFormattingMode="Display"
+                  HeadersVisibility="All"
                   Margin="5"
                   SelectionUnit="FullRow"
                   ItemsSource="{Binding Path=Albums}"
@@ -192,6 +193,9 @@
                     </Style.Triggers>
                 </Style>
             </DataGrid.RowStyle>
+            <DataGrid.RowValidationRules>
+                <ValueConverter:AlbumPriceIsReallyTooMuchValidation ValidationStep="RawProposedValue" />
+            </DataGrid.RowValidationRules>
         </DataGrid>
 
         <ContentControl Grid.Column="0"

--- a/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
@@ -194,7 +194,8 @@
                 </Style>
             </DataGrid.RowStyle>
             <DataGrid.RowValidationRules>
-                <ValueConverter:AlbumPriceIsReallyTooMuchValidation ValidationStep="RawProposedValue" />
+                <ValueConverter:AlbumPriceIsReallyTooMuchValidation ValidatesOnTargetUpdated="True" ValidationStep="CommittedValue" />
+                <ValueConverter:AlbumPriceIsReallyTooMuchValidation ValidatesOnTargetUpdated="True" ValidationStep="UpdatedValue" />
             </DataGrid.RowValidationRules>
         </DataGrid>
 

--- a/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
@@ -160,6 +160,13 @@
                                                       StringFormat="C"
                                                       Minimum="0" />
             </DataGrid.Columns>
+            <DataGrid.Style>
+                <Style BasedOn="{StaticResource MetroDataGrid}"
+                       TargetType="{x:Type DataGrid}">
+                    <Setter Property="AlternatingRowBackground"
+                            Value="{DynamicResource GrayBrush10}" />
+                </Style>
+            </DataGrid.Style>
             <DataGrid.RowStyle>
                 <Style BasedOn="{StaticResource MetroDataGridRow}"
                        TargetType="{x:Type DataGridRow}">
@@ -172,10 +179,6 @@
                                     Value="Red" />
                         </DataTrigger>
                     </Style.Triggers>
-                    <Setter Property="Control.Foreground"
-                            Value="{DynamicResource BlackBrush}" />
-                    <Setter Property="FrameworkElement.Margin"
-                            Value="0" />
                 </Style>
             </DataGrid.RowStyle>
         </DataGrid>

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -218,7 +218,7 @@
                           Margin="1" />
 
                 <Label Content='Min="0", Max="10", TextAlignment="Left"' />
-                <Controls:NumericUpDown Value="5"
+                <Controls:NumericUpDown Value="5" IsEnabled="False"
                                         x:Name="Test"
                                         TextAlignment="Left"
                                         Minimum="0"

--- a/samples/MetroDemo/MetroDemo.NET45.csproj
+++ b/samples/MetroDemo/MetroDemo.NET45.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Navigation\InterestingPage.xaml.cs">
       <DependentUpon>InterestingPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ValueConverter\AlbumPriceIsTooMuchConverter.cs" />
     <Page Include="ExampleViews\ButtonsExample.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/samples/MetroDemo/MetroDemo.csproj
+++ b/samples/MetroDemo/MetroDemo.csproj
@@ -165,6 +165,7 @@
     <Compile Include="ExampleWindows\VSDemo.xaml.cs">
       <DependentUpon>VSDemo.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ValueConverter\AlbumPriceIsTooMuchConverter.cs" />
     <Page Include="ExampleWindows\CleanWindowDemo.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/samples/MetroDemo/Models/Album.cs
+++ b/samples/MetroDemo/Models/Album.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 
@@ -454,6 +455,10 @@ namespace MetroDemo.Models
                     new Album {Title = "Bach: The Cello Suites", Genre = Genres.First(g => g.Name == "Classical"), Price = 8.99M, Artist = Artists.First(a => a.Name == "Yo-Yo Ma"), AlbumArtUrl = "/Content/Images/placeholder.gif"},
                     new Album {Title = "Ao Vivo [IMPORT]", Genre = Genres.First(g => g.Name == "Latin"), Price = 8.99M, Artist = Artists.First(a => a.Name == "Zeca Pagodinho"), AlbumArtUrl = "/Content/Images/placeholder.gif"},
                 };
+
+
+            var r = new Random(Environment.TickCount);
+            Albums.ForEach(x => x.Price = Convert.ToDecimal(r.NextDouble() * 20d));
         }
     }
 }

--- a/samples/MetroDemo/ValueConverter/AlbumPriceIsTooMuchConverter.cs
+++ b/samples/MetroDemo/ValueConverter/AlbumPriceIsTooMuchConverter.cs
@@ -14,7 +14,7 @@ namespace MetroDemo.ValueConverter
             if (value is decimal)
             {
                 var price = (decimal)value;
-                if (price > 15 && price < 18)
+                if (price > 15 && price < 20)
                 {
                     return true;
                 }
@@ -36,7 +36,7 @@ namespace MetroDemo.ValueConverter
             if (bindingGroup != null)
             {
                 var album = (Album)bindingGroup.Items[0];
-                if (album.Price >= 18)
+                if (album.Price >= 20)
                 {
                     return new ValidationResult(false, string.Format("The price {0} of the album '{1}' by '{2}' is too much!", album.Price, album.Title, album.Artist.Name));
                 }

--- a/samples/MetroDemo/ValueConverter/AlbumPriceIsTooMuchConverter.cs
+++ b/samples/MetroDemo/ValueConverter/AlbumPriceIsTooMuchConverter.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Data;
+using MetroDemo.Models;
 
 namespace MetroDemo.ValueConverter
 {
@@ -12,7 +14,7 @@ namespace MetroDemo.ValueConverter
             if (value is decimal)
             {
                 var price = (decimal)value;
-                if (price > 15)
+                if (price > 15 && price < 18)
                 {
                     return true;
                 }
@@ -25,4 +27,22 @@ namespace MetroDemo.ValueConverter
             return DependencyProperty.UnsetValue;
         }
     }
+
+    public class AlbumPriceIsReallyTooMuchValidation : ValidationRule
+    {
+        public override ValidationResult Validate(object value, System.Globalization.CultureInfo cultureInfo)
+        {
+            var bindingGroup = value as BindingGroup;
+            if (bindingGroup != null)
+            {
+                var album = (Album)bindingGroup.Items[0];
+                if (album.Price >= 18)
+                {
+                    return new ValidationResult(false, string.Format("The price {0} of the album '{1}' by '{2}' is too much!", album.Price, album.Title, album.Artist.Name));
+                }
+            }
+            return ValidationResult.ValidResult;
+        }
+    }
+
 }

--- a/samples/MetroDemo/ValueConverter/AlbumPriceIsTooMuchConverter.cs
+++ b/samples/MetroDemo/ValueConverter/AlbumPriceIsTooMuchConverter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace MetroDemo.ValueConverter
+{
+    public class AlbumPriceIsTooMuchConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is decimal)
+            {
+                var price = (decimal)value;
+                if (price > 15)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return DependencyProperty.UnsetValue;
+        }
+    }
+}


### PR DESCRIPTION
- Closes #1939 Hotfix DataGrid row conditional foreground. thx to @spaccabit
- Closes #1876 DataGrid Row Selection Color Lost
- Closes #1492 Overriding DataGridRow Style
- Closes #1243 Any elegant way to override the style of Control, specifically, the DataGridRow?
- Closes #809 How to Change the Accent for a Custom Control
- Closes #1878 Bug with DataGridNumericUpDownColumn
- Closes #1930 Datagrid ValidationRule issue
- improve color styling, so overriding the colors is now easier than before
```xaml
    <!-- DataGrid brushes -->
    <SolidColorBrush x:Key="MetroDataGrid.HighlightBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
    <SolidColorBrush x:Key="MetroDataGrid.DisabledHighlightBrush" Color="{StaticResource Gray7}" options:Freeze="True" />
    <SolidColorBrush x:Key="MetroDataGrid.HighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
    <SolidColorBrush x:Key="MetroDataGrid.MouseOverHighlightBrush" Color="{StaticResource AccentColor3}" options:Freeze="True" />
    <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
    <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
```
- new attached dependency `DisabledVisualElementVisibility` for `TextBox`, `PasswordBox`, `RichTextBox` and `NumericUpDown`, makes it easier to hide this element if we don't want/need it

**Before**
![image](https://cloud.githubusercontent.com/assets/658431/8410903/565a823c-1e81-11e5-9070-d5584b457062.png)

![image](https://cloud.githubusercontent.com/assets/658431/8410911/5e3bb30e-1e81-11e5-9873-95b9e37fb0fc.png)

![image](https://cloud.githubusercontent.com/assets/658431/8410914/619800e8-1e81-11e5-8a3b-43f560723fef.png)

![image](https://cloud.githubusercontent.com/assets/658431/8410916/64baa686-1e81-11e5-8828-2492efa84be5.png)

**After**
![image](https://cloud.githubusercontent.com/assets/658431/8410776/ac588d7e-1e80-11e5-8c41-d17158086559.png)

![image](https://cloud.githubusercontent.com/assets/658431/8410769/a6100a1e-1e80-11e5-9713-435298f5b66d.png)

![image](https://cloud.githubusercontent.com/assets/658431/8410778/b309130a-1e80-11e5-9390-f90001bc61f0.png)

![image](https://cloud.githubusercontent.com/assets/658431/8410781/b754c256-1e80-11e5-8c11-88d463411e35.png)

![image](https://cloud.githubusercontent.com/assets/658431/8410785/ba687a1e-1e80-11e5-8ea5-8090cc35ced9.png)
