### PR TITLE
support for multiple dialogs (fixes #1974)

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using MahApps.Metro.Behaviours;
 
 namespace MahApps.Metro.Controls.Dialogs
 {
@@ -418,10 +417,12 @@ namespace MahApps.Metro.Controls.Dialogs
             return sizeHandler;
         }
 
-        private static void AddDialog(this MetroWindow window, BaseMetroDialog dialog) {
+        private static void AddDialog(this MetroWindow window, BaseMetroDialog dialog)
+        {
             // if there's already an active dialog, move to the background
             var activeDialog = window.metroActiveDialogContainer.Children.Cast<UIElement>().SingleOrDefault();
-            if (activeDialog != null) {
+            if (activeDialog != null)
+            {
                 window.metroActiveDialogContainer.Children.Remove(activeDialog);
                 window.metroInactiveDialogContainer.Children.Add(activeDialog);
             }
@@ -429,17 +430,22 @@ namespace MahApps.Metro.Controls.Dialogs
             window.metroActiveDialogContainer.Children.Add(dialog); //add the dialog to the container}
         }
 
-        private static void RemoveDialog(this MetroWindow window, BaseMetroDialog dialog) {
-            if (window.metroActiveDialogContainer.Children.Contains(dialog)) {
+        private static void RemoveDialog(this MetroWindow window, BaseMetroDialog dialog)
+        {
+            if (window.metroActiveDialogContainer.Children.Contains(dialog))
+            {
                 window.metroActiveDialogContainer.Children.Remove(dialog); //remove the dialog from the container
 
                 // if there's an inactive dialog, bring it to the front
                 var dlg = window.metroInactiveDialogContainer.Children.Cast<UIElement>().LastOrDefault();
-                if (dlg != null) {
+                if (dlg != null)
+                {
                     window.metroInactiveDialogContainer.Children.Remove(dlg);
                     window.metroActiveDialogContainer.Children.Add(dlg);
                 }
-            } else {
+            }
+            else
+            {
                 window.metroInactiveDialogContainer.Children.Remove(dialog);
             }
         }

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -65,7 +65,7 @@ namespace MahApps.Metro.Controls.Dialogs
                                 {
                                     window.SizeChanged -= sizeHandler;
 
-                                    window.metroDialogContainer.Children.Remove(dialog); //remove the dialog from the container
+                                    window.RemoveDialog(dialog);
 
                                     return HandleOverlayOnHide(settings, window);
                                     //window.overlayBox.Visibility = System.Windows.Visibility.Hidden; //deactive the overlay effect
@@ -131,7 +131,7 @@ namespace MahApps.Metro.Controls.Dialogs
                                 {
                                     window.SizeChanged -= sizeHandler;
 
-                                    window.metroDialogContainer.Children.Remove(dialog); //remove the dialog from the container
+                                    window.RemoveDialog(dialog);
 
                                     return HandleOverlayOnHide(settings, window);
                                 }))).ContinueWith(y3 => y).Unwrap();
@@ -198,7 +198,7 @@ namespace MahApps.Metro.Controls.Dialogs
                                 {
                                     window.SizeChanged -= sizeHandler;
 
-                                    window.metroDialogContainer.Children.Remove(dialog); //remove the dialog from the container
+                                    window.RemoveDialog(dialog);
 
                                     return HandleOverlayOnHide(settings, window);
                                 }))).ContinueWith(y3 => y).Unwrap();
@@ -266,7 +266,7 @@ namespace MahApps.Metro.Controls.Dialogs
                                 {
                                     window.SizeChanged -= sizeHandler;
 
-                                    window.metroDialogContainer.Children.Remove(dialog); //remove the dialog from the container
+                                    window.RemoveDialog(dialog);
 
                                     return HandleOverlayOnHide(settings, window);
                                 }));
