### PR TITLE
[RFC] Support for CancellationToken to cancel dialogs

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -9,7 +10,7 @@ namespace MahApps.Metro.Controls.Dialogs
     /// <summary>
     /// The base class for dialogs.
     ///
-    /// You probably don't want to use this class, if you want to add arbitrary content to your dialog, 
+    /// You probably don't want to use this class, if you want to add arbitrary content to your dialog,
     /// use the <see cref="CustomDialog"/> class.
     /// </summary>
     public abstract class BaseMetroDialog : ContentControl
@@ -105,12 +106,12 @@ namespace MahApps.Metro.Controls.Dialogs
             if (DialogSettings != null)
             {
                 var windowTheme = DetectTheme(this);
-                
+
                 if (System.ComponentModel.DesignerProperties.GetIsInDesignMode(this) && windowTheme == null)
                 {
                     return;
                 }
-                
+
                 var theme = windowTheme.Item1;
                 var windowAccent = windowTheme.Item2;
 
@@ -315,6 +316,8 @@ namespace MahApps.Metro.Controls.Dialogs
             MaximumBodyHeight = Double.NaN;
 
             DefaultText = "";
+
+            CancellationToken = CancellationToken.None;
         }
 
         /// <summary>
@@ -356,6 +359,11 @@ namespace MahApps.Metro.Controls.Dialogs
         /// Gets/sets the maximum height. (Default is unlimited height, <a href="http://msdn.microsoft.com/de-de/library/system.double.nan">Double.NaN</a>)
         /// </summary>
         public double MaximumBodyHeight { get; set; }
+
+        /// <summary>
+        /// Gets/sets the token to cancel the dialog.
+        /// </summary>
+        public CancellationToken CancellationToken { get; set; }
     }
 
     /// <summary>

--- a/MahApps.Metro/Controls/Dialogs/InputDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/InputDialog.cs
@@ -35,7 +35,15 @@ namespace MahApps.Metro.Controls.Dialogs
 
             KeyEventHandler escapeKeyHandler = null;
 
-            Action cleanUpHandlers = () =>
+            Action cleanUpHandlers = null;
+
+            var cancellationTokenRegistration = DialogSettings.CancellationToken.Register(() =>
+            {
+                cleanUpHandlers();
+                tcs.TrySetResult(null);
+            });
+
+            cleanUpHandlers = () =>
             {
                 PART_TextBox.KeyDown -= affirmativeKeyHandler;
 
@@ -46,6 +54,8 @@ namespace MahApps.Metro.Controls.Dialogs
 
                 PART_NegativeButton.KeyDown -= negativeKeyHandler;
                 PART_AffirmativeButton.KeyDown -= affirmativeKeyHandler;
+
+                cancellationTokenRegistration.Dispose();
             };
 
             escapeKeyHandler = (sender, e) =>

