### PR TITLE
NumericUpDown with Integer Only Option.

### DIFF
--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -142,11 +142,11 @@ namespace MahApps.Metro.Controls
             typeof(NumericUpDown),
             new PropertyMetadata(true));
 
-        public static readonly DependencyProperty IsIntegerOnlyProperty = DependencyProperty.Register(
-            "IsIntegerOnly",
+        public static readonly DependencyProperty HasDecimalsProperty = DependencyProperty.Register(
+            "HasDecimals",
             typeof(bool), 
             typeof(NumericUpDown),
-            new FrameworkPropertyMetadata(false, OnIsIntegerOnlyChanged));
+            new FrameworkPropertyMetadata(true, OnHasDecimalsChanged));
         
         private const double DefaultInterval = 1d;
         private const int DefaultDelay = 500;
@@ -444,11 +444,11 @@ namespace MahApps.Metro.Controls
         /// </summary>
         [Bindable(true)]
         [Category("Common")]
-        [DefaultValue(false)]
-        public bool IsIntegerOnly
+        [DefaultValue(true)]
+        public bool HasDecimals
         {
-            get { return (bool)GetValue(IsIntegerOnlyProperty); }
-            set { SetValue(IsIntegerOnlyProperty, value); }
+            get { return (bool)GetValue(HasDecimalsProperty); }
+            set { SetValue(HasDecimalsProperty, value); }
         }
 
         /// <summary> 
@@ -671,7 +671,7 @@ namespace MahApps.Metro.Controls
                 {
                     if (textBox.Text.All(i => i.ToString(equivalentCulture) != numberFormatInfo.NumberDecimalSeparator) || allTextSelected)
                     {
-                        if (!IsIntegerOnly)
+                        if (HasDecimals)
                         {
                             e.Handled = false;
                         }
@@ -821,6 +821,10 @@ namespace MahApps.Metro.Controls
             var numericUpDown = (NumericUpDown)d;
             double val = ((double?)value).Value;
 
+            if (numericUpDown.HasDecimals == false)
+            {
+                val = Math.Truncate(val);
+            }
             if (val < numericUpDown.Minimum)
             {
                 return numericUpDown.Minimum;
@@ -892,17 +896,15 @@ namespace MahApps.Metro.Controls
             numericUpDown.OnValueChanged((double?)e.OldValue, (double?)e.NewValue);
         }
 
-        private static void OnIsIntegerOnlyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        private static void OnHasDecimalsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var numericUpDown = (NumericUpDown)d;
             double? oldValue = numericUpDown.Value;
 
-            if ((bool)e.NewValue == true)
+            if ((bool)e.NewValue == false && numericUpDown.Value != null)
             {
                 numericUpDown.Value = Math.Truncate(numericUpDown.Value.GetValueOrDefault());
             }
-
-            numericUpDown.OnValueChanged(oldValue, numericUpDown.Value);
         }
 
       private static bool ValidateDelay(object value)

--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -142,6 +142,12 @@ namespace MahApps.Metro.Controls
             typeof(NumericUpDown),
             new PropertyMetadata(true));
 
+        public static readonly DependencyProperty IsIntegerOnlyProperty = DependencyProperty.Register(
+            "IsIntegerOnly",
+            typeof(bool), 
+            typeof(NumericUpDown),
+            new FrameworkPropertyMetadata(false, OnIsIntegerOnlyChanged));
+        
         private const double DefaultInterval = 1d;
         private const int DefaultDelay = 500;
         private const string ElementNumericDown = "PART_NumericDown";
@@ -433,6 +439,18 @@ namespace MahApps.Metro.Controls
             get { return Culture ?? Language.GetSpecificCulture(); }
         }
 
+        /// <summary>
+        ///     Indicates if the NumericUpDown should show the decimal separator or not.
+        /// </summary>
+        [Bindable(true)]
+        [Category("Common")]
+        [DefaultValue(false)]
+        public bool IsIntegerOnly
+        {
+            get { return (bool)GetValue(IsIntegerOnlyProperty); }
+            set { SetValue(IsIntegerOnlyProperty, value); }
+        }
+
         /// <summary> 
         ///     Called when this element or any below gets focus.
         /// </summary>
@@ -653,7 +671,10 @@ namespace MahApps.Metro.Controls
                 {
                     if (textBox.Text.All(i => i.ToString(equivalentCulture) != numberFormatInfo.NumberDecimalSeparator) || allTextSelected)
                     {
-                        e.Handled = false;
+                        if (!IsIntegerOnly)
+                        {
+                            e.Handled = false;
+                        }
                     }
                 }
                 else
@@ -869,6 +890,19 @@ namespace MahApps.Metro.Controls
             var numericUpDown = (NumericUpDown)d;
 
             numericUpDown.OnValueChanged((double?)e.OldValue, (double?)e.NewValue);