@@ -279,7 +279,7 @@ namespace MahApps.Metro.Controls.Dialogs
 
         private static Task HandleOverlayOnHide(MetroDialogSettings settings, MetroWindow window)
         {
-            if (window.metroDialogContainer.Children.Count == 0)
+            if (window.metroActiveDialogContainer.Children.Count == 0)
             {
                 return (settings == null || settings.AnimateHide ? window.HideOverlayAsync() : Task.Factory.StartNew(() => window.Dispatcher.Invoke(new Action(window.HideOverlay))));
             }
@@ -293,7 +293,7 @@ namespace MahApps.Metro.Controls.Dialogs
 
         private static Task HandleOverlayOnShow(MetroDialogSettings settings, MetroWindow window)
         {
-            if (window.metroDialogContainer.Children.Count == 0)
+            if (window.metroActiveDialogContainer.Children.Count == 0)
             {
                 return (settings == null || settings.AnimateShow ? window.ShowOverlayAsync() : Task.Factory.StartNew(() => window.Dispatcher.Invoke(new Action(window.ShowOverlay))));
             }
@@ -319,7 +319,7 @@ namespace MahApps.Metro.Controls.Dialogs
             MetroDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
-            if (window.metroDialogContainer.Children.Contains(dialog))
+            if (window.metroActiveDialogContainer.Children.Contains(dialog) || window.metroInactiveDialogContainer.Children.Contains(dialog))
                 throw new InvalidOperationException("The provided dialog is already visible in the specified window.");
 
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
@@ -357,7 +357,7 @@ namespace MahApps.Metro.Controls.Dialogs
         public static Task HideMetroDialogAsync(this MetroWindow window, BaseMetroDialog dialog, MetroDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
-            if (!window.metroDialogContainer.Children.Contains(dialog))
+            if (!window.metroActiveDialogContainer.Children.Contains(dialog) && !window.metroInactiveDialogContainer.Children.Contains(dialog))
                 throw new InvalidOperationException("The provided dialog is not visible in the specified window.");
 
             window.SizeChanged -= dialog.SizeChangedHandler;
@@ -374,7 +374,7 @@ namespace MahApps.Metro.Controls.Dialogs
 
                 return (Task)window.Dispatcher.Invoke(new Func<Task>(() =>
                 {
-                    window.metroDialogContainer.Children.Remove(dialog); //remove the dialog from the container
+                    window.RemoveDialog(dialog);
 
                     return HandleOverlayOnHide(settings,window);
                 }));
@@ -391,7 +391,7 @@ namespace MahApps.Metro.Controls.Dialogs
             var t = new TaskCompletionSource<TDialog>();
             window.Dispatcher.Invoke((Action)(() =>
             {
-                TDialog dialog = window.metroDialogContainer.Children.OfType<TDialog>().LastOrDefault();
+                TDialog dialog = window.metroActiveDialogContainer.Children.OfType<TDialog>().LastOrDefault();
                 t.TrySetResult(dialog);
             }));
             return t.Task;
@@ -411,11 +411,37 @@ namespace MahApps.Metro.Controls.Dialogs
 
             window.SizeChanged += sizeHandler;
 
-            window.metroDialogContainer.Children.Add(dialog); //add the dialog to the container
+            window.AddDialog(dialog);
 
             dialog.OnShown();
 
             return sizeHandler;
+        }
+
+        private static void AddDialog(this MetroWindow window, BaseMetroDialog dialog) {
+            // if there's already an active dialog, move to the background
+            var activeDialog = window.metroActiveDialogContainer.Children.Cast<UIElement>().SingleOrDefault();
+            if (activeDialog != null) {
+                window.metroActiveDialogContainer.Children.Remove(activeDialog);
+                window.metroInactiveDialogContainer.Children.Add(activeDialog);
+            }
+
+            window.metroActiveDialogContainer.Children.Add(dialog); //add the dialog to the container}
+        }
+
+        private static void RemoveDialog(this MetroWindow window, BaseMetroDialog dialog) {
+            if (window.metroActiveDialogContainer.Children.Contains(dialog)) {
+                window.metroActiveDialogContainer.Children.Remove(dialog); //remove the dialog from the container
+
+                // if there's an inactive dialog, bring it to the front
+                var dlg = window.metroInactiveDialogContainer.Children.Cast<UIElement>().LastOrDefault();
+                if (dlg != null) {
+                    window.metroInactiveDialogContainer.Children.Remove(dlg);
+                    window.metroActiveDialogContainer.Children.Add(dlg);
+                }
+            } else {
+                window.metroInactiveDialogContainer.Children.Remove(dialog);
+            }
         }
 
         public static BaseMetroDialog ShowDialogExternally(this BaseMetroDialog dialog)

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -23,7 +23,8 @@ namespace MahApps.Metro.Controls
     [TemplatePart(Name = PART_RightWindowCommands, Type = typeof(WindowCommands))]
     [TemplatePart(Name = PART_WindowButtonCommands, Type = typeof(WindowButtonCommands))]
     [TemplatePart(Name = PART_OverlayBox, Type = typeof(Grid))]
-    [TemplatePart(Name = PART_MetroDialogContainer, Type = typeof(Grid))]
+    [TemplatePart(Name = PART_MetroActiveDialogContainer, Type = typeof(Grid))]
+    [TemplatePart(Name = PART_MetroInactiveDialogsContainer, Type = typeof(Grid))]
     [TemplatePart(Name = PART_FlyoutModal, Type = typeof(Rectangle))]
     public class MetroWindow : Window
     {
@@ -34,7 +35,8 @@ namespace MahApps.Metro.Controls
         private const string PART_RightWindowCommands = "PART_RightWindowCommands";
         private const string PART_WindowButtonCommands = "PART_WindowButtonCommands";
         private const string PART_OverlayBox = "PART_OverlayBox";
-        private const string PART_MetroDialogContainer = "PART_MetroDialogContainer";
+        private const string PART_MetroActiveDialogContainer = "PART_MetroActiveDialogContainer";
+        private const string PART_MetroInactiveDialogsContainer = "PART_MetroInactiveDialogsContainer";
         private const string PART_FlyoutModal = "PART_FlyoutModal";
 
         public static readonly DependencyProperty ShowIconOnTitleBarProperty = DependencyProperty.Register("ShowIconOnTitleBar", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true, OnShowIconOnTitleBarPropertyChangedCallback));
@@ -70,7 +72,7 @@ namespace MahApps.Metro.Controls
 
         public static readonly DependencyProperty IconTemplateProperty = DependencyProperty.Register("IconTemplate", typeof(DataTemplate), typeof(MetroWindow), new PropertyMetadata(null));
         public static readonly DependencyProperty TitleTemplateProperty = DependencyProperty.Register("TitleTemplate", typeof(DataTemplate), typeof(MetroWindow), new PropertyMetadata(null));
-        
+
         public static readonly DependencyProperty LeftWindowCommandsProperty = DependencyProperty.Register("LeftWindowCommands", typeof(WindowCommands), typeof(MetroWindow), new PropertyMetadata(null));
         public static readonly DependencyProperty RightWindowCommandsProperty = DependencyProperty.Register("RightWindowCommands", typeof(WindowCommands), typeof(MetroWindow), new PropertyMetadata(null));
 
@@ -82,7 +84,7 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty WindowMinButtonStyleProperty = DependencyProperty.Register("WindowMinButtonStyle", typeof(Style), typeof(MetroWindow), new PropertyMetadata(null));
         public static readonly DependencyProperty WindowMaxButtonStyleProperty = DependencyProperty.Register("WindowMaxButtonStyle", typeof(Style), typeof(MetroWindow), new PropertyMetadata(null));
         public static readonly DependencyProperty WindowCloseButtonStyleProperty = DependencyProperty.Register("WindowCloseButtonStyle", typeof(Style), typeof(MetroWindow), new PropertyMetadata(null));
-        
+
         public static readonly DependencyProperty UseNoneWindowStyleProperty = DependencyProperty.Register("UseNoneWindowStyle", typeof(bool), typeof(MetroWindow), new PropertyMetadata(false, OnUseNoneWindowStylePropertyChangedCallback));
         public static readonly DependencyProperty OverrideDefaultWindowCommandsBrushProperty = DependencyProperty.Register("OverrideDefaultWindowCommandsBrush", typeof(SolidColorBrush), typeof(MetroWindow));
 
@@ -96,16 +98,17 @@ namespace MahApps.Metro.Controls
         internal ContentPresenter LeftWindowCommandsPresenter;
         internal ContentPresenter RightWindowCommandsPresenter;
         internal WindowButtonCommands WindowButtonCommands;
-        
+
         internal Grid overlayBox;
-        internal Grid metroDialogContainer;
+        internal Grid metroActiveDialogContainer;
+        internal Grid metroInactiveDialogContainer;
         private Storyboard overlayStoryboard;
         Rectangle flyoutModal;
 
         public static readonly RoutedEvent FlyoutsStatusChangedEvent = EventManager.RegisterRoutedEvent(
             "FlyoutsStatusChanged", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(MetroWindow));
 
-        // Provide CLR accessors for the event 
+        // Provide CLR accessors for the event
         public event RoutedEventHandler FlyoutsStatusChanged
         {
             add { AddHandler(FlyoutsStatusChangedEvent, value); }
@@ -446,7 +449,7 @@ namespace MahApps.Metro.Controls
             get { return (bool)GetValue(IsMinButtonEnabledProperty); }
             set { SetValue(IsMinButtonEnabledProperty, value); }
         }
-        
+
         /// <summary>
         /// Gets/sets if the max/restore button is enabled.
         /// </summary>
@@ -502,7 +505,7 @@ namespace MahApps.Metro.Controls
                 this.icon.Visibility = iconVisibility;
             }
         }
