### PR TITLE
Progressdialog improvements

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/ProgressDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/ProgressDialog.cs
@@ -29,6 +29,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 ProgressBarForeground = Brushes.White;
             }
         }
+
         internal ProgressDialog(MetroWindow parentWindow)
             : this(parentWindow, null)
         { }
@@ -68,6 +69,34 @@ namespace MahApps.Metro.Controls.Dialogs
         internal CancellationToken CancellationToken
         {
             get { return DialogSettings.CancellationToken; }
+        }
+
+        internal double Minimum
+        {
+            get { return PART_ProgressBar.Minimum; }
+            set { PART_ProgressBar.Minimum = value; }
+        }
+
+        internal double Maximum
+        {
+            get { return PART_ProgressBar.Maximum; }
+            set { PART_ProgressBar.Maximum = value; }
+        }
+
+        internal double ProgressValue
+        {
+            get { return PART_ProgressBar.Value; }
+            set
+            {
+                PART_ProgressBar.IsIndeterminate = false;
+                PART_ProgressBar.Value = value;
+                PART_ProgressBar.ApplyTemplate();
+            }
+        }
+
+        internal void SetIndeterminate()
+        {
+            PART_ProgressBar.IsIndeterminate = true;
         }
     }
 }

--- a/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
+++ b/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
@@ -41,7 +41,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 WrappedDialog.PART_NegativeButton.IsEnabled = false;
             };
 
-            this.InvokeAction(action);
+            InvokeAction(action);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// </summary>
         public void SetIndeterminate()
         {
-            this.InvokeAction(() => WrappedDialog.PART_ProgressBar.IsIndeterminate = true);
+            InvokeAction(() => WrappedDialog.PART_ProgressBar.IsIndeterminate = true);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="value"></param>
         public void SetCancelable(bool value)
         {
-            this.InvokeAction(() => WrappedDialog.IsCancelable = value);
+            InvokeAction(() => WrappedDialog.IsCancelable = value);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 WrappedDialog.PART_ProgressBar.ApplyTemplate();
             };
 
-            this.InvokeAction(action);
+            InvokeAction(action);
         }
 
         /// <summary>
@@ -86,8 +86,8 @@ namespace MahApps.Metro.Controls.Dialogs
         /// </summary>
         public double Minimum
         {
-            get { return this.InvokeFunc(() => WrappedDialog.PART_ProgressBar.Minimum); }
-            set { this.InvokeAction(() => WrappedDialog.PART_ProgressBar.Minimum = value); }
+            get { return InvokeFunc(() => WrappedDialog.PART_ProgressBar.Minimum); }
+            set { InvokeAction(() => WrappedDialog.PART_ProgressBar.Minimum = value); }
         }
 
         /// <summary>