--- a/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
@@ -68,7 +68,7 @@ namespace MahApps.Metro.Controls.Dialogs
 
         internal Task<LoginDialogData> WaitForButtonPressAsync()
         {
-            Dispatcher.BeginInvoke(new Action(() => 
+            Dispatcher.BeginInvoke(new Action(() =>
             {
                 this.Focus();
                 if (string.IsNullOrEmpty(PART_TextBox.Text))
@@ -91,7 +91,15 @@ namespace MahApps.Metro.Controls.Dialogs
 
             KeyEventHandler escapeKeyHandler = null;
 
-            Action cleanUpHandlers = () => {
+            Action cleanUpHandlers = null;
+
+            var cancellationTokenRegistration = DialogSettings.CancellationToken.Register(() =>
+            {
+                cleanUpHandlers();
+                tcs.TrySetResult(null);
+            });
+
+            cleanUpHandlers = () => {
                 PART_TextBox.KeyDown -= affirmativeKeyHandler;
                 PART_TextBox2.KeyDown -= affirmativeKeyHandler;
 
@@ -102,9 +110,11 @@ namespace MahApps.Metro.Controls.Dialogs
 
                 PART_NegativeButton.KeyDown -= negativeKeyHandler;
                 PART_AffirmativeButton.KeyDown -= affirmativeKeyHandler;
+
+                cancellationTokenRegistration.Dispose();
             };
 
-            escapeKeyHandler = (sender, e) => 
+            escapeKeyHandler = (sender, e) =>
             {
                 if (e.Key == Key.Escape)
                 {
@@ -114,7 +124,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 }
             };
 
-            negativeKeyHandler = (sender, e) => 
+            negativeKeyHandler = (sender, e) =>
             {
                 if (e.Key == Key.Enter)
                 {
@@ -124,7 +134,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 }
             };
 
-            affirmativeKeyHandler = (sender, e) => 
+            affirmativeKeyHandler = (sender, e) =>
             {
                 if (e.Key == Key.Enter)
                 {
@@ -133,7 +143,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 }
             };
 
-            negativeHandler = (sender, e) => 
+            negativeHandler = (sender, e) =>
             {
                 cleanUpHandlers();
 
@@ -142,7 +152,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 e.Handled = true;
             };
 
-            affirmativeHandler = (sender, e) => 
+            affirmativeHandler = (sender, e) =>
             {
                 cleanUpHandlers();
 

--- a/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -58,7 +59,15 @@ namespace MahApps.Metro.Controls.Dialogs
 
             KeyEventHandler escapeKeyHandler = null;
 
-            Action cleanUpHandlers = () => {
+            Action cleanUpHandlers = null;
+
+            var cancellationTokenRegistration = DialogSettings.CancellationToken.Register(() =>
+            {
+                cleanUpHandlers();
+                tcs.TrySetResult(ButtonStyle == MessageDialogStyle.Affirmative ? MessageDialogResult.Affirmative : MessageDialogResult.Negative);
+            });
+
+            cleanUpHandlers = () => {
                 PART_NegativeButton.Click -= negativeHandler;
                 PART_AffirmativeButton.Click -= affirmativeHandler;
                 PART_FirstAuxiliaryButton.Click -= firstAuxHandler;
@@ -70,6 +79,8 @@ namespace MahApps.Metro.Controls.Dialogs
                 PART_SecondAuxiliaryButton.KeyDown -= secondAuxKeyHandler;
 
                 KeyDown -= escapeKeyHandler;
+
+                cancellationTokenRegistration.Dispose();
             };
 
             negativeKeyHandler = (sender, e) => {

--- a/MahApps.Metro/Controls/Dialogs/ProgressDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/ProgressDialog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Windows;
 using System.Windows.Media;
 
@@ -62,6 +63,11 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             get { return (Brush)GetValue(ProgressBarForegroundProperty); }
             set { SetValue(ProgressBarForegroundProperty, value); }
+        }
+
+        internal CancellationToken CancellationToken
+        {
+            get { return DialogSettings.CancellationToken; }
         }
     }
 }

--- a/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
+++ b/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
@@ -27,6 +27,11 @@ namespace MahApps.Metro.Controls.Dialogs
             WrappedDialog.PART_NegativeButton.Dispatcher.Invoke(new Action(() => {
                 WrappedDialog.PART_NegativeButton.Click += PART_NegativeButton_Click;
             }));
+
+            dialog.CancellationToken.Register(() =>
+            {
+                PART_NegativeButton_Click(null, new RoutedEventArgs());
+            });
         }
 
         private void PART_NegativeButton_Click(object sender, RoutedEventArgs e)
@@ -76,18 +81,18 @@ namespace MahApps.Metro.Controls.Dialogs
             this.InvokeAction(action);
         }
 
-        /// <summary> 
+        /// <summary>
         ///  Gets/Sets the minimum restriction of the progress Value property
-        /// </summary> 
+        /// </summary>
         public double Minimum
         {
             get { return this.InvokeFunc(() => WrappedDialog.PART_ProgressBar.Minimum); }
             set { this.InvokeAction(() => WrappedDialog.PART_ProgressBar.Minimum = value); }
         }
 
-        /// <summary> 
+        /// <summary>
         ///  Gets/Sets the maximum restriction of the progress Value property
-        /// </summary> 
+        /// </summary>
         public double Maximum
         {
             get { return this.InvokeFunc(() => WrappedDialog.PART_ProgressBar.Maximum); }


### PR DESCRIPTION
As a possible solution for #2018 I implemented support for `CancellationToken` to cancel dialogs.

I added a `CancellationToken` to `MetroDialogSettings` and the handling of that token to `InputDialog`, `LoginDialog`, `MessageDialog`, and `ProgressDialog`. `ProgressDialog`'s implementation is different from the others in that it only sets `ProgressDialogManager.IsCanceled` to `true`. 

Of course, users of MahApps.Metro deriving their dialogs from `BaseMetroDialog` have to implement their own handling of the cancellation.

### Usage
```c#
var cancellationTokenSource = new CancellationTokenSource();

var mySettings = new MetroDialogSettings()
{
    // ...
    CancellationToken = cancellationTokenSource.Token
};
```

Here's an example using a timer to cancel the message box (by calling `cancellationTokenSource.Cancel()`) after 10 seconds:
```c#
DispatcherTimer timer = null;
timer = new DispatcherTimer(
    TimeSpan.FromSeconds(10),
    DispatcherPriority.DataBind,
    (o, args) => {
        timer.Stop();
        cancellationTokenSource.Cancel();
    },
    Dispatcher
    );
timer.Start();

MessageDialogResult result = await this.ShowMessageAsync("Hello", "Welcome to metro!",
    MessageDialogStyle.AffirmativeAndNegative, mySettings);
```