### PR TITLE
FIX: issue with RangeSlider with binding and values between ticks

### DIFF
--- a/MahApps.Metro/Controls/RangeSlider.cs
+++ b/MahApps.Metro/Controls/RangeSlider.cs
@@ -2025,17 +2025,15 @@ namespace MahApps.Metro.Controls
             if (!IsMoveToPointEnabled)
             {
                 //Check if current value is exactly Tick value or it situated between Ticks
-                if (!IsDoubleCloseToInt((chekingValue - Minimum) / TickFrequency))
+                if (!IsDoubleCloseToInt((chekingValue + distance - Minimum) / TickFrequency))
                 {
-                    double x = (chekingValue - Minimum) / TickFrequency;
+                    double x = (chekingValue + distance - Minimum) / TickFrequency;
                     distance = TickFrequency * (int)x;
                     if (dir == Direction.Increase)
                     {
                         distance += TickFrequency;
                     }
                     distance = (distance - Math.Abs(chekingValue - Minimum));
-                    _currenValue = 0;
-                    return Math.Abs(distance);
                 }
             }
             //If we need move directly to next tick without calculating the difference between ticks

--- a/MahApps.Metro/Controls/RangeSlider.cs
+++ b/MahApps.Metro/Controls/RangeSlider.cs
@@ -2036,7 +2036,8 @@ namespace MahApps.Metro.Controls
                         distance += TickFrequency;
                     }
                     distance = (distance - Math.Abs(checkingValuePos));
-                }
+                    _currenValue = 0;
+                    return Math.Abs(distance);                }
             }
             //If we need move directly to next tick without calculating the difference between ticks
             //Use when MoveToPoint disabled

--- a/MahApps.Metro/Controls/RangeSlider.cs
+++ b/MahApps.Metro/Controls/RangeSlider.cs
@@ -2020,20 +2020,22 @@ namespace MahApps.Metro.Controls
         }
 
         //Calculating next value for Tick
-        private Double CalculateNextTick(Direction dir, double chekingValue, double distance, bool moveDirectlyToNextTick)
+        private Double CalculateNextTick(Direction dir, double checkingValue, double distance, bool moveDirectlyToNextTick)
         {
+            double checkingValuePos = checkingValue - Minimum;
             if (!IsMoveToPointEnabled)
             {
                 //Check if current value is exactly Tick value or it situated between Ticks
-                if (!IsDoubleCloseToInt((chekingValue + distance - Minimum) / TickFrequency))
+                double checkingValueChanged = checkingValuePos + distance;
+                double x = checkingValueChanged / TickFrequency;
+                if (!IsDoubleCloseToInt(x))
                 {
-                    double x = (chekingValue + distance - Minimum) / TickFrequency;
                     distance = TickFrequency * (int)x;
                     if (dir == Direction.Increase)
                     {
                         distance += TickFrequency;
                     }
-                    distance = (distance - Math.Abs(chekingValue - Minimum));
+                    distance = (distance - Math.Abs(checkingValuePos));
                 }
             }
             //If we need move directly to next tick without calculating the difference between ticks
@@ -2046,7 +2048,7 @@ namespace MahApps.Metro.Controls
             else
             {
                 //current value in units (exactly in the place under cursor)
-                double currentValue = chekingValue - Minimum + (distance / _density); 
+                double currentValue = checkingValuePos + (distance / _density); 
                 double x = currentValue / TickFrequency;
                 if (dir == Direction.Increase)
                 {
@@ -2054,14 +2056,14 @@ namespace MahApps.Metro.Controls
                         ? (x * TickFrequency) + TickFrequency
                         : ((int)x * TickFrequency) + TickFrequency;
 
-                    distance = (nextvalue - Math.Abs(chekingValue - Minimum));
+                    distance = (nextvalue - Math.Abs(checkingValuePos));
                 }
                 else
                 {
                     double previousValue = x.ToString(CultureInfo.InvariantCulture).ToLower().Contains("e+")
                         ? x * TickFrequency
                         : (int)x * TickFrequency;
-                    distance = (Math.Abs(chekingValue - Minimum) - previousValue);
+                    distance = (Math.Abs(checkingValuePos) - previousValue);
                 }
             }
             //return absolute value without sign not to depend on it if value is negative 


### PR DESCRIPTION
Had an issue with a range slider where I could not move the thumb all the way to the right. In this case CalculateNextTick() moved into the !IsDoubleCloseToInt() code and that did not respect the passed in distance.