### PR TITLE
Fix obj ref null exception if there is no Window Theme at runtime.

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -118,7 +118,7 @@ namespace MahApps.Metro.Controls.Dialogs
             {
                 var windowTheme = DetectTheme(this);
 
-                if (System.ComponentModel.DesignerProperties.GetIsInDesignMode(this) && windowTheme == null)
+                if (windowTheme == null)
                 {
                     return;
                 }


### PR DESCRIPTION
There isn't a Window Theme if using Material Design In Xaml Toolkit as the App.xaml is configured differently.  Safely jumping out at this point allows dialogs to work with Material Design In Xaml Toolkit.