### PR TITLE
 NumericUpDown Culture problem #2149

### DIFF
--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1037,20 +1037,17 @@ namespace MahApps.Metro.Controls
             {
                 TextBox textBox = sender as TextBox;
 
-                if (this.Culture != null)
+                if (textBox.Text.Contains(this.SpecificCultureInfo.NumberFormat.NumberDecimalSeparator) == false)
                 {
-                    if (textBox.Text.Contains(this.Culture.NumberFormat.NumberDecimalSeparator) == false)
-                    {
-                        //the control doesn't contai the decimal separator
-                        //so we get the current caret index to insert the current culture decimal separator
-                        var caret = textBox.CaretIndex;
-                        //update the control text
-                        textBox.Text = textBox.Text.Insert(caret, this.Culture.NumberFormat.CurrencyDecimalSeparator);
-                        //move the caret to the correct position
-                        textBox.CaretIndex = caret + 1;
-                    }
-                    e.Handled = true;
+                    //the control doesn't contai the decimal separator
+                    //so we get the current caret index to insert the current culture decimal separator
+                    var caret = textBox.CaretIndex;
+                    //update the control text
+                    textBox.Text = textBox.Text.Insert(caret, this.SpecificCultureInfo.NumberFormat.CurrencyDecimalSeparator);
+                    //move the caret to the correct position
+                    textBox.CaretIndex = caret + 1;
                 }
+                e.Handled = true;
             }
         }
 

--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1032,6 +1032,26 @@ namespace MahApps.Metro.Controls
         private void OnTextBoxKeyDown(object sender, KeyEventArgs e)
         {
             _manualChange = true;
+
+            if (e.Key == Key.Decimal || e.Key == Key.OemPeriod)
+            {
+                TextBox textBox = sender as TextBox;
+
+                if (this.Culture != null)
+                {
+                    if (textBox.Text.Contains(this.Culture.NumberFormat.NumberDecimalSeparator) == false)
+                    {
+                        //the control doesn't contai the decimal separator
+                        //so we get the current caret index to insert the current culture decimal separator
+                        var caret = textBox.CaretIndex;
+                        //update the control text
+                        textBox.Text = textBox.Text.Insert(caret, this.Culture.NumberFormat.CurrencyDecimalSeparator);
+                        //move the caret to the correct position
+                        textBox.CaretIndex = caret + 1;
+                    }
+                    e.Handled = true;
+                }
+            }
         }
 
         private void OnTextBoxLostFocus(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Tested with different cultures and it seems to work just fine.
When the culture NumberDecimalSeparator is ',' (comma) the control replaces the '.' (period or decimal key) with the corrent NumberDecimalSeparator symbol.

All of the remaining functionality is the same.