### PR TITLE
[RFC] ContentCharacterCasing usage instead PreserveTextCase

### DIFF
--- a/MahApps.Metro/Controls/Helper/ButtonHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ButtonHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 
@@ -6,11 +7,25 @@ namespace MahApps.Metro.Controls
 {
     public static class ButtonHelper
     {
+        [Obsolete(@"This property will be deleted in the next release. You should use ContentCharacterCasing attached property located at ControlsHelper.")]
         public static readonly DependencyProperty PreserveTextCaseProperty =
             DependencyProperty.RegisterAttached("PreserveTextCase", typeof(bool), typeof(ButtonHelper),
                                                 new FrameworkPropertyMetadata(
                                                     false,
-                                                    FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
+                                                    FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure,
+                                                    PreserveTextCasePropertyChangedCallback));
+
+        private static void PreserveTextCasePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is bool)
+            {
+                var button = dependencyObject as Button;
+                if (button != null)
+                {
+                    ControlsHelper.SetContentCharacterCasing(button, (bool)e.NewValue ? CharacterCasing.Normal : CharacterCasing.Upper);
+                }
+            }
+        }
 
         /// <summary>
         /// Overrides the text case behavior for certain buttons.

--- a/MahApps.Metro/Controls/Helper/ControlsHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ControlsHelper.cs
@@ -49,6 +49,7 @@ namespace MahApps.Metro.Controls
         /// </summary>
         [AttachedPropertyBrowsableForType(typeof(ContentControl))]
         [AttachedPropertyBrowsableForType(typeof(DropDownButton))]
+        [AttachedPropertyBrowsableForType(typeof(WindowCommands))]
         public static CharacterCasing GetContentCharacterCasing(UIElement element)
         {
             return (CharacterCasing)element.GetValue(ContentCharacterCasingProperty);

--- a/MahApps.Metro/Controls/Helper/ControlsHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ControlsHelper.cs
@@ -32,32 +32,9 @@ namespace MahApps.Metro.Controls
             element.SetValue(DisabledVisualElementVisibilityProperty, value);
         }
 
-        public static readonly DependencyProperty PreserveTextCaseProperty = DependencyProperty.RegisterAttached("PreserveTextCase", typeof(bool), typeof(ControlsHelper), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure));
-
-        /// <summary>
-        /// Gets the value to override the text case behavior for the header content.
-        /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
-        /// </summary>
-        [AttachedPropertyBrowsableForType(typeof(Expander))]
-        [AttachedPropertyBrowsableForType(typeof(GroupBox))]
-        public static bool GetPreserveTextCase(UIElement element)
-        {
-            return (bool)element.GetValue(PreserveTextCaseProperty);
-        }
-
-        /// <summary>
-        /// Sets the value to override the text case behavior for the header content.
-        /// When set to <c>true</c>, the text case will be preserved and won't be changed to upper or lower case.
-        /// </summary>
-        public static void SetPreserveTextCase(UIElement element, bool value)
-        {
-            element.SetValue(PreserveTextCaseProperty, value);
-        }
-
         /// <summary>
         /// The DependencyProperty for the CharacterCasing property.
         /// Controls whether or not content is converted to upper or lower case
