### PR TITLE
Only apply SizeToContent workaround when necessary

### DIFF
--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -312,13 +312,18 @@ namespace MahApps.Metro.Behaviours
                 hwndSource.AddHook(WindowProc);
             }
 
-            // handle size to content (thanks @lynnx)
-            var sizeToContent = AssociatedObject.SizeToContent;
-            var snapsToDevicePixels = AssociatedObject.SnapsToDevicePixels;
-            AssociatedObject.SnapsToDevicePixels = true;
-            AssociatedObject.SizeToContent = sizeToContent == SizeToContent.WidthAndHeight ? SizeToContent.Height : SizeToContent.Manual;
-            AssociatedObject.SizeToContent = sizeToContent;
-            AssociatedObject.SnapsToDevicePixels = snapsToDevicePixels;
+            if (AssociatedObject.ResizeMode != ResizeMode.NoResize)
+            {
+                // handle size to content (thanks @lynnx).
+                // This is necessary when ResizeMode != NoResize. Without this workaround,
+                // black bars appear at the right and bottom edge of the window.
+                var sizeToContent = AssociatedObject.SizeToContent;
+                var snapsToDevicePixels = AssociatedObject.SnapsToDevicePixels;
+                AssociatedObject.SnapsToDevicePixels = true;
+                AssociatedObject.SizeToContent = sizeToContent == SizeToContent.WidthAndHeight ? SizeToContent.Height : SizeToContent.Manual;
+                AssociatedObject.SizeToContent = sizeToContent;
+                AssociatedObject.SnapsToDevicePixels = snapsToDevicePixels;
+            }
         }
 
         private void AssociatedObject_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
The existing `SizeToContent` workaround is only necessary when `ResizeMode != NoResize`. The workaround solves the problem of black bars appearing at the right and bottom edges of the window. But when `ResizeMode == NoResize`, no such black bars appear.

The reason for this pull request is that the `SizeToContent` workaround turns out to be a problem in some `SizeToContent=WidthAndHeight` edge cases. Specifically, when the size of the content changes as the window is loading, due to code in `SourceInitialized` and `LayoutUpdated` in our app. Unfortunately the repro is pretty complicated, and I haven't been able to create a minimal repro.