+        }
+
+        private static void OnIsIntegerOnlyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var numericUpDown = (NumericUpDown)d;
+            double? oldValue = numericUpDown.Value;
+
+            if ((bool)e.NewValue == true)
+            {
+                numericUpDown.Value = Math.Truncate(numericUpDown.Value.GetValueOrDefault());
+            }
+
+            numericUpDown.OnValueChanged(oldValue, numericUpDown.Value);
         }
 
       private static bool ValidateDelay(object value)

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -223,17 +223,25 @@
                                         TextAlignment="Left"
                                         Minimum="0"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
+                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"                                                                                
                                         Maximum="10" />
 
                 <Label Content='Interval="2"' />
+             
+                <CheckBox x:Name="IntegerOnlyCheckBox"
+                          Content="IsIntegerOnly"
+                          Margin="0,7" />
+                
                 <Controls:NumericUpDown Value="5"
-                                        ButtonsAlignment="Left"
+                                        ButtonsAlignment="Left" 
+                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Interval="2" />
 
                 <Label Content='Interval="5"' />
                 <Controls:NumericUpDown Value="5"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
+                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"                                        
                                         Controls:TextBoxHelper.ClearTextButton="True"
                                         ButtonsAlignment="Left"
                                         Interval="5" />
@@ -241,9 +249,11 @@
                 <Controls:NumericUpDown Margin="{StaticResource ControlMargin}"
                                         Controls:TextBoxHelper.Watermark="No Speedup when long pressed"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
+                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"                                        
                                         Speedup="false" />
                 <Controls:NumericUpDown Margin="{StaticResource ControlMargin}"
                                         Controls:TextBoxHelper.Watermark="Speedup when long pressed after 500ms"
+                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Delay="500"
                                         Speedup="true" />
@@ -254,6 +264,7 @@
                 <Controls:NumericUpDown Value="5"
                                         x:Name="test"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
+                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         StringFormat="pcs. {0:N2} pcs."
                                         Maximum="100" />
                 <Grid Margin="{StaticResource ControlMargin}">
@@ -287,6 +298,7 @@
                 <Controls:NumericUpDown x:Name="StringFormatNumUpDown"
                                         Margin="{StaticResource ControlMargin}"
                                         Value="{Binding ElementName=test, Path=Value, Mode=TwoWay}"
+                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Interval=".1"
                                         StringFormat="0,000.00" />

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -223,25 +223,26 @@
                                         TextAlignment="Left"
                                         Minimum="0"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
-                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"                                                                                
+                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"                                                                                
                                         Maximum="10" />
 
                 <Label Content='Interval="2"' />
              
-                <CheckBox x:Name="IntegerOnlyCheckBox"
-                          Content="IsIntegerOnly"
+                <CheckBox x:Name="HasDecimalsCheckBox"
+                          Content="HasDecimals"
+                          IsChecked="True"
                           Margin="0,7" />
                 
                 <Controls:NumericUpDown Value="5"
                                         ButtonsAlignment="Left" 
-                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"
+                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Interval="2" />
 
                 <Label Content='Interval="5"' />
                 <Controls:NumericUpDown Value="5"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
-                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"                                        
+                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"                                        
                                         Controls:TextBoxHelper.ClearTextButton="True"
                                         ButtonsAlignment="Left"
                                         Interval="5" />
@@ -249,11 +250,11 @@
                 <Controls:NumericUpDown Margin="{StaticResource ControlMargin}"
                                         Controls:TextBoxHelper.Watermark="No Speedup when long pressed"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
-                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"                                        
+                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"                                        
                                         Speedup="false" />
                 <Controls:NumericUpDown Margin="{StaticResource ControlMargin}"
                                         Controls:TextBoxHelper.Watermark="Speedup when long pressed after 500ms"
-                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"
+                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Delay="500"
                                         Speedup="true" />
@@ -264,7 +265,7 @@
                 <Controls:NumericUpDown Value="5"
                                         x:Name="test"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
-                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"
+                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         StringFormat="pcs. {0:N2} pcs."
                                         Maximum="100" />
                 <Grid Margin="{StaticResource ControlMargin}">
@@ -298,7 +299,7 @@
                 <Controls:NumericUpDown x:Name="StringFormatNumUpDown"
                                         Margin="{StaticResource ControlMargin}"
                                         Value="{Binding ElementName=test, Path=Value, Mode=TwoWay}"
-                                        IsIntegerOnly="{Binding ElementName=IntegerOnlyCheckBox, Path=IsChecked, Mode=TwoWay}"
+                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         Interval=".1"
                                         StringFormat="0,000.00" />


### PR DESCRIPTION
Added the possibility for the NumericUpDown to behave as if it's Value is an Integer, removing the decimal separator as requested in Issue #2059.

Updated the Sample to reflect this change. The user can now use a CheckBox to turn the "HasDecimals" true or false to test it.