-        /// This will be used later for all controls which are using the PreserveTextCase property (> v1.2.0).
         /// </summary>
         public static readonly DependencyProperty ContentCharacterCasingProperty =
             DependencyProperty.RegisterAttached(

--- a/MahApps.Metro/Converters/ToUpperConverter.cs
+++ b/MahApps.Metro/Converters/ToUpperConverter.cs
@@ -1,11 +1,26 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Data;
+using System.Windows.Markup;
 
 namespace MahApps.Metro.Converters
 {
+    [MarkupExtensionReturnType(typeof(IValueConverter))]
     public class ToUpperConverter : MarkupConverter
     {
+        private static ToUpperConverter _instance;
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static ToUpperConverter()
+        {
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance ?? (_instance = new ToUpperConverter());
+        }
+
         protected override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var val = value as string;
@@ -18,8 +33,22 @@ namespace MahApps.Metro.Converters
         }
     }
 
+    [MarkupExtensionReturnType(typeof(IValueConverter))]
     public class ToLowerConverter : MarkupConverter
     {
+        private static ToLowerConverter _instance;
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static ToLowerConverter()
+        {
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance ?? (_instance = new ToLowerConverter());
+        }
+
         protected override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var val = value as string;

--- a/MahApps.Metro/Styles/Clean/CleanWindow.xaml
+++ b/MahApps.Metro/Styles/Clean/CleanWindow.xaml
@@ -13,7 +13,6 @@
     <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="#ADADAD" options:Freeze="True" />
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-    <Converters:ToUpperConverter x:Key="ToUpperConverter" />
 
     <ControlTemplate x:Key="CleanWindowTemplate"
                      TargetType="{x:Type Controls:MetroWindow}">
@@ -277,7 +276,7 @@
                      Value="True">
                 <Setter TargetName="TitleControl"
                         Property="Content"
-                        Value="{Binding Path=Title, Converter={StaticResource ToUpperConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
+                        Value="{Binding Path=Title, Converter={Converters:ToUpperConverter}, RelativeSource={RelativeSource TemplatedParent}}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>

--- a/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -297,6 +297,8 @@
     <!-- style for default button -->
     <Style TargetType="{x:Type Button}"
            x:Key="MetroButton">
+        <Setter Property="Controls:ControlsHelper.ContentCharacterCasing"
+                Value="Upper" />
         <Setter Property="Controls:ButtonHelper.CornerRadius"
                 Value="3" />
         <Setter Property="MinHeight"
@@ -345,18 +347,25 @@
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="Controls:ButtonHelper.PreserveTextCase"
-                                 Value="False">
-                            <Setter TargetName="contentPresenter"
-                                    Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToUpperConverter}}" />
-                        </Trigger>
-                        <Trigger Property="Controls:ButtonHelper.PreserveTextCase"
-                                 Value="True">
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Normal">
                             <Setter TargetName="contentPresenter"
                                     Property="Content"
                                     Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content}" />
                         </Trigger >
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Upper">
+                            <Setter TargetName="contentPresenter"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToUpperConverter}}" />
+                        </Trigger>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Lower">
+                            <Setter TargetName="contentPresenter"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToLowerConverter}}" />
+                        </Trigger>
+
                         <Trigger Property="IsMouseOver"
                                  Value="True">
                             <Setter TargetName="Background"
@@ -395,6 +404,8 @@
 
     <Style x:Key="SquareButtonStyle"
            TargetType="{x:Type Button}">
+        <Setter Property="Controls:ControlsHelper.ContentCharacterCasing"
+                Value="Lower" />
         <Setter Property="MinHeight"
                 Value="25" />
         <Setter Property="FontFamily"
@@ -465,18 +476,25 @@
                     </Grid>
 
                     <ControlTemplate.Triggers>
-                        <Trigger Property="Controls:ButtonHelper.PreserveTextCase"
-                                 Value="False">
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Normal">
+                            <Setter TargetName="contentPresenter"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content}" />
+                        </Trigger >
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Upper">
+                            <Setter TargetName="contentPresenter"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToUpperConverter}}" />
+                        </Trigger>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Lower">
                             <Setter TargetName="contentPresenter"
                                     Property="Content"
                                     Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToLowerConverter}}" />
                         </Trigger>
-                        <Trigger Property="Controls:ButtonHelper.PreserveTextCase"
-                                 Value="True">
-                            <Setter TargetName="contentPresenter"
-                                    Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content}" />
-                        </Trigger>
+
                         <Trigger Property="IsMouseOver"
                                  Value="True">
                             <Setter Property="Background"
@@ -565,18 +583,25 @@
                     </Grid>
 
                     <ControlTemplate.Triggers>
-                        <Trigger Property="Controls:ButtonHelper.PreserveTextCase"
-                                 Value="False">
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Normal">
+                            <Setter TargetName="contentPresenter"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content}" />
+                        </Trigger >
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Upper">
+                            <Setter TargetName="contentPresenter"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToUpperConverter}}" />
+                        </Trigger>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Lower">
                             <Setter TargetName="contentPresenter"
                                     Property="Content"
                                     Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToLowerConverter}}" />
                         </Trigger>