@@ -95,8 +95,8 @@ namespace MahApps.Metro.Controls.Dialogs
         /// </summary>
         public double Maximum
         {
-            get { return this.InvokeFunc(() => WrappedDialog.PART_ProgressBar.Maximum); }
-            set { this.InvokeAction(() => WrappedDialog.PART_ProgressBar.Maximum = value); }
+            get { return InvokeFunc(() => WrappedDialog.PART_ProgressBar.Maximum); }
+            set { InvokeAction(() => WrappedDialog.PART_ProgressBar.Maximum = value); }
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="message">The message to be set.</param>
         public void SetMessage(string message)
         {
-            this.InvokeAction(() => WrappedDialog.Message = message);
+            InvokeAction(() => WrappedDialog.Message = message);
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="title">The title to be set.</param>
         public void SetTitle(string title)
         {
-            this.InvokeAction(() => WrappedDialog.Title = title);
+            InvokeAction(() => WrappedDialog.Title = title);
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 WrappedDialog.PART_NegativeButton.Click -= PART_NegativeButton_Click;
             };
 
-            this.InvokeAction(action);
+            InvokeAction(action);
 
             return CloseCallback().ContinueWith(x => WrappedDialog.Dispatcher.Invoke(new Action(() => {
                 IsOpen = false;
@@ -152,7 +152,7 @@ namespace MahApps.Metro.Controls.Dialogs
             }
             else
             {
-                return (double)this.WrappedDialog.Dispatcher.Invoke(new Func<double>(getValueFunc));
+                return (double)WrappedDialog.Dispatcher.Invoke(new Func<double>(getValueFunc));
             }
         }
 
@@ -164,7 +164,7 @@ namespace MahApps.Metro.Controls.Dialogs
             }
             else
             {
-                WrappedDialog.Dispatcher.Invoke(new Action(setValueAction));
+                WrappedDialog.Dispatcher.Invoke(setValueAction);
             }
         }
     }

--- a/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
+++ b/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
@@ -15,7 +15,13 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <summary>
         /// Gets if the wrapped ProgressDialog is open.
         /// </summary>
+        [Obsolete("Use the Closed event instead")]
         public bool IsOpen { get; private set; }
+
+        /// <summary>
+        /// This event is raised when the associated <see cref="ProgressDialog"/> was closed.
+        /// </summary>
+        public event EventHandler Closed;
 
         internal ProgressDialogController(ProgressDialog dialog, Func<Task> closeCallBack)
         {
@@ -139,6 +145,11 @@ namespace MahApps.Metro.Controls.Dialogs
 
             return CloseCallback().ContinueWith(_ => InvokeAction(new Action(() => {
                 IsOpen = false;
+
+                var handler = Closed;
+                if (handler != null) {
+                    handler(this, EventArgs.Empty);
+                }
             })));
         }
 

--- a/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
+++ b/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
@@ -12,17 +12,10 @@ namespace MahApps.Metro.Controls.Dialogs
         private ProgressDialog WrappedDialog { get; set; }
         private Func<Task> CloseCallback { get; set; }
 
-        /// <summary>
-        /// Gets if the wrapped ProgressDialog is open.
-        /// </summary>
-        public bool IsOpen { get; private set; }
-
         internal ProgressDialogController(ProgressDialog dialog, Func<Task> closeCallBack)
         {
             WrappedDialog = dialog;
             CloseCallback = closeCallBack;
-
-            IsOpen = dialog.IsVisible;
 
             WrappedDialog.PART_NegativeButton.Dispatcher.Invoke(new Action(() => {
                 WrappedDialog.PART_NegativeButton.Click += PART_NegativeButton_Click;
@@ -129,7 +122,7 @@ namespace MahApps.Metro.Controls.Dialogs
         public Task CloseAsync()
         {
             Action action = () => {
-                if (!IsOpen)
+                if (!WrappedDialog.IsVisible)
                 {
                     throw new InvalidOperationException();
                 }
@@ -139,9 +132,7 @@ namespace MahApps.Metro.Controls.Dialogs
 
             InvokeAction(action);
 
-            return CloseCallback().ContinueWith(x => WrappedDialog.Dispatcher.Invoke(new Action(() => {
-                IsOpen = false;
-            })));
+            return CloseCallback();
         }
 
         private double InvokeFunc(Func<double> getValueFunc)

--- a/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
+++ b/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
@@ -12,10 +12,17 @@ namespace MahApps.Metro.Controls.Dialogs
         private ProgressDialog WrappedDialog { get; set; }
         private Func<Task> CloseCallback { get; set; }
 
+        /// <summary>
+        /// Gets if the wrapped ProgressDialog is open.
+        /// </summary>
+        public bool IsOpen { get; private set; }
+
         internal ProgressDialogController(ProgressDialog dialog, Func<Task> closeCallBack)
         {
             WrappedDialog = dialog;
             CloseCallback = closeCallBack;
+
+            IsOpen = dialog.IsVisible;
 
             InvokeAction(() => {
                 WrappedDialog.PART_NegativeButton.Click += PART_NegativeButton_Click;
@@ -130,7 +137,9 @@ namespace MahApps.Metro.Controls.Dialogs
 
             InvokeAction(action);
 
-            return CloseCallback();
+            return CloseCallback().ContinueWith(_ => InvokeAction(new Action(() => {
+                IsOpen = false;
+            })));
         }
 
         private double InvokeFunc(Func<double> getValueFunc)

--- a/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
+++ b/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
@@ -17,9 +17,9 @@ namespace MahApps.Metro.Controls.Dialogs
             WrappedDialog = dialog;
             CloseCallback = closeCallBack;
 
-            WrappedDialog.PART_NegativeButton.Dispatcher.Invoke(new Action(() => {
+            InvokeAction(() => {
                 WrappedDialog.PART_NegativeButton.Click += PART_NegativeButton_Click;
-            }));
+            });
 
             dialog.CancellationToken.Register(() =>
             {
@@ -42,7 +42,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// </summary>
         public void SetIndeterminate()
         {
-            InvokeAction(() => WrappedDialog.PART_ProgressBar.IsIndeterminate = true);
+            InvokeAction(() => WrappedDialog.SetIndeterminate());
         }
 
         /// <summary>
@@ -61,14 +61,12 @@ namespace MahApps.Metro.Controls.Dialogs
         public void SetProgress(double value)
         {
             Action action = () => {
-                if (value < WrappedDialog.PART_ProgressBar.Minimum || value > WrappedDialog.PART_ProgressBar.Maximum)
+                if (value < WrappedDialog.Minimum || value > WrappedDialog.Maximum)
                 {
                     throw new ArgumentOutOfRangeException("value");
                 }
 
-                WrappedDialog.PART_ProgressBar.IsIndeterminate = false;
-                WrappedDialog.PART_ProgressBar.Value = value;
-                WrappedDialog.PART_ProgressBar.ApplyTemplate();
+                WrappedDialog.ProgressValue = value;
             };
 
             InvokeAction(action);
@@ -79,8 +77,8 @@ namespace MahApps.Metro.Controls.Dialogs
         /// </summary>
         public double Minimum
         {
-            get { return InvokeFunc(() => WrappedDialog.PART_ProgressBar.Minimum); }
-            set { InvokeAction(() => WrappedDialog.PART_ProgressBar.Minimum = value); }
+            get { return InvokeFunc(() => WrappedDialog.Minimum); }
+            set { InvokeAction(() => WrappedDialog.Minimum = value); }
         }
 
         /// <summary>
@@ -88,8 +86,8 @@ namespace MahApps.Metro.Controls.Dialogs
         /// </summary>
         public double Maximum
         {
-            get { return InvokeFunc(() => WrappedDialog.PART_ProgressBar.Maximum); }
-            set { InvokeAction(() => WrappedDialog.PART_ProgressBar.Maximum = value); }
+            get { return InvokeFunc(() => WrappedDialog.Maximum); }
+            set { InvokeAction(() => WrappedDialog.Maximum = value); }
         }
 
         /// <summary>

--- a/MahApps.Metro/Themes/Dialogs/ProgressDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/ProgressDialog.xaml
@@ -39,7 +39,6 @@
                                    Height="6"
                                    EllipseDiameter="5"
                                    Panel.ZIndex="5"
-                                   IsIndeterminate="True"
                                    Minimum="0.0"
                                    Maximum="1.0"
                                    Foreground="{Binding ProgressBarForeground, RelativeSource={RelativeSource AncestorType=Dialogs:ProgressDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"

--- a/docs/release-notes/1.2.0.md
+++ b/docs/release-notes/1.2.0.md
@@ -77,6 +77,8 @@ This is a bug fix and feature release of MahApps.Metro v1.2.0.
 	+ introduce `VirtualisedMetroTreeView`
 - SelectAllOnFocus for input and login dialogs #1750
 - New `MetroValidationPopup` style and new `CloseOnMouseLeftButtonDown` dependency property #2058 #1469
+- Progress bar in `ProgressDialog` is not set to Indetermined by default anymore, must be set explicitly by calling `ProgressDialogController.SetIndeterminate()` #2097
+- Added `Closed` event to `ProgressDialogController` #2097
 
 # Bugfixes
 

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -246,6 +246,7 @@ namespace MetroDemo
         private async void ShowProgressDialog(object sender, RoutedEventArgs e)
         {
             var controller = await this.ShowProgressAsync("Please wait...", "We are baking some cupcakes!");
+            controller.SetIndeterminate();
 
             await TaskEx.Delay(5000);
 


### PR DESCRIPTION
As far as I can see there is some, er, room for improvements in `ProgressDialogController`:

* `ProgressDialogController.IsOpen` is only set in the c'tor and when the dialog is closed. In fact, I see no reason to have that property, so I eliminated it.
* By default the state of the progress bar in the dialog is indeterminated. IMHO this should be set by the user explicitly.
* `ProgressDialogController` makes direct calls to several controls of `ProgressDialog`, e.g. `WrappedDialog.PART_ProgressBar.IsIndeterminate = true`. Instead I'd like to add appropriate methods to `ProgressDialog`, because the controls are implementation details of the dialog and not the concern of the controller.
