### PR TITLE
Use thumb for dragmove

### DIFF
--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -520,7 +520,7 @@ namespace MahApps.Metro.Controls
         private void WindowTitleThumbMoveOnDragDelta(object sender, DragDeltaEventArgs dragDeltaEventArgs)
         {
             var window = this.ParentWindow;
-            if (window != null)
+            if (window != null && this.Position != Position.Bottom)
             {
                 MetroWindow.DoWindowTitleThumbMoveOnDragDelta(window, dragDeltaEventArgs);
             }
@@ -529,7 +529,7 @@ namespace MahApps.Metro.Controls
         private void WindowTitleThumbChangeWindowStateOnMouseDoubleClick(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
             var window = this.ParentWindow;
-            if (window != null)
+            if (window != null && this.Position != Position.Bottom)
             {
                 MetroWindow.DoWindowTitleThumbChangeWindowStateOnMouseDoubleClick(window, mouseButtonEventArgs);
             }
@@ -538,7 +538,7 @@ namespace MahApps.Metro.Controls
         private void WindowTitleThumbSystemMenuOnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
         {
             var window = this.ParentWindow;
-            if (window != null)
+            if (window != null && this.Position != Position.Bottom)
             {
                 MetroWindow.DoWindowTitleThumbSystemMenuOnMouseRightButtonUp(window, e);
             }

--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -15,7 +15,7 @@ namespace MahApps.Metro.Controls
     /// <seealso cref="FlyoutsControl"/>
     /// </summary>
     [TemplatePart(Name = "PART_BackButton", Type = typeof(Button))]
-    [TemplatePart(Name = "PART_WindowRestoreThumb", Type = typeof(Thumb))]
+    [TemplatePart(Name = "PART_WindowTitleThumb", Type = typeof(Thumb))]
     [TemplatePart(Name = "PART_Header", Type = typeof(ContentPresenter))]
     [TemplatePart(Name = "PART_Content", Type = typeof(ContentPresenter))]
     public class Flyout : ContentControl
@@ -468,7 +468,7 @@ namespace MahApps.Metro.Controls
         SplineDoubleKeyFrame fadeOutFrame;
         ContentPresenter PART_Header;
         ContentPresenter PART_Content;
-        Thumb windowRestoreThumb;
+        Thumb windowTitleThumb;
 
         public override void OnApplyTemplate()
         {
@@ -480,17 +480,17 @@ namespace MahApps.Metro.Controls
 
             PART_Header = (ContentPresenter)GetTemplateChild("PART_Header");
             PART_Content = (ContentPresenter)GetTemplateChild("PART_Content");
-            windowRestoreThumb = GetTemplateChild("PART_WindowRestoreThumb") as Thumb;
+            this.windowTitleThumb = GetTemplateChild("PART_WindowTitleThumb") as Thumb;
 
-            if (windowRestoreThumb != null)
+            if (this.windowTitleThumb != null)
             {
-                windowRestoreThumb.DragDelta -= WindowMoveThumbOnDragDelta;
-                windowRestoreThumb.MouseDoubleClick -= WindowRestoreThumbOnMouseDoubleClick;
-                windowRestoreThumb.MouseRightButtonUp -= WindowMenuThumbOnMouseRightButtonUp;
+                this.windowTitleThumb.DragDelta -= this.WindowTitleThumbMoveOnDragDelta;
+                this.windowTitleThumb.MouseDoubleClick -= this.WindowTitleThumbChangeWindowStateOnMouseDoubleClick;
+                this.windowTitleThumb.MouseRightButtonUp -= this.WindowTitleThumbSystemMenuOnMouseRightButtonUp;
 
-                windowRestoreThumb.DragDelta += WindowMoveThumbOnDragDelta;
-                windowRestoreThumb.MouseDoubleClick += WindowRestoreThumbOnMouseDoubleClick;
-                windowRestoreThumb.MouseRightButtonUp += WindowMenuThumbOnMouseRightButtonUp;
+                this.windowTitleThumb.DragDelta += this.WindowTitleThumbMoveOnDragDelta;
+                this.windowTitleThumb.MouseDoubleClick += this.WindowTitleThumbChangeWindowStateOnMouseDoubleClick;
+                this.windowTitleThumb.MouseRightButtonUp += this.WindowTitleThumbSystemMenuOnMouseRightButtonUp;
             }
 
             hideStoryboard = (Storyboard)GetTemplateChild("HideStoryboard");
@@ -508,39 +508,39 @@ namespace MahApps.Metro.Controls
 
         protected internal void CleanUp(FlyoutsControl flyoutsControl)
         {
-            if (windowRestoreThumb != null)
+            if (this.windowTitleThumb != null)
             {
-                windowRestoreThumb.DragDelta -= WindowMoveThumbOnDragDelta;
-                windowRestoreThumb.MouseDoubleClick -= WindowRestoreThumbOnMouseDoubleClick;
-                windowRestoreThumb.MouseRightButtonUp -= WindowMenuThumbOnMouseRightButtonUp;
+                this.windowTitleThumb.DragDelta -= this.WindowTitleThumbMoveOnDragDelta;
+                this.windowTitleThumb.MouseDoubleClick -= this.WindowTitleThumbChangeWindowStateOnMouseDoubleClick;
+                this.windowTitleThumb.MouseRightButtonUp -= this.WindowTitleThumbSystemMenuOnMouseRightButtonUp;
             }
             this.parentWindow = null;
         }
 
-        private void WindowMoveThumbOnDragDelta(object sender, DragDeltaEventArgs dragDeltaEventArgs)
+        private void WindowTitleThumbMoveOnDragDelta(object sender, DragDeltaEventArgs dragDeltaEventArgs)
         {
             var window = this.ParentWindow;
             if (window != null)
             {
-                MetroWindow.DoWindowMoveThumbOnDragDelta(window, dragDeltaEventArgs);
+                MetroWindow.DoWindowTitleThumbMoveOnDragDelta(window, dragDeltaEventArgs);
             }
         }
 
-        private void WindowRestoreThumbOnMouseDoubleClick(object sender, MouseButtonEventArgs mouseButtonEventArgs)
+        private void WindowTitleThumbChangeWindowStateOnMouseDoubleClick(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
             var window = this.ParentWindow;
             if (window != null)
             {
-                MetroWindow.DoWindowRestoreThumbOnMouseDoubleClick(window, mouseButtonEventArgs);
+                MetroWindow.DoWindowTitleThumbChangeWindowStateOnMouseDoubleClick(window, mouseButtonEventArgs);
             }
         }
 
-        private void WindowMenuThumbOnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        private void WindowTitleThumbSystemMenuOnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
         {
             var window = this.ParentWindow;
             if (window != null)
             {
-                MetroWindow.DoWindowMenuThumbOnMouseRightButtonUp(window, e);
+                MetroWindow.DoWindowTitleThumbSystemMenuOnMouseRightButtonUp(window, e);
             }
         }
 

--- a/MahApps.Metro/Controls/FlyoutsControl.cs
+++ b/MahApps.Metro/Controls/FlyoutsControl.cs
@@ -58,6 +58,12 @@ namespace MahApps.Metro.Controls
             this.AttachHandlers((Flyout)element);
         }
 
+        protected override void ClearContainerForItemOverride(DependencyObject element, object item)
+        {
+            ((Flyout) element).CleanUp(this);
+            base.ClearContainerForItemOverride(element, item);
+        }
+
         private void AttachHandlers(Flyout flyout)
         {
             var isOpenNotifier = new PropertyChangeNotifier(flyout, Flyout.IsOpenProperty);

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -906,6 +906,7 @@ namespace MahApps.Metro.Controls
             {
                 windowRestoreThumb.DragDelta -= WindowMoveThumbOnDragDelta;
                 windowRestoreThumb.MouseDoubleClick -= WindowRestoreThumbOnMouseDoubleClick;
+                windowRestoreThumb.MouseRightButtonUp -= WindowMenuThumbOnMouseRightButtonUp;
             }
             if (titleBarBackground != null)
             {
@@ -941,6 +942,7 @@ namespace MahApps.Metro.Controls
             {
                 windowRestoreThumb.DragDelta += WindowMoveThumbOnDragDelta;
                 windowRestoreThumb.MouseDoubleClick += WindowRestoreThumbOnMouseDoubleClick;
+                windowRestoreThumb.MouseRightButtonUp += WindowMenuThumbOnMouseRightButtonUp;
             }
 
             // handle mouse events for PART_WindowTitleBackground -> MetroWindow
@@ -1020,8 +1022,8 @@ namespace MahApps.Metro.Controls
             {
                 // we can maximize or restore the window if the title bar height is set (also if title bar is hidden)
                 var canResize = this.ResizeMode == ResizeMode.CanResizeWithGrip || this.ResizeMode == ResizeMode.CanResize;
-                var mPoint = Mouse.GetPosition(this);
-                var isMouseOnTitlebar = mPoint.Y <= this.TitlebarHeight && this.TitlebarHeight > 0;
+                var mousePos = Mouse.GetPosition(this);
+                var isMouseOnTitlebar = mousePos.Y <= this.TitlebarHeight && this.TitlebarHeight > 0;
                 if (canResize && isMouseOnTitlebar)
                 {
                     if (this.WindowState == WindowState.Maximized)
@@ -1033,6 +1035,19 @@ namespace MahApps.Metro.Controls
                         Microsoft.Windows.Shell.SystemCommands.MaximizeWindow(this);
                     }
                     mouseButtonEventArgs.Handled = true;
+                }
+            }
+        }
+
+        private void WindowMenuThumbOnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            if (this.ShowSystemMenuOnRightClick)
+            {
+                // show menu only if mouse pos is on title bar or if we have a window with none style and no title bar
+                var mousePos = e.GetPosition(this);
+                if ((mousePos.Y <= this.TitlebarHeight && this.TitlebarHeight > 0) || (this.UseNoneWindowStyle && this.TitlebarHeight <= 0))
+                {
+                    ShowSystemMenuPhysicalCoordinates(this, PointToScreen(mousePos));
                 }
             }
         }

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -973,7 +973,7 @@ namespace MahApps.Metro.Controls
         internal static void DoWindowMoveThumbOnDragDelta(MetroWindow window, DragDeltaEventArgs dragDeltaEventArgs)
         {
             // drag only if IsWindowDraggable is set to true
-            if (!window.IsWindowDraggable &&
+            if (!window.IsWindowDraggable ||
                 (!(Math.Abs(dragDeltaEventArgs.HorizontalChange) > 2) &&
                  !(Math.Abs(dragDeltaEventArgs.VerticalChange) > 2))) return;
 

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -957,17 +957,32 @@ namespace MahApps.Metro.Controls
 
         private void WindowMoveThumbOnDragDelta(object sender, DragDeltaEventArgs dragDeltaEventArgs)
         {
+            DoWindowMoveThumbOnDragDelta(this, dragDeltaEventArgs);
+        }
+
+        private void WindowRestoreThumbOnMouseDoubleClick(object sender, MouseButtonEventArgs mouseButtonEventArgs)
+        {
+            DoWindowRestoreThumbOnMouseDoubleClick(this, mouseButtonEventArgs);
+        }
+
+        private void WindowMenuThumbOnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            DoWindowMenuThumbOnMouseRightButtonUp(this, e);
+        }
+
+        internal static void DoWindowMoveThumbOnDragDelta(MetroWindow window, DragDeltaEventArgs dragDeltaEventArgs)
+        {
             // drag only if IsWindowDraggable is set to true
-            if (!IsWindowDraggable &&
+            if (!window.IsWindowDraggable &&
                 (!(Math.Abs(dragDeltaEventArgs.HorizontalChange) > 2) &&
                  !(Math.Abs(dragDeltaEventArgs.VerticalChange) > 2))) return;
 
-            var windowHandle = new WindowInteropHelper(this).Handle;
+            var windowHandle = new WindowInteropHelper(window).Handle;
             var cursorPos = Standard.NativeMethods.GetCursorPos();
 
             // if the window is maximized dragging is only allowed on title bar (also if not visible)
-            var windowIsMaximized = WindowState == WindowState.Maximized;
-            var isMouseOnTitlebar = cursorPos.y <= this.TitlebarHeight && this.TitlebarHeight > 0;
+            var windowIsMaximized = window.WindowState == WindowState.Maximized;
+            var isMouseOnTitlebar = cursorPos.y <= window.TitlebarHeight && window.TitlebarHeight > 0;
             if (!isMouseOnTitlebar && windowIsMaximized)
             {
                 return;
@@ -975,47 +990,47 @@ namespace MahApps.Metro.Controls
 
             if (windowIsMaximized)
             {
-                Top = 2;
-                Left = Math.Max(cursorPos.x - RestoreBounds.Width / 2, 0);
+                window.Top = 2;
+                window.Left = Math.Max(cursorPos.x - window.RestoreBounds.Width / 2, 0);
             }
             var lParam = (int)(uint)cursorPos.x | (cursorPos.y << 16);
             Standard.NativeMethods.SendMessage(windowHandle, Standard.WM.LBUTTONUP, (IntPtr)Standard.HT.CAPTION, (IntPtr)lParam);
             Standard.NativeMethods.SendMessage(windowHandle, Standard.WM.SYSCOMMAND, (IntPtr)Standard.SC.MOUSEMOVE, IntPtr.Zero);
         }
 
-        private void WindowRestoreThumbOnMouseDoubleClick(object sender, MouseButtonEventArgs mouseButtonEventArgs)
+        internal static void DoWindowRestoreThumbOnMouseDoubleClick(MetroWindow window, MouseButtonEventArgs mouseButtonEventArgs)
         {
             // restore/maximize only with left button
             if (mouseButtonEventArgs.ChangedButton == MouseButton.Left)
             {
                 // we can maximize or restore the window if the title bar height is set (also if title bar is hidden)
-                var canResize = this.ResizeMode == ResizeMode.CanResizeWithGrip || this.ResizeMode == ResizeMode.CanResize;
-                var mousePos = Mouse.GetPosition(this);
-                var isMouseOnTitlebar = mousePos.Y <= this.TitlebarHeight && this.TitlebarHeight > 0;
+                var canResize = window.ResizeMode == ResizeMode.CanResizeWithGrip || window.ResizeMode == ResizeMode.CanResize;
+                var mousePos = Mouse.GetPosition(window);
+                var isMouseOnTitlebar = mousePos.Y <= window.TitlebarHeight && window.TitlebarHeight > 0;
                 if (canResize && isMouseOnTitlebar)
                 {
-                    if (this.WindowState == WindowState.Maximized)
+                    if (window.WindowState == WindowState.Maximized)
                     {
-                        Microsoft.Windows.Shell.SystemCommands.RestoreWindow(this);
+                        Microsoft.Windows.Shell.SystemCommands.RestoreWindow(window);
                     }
                     else
                     {
-                        Microsoft.Windows.Shell.SystemCommands.MaximizeWindow(this);
+                        Microsoft.Windows.Shell.SystemCommands.MaximizeWindow(window);
                     }
                     mouseButtonEventArgs.Handled = true;
                 }
             }
         }
 
-        private void WindowMenuThumbOnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        internal static void DoWindowMenuThumbOnMouseRightButtonUp(MetroWindow window, MouseButtonEventArgs e)
         {
-            if (this.ShowSystemMenuOnRightClick)
+            if (window.ShowSystemMenuOnRightClick)
             {
                 // show menu only if mouse pos is on title bar or if we have a window with none style and no title bar
-                var mousePos = e.GetPosition(this);
-                if ((mousePos.Y <= this.TitlebarHeight && this.TitlebarHeight > 0) || (this.UseNoneWindowStyle && this.TitlebarHeight <= 0))
+                var mousePos = e.GetPosition(window);
+                if ((mousePos.Y <= window.TitlebarHeight && window.TitlebarHeight > 0) || (window.UseNoneWindowStyle && window.TitlebarHeight <= 0))
                 {
-                    ShowSystemMenuPhysicalCoordinates(this, PointToScreen(mousePos));
+                    ShowSystemMenuPhysicalCoordinates(window, window.PointToScreen(mousePos));
                 }
             }
         }

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -987,14 +987,23 @@ namespace MahApps.Metro.Controls
 
         private void WindowMoveThumbOnDragDelta(object sender, DragDeltaEventArgs dragDeltaEventArgs)
         {
+            // drag only if IsWindowDraggable is set to true
             if (!IsWindowDraggable &&
                 (!(Math.Abs(dragDeltaEventArgs.HorizontalChange) > 2) &&
                  !(Math.Abs(dragDeltaEventArgs.VerticalChange) > 2))) return;
 
             var windowHandle = new WindowInteropHelper(this).Handle;
             var cursorPos = Standard.NativeMethods.GetCursorPos();
-            //UnsafeNativeMethods.ReleaseCapture();
-            if (WindowState == WindowState.Maximized)
+
+            // if the window is maximized dragging is only allowed on title bar (also if not visible)
+            var windowIsMaximized = WindowState == WindowState.Maximized;
+            var isMouseOnTitlebar = cursorPos.y <= this.TitlebarHeight && this.TitlebarHeight > 0;
+            if (!isMouseOnTitlebar && windowIsMaximized)
+            {
+                return;
+            }
+
+            if (windowIsMaximized)
             {
                 Top = 2;
                 Left = Math.Max(cursorPos.x - RestoreBounds.Width / 2, 0);
@@ -1006,16 +1015,15 @@ namespace MahApps.Metro.Controls
 
         private void WindowRestoreThumbOnMouseDoubleClick(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
-            // if UseNoneWindowStyle = true no movement, no maximize please
-            if (mouseButtonEventArgs.ChangedButton == MouseButton.Left && !this.UseNoneWindowStyle)
+            // restore/maximize only with left button
+            if (mouseButtonEventArgs.ChangedButton == MouseButton.Left)
             {
-                var mPoint = Mouse.GetPosition(this);
-                var canResize = this.ResizeMode == ResizeMode.CanResizeWithGrip || this.ResizeMode == ResizeMode.CanResize;
                 // we can maximize or restore the window if the title bar height is set (also if title bar is hidden)
+                var canResize = this.ResizeMode == ResizeMode.CanResizeWithGrip || this.ResizeMode == ResizeMode.CanResize;
+                var mPoint = Mouse.GetPosition(this);
                 var isMouseOnTitlebar = mPoint.Y <= this.TitlebarHeight && this.TitlebarHeight > 0;
                 if (canResize && isMouseOnTitlebar)
                 {
-                    //UnsafeNativeMethods.ReleaseCapture();
                     if (this.WindowState == WindowState.Maximized)
                     {
                         Microsoft.Windows.Shell.SystemCommands.RestoreWindow(this);

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -908,22 +908,10 @@ namespace MahApps.Metro.Controls
                 windowRestoreThumb.MouseDoubleClick -= WindowRestoreThumbOnMouseDoubleClick;
                 windowRestoreThumb.MouseRightButtonUp -= WindowMenuThumbOnMouseRightButtonUp;
             }
-            if (titleBarBackground != null)
-            {
-                titleBarBackground.MouseDown -= TitleBarMouseDown;
-                titleBarBackground.MouseUp -= TitleBarMouseUp;
-            }
-            if (titleBar != null)
-            {
-                titleBar.MouseDown -= TitleBarMouseDown;
-                titleBar.MouseUp -= TitleBarMouseUp;
-            }
             if (icon != null)
             {
                 icon.MouseDown -= IconMouseDown;
             }
-            MouseDown -= TitleBarMouseDown;
-            MouseUp -= TitleBarMouseUp;
             SizeChanged -= MetroWindow_SizeChanged;
         }
 
@@ -945,30 +933,10 @@ namespace MahApps.Metro.Controls
                 windowRestoreThumb.MouseRightButtonUp += WindowMenuThumbOnMouseRightButtonUp;
             }
 
-            // handle mouse events for PART_WindowTitleBackground -> MetroWindow
-            if (titleBarBackground != null && titleBarBackground.Visibility == Visibility.Visible)
+            // handle size if we have a Grid for the title (e.g. clean window have a centered title)
+            if (titleBar != null && titleBar.GetType() == typeof(Grid))
             {
-                //titleBarBackground.MouseDown += TitleBarMouseDown;
-                //titleBarBackground.MouseUp += TitleBarMouseUp;
-            }
-
-            // handle mouse events for PART_TitleBar -> MetroWindow
-            if (titleBar != null && titleBar.Visibility == Visibility.Visible)
-            {
-                //titleBar.MouseDown += TitleBarMouseDown;
-                //titleBar.MouseUp += TitleBarMouseUp;
-
-                // special title resizing for centered title
-                if (titleBar.GetType() == typeof(Grid))
-                {
-                    SizeChanged += MetroWindow_SizeChanged;
-                }
-            }
-            else
-            {
-                // handle mouse events for windows without PART_WindowTitleBackground or PART_TitleBar
-                //MouseDown += TitleBarMouseDown;
-                //MouseUp += TitleBarMouseUp;
+                SizeChanged += MetroWindow_SizeChanged;
             }
         }
 
@@ -1048,42 +1016,6 @@ namespace MahApps.Metro.Controls
                 if ((mousePos.Y <= this.TitlebarHeight && this.TitlebarHeight > 0) || (this.UseNoneWindowStyle && this.TitlebarHeight <= 0))
                 {
                     ShowSystemMenuPhysicalCoordinates(this, PointToScreen(mousePos));
-                }
-            }
-        }
-
-        protected void TitleBarMouseDown(object sender, MouseButtonEventArgs e)
-        {
-            // if UseNoneWindowStyle = true no movement, no maximize please
-            if (e.ChangedButton == MouseButton.Left && !this.UseNoneWindowStyle)
-            {
-                var mPoint = Mouse.GetPosition(this);
-
-                var canResize = this.ResizeMode == ResizeMode.CanResizeWithGrip || this.ResizeMode == ResizeMode.CanResize;
-                // we can maximize or restore the window if the title bar height is set (also if title bar is hidden)
-                var isMouseOnTitlebar = mPoint.Y <= this.TitlebarHeight && this.TitlebarHeight > 0;
-                if (e.ClickCount == 2 && canResize && isMouseOnTitlebar)
-                {
-                    if (this.WindowState == WindowState.Maximized)
-                    {
-                        Microsoft.Windows.Shell.SystemCommands.RestoreWindow(this);
-                    }
-                    else
-                    {
-                        Microsoft.Windows.Shell.SystemCommands.MaximizeWindow(this);
-                    }
-                }
-            }
-        }
-
-        protected void TitleBarMouseUp(object sender, MouseButtonEventArgs e)
-        {
-            if (ShowSystemMenuOnRightClick)
-            {
-                var mousePosition = e.GetPosition(this);
-                if (e.ChangedButton == MouseButton.Right && (UseNoneWindowStyle || mousePosition.Y <= TitlebarHeight))
-                {
-                    ShowSystemMenuPhysicalCoordinates(this, PointToScreen(mousePosition));
                 }
             }
         }

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -20,7 +20,7 @@ namespace MahApps.Metro.Controls
     [TemplatePart(Name = PART_Icon, Type = typeof(UIElement))]
     [TemplatePart(Name = PART_TitleBar, Type = typeof(UIElement))]
     [TemplatePart(Name = PART_WindowTitleBackground, Type = typeof(UIElement))]
-    [TemplatePart(Name = PART_WindowRestoreThumb, Type = typeof(Thumb))]
+    [TemplatePart(Name = PART_WindowTitleThumb, Type = typeof(Thumb))]
     [TemplatePart(Name = PART_LeftWindowCommands, Type = typeof(WindowCommands))]
     [TemplatePart(Name = PART_RightWindowCommands, Type = typeof(WindowCommands))]
     [TemplatePart(Name = PART_WindowButtonCommands, Type = typeof(WindowButtonCommands))]
@@ -33,7 +33,7 @@ namespace MahApps.Metro.Controls
         private const string PART_Icon = "PART_Icon";
         private const string PART_TitleBar = "PART_TitleBar";
         private const string PART_WindowTitleBackground = "PART_WindowTitleBackground";
-        private const string PART_WindowRestoreThumb = "PART_WindowRestoreThumb";
+        private const string PART_WindowTitleThumb = "PART_WindowTitleThumb";
         private const string PART_LeftWindowCommands = "PART_LeftWindowCommands";
         private const string PART_RightWindowCommands = "PART_RightWindowCommands";
         private const string PART_WindowButtonCommands = "PART_WindowButtonCommands";
@@ -102,7 +102,7 @@ namespace MahApps.Metro.Controls
         UIElement icon;
         UIElement titleBar;
         UIElement titleBarBackground;
-        Thumb windowRestoreThumb;
+        Thumb windowTitleThumb;
         internal ContentPresenter LeftWindowCommandsPresenter;
         internal ContentPresenter RightWindowCommandsPresenter;
         internal WindowButtonCommands WindowButtonCommands;
@@ -894,7 +894,7 @@ namespace MahApps.Metro.Controls
             icon = GetTemplateChild(PART_Icon) as UIElement;
             titleBar = GetTemplateChild(PART_TitleBar) as UIElement;
             titleBarBackground = GetTemplateChild(PART_WindowTitleBackground) as UIElement;
-            windowRestoreThumb = GetTemplateChild(PART_WindowRestoreThumb) as Thumb;
+            this.windowTitleThumb = GetTemplateChild(PART_WindowTitleThumb) as Thumb;
 
             this.SetVisibiltyForAllTitleElements(this.TitlebarHeight > 0);
         }
@@ -902,11 +902,11 @@ namespace MahApps.Metro.Controls
         private void ClearWindowEvents()
         {
             // clear all event handlers first:
-            if (windowRestoreThumb != null)
+            if (this.windowTitleThumb != null)
             {
-                windowRestoreThumb.DragDelta -= WindowMoveThumbOnDragDelta;
-                windowRestoreThumb.MouseDoubleClick -= WindowRestoreThumbOnMouseDoubleClick;
-                windowRestoreThumb.MouseRightButtonUp -= WindowMenuThumbOnMouseRightButtonUp;
+                this.windowTitleThumb.DragDelta -= this.WindowTitleThumbMoveOnDragDelta;
+                this.windowTitleThumb.MouseDoubleClick -= this.WindowTitleThumbChangeWindowStateOnMouseDoubleClick;
+                this.windowTitleThumb.MouseRightButtonUp -= this.WindowTitleThumbSystemMenuOnMouseRightButtonUp;
             }
             if (icon != null)
             {
@@ -926,11 +926,11 @@ namespace MahApps.Metro.Controls
                 icon.MouseDown += IconMouseDown;
             }
 
-            if (windowRestoreThumb != null)
+            if (this.windowTitleThumb != null)
             {
-                windowRestoreThumb.DragDelta += WindowMoveThumbOnDragDelta;
-                windowRestoreThumb.MouseDoubleClick += WindowRestoreThumbOnMouseDoubleClick;
-                windowRestoreThumb.MouseRightButtonUp += WindowMenuThumbOnMouseRightButtonUp;
+                this.windowTitleThumb.DragDelta += this.WindowTitleThumbMoveOnDragDelta;
+                this.windowTitleThumb.MouseDoubleClick += this.WindowTitleThumbChangeWindowStateOnMouseDoubleClick;
+                this.windowTitleThumb.MouseRightButtonUp += this.WindowTitleThumbSystemMenuOnMouseRightButtonUp;
             }
 
             // handle size if we have a Grid for the title (e.g. clean window have a centered title)
@@ -955,22 +955,22 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        private void WindowMoveThumbOnDragDelta(object sender, DragDeltaEventArgs dragDeltaEventArgs)
+        private void WindowTitleThumbMoveOnDragDelta(object sender, DragDeltaEventArgs dragDeltaEventArgs)
         {
-            DoWindowMoveThumbOnDragDelta(this, dragDeltaEventArgs);
+            DoWindowTitleThumbMoveOnDragDelta(this, dragDeltaEventArgs);
         }
 
-        private void WindowRestoreThumbOnMouseDoubleClick(object sender, MouseButtonEventArgs mouseButtonEventArgs)
+        private void WindowTitleThumbChangeWindowStateOnMouseDoubleClick(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
-            DoWindowRestoreThumbOnMouseDoubleClick(this, mouseButtonEventArgs);
+            DoWindowTitleThumbChangeWindowStateOnMouseDoubleClick(this, mouseButtonEventArgs);
         }
 
-        private void WindowMenuThumbOnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        private void WindowTitleThumbSystemMenuOnMouseRightButtonUp(object sender, MouseButtonEventArgs e)
         {
-            DoWindowMenuThumbOnMouseRightButtonUp(this, e);
+            DoWindowTitleThumbSystemMenuOnMouseRightButtonUp(this, e);
         }
 
-        internal static void DoWindowMoveThumbOnDragDelta(MetroWindow window, DragDeltaEventArgs dragDeltaEventArgs)
+        internal static void DoWindowTitleThumbMoveOnDragDelta(MetroWindow window, DragDeltaEventArgs dragDeltaEventArgs)
         {
             // drag only if IsWindowDraggable is set to true
             if (!window.IsWindowDraggable ||
@@ -998,7 +998,7 @@ namespace MahApps.Metro.Controls
             Standard.NativeMethods.SendMessage(windowHandle, Standard.WM.SYSCOMMAND, (IntPtr)Standard.SC.MOUSEMOVE, IntPtr.Zero);
         }
 
-        internal static void DoWindowRestoreThumbOnMouseDoubleClick(MetroWindow window, MouseButtonEventArgs mouseButtonEventArgs)
+        internal static void DoWindowTitleThumbChangeWindowStateOnMouseDoubleClick(MetroWindow window, MouseButtonEventArgs mouseButtonEventArgs)
         {
             // restore/maximize only with left button
             if (mouseButtonEventArgs.ChangedButton == MouseButton.Left)
@@ -1022,7 +1022,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        internal static void DoWindowMenuThumbOnMouseRightButtonUp(MetroWindow window, MouseButtonEventArgs e)
+        internal static void DoWindowTitleThumbSystemMenuOnMouseRightButtonUp(MetroWindow window, MouseButtonEventArgs e)
         {
             if (window.ShowSystemMenuOnRightClick)
             {

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -642,6 +642,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Themes\Thumb.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Themes\Tile.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -593,6 +593,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Themes\Thumb.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Themes\Tile.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
@@ -1160,6 +1160,7 @@
     {
         SIZE = 0xF000,
         MOVE = 0xF010,
+        MOUSEMOVE = 0xF012,
         MINIMIZE = 0xF020,
         MAXIMIZE = 0xF030,
         NEXTWINDOW = 0xF040,

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -247,7 +247,7 @@
             <Thumb Style="{StaticResource InvisibleThumbStyle}"
                    Height="{Binding Path=TitlebarHeight, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}"
                    VerticalAlignment="Top"
-                   x:Name="PART_WindowRestoreThumb" />
+                   x:Name="PART_WindowTitleThumb" />
         </Grid>
         <ControlTemplate.Triggers>
             <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource Self}}"

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -7,20 +7,8 @@
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/Thumb.xaml" />
     </ResourceDictionary.MergedDictionaries>
-
-    <Style TargetType="{x:Type Thumb}"
-           x:Key="InvisibleThumbStyle">
-        <Setter Property="Background"
-                Value="Transparent" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate>
-                    <Grid Background="{TemplateBinding Background}" />
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
 
     <DataTemplate x:Key="HeaderTemplate"
                   x:Shared="False">
@@ -244,7 +232,7 @@
                                       DockPanel.Dock="Bottom" />
                 </DockPanel>
             </AdornerDecorator>
-            <Thumb Style="{StaticResource InvisibleThumbStyle}"
+            <Thumb Style="{StaticResource WindowTitleThumbStyle}"
                    Height="{Binding Path=TitlebarHeight, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}"
                    VerticalAlignment="Top"
                    x:Name="PART_WindowTitleThumb" />

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -9,6 +9,19 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
+    <Style TargetType="{x:Type Thumb}"
+           x:Key="InvisibleThumbStyle">
+        <Setter Property="Background"
+                Value="Transparent" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid Background="{TemplateBinding Background}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <DataTemplate x:Key="HeaderTemplate"
                   x:Shared="False">
         <DockPanel x:Name="dpHeader"
@@ -231,6 +244,10 @@
                                       DockPanel.Dock="Bottom" />
                 </DockPanel>
             </AdornerDecorator>
+            <Thumb Style="{StaticResource InvisibleThumbStyle}"
+                   Height="{Binding Path=TitlebarHeight, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}}"
+                   VerticalAlignment="Top"
+                   x:Name="PART_WindowRestoreThumb" />
         </Grid>
         <ControlTemplate.Triggers>
             <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource Self}}"

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -234,7 +234,7 @@
         
         <ControlTemplate.Triggers>
             <Trigger Property="UseNoneWindowStyle" Value="True">
-                <Setter TargetName="PART_WindowRestoreThumb" Property="Grid.Row" Value="2" />
+                <Setter TargetName="PART_WindowRestoreThumb" Property="Grid.RowSpan" Value="2" />
             </Trigger>
             <!-- handle active/inactive state -->
             <Trigger Property="IsActive"
@@ -515,7 +515,7 @@
 
         <ControlTemplate.Triggers>
             <Trigger Property="UseNoneWindowStyle" Value="True">
-                <Setter TargetName="PART_WindowRestoreThumb" Property="Grid.Row" Value="2" />
+                <Setter TargetName="PART_WindowRestoreThumb" Property="Grid.RowSpan" Value="2" />
             </Trigger>
             <!-- handle active/inactive state -->
             <Trigger Property="IsActive"

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -109,7 +109,7 @@
                            Grid.Column="0"
                            Grid.ColumnSpan="5"
                            Style="{StaticResource InvisibleThumbStyle}"
-                           x:Name="PART_WindowRestoreThumb" />
+                           x:Name="PART_WindowTitleThumb" />
 
                     <!-- the right window commands -->
                     <ContentPresenter x:Name="PART_RightWindowCommands"
@@ -234,7 +234,7 @@
         
         <ControlTemplate.Triggers>
             <Trigger Property="UseNoneWindowStyle" Value="True">
-                <Setter TargetName="PART_WindowRestoreThumb" Property="Grid.RowSpan" Value="2" />
+                <Setter TargetName="PART_WindowTitleThumb" Property="Grid.RowSpan" Value="2" />
             </Trigger>
             <!-- handle active/inactive state -->
             <Trigger Property="IsActive"
@@ -390,7 +390,7 @@
                            Grid.Column="0"
                            Grid.ColumnSpan="5"
                            Style="{StaticResource InvisibleThumbStyle}"
-                           x:Name="PART_WindowRestoreThumb" />
+                           x:Name="PART_WindowTitleThumb" />
 
                     <!-- the right window commands -->
                     <ContentPresenter x:Name="PART_RightWindowCommands"
@@ -515,7 +515,7 @@
 
         <ControlTemplate.Triggers>
             <Trigger Property="UseNoneWindowStyle" Value="True">
-                <Setter TargetName="PART_WindowRestoreThumb" Property="Grid.RowSpan" Value="2" />
+                <Setter TargetName="PART_WindowTitleThumb" Property="Grid.RowSpan" Value="2" />
             </Trigger>
             <!-- handle active/inactive state -->
             <Trigger Property="IsActive"

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -10,6 +10,19 @@
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
+    <Style TargetType="{x:Type Thumb}"
+           x:Key="InvisibleThumbStyle">
+        <Setter Property="Background"
+                Value="Transparent" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid Background="{TemplateBinding Background}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <ControlTemplate x:Key="WindowTemplateKey"
                      TargetType="{x:Type Controls:MetroWindow}">
         <Grid>
@@ -91,6 +104,12 @@
                             </MultiBinding>
                         </ContentControl.Foreground>
                     </ContentControl>
+
+                    <Thumb Grid.Row="0"
+                           Grid.Column="0"
+                           Grid.ColumnSpan="5"
+                           Style="{StaticResource InvisibleThumbStyle}"
+                           x:Name="PART_WindowRestoreThumb" />
 
                     <!-- the right window commands -->
                     <ContentPresenter x:Name="PART_RightWindowCommands"
@@ -214,6 +233,9 @@
         </ControlTemplate.Resources>
         
         <ControlTemplate.Triggers>
+            <Trigger Property="UseNoneWindowStyle" Value="True">
+                <Setter TargetName="PART_WindowRestoreThumb" Property="Grid.Row" Value="2" />
+            </Trigger>
             <!-- handle active/inactive state -->
             <Trigger Property="IsActive"
                      Value="False">
@@ -364,6 +386,12 @@
                         </Label>
                     </Grid>
 
+                    <Thumb Grid.Row="0"
+                           Grid.Column="0"
+                           Grid.ColumnSpan="5"
+                           Style="{StaticResource InvisibleThumbStyle}"
+                           x:Name="PART_WindowRestoreThumb" />
+
                     <!-- the right window commands -->
                     <ContentPresenter x:Name="PART_RightWindowCommands"
                                       Focusable="False"
@@ -486,6 +514,9 @@
         </ControlTemplate.Resources>
 
         <ControlTemplate.Triggers>
+            <Trigger Property="UseNoneWindowStyle" Value="True">
+                <Setter TargetName="PART_WindowRestoreThumb" Property="Grid.Row" Value="2" />
+            </Trigger>
             <!-- handle active/inactive state -->
             <Trigger Property="IsActive"
                      Value="False">

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -6,22 +6,10 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TextBlock.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/Thumb.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-
-    <Style TargetType="{x:Type Thumb}"
-           x:Key="InvisibleThumbStyle">
-        <Setter Property="Background"
-                Value="Transparent" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate>
-                    <Grid Background="{TemplateBinding Background}" />
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
 
     <ControlTemplate x:Key="WindowTemplateKey"
                      TargetType="{x:Type Controls:MetroWindow}">
@@ -108,7 +96,7 @@
                     <Thumb Grid.Row="0"
                            Grid.Column="0"
                            Grid.ColumnSpan="5"
-                           Style="{StaticResource InvisibleThumbStyle}"
+                           Style="{StaticResource WindowTitleThumbStyle}"
                            x:Name="PART_WindowTitleThumb" />
 
                     <!-- the right window commands -->
@@ -389,7 +377,7 @@
                     <Thumb Grid.Row="0"
                            Grid.Column="0"
                            Grid.ColumnSpan="5"
-                           Style="{StaticResource InvisibleThumbStyle}"
+                           Style="{StaticResource WindowTitleThumbStyle}"
                            x:Name="PART_WindowTitleThumb" />
 
                     <!-- the right window commands -->

--- a/MahApps.Metro/Themes/Thumb.xaml
+++ b/MahApps.Metro/Themes/Thumb.xaml
@@ -1,0 +1,15 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style TargetType="{x:Type Thumb}" x:Key="WindowTitleThumbStyle">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Grid Background="{TemplateBinding Background}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/docs/release-notes/1.2.0.md
+++ b/docs/release-notes/1.2.0.md
@@ -98,7 +98,6 @@ This is a bug fix and feature release of MahApps.Metro v1.2.0.
 - New `ContentControlEx` to reduce some boilerplate XAML code
 	+ Used for all possible `ContentCharacterCasing` usage (`Button`, `GroupBox`, `Expander`, `ListView` columns, `DataGrid` columns, `DropDownButton`, `SplitButton`, `WindowCommands`, `TabItem`)
 - Copy command for the message text in `MessageDialog` #2223 (@akinyooa)
-- Use a `Thumb` for Window DragMove #2226
 
 # Bugfixes
 
@@ -160,6 +159,3 @@ This is a bug fix and feature release of MahApps.Metro v1.2.0.
 - Fixed `ComboBox` watermark padding issue with `IsEditable` states #2210
 - Fixed missing `ContentCharacterCasing` for `TabItem` #2209
 - Fixed style inheritence of `MetroAnimatedTabControl` style #2219
-- Fixed not draggable Window when Flyout is open #1821 #1635 #2226
-- Fixed `AvalonDock` anchorables could not be dragged inside `MetroWindow` #2036 #2226
-- Fixed System menu present everywhere when fullscreen is toggled on #1849

--- a/docs/release-notes/1.2.0.md
+++ b/docs/release-notes/1.2.0.md
@@ -98,6 +98,7 @@ This is a bug fix and feature release of MahApps.Metro v1.2.0.
 - New `ContentControlEx` to reduce some boilerplate XAML code
 	+ Used for all possible `ContentCharacterCasing` usage (`Button`, `GroupBox`, `Expander`, `ListView` columns, `DataGrid` columns, `DropDownButton`, `SplitButton`, `WindowCommands`, `TabItem`)
 - Copy command for the message text in `MessageDialog` #2223 (@akinyooa)
+- Use a `Thumb` for Window DragMove #2226
 
 # Bugfixes
 
@@ -159,3 +160,6 @@ This is a bug fix and feature release of MahApps.Metro v1.2.0.
 - Fixed `ComboBox` watermark padding issue with `IsEditable` states #2210
 - Fixed missing `ContentCharacterCasing` for `TabItem` #2209
 - Fixed style inheritence of `MetroAnimatedTabControl` style #2219
+- Fixed not draggable Window when Flyout is open #1821 #1635 #2226
+- Fixed `AvalonDock` anchorables could not be dragged inside `MetroWindow` #2036 #2226
+- Fixed System menu present everywhere when fullscreen is toggled on #1849


### PR DESCRIPTION
- [x] use thumb for DragMove actions (makes it possible that animations not hangs)
- [x] double click in thumb
- [x] DragMove with UseNoneWindowStyle
- [x] right click on thumb
- [x] allow DragMove with open Flyouts
- [x] some code cleanup after Flyout implementation
- [x] test it with Avalon dock for @QuantumDeveloper 
- [x] hopefully not a breaking change :-D

thx @ButchersBoy for the code from [Dragablz](https://github.com/ButchersBoy/Dragablz)

Closes #1821 Move window when flyout is open
Closes #1635 Fylout window not draggable?
Closes #2036 Avalondock Anchorables could not be dragged inside MetroWindow
Closes #2122 Use behavior/attached property to control window dragging
Closes #1849 System menu present everywhere when fullscreen is toggled on