-                        <Trigger Property="Controls:ButtonHelper.PreserveTextCase"
-                                 Value="True">
-                            <Setter TargetName="contentPresenter"
-                                    Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content}" />
-                        </Trigger>
+
                         <Trigger Property="IsMouseOver"
                                  Value="True">
                             <Setter Property="Background"

--- a/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -3,9 +3,6 @@
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
-    <Converters:ToUpperConverter x:Key="ToUpperConverter" />
-    <Converters:ToLowerConverter x:Key="ToLowerConverter" />
-
     <Style x:Key="MetroFlatButton"
            TargetType="{x:Type Button}">
         <Setter Property="Background"
@@ -357,13 +354,13 @@
                                  Value="Upper">
                             <Setter TargetName="contentPresenter"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToUpperConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={Converters:ToUpperConverter}}" />
                         </Trigger>
                         <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
                                  Value="Lower">
                             <Setter TargetName="contentPresenter"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToLowerConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={Converters:ToLowerConverter}}" />
                         </Trigger>
 
                         <Trigger Property="IsMouseOver"
@@ -486,13 +483,13 @@
                                  Value="Upper">
                             <Setter TargetName="contentPresenter"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToUpperConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={Converters:ToUpperConverter}}" />
                         </Trigger>
                         <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
                                  Value="Lower">
                             <Setter TargetName="contentPresenter"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToLowerConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={Converters:ToLowerConverter}}" />
                         </Trigger>
 
                         <Trigger Property="IsMouseOver"
@@ -593,13 +590,13 @@
                                  Value="Upper">
                             <Setter TargetName="contentPresenter"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToUpperConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={Converters:ToUpperConverter}}" />
                         </Trigger>
                         <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
                                  Value="Lower">
                             <Setter TargetName="contentPresenter"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToLowerConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={Converters:ToLowerConverter}}" />
                         </Trigger>
 
                         <Trigger Property="IsMouseOver"

--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -7,7 +7,6 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.CheckBox.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Converters:ToUpperConverter x:Key="ToUpperConverter" />
     <BooleanToVisibilityConverter x:Key="bool2VisibilityConverter" />
 
     <Style x:Key="MetroDataGridCheckBox"
@@ -246,7 +245,7 @@
             <Setter.Value>
                 <DataTemplate>
                     <TextBlock FontWeight="SemiBold"
-                               Text="{Binding Converter={StaticResource ToUpperConverter}}" />
+                               Text="{Binding Converter={Converters:ToUpperConverter}}" />
                 </DataTemplate>
             </Setter.Value>
         </Setter>

--- a/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -116,6 +116,10 @@
 
     <Style x:Key="MetroDataGridColumnHeader"
            TargetType="{x:Type DataGridColumnHeader}">
+        <Setter Property="Controls:ControlsHelper.ContentCharacterCasing"
+                Value="Upper" />
+        <Setter Property="FontWeight"
+                Value="SemiBold" />
         <Setter Property="SnapsToDevicePixels"
                 Value="True" />
         <Setter Property="MinWidth"
@@ -187,6 +191,25 @@
                                Grid.Column="1" />
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Normal">
+                            <Setter TargetName="HeaderContent"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content}" />
+                        </Trigger >
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Upper">
+                            <Setter TargetName="HeaderContent"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={Converters:ToUpperConverter}}" />
+                        </Trigger>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Lower">
+                            <Setter TargetName="HeaderContent"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={Converters:ToLowerConverter}}" />
+                        </Trigger>
+
                         <Trigger Property="SortDirection"
                                  Value="{x:Null}">
                             <Setter TargetName="BackgroundBorder"
@@ -239,14 +262,6 @@
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="ContentTemplate">
-            <Setter.Value>
-                <DataTemplate>
-                    <TextBlock FontWeight="SemiBold"
-                               Text="{Binding Converter={Converters:ToUpperConverter}}" />
-                </DataTemplate>
             </Setter.Value>
         </Setter>
     </Style>

--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -4,6 +4,7 @@
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
     <Converters:ToUpperConverter x:Key="ToUpperConverter" />