-        
+
         private void SetVisibiltyForAllTitleElements(bool visible)
         {
             this.SetVisibiltyForIcon();
@@ -527,7 +530,7 @@ namespace MahApps.Metro.Controls
             }
             if (this.WindowButtonCommands != null)
             {
-                this.WindowButtonCommands.Visibility = this.WindowButtonCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) ? 
+                this.WindowButtonCommands.Visibility = this.WindowButtonCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) ?
                     Visibility.Visible : newVisibility;
             }
 
@@ -798,7 +801,7 @@ namespace MahApps.Metro.Controls
                 this.HandleWindowCommandsForFlyouts(flyouts);
             }
         }
-        
+
         private void FlyoutsPreviewMouseDown(object sender, MouseButtonEventArgs e)
         {
             var element = (e.OriginalSource as DependencyObject);
@@ -813,7 +816,7 @@ namespace MahApps.Metro.Controls
                     return;
                 }
             }
-            
+
             if (Flyouts.OverrideExternalCloseButton == null)
             {
                 foreach (var flyout in Flyouts.GetFlyouts().Where(x => x.IsOpen && x.ExternalCloseButton == e.ChangedButton && (!x.IsPinned || Flyouts.OverrideIsPinned)))
@@ -859,8 +862,9 @@ namespace MahApps.Metro.Controls
             }
 
             overlayBox = GetTemplateChild(PART_OverlayBox) as Grid;
