### PR TITLE
Removed unneeded MessageDialogStyle param from IDialogCoordinator.ShowLoginAsync method

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/DialogCoordinator.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogCoordinator.cs
@@ -18,7 +18,7 @@ namespace MahApps.Metro.Controls.Dialogs
             return metroWindow.ShowInputAsync(title, message, metroDialogSettings);
         }
 
-        public Task<LoginDialogData> ShowLoginAsync(object context, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, LoginDialogSettings settings = null)
+        public Task<LoginDialogData> ShowLoginAsync(object context, string title, string message, LoginDialogSettings settings = null)
         {
             var metroWindow = GetMetroWindow(context);
 

--- a/MahApps.Metro/Controls/Dialogs/IDialogCoordinator.cs
+++ b/MahApps.Metro/Controls/Dialogs/IDialogCoordinator.cs
@@ -27,7 +27,7 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <param name="style"></param>
         /// <param name="settings">Optional settings that override the global metro dialog settings.</param>
         /// <returns>The text that was entered or null (Nothing in Visual Basic) if the user cancelled the operation.</returns>
-        Task<LoginDialogData> ShowLoginAsync(object context, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, LoginDialogSettings settings = null);
+        Task<LoginDialogData> ShowLoginAsync(object context, string title, string message, LoginDialogSettings settings = null);
 
         /// <summary>
         /// Creates a MessageDialog inside of the current window.


### PR DESCRIPTION
MessageDialogStyle does not makes sense for a Login dialog window and DialogManager.ShowLoginAsync (which DialogCoordinator.ShowLoginAsync is wrapping) does not take MessageDialogStyle either. 