### PR TITLE
MetroProgressBar System.Windows.Media.Animation warning fix

### DIFF
--- a/MahApps.Metro/Controls/MetroProgressBar.cs
+++ b/MahApps.Metro/Controls/MetroProgressBar.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -21,6 +20,7 @@ namespace MahApps.Metro.Controls
             DependencyProperty.Register("EllipseOffset", typeof(double), typeof(MetroProgressBar),
                                         new PropertyMetadata(default(double)));
 
+        private readonly object lockme = new object();
         private Storyboard indeterminateStoryboard;
 
         static MetroProgressBar()
@@ -29,35 +29,38 @@ namespace MahApps.Metro.Controls
             IsIndeterminateProperty.OverrideMetadata(typeof(MetroProgressBar), new FrameworkPropertyMetadata(OnIsIndeterminateChanged));
         }
 
-        public MetroProgressBar()
-        {
-            SizeChanged += SizeChangedHandler;
-            IsVisibleChanged += VisibleChangedHandler;
-        }
-
-        void VisibleChangedHandler(object sender, DependencyPropertyChangedEventArgs e)
+        private void VisibleChangedHandler(object sender, DependencyPropertyChangedEventArgs e)
         {
             //reset Storyboard if Visibility is set to Visible #1300
-            if (e.NewValue is bool && (bool)e.NewValue)
+            if (IsIndeterminate)
             {
-                ResetStoryboard(ActualWidth);
+                ToggleIndeterminate(this, (bool)e.OldValue, (bool)e.NewValue);
             }
         }
 
         private static void OnIsIndeterminateChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
-            var bar = dependencyObject as MetroProgressBar;
-            if (bar != null && e.NewValue != e.OldValue)
+            ToggleIndeterminate(dependencyObject as MetroProgressBar, (bool)e.OldValue, (bool)e.NewValue);
+        }
+
+        private static void ToggleIndeterminate(MetroProgressBar bar, bool oldValue, bool newValue)
+        {
+            if (bar != null && newValue != oldValue)
             {
                 var indeterminateState = bar.GetIndeterminate();
                 var containingObject = bar.GetTemplateChild("ContainingGrid") as FrameworkElement;
                 if (indeterminateState != null && containingObject != null)
                 {
-                    if (indeterminateState.Storyboard != null)
+                    if (oldValue && indeterminateState.Storyboard != null)
                     {
+                        // remove the previous storyboard from the Grid #1855
                         indeterminateState.Storyboard.Stop(containingObject);
+                        indeterminateState.Storyboard.Remove(containingObject);
                     }
-                    bar.ResetStoryboard(bar.ActualWidth);
+                    if (newValue)
+                    {
+                        bar.ResetStoryboard(bar.ActualWidth, false);
+                    }
                 }
             }
         }
@@ -82,37 +85,41 @@ namespace MahApps.Metro.Controls
 
         private void SizeChangedHandler(object sender, SizeChangedEventArgs e)
         {
-            double actualWidth = ActualWidth;
-            MetroProgressBar bar = this;
-            if (this.Visibility == Visibility.Visible)
+            var actualWidth = ActualWidth;
+            var bar = this;
+            if (this.Visibility == Visibility.Visible && this.IsIndeterminate)
             {
-                bar.ResetStoryboard(actualWidth);
+                bar.ResetStoryboard(actualWidth, true);
             }
         }
 