-            metroDialogContainer = GetTemplateChild(PART_MetroDialogContainer) as Grid;
-            flyoutModal = (Rectangle) GetTemplateChild(PART_FlyoutModal);
+            metroActiveDialogContainer = GetTemplateChild(PART_MetroActiveDialogContainer) as Grid;
+            metroInactiveDialogContainer = GetTemplateChild(PART_MetroInactiveDialogsContainer) as Grid;
+            flyoutModal = (Rectangle)GetTemplateChild(PART_FlyoutModal);
             flyoutModal.PreviewMouseDown += FlyoutsPreviewMouseDown;
             this.PreviewMouseDown += FlyoutsPreviewMouseDown;
 
@@ -952,7 +956,7 @@ namespace MahApps.Metro.Controls
             if (e.ChangedButton == MouseButton.Left && !this.UseNoneWindowStyle)
             {
                 var mPoint = Mouse.GetPosition(this);
-                
+
                 if (IsWindowDraggable)
                 {
                     IntPtr windowHandle = new WindowInteropHelper(this).Handle;
@@ -1022,7 +1026,7 @@ namespace MahApps.Metro.Controls
 
             var hmenu = UnsafeNativeMethods.GetSystemMenu(hwnd, false);
 
-            var cmd = UnsafeNativeMethods.TrackPopupMenuEx(hmenu, Constants.TPM_LEFTBUTTON | Constants.TPM_RETURNCMD, 
+            var cmd = UnsafeNativeMethods.TrackPopupMenuEx(hmenu, Constants.TPM_LEFTBUTTON | Constants.TPM_RETURNCMD,
                 (int)physicalScreenLocation.X, (int)physicalScreenLocation.Y, hwnd, IntPtr.Zero);
             if (0 != cmd)
                 UnsafeNativeMethods.PostMessage(hwnd, Constants.SYSCOMMAND, new IntPtr(cmd), IntPtr.Zero);
@@ -1037,10 +1041,10 @@ namespace MahApps.Metro.Controls
                 var zIndex = flyout.IsOpen ? Panel.GetZIndex(flyout) + 3 : visibleFlyouts.Count() + 2;
 
                 // Note: ShowWindowCommandsOnTop is here for backwards compatibility reasons
-                //if the the corresponding behavior has the right flag, set the window commands' and icon zIndex to a number that is higher than the flyout's. 
+                //if the the corresponding behavior has the right flag, set the window commands' and icon zIndex to a number that is higher than the flyout's.
                 if (icon != null)
                 {
-                    icon.SetValue(Panel.ZIndexProperty, 
+                    icon.SetValue(Panel.ZIndexProperty,
                         this.IconOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.Flyouts) ? zIndex : 1);
                 }
 

--- a/MahApps.Metro/Styles/Clean/CleanWindow.xaml
+++ b/MahApps.Metro/Styles/Clean/CleanWindow.xaml
@@ -153,12 +153,21 @@
                                     Content="{Binding Flyouts, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                     VerticalAlignment="Stretch" />
 
-                    <!-- Used to create that overlay effect. Can be used for anything. -->
+                    <!-- Container for inactive dialogs. -->
                     <Grid Grid.Row="0"
                           Grid.Column="0"
                           Grid.ColumnSpan="5"
                           Grid.RowSpan="2"
                           Panel.ZIndex="3"
+                          FocusVisualStyle="{x:Null}"
+                          x:Name="PART_MetroInactiveDialogsContainer" />
+
+                    <!-- Used to create that overlay effect. Can be used for anything. -->
+                    <Grid Grid.Row="0"
+                          Grid.Column="0"
+                          Grid.ColumnSpan="5"
+                          Grid.RowSpan="2"
+                          Panel.ZIndex="4"
                           Focusable="False"
                           FocusVisualStyle="{x:Null}"
                           x:Name="PART_OverlayBox"
@@ -166,13 +175,14 @@
                           Opacity="0"
                           Visibility="Hidden" />
 
+                    <!-- Container for the active dialog. -->
                     <Grid Grid.Row="0"
                           Grid.Column="0"
                           Grid.ColumnSpan="5"
                           Grid.RowSpan="2"
-                          Panel.ZIndex="4"
+                          Panel.ZIndex="5"
                           FocusVisualStyle="{x:Null}"
-                          x:Name="PART_MetroDialogContainer" />
+                          x:Name="PART_MetroActiveDialogContainer" />
                 </Grid>
             </AdornerDecorator>
             <Border x:Name="PART_Border"
@@ -262,7 +272,7 @@
     <Style TargetType="{x:Type Controls:MetroWindow}"
            BasedOn="{StaticResource {x:Type Controls:MetroWindow}}"
            x:Key="CleanWindowStyleKey">
-        
+
         <Setter Property="ShowTitleBar"
                 Value="True" />
         <Setter Property="MinWidth"
@@ -279,7 +289,7 @@
                 Value="{DynamicResource CleanWindowButtonStyle}" />
         <Setter Property="WindowCloseButtonStyle"
                 Value="{DynamicResource CleanCloseWindowButtonStyle}" />
-        
+
     </Style>
 
     <Style x:Key="CleanWindowButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource MetroWindowButtonStyle}">
@@ -312,5 +322,5 @@
 
         </Style.Triggers>
     </Style>
-    
+
 </ResourceDictionary>

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -149,12 +149,21 @@
                                     Content="{Binding Flyouts, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                     VerticalAlignment="Stretch" />
 
-                    <!-- Used to create that overlay effect. Can be used for anything. -->
+                    <!-- Container for inactive dialogs. -->
                     <Grid Grid.Row="0"
                           Grid.Column="0"
                           Grid.ColumnSpan="5"
                           Grid.RowSpan="2"
                           Panel.ZIndex="3"
+                          FocusVisualStyle="{x:Null}"
+                          x:Name="PART_MetroInactiveDialogsContainer" />
+
+                    <!-- Used to create that overlay effect. Can be used for anything. -->
+                    <Grid Grid.Row="0"
+                          Grid.Column="0"
+                          Grid.ColumnSpan="5"
+                          Grid.RowSpan="2"
+                          Panel.ZIndex="4"
                           Focusable="False"
                           FocusVisualStyle="{x:Null}"
                           x:Name="PART_OverlayBox"
@@ -162,13 +171,14 @@
                           Opacity="0"
                           Visibility="Hidden" />
 
+                    <!-- Container for the active dialog. -->
                     <Grid Grid.Row="0"
                           Grid.Column="0"
                           Grid.ColumnSpan="5"
                           Grid.RowSpan="2"
-                          Panel.ZIndex="4"
+                          Panel.ZIndex="5"
                           FocusVisualStyle="{x:Null}"
-                          x:Name="PART_MetroDialogContainer" />
+                          x:Name="PART_MetroActiveDialogContainer" />
                 </Grid>
             </AdornerDecorator>
 

--- a/docs/release-notes/1.2.0.md
+++ b/docs/release-notes/1.2.0.md
@@ -61,6 +61,7 @@ This is a bug fix and feature release of MahApps.Metro v1.2.0.
 		- Styling fixes (margin, padding, border thickness)
 		- New `PreserveTextCase` attached property.
 		- Better handling with `BorderThickness` property.
+- Support for multiple dialogs #1974
 
 # Bugfixes
 

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -67,9 +67,9 @@
             </Style>
 
             <Dialog:CustomDialog x:Key="CustomDialogTest"
-                                 Title="This dialog allows arbitrary content. It will close in 5 seconds."
+                                 Title="This dialog allows arbitrary content."
                                  x:Name="CustomTestDialog">
-                <TextBlock Height="30" Text="{Binding Artists[0].Name}" Foreground="{DynamicResource AccentColorBrush}" />
+                <TextBlock Height="200" x:Name="MessageTextBlock" Text="{Binding Artists[0].Name}" Foreground="{DynamicResource AccentColorBrush}" />
             </Dialog:CustomDialog>
 
             <Dialog:CustomDialog x:Key="CustomCloseDialogTest"

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -19,7 +19,7 @@ namespace MetroDemo
         {
             _viewModel = new MainWindowViewModel(DialogCoordinator.Instance);
             DataContext = _viewModel;
-            
+
             InitializeComponent();
 
             flyoutDemo = new FlyoutDemo();
@@ -200,7 +200,15 @@ namespace MetroDemo
 
             await this.ShowMetroDialogAsync(dialog);
 
+            var textBlock = dialog.FindChild<TextBlock>("MessageTextBlock");
+            textBlock.Text = "A message box will appear in 5 seconds.";
+
             await TaskEx.Delay(5000);
+
+            await this.ShowMessageAsync("Secondary dialog", "This message is shown on top of another.");
+
+            textBlock.Text = "The dialog will close in 2 seconds.";
+            await TaskEx.Delay(2000);
 
             await this.HideMetroDialogAsync(dialog);
         }


### PR DESCRIPTION
This PR adds support for multiple dialogs at once as requested in #1974. There can only be one active dialog, and there's no support for switching between dialogs. It's like a stack of dialogs.

I hope the changes are self-explanatory.

However, there's one breaking change: previously the `MetroWindow`'s template contained a part named `PART_MetroDialogContainer`, now there are two parts named `PART_MetroActiveDialogContainer` and `PART_MetroInactiveDialogsContainer`. When someone has created his own style for `MetroWindow` it will break.