### PR TITLE
If the user.config file is corrupt the whole application crashes

### DIFF
--- a/MahApps.Metro/Controls/WindowSettings.cs
+++ b/MahApps.Metro/Controls/WindowSettings.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel;
 using System.Configuration;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;

--- a/MahApps.Metro/Controls/WindowSettings.cs
+++ b/MahApps.Metro/Controls/WindowSettings.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Configuration;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
@@ -64,9 +65,20 @@ namespace MahApps.Metro.Controls
         {
             get
             {
-                if (this["UpgradeSettings"] != null)
+                try
                 {
-                    return (bool)this["UpgradeSettings"];
+                    if (this["UpgradeSettings"] != null)
+                    {
+                        return (bool)this["UpgradeSettings"];
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine("Failed to load settings file:\r\n{0}", ex);
+                    var filename = ((ConfigurationErrorsException)ex.InnerException).Filename;
+                    File.Delete(filename);
+                    Process.Start(Application.ResourceAssembly.Location);
+                    Application.Current.Shutdown();
                 }
                 return true;
             }

--- a/MahApps.Metro/Controls/WindowSettings.cs
+++ b/MahApps.Metro/Controls/WindowSettings.cs
@@ -72,13 +72,10 @@ namespace MahApps.Metro.Controls
                         return (bool)this["UpgradeSettings"];
                     }
                 }
-                catch (Exception ex)
+                catch (ConfigurationErrorsException ex)
                 {
-                    Debug.WriteLine("Failed to load settings file:\r\n{0}", ex);
                     var filename = ((ConfigurationErrorsException)ex.InnerException).Filename;
-                    File.Delete(filename);
-                    Process.Start(Application.ResourceAssembly.Location);
-                    Application.Current.Shutdown();
+                    throw new MahAppsException(string.Format("The settings file {0} seems to be corrupted", filename), ex);
                 }
                 return true;
             }

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -106,6 +106,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Lib\NET45\System.Windows.Interactivity.dll</HintPath>

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -68,6 +68,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Lib\NET40\System.Windows.Interactivity.dll</HintPath>

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -22,6 +22,7 @@
                       d:DataContext="{d:DesignInstance MetroDemo:MainWindowViewModel}"
                       Closing="MetroWindow_Closing"
                       Dialog:DialogParticipation.Register="{Binding}"
+                      SaveWindowPosition="True"
                       >
 
     <Window.Resources>


### PR DESCRIPTION
I had the problem, that a customer could suddenly not open my
application anymore. It turned out that this is because the user.config
file was just empty and this caused a ConfigurationErrorsException. Then I
added an UnhandledExceptionHandler but this exception seems to happen
earlier. The only working solution is to delete the odd user.config and
restart the application.
For more details see here:
http://www.codeproject.com/Articles/30216/Handling-Corrupt-user-config-Settings

You can test this by editing the user.config and delete all content. But do NOT delete the file!
Then you need a window with the setting SaveWindowPosition="True" - otherwise no user.config file is created.