-        private void ResetStoryboard(double width)
+        private void ResetStoryboard(double width, bool removeOldStoryboard)
         {
-            lock (this)
+            if (!this.IsIndeterminate)
+            {
+                return;
+            }
+            lock (this.lockme)
             {
                 //perform calculations
-                double containerAnimStart = CalcContainerAnimStart(width);
-                double containerAnimEnd = CalcContainerAnimEnd(width);
-                double ellipseAnimWell = CalcEllipseAnimWell(width);
-                double ellipseAnimEnd = CalcEllipseAnimEnd(width);
+                var containerAnimStart = CalcContainerAnimStart(width);
+                var containerAnimEnd = CalcContainerAnimEnd(width);
+                var ellipseAnimWell = CalcEllipseAnimWell(width);
+                var ellipseAnimEnd = CalcEllipseAnimEnd(width);
                 //reset the main double animation
                 try
                 {
-                    VisualState indeterminate = GetIndeterminate();
+                    var indeterminate = GetIndeterminate();
 
                     if (indeterminate != null && this.indeterminateStoryboard != null)
                     {
-                        Storyboard newStoryboard = this.indeterminateStoryboard.Clone();
-                        Timeline doubleAnim = newStoryboard.Children.First(t => t.Name == "MainDoubleAnim");
+                        var newStoryboard = this.indeterminateStoryboard.Clone();
+                        var doubleAnim = newStoryboard.Children.First(t => t.Name == "MainDoubleAnim");
                         doubleAnim.SetValue(DoubleAnimation.FromProperty, containerAnimStart);
                         doubleAnim.SetValue(DoubleAnimation.ToProperty, containerAnimEnd);
 
                         var namesOfElements = new[] { "E1", "E2", "E3", "E4", "E5" };
-                        foreach (string elemName in namesOfElements)
+                        foreach (var elemName in namesOfElements)
                         {
                             var doubleAnimParent = (DoubleAnimationUsingKeyFrames)newStoryboard.Children.First(t => t.Name == elemName + "Anim");
                             DoubleKeyFrame first, second, third;
@@ -142,7 +149,7 @@ namespace MahApps.Metro.Controls
 
                         var containingGrid = (FrameworkElement)GetTemplateChild("ContainingGrid");
 
-                        if (indeterminate.Storyboard != null)
+                        if (removeOldStoryboard && indeterminate.Storyboard != null)
                         {
                             // remove the previous storyboard from the Grid #1855
                             indeterminate.Storyboard.Stop(containingGrid);
@@ -150,11 +157,6 @@ namespace MahApps.Metro.Controls
                         }
 
                         indeterminate.Storyboard = newStoryboard;
-
-                        if (!IsIndeterminate)
-                        {
-                            return;
-                        }
 
                         if (indeterminate.Storyboard != null)
                         {
@@ -176,14 +178,13 @@ namespace MahApps.Metro.Controls
             {
                 return null;
             }
-            IList groups = VisualStateManager.GetVisualStateGroups(templateGrid);
+            var groups = VisualStateManager.GetVisualStateGroups(templateGrid);
             return groups != null
-                       ? groups.Cast<VisualStateGroup>()
-                               .SelectMany(@group => @group.States.Cast<VisualState>())
-                               .FirstOrDefault(state => state.Name == "Indeterminate")
-                       : null;
+                ? groups.Cast<VisualStateGroup>()
+                        .SelectMany(@group => @group.States.Cast<VisualState>())
+                        .FirstOrDefault(state => state.Name == "Indeterminate")
+                : null;
         }
-
 
         private void SetEllipseDiameter(double width)
         {
@@ -220,20 +221,28 @@ namespace MahApps.Metro.Controls
         private double CalcContainerAnimStart(double width)
         {
             if (width <= 180)
+            {
                 return -34;
+            }
             if (width <= 280)
+            {
                 return -50.5;
+            }
 
             return -63;
         }
 
         private double CalcContainerAnimEnd(double width)
         {
-            double firstPart = 0.4352 * width;
+            var firstPart = 0.4352 * width;
             if (width <= 180)
+            {
                 return firstPart - 25.731;
+            }
             if (width <= 280)
+            {
                 return firstPart + 27.84;
+            }
 
             return firstPart + 58.862;
         }
@@ -248,12 +257,25 @@ namespace MahApps.Metro.Controls
             return width * 2.0 / 3.0;
         }
 
-
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
-            indeterminateStoryboard = this.TryFindResource("IndeterminateStoryboard") as Storyboard;
+
+            lock (this.lockme)
+            {
+                this.indeterminateStoryboard = this.TryFindResource("IndeterminateStoryboard") as Storyboard;
+            }
+
+            Loaded -= LoadedHandler;
+            Loaded += LoadedHandler;
+        }
+
+        private void LoadedHandler(object sender, RoutedEventArgs routedEventArgs)
+        {
+            Loaded -= LoadedHandler;
             SizeChangedHandler(null, null);
+            SizeChanged += SizeChangedHandler;
+            IsVisibleChanged += VisibleChangedHandler;
         }
 
         protected override void OnInitialized(EventArgs e)
@@ -263,9 +285,13 @@ namespace MahApps.Metro.Controls
             // Update the Ellipse properties to their default values
             // only if they haven't been user-set.
             if (EllipseDiameter.Equals(0))
+            {
                 SetEllipseDiameter(ActualWidth);
+            }
             if (EllipseOffset.Equals(0))
+            {
                 SetEllipseOffset(ActualWidth);
+            }
         }
     }
 }

--- a/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/DataGridExamples.xaml
@@ -194,8 +194,10 @@
                 </Style>
             </DataGrid.RowStyle>
             <DataGrid.RowValidationRules>
-                <ValueConverter:AlbumPriceIsReallyTooMuchValidation ValidatesOnTargetUpdated="True" ValidationStep="CommittedValue" />
-                <ValueConverter:AlbumPriceIsReallyTooMuchValidation ValidatesOnTargetUpdated="True" ValidationStep="UpdatedValue" />
+                <ValueConverter:AlbumPriceIsReallyTooMuchValidation ValidatesOnTargetUpdated="True"
+                                                                    ValidationStep="CommittedValue" />
+                <ValueConverter:AlbumPriceIsReallyTooMuchValidation ValidatesOnTargetUpdated="True"
+                                                                    ValidationStep="UpdatedValue" />
             </DataGrid.RowValidationRules>
         </DataGrid>
 
@@ -226,10 +228,21 @@
                                     Binding="{Binding Artist.Name}" />
                 <DataGridTextColumn Header="Genre"
                                     Binding="{Binding Genre.Name}" />
-                <controls:DataGridNumericUpDownColumn Header="Price"
-                                                      Binding="{Binding Price}"
-                                                      StringFormat="C"
-                                                      Minimum="0" />
+                <DataGridTemplateColumn Header="Price">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <controls:MetroProgressBar x:Name="PriceProgressBar"
+                                                       Value="{Binding Price}"
+                                                       Minimum="0"
+                                                       Maximum="20"
+                                                       Foreground="{DynamicResource AccentColorBrush}"
+                                                       Background="Transparent"
+                                                       VerticalAlignment="Center"
+                                                       Height="20"
+                                                       Margin="5 2" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
 

--- a/samples/MetroDemo/ExampleViews/SliderProgressExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/SliderProgressExamples.xaml
@@ -108,7 +108,9 @@
                                       SmallChange="0.1"
                                       LowerValue="-70"
                                       UpperValue="60" />
-                <StackPanel Orientation="Vertical" Margin="5, 0, 0, 0" Width="228">
+                <StackPanel Orientation="Vertical"
+                            Margin="5, 0, 0, 0"
+                            Width="228">
 
                     <Controls:RangeSlider Orientation="Horizontal"
                                           MinRangeWidth="20"
@@ -149,12 +151,10 @@
                                           Maximum="610"
                                           Margin="0,0,0,20" />
 
-                    <Controls:RangeSlider
-                                          TickPlacement="Both"
+                    <Controls:RangeSlider TickPlacement="Both"
                                           IsEnabled="False"
                                           Margin="0,0,0,20" />
-                    <Controls:RangeSlider
-                                          Height="20"
+                    <Controls:RangeSlider Height="20"
                                           IsEnabled="False"
                                           LowerValue="20"
                                           UpperValue="60"
@@ -189,8 +189,15 @@
                                        Width="200"
                                        Foreground="{DynamicResource AccentColorBrush}"
                                        Margin="0, 10, 0, 0" />
-            <Controls:MetroProgressBar IsIndeterminate="True"
+            <CheckBox Margin="0, 10, 0, 0"
+                      Width="200"
+                      Content="IsIndeterminate"
+                      Visibility="{Binding MagicToggleButtonIsChecked, Converter={StaticResource BoolToVisibilityConverter}, UpdateSourceTrigger=PropertyChanged}"
+                      IsChecked="{Binding ElementName=IsIndeterminatePB, Path=IsIndeterminate, UpdateSourceTrigger=PropertyChanged}" />
+            <Controls:MetroProgressBar x:Name="IsIndeterminatePB"
+                                       IsIndeterminate="True"
                                        Value="{Binding ElementName=horizSlider, Path=Value}"
+                                       Visibility="{Binding MagicToggleButtonIsChecked, Converter={StaticResource BoolToVisibilityConverter}, UpdateSourceTrigger=PropertyChanged}"
                                        Minimum="0"
                                        Maximum="100"
                                        Width="200"


### PR DESCRIPTION
this PR fix this two possible animation warnings, so a DataGrid with a `MetroProgressBar` should now be faster!

```
System.Windows.Media.Animation Warning: 6 : Unable to perform action because the specified Storyboard was never applied to this object for interactive control.; Action='Stop'; Storyboard='System.Windows.Media.Animation.Storyboard'; Storyboard.HashCode='39750236'; Storyboard.Type='System.Windows.Media.Animation.Storyboard'; TargetElement='System.Windows.Controls.Grid'; TargetElement.HashCode='19146950'; TargetElement.Type='System.Windows.Controls.Grid'
```
```
System.Windows.Media.Animation Warning: 6 : Unable to perform action because the specified Storyboard was never applied to this object for interactive control.; Action='Remove'; Storyboard='System.Windows.Media.Animation.Storyboard'; Storyboard.HashCode='39750236'; Storyboard.Type='System.Windows.Media.Animation.Storyboard'; TargetElement='System.Windows.Controls.Grid'; TargetElement.HashCode='19146950'; TargetElement.Type='System.Windows.Controls.Grid'
```