+    <Converters:ToLowerConverter x:Key="ToLowerConverter" />
     <Converters:ThicknessBindingConverter x:Key="ThicknessBindingConverter" />
 
     <Style x:Key="ExpanderBaseHeaderStyle"
@@ -352,6 +353,8 @@
 
     <Style x:Key="MetroExpander"
            TargetType="{x:Type Expander}">
+        <Setter Property="Controls:ControlsHelper.ContentCharacterCasing"
+                Value="Upper" />
         <Setter Property="Padding"
                 Value="5" />
         <Setter Property="SnapsToDevicePixels"
@@ -456,12 +459,25 @@
                         </DockPanel>
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="Controls:ControlsHelper.PreserveTextCase"
-                                 Value="False">
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Normal">
                             <Setter TargetName="ToggleSite"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Mode=OneWay, Converter={StaticResource ToUpperConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header}" />
+                        </Trigger >
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Upper">
+                            <Setter TargetName="ToggleSite"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={StaticResource ToUpperConverter}}" />
                         </Trigger>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Lower">
+                            <Setter TargetName="ToggleSite"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={StaticResource ToLowerConverter}}" />
+                        </Trigger>
+
                         <Trigger Property="IsExpanded"
                                  Value="true">
                             <Setter TargetName="ExpandSite"

--- a/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -3,8 +3,6 @@
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
-    <Converters:ToUpperConverter x:Key="ToUpperConverter" />
-    <Converters:ToLowerConverter x:Key="ToLowerConverter" />
     <Converters:ThicknessBindingConverter x:Key="ThicknessBindingConverter" />
 
     <Style x:Key="ExpanderBaseHeaderStyle"
@@ -469,13 +467,13 @@
                                  Value="Upper">
                             <Setter TargetName="ToggleSite"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={StaticResource ToUpperConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={Converters:ToUpperConverter}}" />
                         </Trigger>
                         <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
                                  Value="Lower">
                             <Setter TargetName="ToggleSite"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={StaticResource ToLowerConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={Converters:ToLowerConverter}}" />
                         </Trigger>
 
                         <Trigger Property="IsExpanded"

--- a/MahApps.Metro/Styles/Controls.GroupBox.xaml
+++ b/MahApps.Metro/Styles/Controls.GroupBox.xaml
@@ -4,10 +4,13 @@
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
     <Converters:ToUpperConverter x:Key="ToUpperConverter" />
+    <Converters:ToLowerConverter x:Key="ToLowerConverter" />
     <Converters:ThicknessBindingConverter x:Key="ThicknessBindingConverter" />
 
     <Style x:Key="MetroGroupBox"
            TargetType="{x:Type GroupBox}">
+        <Setter Property="Controls:ControlsHelper.ContentCharacterCasing"
+                Value="Upper" />
         <Setter Property="Margin"
                 Value="5" />
         <Setter Property="Padding"
@@ -78,11 +81,23 @@
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="Controls:ControlsHelper.PreserveTextCase"
-                                 Value="False">
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Normal">
                             <Setter TargetName="HeaderContent"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Mode=OneWay, Converter={StaticResource ToUpperConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header}" />
+                        </Trigger >
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Upper">
+                            <Setter TargetName="HeaderContent"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={StaticResource ToUpperConverter}}" />
+                        </Trigger>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Lower">
+                            <Setter TargetName="HeaderContent"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={StaticResource ToLowerConverter}}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/MahApps.Metro/Styles/Controls.GroupBox.xaml
+++ b/MahApps.Metro/Styles/Controls.GroupBox.xaml
@@ -3,8 +3,6 @@
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
-    <Converters:ToUpperConverter x:Key="ToUpperConverter" />
-    <Converters:ToLowerConverter x:Key="ToLowerConverter" />
     <Converters:ThicknessBindingConverter x:Key="ThicknessBindingConverter" />
 
     <Style x:Key="MetroGroupBox"
