### PR TITLE
MetroDialogs fixes

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -156,6 +156,11 @@ namespace MahApps.Metro.Controls.Dialogs
             if (this.ParentDialogWindow != null)
             {
                 this.ParentDialogWindow.SetValue(BackgroundProperty, this.Background);
+                var glowBrush = ThemeManager.GetResourceFromAppStyle(this.OwningWindow ?? Application.Current.MainWindow, "AccentColorBrush");
+                if (glowBrush != null)
+                {
+                    this.ParentDialogWindow.SetValue(MetroWindow.GlowBrushProperty, glowBrush);
+                }
             }
         }
 

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -482,13 +482,15 @@ namespace MahApps.Metro.Controls.Dialogs
                 WindowStartupLocation = WindowStartupLocation.CenterScreen,
                 ShowTitleBar = false,
                 ShowCloseButton = false,
-                WindowTransitionsEnabled = false,
-                Background = dialog.Background
+                WindowTransitionsEnabled = false
             };
 
             try
             {
-                win.GlowBrush = win.TryFindResource("AccentColorBrush") as SolidColorBrush;
+                win.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml") });
+                win.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml") });
+                win.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml") });
+                win.SetResourceReference(MetroWindow.GlowBrushProperty, "AccentColorBrush");
             }
             catch (Exception) { }
 

--- a/MahApps.Metro/Controls/Dialogs/InputDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/InputDialog.cs
@@ -119,7 +119,7 @@ namespace MahApps.Metro.Controls.Dialogs
             return tcs.Task;
         }
 
-        private void Dialog_Loaded(object sender, RoutedEventArgs e)
+        protected override void OnLoaded()
         {
             this.AffirmativeButtonText = this.DialogSettings.AffirmativeButtonText;
             this.NegativeButtonText = this.DialogSettings.NegativeButtonText;
@@ -129,6 +129,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 case MetroDialogColorScheme.Accented:
                     this.PART_NegativeButton.Style = this.FindResource("AccentedDialogHighlightedSquareButton") as Style;
                     PART_TextBox.SetResourceReference(ForegroundProperty, "BlackColorBrush");
+                    PART_TextBox.SetResourceReference(ControlsHelper.FocusBorderBrushProperty, "TextBoxFocusBorderBrush");
                     break;
             }
         }

--- a/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
@@ -56,14 +56,6 @@ namespace MahApps.Metro.Controls.Dialogs
             UsernameWatermark = settings.UsernameWatermark;
             PasswordWatermark = settings.PasswordWatermark;
             NegativeButtonButtonVisibility = settings.NegativeButtonVisibility;
-            if (settings.EnablePasswordPreview)
-            {
-                object resource = Application.Current.FindResource("Win8MetroPasswordBox");
-                if (resource != null && resource.GetType() == typeof(Style))
-                {
-                    PART_TextBox2.Style = (Style)resource;
-                }
-            }
         }
 
         internal Task<LoginDialogData> WaitForButtonPressAsync()
@@ -175,8 +167,18 @@ namespace MahApps.Metro.Controls.Dialogs
             return tcs.Task;
         }
 
-        private void Dialog_Loaded(object sender, RoutedEventArgs e)
+        protected override void OnLoaded()
         {
+            var settings = this.DialogSettings as LoginDialogSettings;
+            if (settings != null && settings.EnablePasswordPreview)
+            {
+                var win8MetroPasswordStyle = this.FindResource("Win8MetroPasswordBox") as Style;
+                if (win8MetroPasswordStyle != null)
+                {
+                    PART_TextBox2.Style = win8MetroPasswordStyle;
+                }
+            }
+
             this.AffirmativeButtonText = this.DialogSettings.AffirmativeButtonText;
             this.NegativeButtonText = this.DialogSettings.NegativeButtonText;
 

--- a/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
@@ -242,7 +242,7 @@ namespace MahApps.Metro.Controls.Dialogs
             }
         }
 
-        private void Dialog_Loaded(object sender, RoutedEventArgs e)
+        protected override void OnLoaded()
         {
             SetButtonState(this);
         }

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -13,34 +13,6 @@
     <Converters:StringToVisibilityConverter x:Key="StringToVisibilityConverter" />
     <Converters:StringToVisibilityConverter x:Key="StringToOppositeVisibilityConverter" OppositeStringValue="True" />
 
