### PR TITLE
Fix incorrect restore location after Aero Snap

### DIFF
--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
@@ -3300,6 +3300,11 @@
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsZoomed(IntPtr hwnd);
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool IsWindowVisible(IntPtr hwnd);
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -1038,8 +1038,7 @@ namespace Microsoft.Windows.Shell
              * MonitorFromWindow gives us the wrong (old) monitor! This is fixed in _HandleMoveForRealSize.
              */
             var ignoreTaskBar = _chromeInfo.IgnoreTaskbarOnMaximize;// || _chromeInfo.UseNoneWindowStyle;
-            WindowState state = _GetHwndState();
-            if (ignoreTaskBar && state == WindowState.Maximized)
+            if (ignoreTaskBar && NativeMethods.IsZoomed(_hwnd))
             {
                 MINMAXINFO mmi = (MINMAXINFO)Marshal.PtrToStructure(lParam, typeof(MINMAXINFO));
                 IntPtr monitor = NativeMethods.MonitorFromWindow(_hwnd, (uint)MonitorOptions.MONITOR_DEFAULTTONEAREST);


### PR DESCRIPTION
Fixes an odd side effect in calling GetWindowPlacement from WindowChromeWorker._HandleGetMinMaxInfo that caused the window to restore to the end of the drag instead of the beginning after doing an Aero Snap.

Steps to repro the bug that this PR fixes:

1. In the MahApps demo app, drag window to top of screen, which maximises the window.
2. Click Restore.
3. Window is restored to a location slightly off the top of the screen (which is, incorrectly, the location of the end of the previous drag).

Calling `IsZoomed` instead of `GetWindowPlacement` fixes this issue.