@@ -91,13 +89,13 @@
                                  Value="Upper">
                             <Setter TargetName="HeaderContent"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={StaticResource ToUpperConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={Converters:ToUpperConverter}}" />
                         </Trigger>
                         <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
                                  Value="Lower">
                             <Setter TargetName="HeaderContent"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={StaticResource ToLowerConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Header, Converter={Converters:ToLowerConverter}}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/MahApps.Metro/Styles/Controls.ListView.xaml
+++ b/MahApps.Metro/Styles/Controls.ListView.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters"
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
     <Style x:Key="MetroGridViewScrollViewerStyle"
            TargetType="{x:Type ScrollViewer}"
@@ -347,6 +348,10 @@
 
     <Style x:Key="MetroGridViewColumnHeader"
            TargetType="GridViewColumnHeader">
+        <Setter Property="Controls:ControlsHelper.ContentCharacterCasing"
+                Value="Upper" />
+        <Setter Property="FontWeight"
+                Value="SemiBold" />
         <Setter Property="Foreground"
                 Value="{DynamicResource BlackBrush}" />
         <Setter Property="SnapsToDevicePixels"
@@ -380,6 +385,25 @@
                                Style="{StaticResource GridViewColumnHeaderGripper}" />
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Normal">
+                            <Setter TargetName="HeaderContent"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content}" />
+                        </Trigger >
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Upper">
+                            <Setter TargetName="HeaderContent"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={Converters:ToUpperConverter}}" />
+                        </Trigger>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing"
+                                 Value="Lower">
+                            <Setter TargetName="HeaderContent"
+                                    Property="Content"
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={Converters:ToLowerConverter}}" />
+                        </Trigger>
+
                         <Trigger Property="IsPressed"
                                  Value="true">
                             <Setter TargetName="HeaderBorder"
@@ -396,14 +420,6 @@
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="ContentTemplate">
-            <Setter.Value>
-                <DataTemplate>
-                    <TextBlock TextBlock.FontWeight="SemiBold"
-                               Text="{Binding Converter={Converters:ToUpperConverter}}" />
-                </DataTemplate>
             </Setter.Value>
         </Setter>
         <Style.Triggers>
@@ -426,6 +442,4 @@
         </Style.Triggers>
     </Style>
 
-    <Style TargetType="{x:Type GridViewColumnHeader}"
-           BasedOn="{StaticResource MetroGridViewColumnHeader}" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.ListView.xaml
+++ b/MahApps.Metro/Styles/Controls.ListView.xaml
@@ -2,8 +2,6 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
-    <Converters:ToUpperConverter x:Key="ToUpperConverter" />
-
     <Style x:Key="MetroGridViewScrollViewerStyle"
            TargetType="{x:Type ScrollViewer}"
            BasedOn="{StaticResource {x:Static GridView.GridViewScrollViewerStyleKey}}">
@@ -404,7 +402,7 @@
             <Setter.Value>
                 <DataTemplate>
                     <TextBlock TextBlock.FontWeight="SemiBold"
-                               Text="{Binding Converter={StaticResource ToUpperConverter}}" />
+                               Text="{Binding Converter={Converters:ToUpperConverter}}" />
                 </DataTemplate>
             </Setter.Value>
         </Setter>

--- a/MahApps.Metro/Styles/Controls.xaml
+++ b/MahApps.Metro/Styles/Controls.xaml
@@ -62,6 +62,7 @@
     <Style TargetType="GroupBox" BasedOn="{StaticResource MetroGroupBox}" />
     <Style TargetType="ListBox" BasedOn="{StaticResource MetroListBox}" />
     <Style TargetType="ListBoxItem" BasedOn="{StaticResource MetroListBoxItem}" />
+    <Style TargetType="GridViewColumnHeader" BasedOn="{StaticResource MetroGridViewColumnHeader}" />
     <Style TargetType="ListView" BasedOn="{StaticResource MetroListView}" />
     <Style TargetType="ListViewItem" BasedOn="{StaticResource MetroListViewItem}" />
     <Style TargetType="TreeView" BasedOn="{StaticResource MetroTreeView}" />

--- a/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -9,22 +9,22 @@
 
     <Style BasedOn="{StaticResource SquareButtonStyle}"
            TargetType="{x:Type Button}">