-    <!--Button Style for Win8MetroPasswordBox-->
-    <Style x:Key="RevealButtonStyle" TargetType="{x:Type Button}">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid>
-                        <Border x:Name="PasswordRevealIconEyeBorder" Background="Transparent" Margin="1,1,3,1" BorderThickness="{TemplateBinding BorderThickness}">
-                            <Rectangle Width="20" Height="15" x:Name="IconEye" VerticalAlignment="Center" Margin="3,0" HorizontalAlignment="Center" Fill="{Binding Path=Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Button}}}">
-                                <Rectangle.OpacityMask>
-                                    <VisualBrush Stretch="Fill" Visual="{DynamicResource RevealButtonIcon}" />
-                                </Rectangle.OpacityMask>
-                            </Rectangle>
-                        </Border>
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <DataTrigger Binding="{Binding ElementName=PasswordRevealIconEyeBorder, Path=IsMouseOver}" Value="True">
-                            <Setter TargetName="PasswordRevealIconEyeBorder" Property="Background" Value="Gainsboro" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True">
-                            <Setter TargetName="PasswordRevealIconEyeBorder" Property="Background" Value="Black" />
-                            <Setter TargetName="IconEye" Property="Fill" Value="White" />
-                        </DataTrigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
     <Grid x:Key="RevealButtonIcon"
           x:Shared="False"
           Background="{DynamicResource BlackBrush}"
@@ -52,13 +24,44 @@
                 <VisualBrush.Visual>
                     <Canvas Height="25.8461"
                             Width="42">
-                        <Path Canvas.Left="17" Canvas.Top="25.0769" Stretch="Fill" Data="F1 M 38,33.1538C 40.6765,33.1538 42.8462,35.3235 42.8462,38C 42.8462,40.6765 40.6765,42.8461 38,42.8461C 35.3235,42.8461 33.1539,40.6765 33.1539,38C 33.1539,35.3235 35.3236,33.1538 38,33.1538 Z M 38,25.0769C 49.3077,25.0769 59,33.1538 59,38C 59,42.8461 49.3077,50.9231 38,50.9231C 26.6923,50.9231 17,42.8461 17,38C 17,33.1538 26.6923,25.0769 38,25.0769 Z M 38,29.1154C 33.0932,29.1154 29.1154,33.0932 29.1154,38C 29.1154,42.9068 33.0932,46.8846 38,46.8846C 42.9068,46.8846 46.8846,42.9068 46.8846,38C 46.8846,33.0932 42.9068,29.1154 38,29.1154 Z "
+                        <Path Canvas.Left="17"
+                              Canvas.Top="25.0769"
+                              Stretch="Fill"
+                              Data="F1 M 38,33.1538C 40.6765,33.1538 42.8462,35.3235 42.8462,38C 42.8462,40.6765 40.6765,42.8461 38,42.8461C 35.3235,42.8461 33.1539,40.6765 33.1539,38C 33.1539,35.3235 35.3236,33.1538 38,33.1538 Z M 38,25.0769C 49.3077,25.0769 59,33.1538 59,38C 59,42.8461 49.3077,50.9231 38,50.9231C 26.6923,50.9231 17,42.8461 17,38C 17,33.1538 26.6923,25.0769 38,25.0769 Z M 38,29.1154C 33.0932,29.1154 29.1154,33.0932 29.1154,38C 29.1154,42.9068 33.0932,46.8846 38,46.8846C 42.9068,46.8846 46.8846,42.9068 46.8846,38C 46.8846,33.0932 42.9068,29.1154 38,29.1154 Z "
                               Fill="Black" />
                     </Canvas>
                 </VisualBrush.Visual>
             </VisualBrush>
         </Grid.OpacityMask>
     </Grid>
