### PR TITLE
Fix missing glow border corners

### DIFF
--- a/MahApps.Metro/Controls/GlowWindow.xaml.cs
+++ b/MahApps.Metro/Controls/GlowWindow.xaml.cs
@@ -58,9 +58,9 @@ namespace MahApps.Metro.Controls
                     glow.Orientation = Orientation.Vertical;
                     glow.HorizontalAlignment = HorizontalAlignment.Right;
                     getLeft = (rect) => rect.left - glowSize;
-                    getTop = (rect) => rect.top - owner.BorderThickness.Top;
+                    getTop = (rect) => rect.top - owner.BorderThickness.Top + 1;
                     getWidth = (rect) => glowSize;
-                    getHeight = (rect) => rect.Height + owner.BorderThickness.Top + owner.BorderThickness.Bottom;
+                    getHeight = (rect) => rect.Height + owner.BorderThickness.Top + owner.BorderThickness.Bottom - 2;
                     getHitTestValue = p => new Rect(0, 0, ActualWidth, edgeSize).Contains(p)
                                                ? HitTestValues.HTTOPLEFT
                                                : new Rect(0, ActualHeight - edgeSize, ActualWidth, edgeSize).Contains(p)
@@ -81,9 +81,9 @@ namespace MahApps.Metro.Controls
                     glow.Orientation = Orientation.Vertical;
                     glow.HorizontalAlignment = HorizontalAlignment.Left;
                     getLeft = (rect) => rect.right;
-                    getTop = (rect) => rect.top - owner.BorderThickness.Top;
+                    getTop = (rect) => rect.top - owner.BorderThickness.Top + 1;
                     getWidth = (rect) => glowSize;
-                    getHeight = (rect) => rect.Height + owner.BorderThickness.Top + owner.BorderThickness.Bottom;
+                    getHeight = (rect) => rect.Height + owner.BorderThickness.Top + owner.BorderThickness.Bottom - 2;
                     getHitTestValue = p => new Rect(0, 0, ActualWidth, edgeSize).Contains(p)
                                                ? HitTestValues.HTTOPRIGHT
                                                : new Rect(0, ActualHeight - edgeSize, ActualWidth, edgeSize).Contains(p)
@@ -103,9 +103,9 @@ namespace MahApps.Metro.Controls
                 case GlowDirection.Top:
                     glow.Orientation = Orientation.Horizontal;
                     glow.VerticalAlignment = VerticalAlignment.Bottom;
-                    getLeft = (rect) => rect.left - owner.BorderThickness.Left;
+                    getLeft = (rect) => rect.left - owner.BorderThickness.Left - glowSize;
                     getTop = (rect) => rect.top - glowSize;
-                    getWidth = (rect) => rect.Width + owner.BorderThickness.Left + owner.BorderThickness.Right;
+                    getWidth = (rect) => rect.Width + owner.BorderThickness.Left + owner.BorderThickness.Right + glowSize + glowSize;
                     getHeight = (rect) => glowSize;
                     getHitTestValue = p => new Rect(0, 0, edgeSize - glowSize, ActualHeight).Contains(p)
                                                ? HitTestValues.HTTOPLEFT
@@ -128,9 +128,9 @@ namespace MahApps.Metro.Controls
                 case GlowDirection.Bottom:
                     glow.Orientation = Orientation.Horizontal;
                     glow.VerticalAlignment = VerticalAlignment.Top;
-                    getLeft = (rect) => rect.left - owner.BorderThickness.Left;
+                    getLeft = (rect) => rect.left - owner.BorderThickness.Left - glowSize;
                     getTop = (rect) => rect.bottom;
-                    getWidth = (rect) => rect.Width + owner.BorderThickness.Left + owner.BorderThickness.Right;
+                    getWidth = (rect) => rect.Width + owner.BorderThickness.Left + owner.BorderThickness.Right + glowSize + glowSize;
                     getHeight = (rect) => glowSize;
                     getHitTestValue = p => new Rect(0, 0, edgeSize - glowSize, ActualHeight).Contains(p)
                                                ? HitTestValues.HTBOTTOMLEFT

--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
@@ -3300,6 +3300,11 @@
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsZoomed(IntPtr hwnd);
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool IsWindowVisible(IntPtr hwnd);
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -1038,8 +1038,7 @@ namespace Microsoft.Windows.Shell
              * MonitorFromWindow gives us the wrong (old) monitor! This is fixed in _HandleMoveForRealSize.
              */
             var ignoreTaskBar = _chromeInfo.IgnoreTaskbarOnMaximize;// || _chromeInfo.UseNoneWindowStyle;
-            WindowState state = _GetHwndState();
-            if (ignoreTaskBar && state == WindowState.Maximized)
+            if (ignoreTaskBar && NativeMethods.IsZoomed(_hwnd))
             {
                 MINMAXINFO mmi = (MINMAXINFO)Marshal.PtrToStructure(lParam, typeof(MINMAXINFO));
                 IntPtr monitor = NativeMethods.MonitorFromWindow(_hwnd, (uint)MonitorOptions.MONITOR_DEFAULTTONEAREST);

--- a/MahApps.Metro/Themes/Glow.xaml
+++ b/MahApps.Metro/Themes/Glow.xaml
@@ -22,10 +22,10 @@
                      Value="Horizontal">
                 <Setter TargetName="glowBorder"
                         Property="Margin"
-                        Value="1,0" />
+                        Value="8,0" />
                 <Setter TargetName="glowSource"
                         Property="Margin"
-                        Value="0,-1" />
+                        Value="7,-1" />
             </Trigger>
             <Trigger Property="BorderThickness"
                      Value="0">


### PR DESCRIPTION
This will fix the missing corners in the glow effect as described in issue #2118 by:

- Extending the horizontal glow areas (but not borders) to fill in the corners - the blur effect already renders these nicely
- Reducing the vertical glow areas by 1px to avoid overlapping the -1px margin in the extended horizontal borders

Also (I meant to submit this in a separate PR but am a bit of a Git newbie) fixed an odd side effect in calling GetWindowPlacement from WindowChromeWorker._HandleGetMinMaxInfo that caused the window to restore to the end of the drag instead of the beginning after doing an Aero Snap.