-        <Setter Property="controls:ButtonHelper.PreserveTextCase"
-                Value="True" />
+        <Setter Property="controls:ControlsHelper.ContentCharacterCasing"
+                Value="Normal" />
     </Style>
 
     <Style x:Key="AccentedDialogSquareButton"
            BasedOn="{StaticResource AccentedSquareButtonStyle}"
            TargetType="{x:Type Button}">
-        <Setter Property="controls:ButtonHelper.PreserveTextCase"
-                Value="True" />
+        <Setter Property="controls:ControlsHelper.ContentCharacterCasing"
+                Value="Normal" />
     </Style>
 
     <Style x:Key="AccentedDialogHighlightedSquareButton"
            BasedOn="{StaticResource HighlightedSquareButtonStyle}"
            TargetType="{x:Type Button}">
-        <Setter Property="controls:ButtonHelper.PreserveTextCase"
-                Value="True" />
+        <Setter Property="controls:ControlsHelper.ContentCharacterCasing"
+                Value="Normal" />
     </Style>
 
     <Storyboard x:Key="DialogShownStoryboard">

--- a/MahApps.Metro/Themes/DropDownButton.xaml
+++ b/MahApps.Metro/Themes/DropDownButton.xaml
@@ -151,9 +151,6 @@
         </Border>
     </ControlTemplate>
 
-    <converters:ToUpperConverter x:Key="ToUpperConverter" />
-    <converters:ToLowerConverter x:Key="ToLowerConverter" />
-
     <Style x:Key="ButtonDropDownFocusVisual">
         <Setter Property="Control.Template">
             <Setter.Value>
@@ -303,13 +300,13 @@
                                  Value="Upper">
                             <Setter TargetName="PART_ButtonContent"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToUpperConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={converters:ToUpperConverter}}" />
                         </Trigger>
                         <Trigger Property="local:ControlsHelper.ContentCharacterCasing"
                                  Value="Lower">
                             <Setter TargetName="PART_ButtonContent"
                                     Property="Content"
-                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={StaticResource ToLowerConverter}}" />
+                                    Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={converters:ToLowerConverter}}" />
                         </Trigger>
 
                         <Trigger Property="Content"

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -10,7 +10,6 @@
     </ResourceDictionary.MergedDictionaries>
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-    <conv:ToUpperConverter x:Key="ToUpperConverter" />
 
     <ControlTemplate x:Key="WindowTemplateKey"
                      TargetType="{x:Type Controls:MetroWindow}">
@@ -320,12 +319,12 @@
             </Setter.Value>
         </Setter>
         <Style.Triggers>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=TitleCaps, Mode=OneWay, Converter={StaticResource ToUpperConverter}}"
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=TitleCaps, Mode=OneWay}"
                          Value="True">
                 <Setter Property="TitleTemplate">
                     <Setter.Value>
                         <DataTemplate>
-                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content, Converter={StaticResource ToUpperConverter}}"
+                            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content, Converter={conv:ToUpperConverter}}"
                                        TextTrimming="CharacterEllipsis"
                                        VerticalAlignment="Center"
                                        Margin="8 -1 0 0"

--- a/Mahapps.Metro.Tests/ButtonTest.cs
+++ b/Mahapps.Metro.Tests/ButtonTest.cs
@@ -34,6 +34,26 @@ namespace MahApps.Metro.Tests
         }
 
         [Fact]
+        public async Task DefaultButtonRespectsControlsHelperContentCharacterCasing()
+        {
+            await TestHost.SwitchToAppThread();
+
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<ButtonWindow>();
+
+            Button defaultButton = window.DefaultButton;
+            var presenter = defaultButton.FindChild<ContentPresenter>("contentPresenter");
+
+            ControlsHelper.SetContentCharacterCasing(defaultButton, CharacterCasing.Normal);
+            Assert.Equal("SomeText", presenter.Content); 
+
+            ControlsHelper.SetContentCharacterCasing(defaultButton, CharacterCasing.Lower);
+            Assert.Equal("sometext", presenter.Content); 
+
+            ControlsHelper.SetContentCharacterCasing(defaultButton, CharacterCasing.Upper);
+            Assert.Equal("SOMETEXT", presenter.Content); 
+        }
+
+        [Fact]
         public async Task SquareButtonButtonTextIsLowerCase()
         {
             await TestHost.SwitchToAppThread();
@@ -45,14 +65,14 @@ namespace MahApps.Metro.Tests
         }
 
         [Fact]