+
+    <!--Button Style for Win8MetroPasswordBox-->
+    <Style x:Key="RevealButtonStyle" TargetType="{x:Type Button}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Grid>
+                        <Border x:Name="PasswordRevealIconEyeBorder" Background="Transparent" Margin="1,1,3,1" BorderThickness="{TemplateBinding BorderThickness}">
+                            <Rectangle Width="20" Height="15" x:Name="IconEye" VerticalAlignment="Center" Margin="3,0" HorizontalAlignment="Center" Fill="{Binding Path=Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Button}}}">
+                                <Rectangle.OpacityMask>
+                                    <VisualBrush Stretch="Fill" Visual="{StaticResource RevealButtonIcon}" />
+                                </Rectangle.OpacityMask>
+                            </Rectangle>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding ElementName=PasswordRevealIconEyeBorder, Path=IsMouseOver}" Value="True">
+                            <Setter TargetName="PasswordRevealIconEyeBorder" Property="Background" Value="Gainsboro" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True">
+                            <Setter TargetName="PasswordRevealIconEyeBorder" Property="Background" Value="{DynamicResource BlackBrush}" />
+                            <Setter TargetName="IconEye" Property="Fill" Value="{DynamicResource WhiteBrush}" />
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 
     <!--Win8MetroPasswordBox Style-->
     <Style TargetType="{x:Type PasswordBox}" x:Key="Win8MetroPasswordBox">

--- a/MahApps.Metro/ThemeManager.cs
+++ b/MahApps.Metro/ThemeManager.cs
@@ -422,6 +422,28 @@ namespace MahApps.Metro
         }
 
         /// <summary>
+        /// Copies all resource keys from one resource to another.
+        /// </summary>
+        /// <param name="fromRD">The source resource dictionary.</param>
+        /// <param name="toRD">The destination resource dictionary.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// fromRD
+        /// or
+        /// toRD
+        /// </exception>
+        internal static void CopyResource(ResourceDictionary fromRD, ResourceDictionary toRD)
+        {
+            if (fromRD == null) throw new ArgumentNullException("fromRD");
+            if (toRD == null) throw new ArgumentNullException("toRD");
+
+            ApplyResourceDictionary(fromRD, toRD);
+            foreach (var rd in fromRD.MergedDictionaries)
+            {
+                CopyResource(rd, toRD);
+            }
+        }
+
+        /// <summary>
         /// Scans the window resources and returns it's accent and theme.
         /// </summary>
         public static Tuple<AppTheme, Accent> DetectAppStyle()

--- a/MahApps.Metro/Themes/Dialogs/InputDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/InputDialog.xaml
@@ -2,8 +2,7 @@
                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                          xmlns:Dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs"
                          xmlns:controls="clr-namespace:MahApps.Metro.Controls"
-                         x:Class="MahApps.Metro.Controls.Dialogs.InputDialog"
-                         Loaded="Dialog_Loaded">
+                         x:Class="MahApps.Metro.Controls.Dialogs.InputDialog">
     <Grid Margin="0 10 0 0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"

--- a/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
@@ -3,8 +3,7 @@
                          xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
                          xmlns:Dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs"
                          xmlns:Behaviors="clr-namespace:MahApps.Metro.Behaviours"
-                         x:Class="MahApps.Metro.Controls.Dialogs.LoginDialog"
-                         Loaded="Dialog_Loaded">
+                         x:Class="MahApps.Metro.Controls.Dialogs.LoginDialog">
     <Grid Margin="0 10 0 0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"

--- a/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
@@ -1,8 +1,7 @@
 ﻿<Dialogs:BaseMetroDialog xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                          xmlns:Dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs"
-                         x:Class="MahApps.Metro.Controls.Dialogs.MessageDialog"
-                         Loaded="Dialog_Loaded">
+                         x:Class="MahApps.Metro.Controls.Dialogs.MessageDialog">
     <Grid Margin="0 10 0 0">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -147,6 +147,7 @@ namespace MetroDemo
         private async void ShowDialogOutside(object sender, RoutedEventArgs e)
         {
             var dialog = (BaseMetroDialog)this.Resources["CustomDialogTest"];
+            dialog.DialogSettings.ColorScheme = MetroDialogOptions.ColorScheme;
             dialog = dialog.ShowDialogExternally();
 
             await TaskEx.Delay(5000);


### PR DESCRIPTION
- DialogSettings property is now public
- load Controls, Fonts and Colors resource dictionries to prevent
System.Windows.ResourceDictionary Warning: 9
- new virtual methon OnLoaded
- fix external dialog background
- new property CustomResourceDictionary for DialogSettings
- fix InputDialog FocusBorderBrush when using Accented dialogs
- fix using Win8MetroPasswordBox style

Closes #1149 ProgressDialog cannot find the AccentColorBrush Resources