-        public async Task SquareButtonBespectsButtonHelperPreserveTextCase()
+        public async Task SquareButtonBespectsButtonHelperContentCharacterCasing()
         {
             await TestHost.SwitchToAppThread();
 
             var window = await WindowHelpers.CreateInvisibleWindowAsync<ButtonWindow>();
 
             Button defaultButton = window.SquareButton;
-            ButtonHelper.SetPreserveTextCase(defaultButton, true);
+            ControlsHelper.SetContentCharacterCasing(defaultButton, CharacterCasing.Normal);
             var presenter = defaultButton.FindChild<ContentPresenter>("contentPresenter");
 
             Assert.Equal("SomeText", presenter.Content);

--- a/samples/MetroDemo/ExampleViews/SelectionExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/SelectionExamples.xaml
@@ -24,6 +24,7 @@
         <TabItem Header="List/GridView">
             <UniformGrid Rows="2">
                 <ListView Margin="5"
+                          Style="{StaticResource VirtualisedMetroListView}"
                           BorderThickness="0"
                           ItemsSource="{Binding Artists}"
                           SelectedIndex="0">
@@ -37,6 +38,7 @@
                     </ListView.View>
                 </ListView>
                 <ListView Margin="5"
+                          Style="{StaticResource VirtualisedMetroListView}"
                           BorderThickness="0"
                           IsEnabled="False"
                           ItemsSource="{Binding Artists}"
@@ -55,7 +57,7 @@
         <TabItem Header="TreeView">
             <UniformGrid Rows="2">
                 <TreeView ItemsSource="{Binding Artists}"
-                          Style="{DynamicResource VirtualisedMetroTreeView}">
+                          Style="{StaticResource VirtualisedMetroTreeView}">
                     <TreeView.ItemTemplate>
                         <HierarchicalDataTemplate ItemsSource="{Binding Albums}">
                             <TextBlock Text="{Binding Name}" />
@@ -95,11 +97,13 @@
         <TabItem Header="ListBox">
             <UniformGrid Columns="2"
                          Rows="2">
-                <ListBox ItemsSource="{Binding Artists}"
+                <ListBox Style="{StaticResource VirtualisedMetroListBox}"
+                         ItemsSource="{Binding Artists}"
                          DisplayMemberPath="Name"
                          Margin="1"
                          SelectedIndex="0" />
-                <ListBox ItemsSource="{Binding Albums}"
+                <ListBox Style="{StaticResource VirtualisedMetroListBox}"
+                         ItemsSource="{Binding Albums}"
                          DisplayMemberPath="Title"
                          Margin="1"
                          IsEnabled="False"

--- a/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
+++ b/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
@@ -6,6 +6,7 @@
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                       xmlns:metroDemo="clr-namespace:MetroDemo"
                       xmlns:exampleWindows="clr-namespace:MetroDemo.ExampleWindows"
+                      xmlns:converters="http://metro.mahapps.com/winfx/xaml/shared"
                       Title="Flyouts Demo"
                       MinWidth="700"
                       Width="700"
@@ -55,7 +56,7 @@
 
     <Controls:MetroWindow.TitleTemplate>
         <DataTemplate>
-            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content, Converter={StaticResource ToUpperConverter}}"
+            <TextBlock Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content, Converter={converters:ToUpperConverter}}"
                        TextTrimming="CharacterEllipsis"
                        HorizontalAlignment="Right"
                        VerticalAlignment="Center"


### PR DESCRIPTION
I think `ContentCharacterCasing` is better than saying `PreserveTextCase` true or false...

- [x] change usage
- [x] remove PreserveTextCase from ControlsHelper (cause it was introduced in alpha version)
- [x] mark PreserveTextCase as obsolete in ButtonHelper
- [x] tests should be run
- [x] use ContentCharacterCasing for MetroDataGridColumnHeader and MetroGridViewColumnHeader too