### PR TITLE
Hide username on LoginDialog

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
@@ -10,7 +10,7 @@ namespace MahApps.Metro.Controls.Dialogs
         private const string DefaultUsernameWatermark = "Username...";
         private const string DefaultPasswordWatermark = "Password...";
         private const Visibility DefaultNegativeButtonVisibility = Visibility.Collapsed;
-        private const Visibility DefaultUsernameVisibility = Visibility.Visible;
+        private const bool DefaultShouldHideUsername = false;
         private const bool DefaultEnablePasswordPreview = false;
 
         public LoginDialogSettings()
@@ -18,7 +18,7 @@ namespace MahApps.Metro.Controls.Dialogs
             UsernameWatermark = DefaultUsernameWatermark;
             PasswordWatermark = DefaultPasswordWatermark;
             NegativeButtonVisibility = DefaultNegativeButtonVisibility;
-            UsernameVisibility = DefaultUsernameVisibility;
+            ShouldHideUsername = DefaultShouldHideUsername;
             AffirmativeButtonText = "Login";
             EnablePasswordPreview = DefaultEnablePasswordPreview;
         }
@@ -29,7 +29,7 @@ namespace MahApps.Metro.Controls.Dialogs
 
         public string UsernameWatermark { get; set; }
 
-        public Visibility UsernameVisibility { get; set; }
+        public bool ShouldHideUsername { get; set; }
 
         public string PasswordWatermark { get; set; }
 
@@ -60,7 +60,7 @@ namespace MahApps.Metro.Controls.Dialogs
             UsernameWatermark = settings.UsernameWatermark;
             PasswordWatermark = settings.PasswordWatermark;
             NegativeButtonButtonVisibility = settings.NegativeButtonVisibility;
-            UsernameVisibility = settings.UsernameVisibility;
+            ShouldHideUsername = settings.ShouldHideUsername;
         }
 
         internal Task<LoginDialogData> WaitForButtonPressAsync()
@@ -68,7 +68,7 @@ namespace MahApps.Metro.Controls.Dialogs
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 this.Focus();
-                if (string.IsNullOrEmpty(PART_TextBox.Text) && UsernameVisibility == Visibility.Visible)
+                if (string.IsNullOrEmpty(PART_TextBox.Text) && !ShouldHideUsername)
                 {
                     PART_TextBox.Focus();
                 }
@@ -205,7 +205,7 @@ namespace MahApps.Metro.Controls.Dialogs
         public static readonly DependencyProperty AffirmativeButtonTextProperty = DependencyProperty.Register("AffirmativeButtonText", typeof(string), typeof(LoginDialog), new PropertyMetadata("OK"));
         public static readonly DependencyProperty NegativeButtonTextProperty = DependencyProperty.Register("NegativeButtonText", typeof(string), typeof(LoginDialog), new PropertyMetadata("Cancel"));
         public static readonly DependencyProperty NegativeButtonButtonVisibilityProperty = DependencyProperty.Register("NegativeButtonButtonVisibility", typeof(Visibility), typeof(LoginDialog), new PropertyMetadata(Visibility.Collapsed));
-        public static readonly DependencyProperty UsernameVisibilityProperty = DependencyProperty.Register("UsernameVisibility", typeof(Visibility), typeof(LoginDialog), new PropertyMetadata(Visibility.Visible));
+        public static readonly DependencyProperty ShouldHideUsernameProperty = DependencyProperty.Register("ShouldHideUsername", typeof(bool), typeof(LoginDialog), new PropertyMetadata(false));
 
         public string Message
         {
@@ -255,10 +255,10 @@ namespace MahApps.Metro.Controls.Dialogs
             set { SetValue(NegativeButtonButtonVisibilityProperty, value); }
         }
 
-        public Visibility UsernameVisibility
+        public bool ShouldHideUsername
         {
-            get { return (Visibility)GetValue(UsernameVisibilityProperty); }
-            set { SetValue(UsernameVisibilityProperty, value); }
+            get { return (bool)GetValue(ShouldHideUsernameProperty); }
+            set { SetValue(ShouldHideUsernameProperty, value); }
         }
     }
 }

--- a/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/LoginDialog.cs
@@ -10,6 +10,7 @@ namespace MahApps.Metro.Controls.Dialogs
         private const string DefaultUsernameWatermark = "Username...";
         private const string DefaultPasswordWatermark = "Password...";
         private const Visibility DefaultNegativeButtonVisibility = Visibility.Collapsed;
+        private const Visibility DefaultUsernameVisibility = Visibility.Visible;
         private const bool DefaultEnablePasswordPreview = false;
 
         public LoginDialogSettings()
@@ -17,6 +18,7 @@ namespace MahApps.Metro.Controls.Dialogs
             UsernameWatermark = DefaultUsernameWatermark;
             PasswordWatermark = DefaultPasswordWatermark;
             NegativeButtonVisibility = DefaultNegativeButtonVisibility;
+            UsernameVisibility = DefaultUsernameVisibility;
             AffirmativeButtonText = "Login";
             EnablePasswordPreview = DefaultEnablePasswordPreview;
         }
@@ -26,6 +28,8 @@ namespace MahApps.Metro.Controls.Dialogs
         public string InitialPassword { get; set; }
 
         public string UsernameWatermark { get; set; }
+
+        public Visibility UsernameVisibility { get; set; }
 
         public string PasswordWatermark { get; set; }
 
@@ -56,6 +60,7 @@ namespace MahApps.Metro.Controls.Dialogs
             UsernameWatermark = settings.UsernameWatermark;
             PasswordWatermark = settings.PasswordWatermark;
             NegativeButtonButtonVisibility = settings.NegativeButtonVisibility;
+            UsernameVisibility = settings.UsernameVisibility;
         }
 
         internal Task<LoginDialogData> WaitForButtonPressAsync()
@@ -63,7 +68,7 @@ namespace MahApps.Metro.Controls.Dialogs
             Dispatcher.BeginInvoke(new Action(() =>
             {
                 this.Focus();
-                if (string.IsNullOrEmpty(PART_TextBox.Text))
+                if (string.IsNullOrEmpty(PART_TextBox.Text) && UsernameVisibility == Visibility.Visible)
                 {
                     PART_TextBox.Focus();
                 }
@@ -200,6 +205,7 @@ namespace MahApps.Metro.Controls.Dialogs
         public static readonly DependencyProperty AffirmativeButtonTextProperty = DependencyProperty.Register("AffirmativeButtonText", typeof(string), typeof(LoginDialog), new PropertyMetadata("OK"));
         public static readonly DependencyProperty NegativeButtonTextProperty = DependencyProperty.Register("NegativeButtonText", typeof(string), typeof(LoginDialog), new PropertyMetadata("Cancel"));
         public static readonly DependencyProperty NegativeButtonButtonVisibilityProperty = DependencyProperty.Register("NegativeButtonButtonVisibility", typeof(Visibility), typeof(LoginDialog), new PropertyMetadata(Visibility.Collapsed));
+        public static readonly DependencyProperty UsernameVisibilityProperty = DependencyProperty.Register("UsernameVisibility", typeof(Visibility), typeof(LoginDialog), new PropertyMetadata(Visibility.Visible));
 
         public string Message
         {
@@ -247,6 +253,12 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             get { return (Visibility)GetValue(NegativeButtonButtonVisibilityProperty); }
             set { SetValue(NegativeButtonButtonVisibilityProperty, value); }
+        }
+
+        public Visibility UsernameVisibility
+        {
+            get { return (Visibility)GetValue(UsernameVisibilityProperty); }
+            set { SetValue(UsernameVisibilityProperty, value); }
         }
     }
 }

--- a/MahApps.Metro/Converters/InvertedBooleanToVisibilityConverter.cs
+++ b/MahApps.Metro/Converters/InvertedBooleanToVisibilityConverter.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Data;
+
+namespace MahApps.Metro.Converters
+{    
+    public class InvertedBooleanToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {            
+            var shouldBeCollapsed = false;
+            
+            if(value is bool)
+            {
+                shouldBeCollapsed = (bool)value;
+            }
+            else if(value is bool?)
+            {
+                var valueAsNullable = (bool?)value;
+                shouldBeCollapsed = valueAsNullable.HasValue ? valueAsNullable.Value : false;
+            }
+
+            return shouldBeCollapsed ? Visibility.Collapsed : Visibility.Hidden;
+            
+
+        }
+     
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Visibility)
+            {
+                return (Visibility)value == Visibility.Collapsed;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Controls\WindowCommandsOverlayBehavior.cs" />
     <Compile Include="Converters\BackgroundToForegroundConverter.cs" />
     <Compile Include="Converters\FontSizeOffsetConverter.cs" />
+    <Compile Include="Converters\InvertedBooleanToVisibilityConverter.cs" />
     <Compile Include="Converters\IsNullConverter.cs" />
     <Compile Include="Converters\MetroTabItemCloseButtonWidthConverter.cs" />
     <Compile Include="Converters\OffOnConverter.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -162,6 +162,7 @@
     </Compile>
     <Compile Include="Controls\WindowCommandsOverlayBehavior.cs" />
     <Compile Include="Converters\BackgroundToForegroundConverter.cs" />
+    <Compile Include="Converters\InvertedBooleanToVisibilityConverter.cs" />
     <Compile Include="Converters\ThicknessBindingConverter.cs" />
     <Compile Include="Converters\IsNullConverter.cs" />
     <Compile Include="Converters\FontSizeOffsetConverter.cs" />

--- a/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
@@ -26,6 +26,7 @@
                  Controls:TextBoxHelper.SelectAllOnFocus="True"
                  Text="{Binding Username, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  TextWrapping="Wrap"
+                 Visibility="{Binding UsernameVisibility, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         <PasswordBox Grid.Row="2"
                      Margin="0 5 0 0"

--- a/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
@@ -1,9 +1,13 @@
 ﻿<Dialogs:BaseMetroDialog xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                          xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
+                         xmlns:Converters="clr-namespace:MahApps.Metro.Converters"
                          xmlns:Dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs"
                          xmlns:Behaviors="clr-namespace:MahApps.Metro.Behaviours"
                          x:Class="MahApps.Metro.Controls.Dialogs.LoginDialog">
+    <Dialogs:BaseMetroDialog.Resources>
+        <Converters:InvertedBooleanToVisibilityConverter x:Key="InvertedBooleanToVisibilityConverter"/>
+    </Dialogs:BaseMetroDialog.Resources>
     <Grid Margin="0 10 0 0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"
@@ -26,7 +30,7 @@
                  Controls:TextBoxHelper.SelectAllOnFocus="True"
                  Text="{Binding Username, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  TextWrapping="Wrap"
-                 Visibility="{Binding UsernameVisibility, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                 Visibility="{Binding ShouldHideUsername, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource InvertedBooleanToVisibilityConverter}}"
                  Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         <PasswordBox Grid.Row="2"
                      Margin="0 5 0 0"

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -224,7 +224,7 @@
                 </UniformGrid>
 
                 <Label Content='Min="0", Max="10", TextAlignment="Left"' />
-                <Controls:NumericUpDown Value="5" IsEnabled="False"
+                <Controls:NumericUpDown Value="5" IsEnabled="True"
                                         x:Name="Test"
                                         TextAlignment="Left"
                                         Minimum="0"

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -224,7 +224,7 @@
                 </UniformGrid>
 
                 <Label Content='Min="0", Max="10", TextAlignment="Left"' />
-                <Controls:NumericUpDown Value="5" IsEnabled="True"
+                <Controls:NumericUpDown Value="5" IsEnabled="False"
                                         x:Name="Test"
                                         TextAlignment="Left"
                                         Minimum="0"

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -168,6 +168,8 @@
                               Header="Show LoginDialog" />
                     <MenuItem Click="ShowLoginDialogPasswordPreview"
                               Header="Show Password Preview LoginDialog" />
+                    <MenuItem Click="ShowLoginDialogOnlyPassword"
+                              Header="Show LoginDialog (Only Password)" />
                     <MenuItem Click="ShowMessageDialog"
                               Header="Show MessageDialog" />
                     <MenuItem Click="ShowLimitedMessageDialog"

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -246,7 +246,7 @@ namespace MetroDemo
 
         private async void ShowLoginDialogOnlyPassword(object sender, RoutedEventArgs e)
         {
-            LoginDialogData result = await this.ShowLoginAsync("Authentication", "Enter your password", new LoginDialogSettings { ColorScheme = this.MetroDialogOptions.ColorScheme, UsernameVisibility = Visibility.Collapsed });
+            LoginDialogData result = await this.ShowLoginAsync("Authentication", "Enter your password", new LoginDialogSettings { ColorScheme = this.MetroDialogOptions.ColorScheme, ShouldHideUsername = true });
             if (result == null)
             {
                 //User pressed cancel

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -231,7 +231,7 @@ namespace MetroDemo
             await this.HideMetroDialogAsync(dialog);
         }
 
-         private async void ShowLoginDialogPasswordPreview(object sender, RoutedEventArgs e)
+        private async void ShowLoginDialogPasswordPreview(object sender, RoutedEventArgs e)
         {
             LoginDialogData result = await this.ShowLoginAsync("Authentication", "Enter your credentials", new LoginDialogSettings { ColorScheme = this.MetroDialogOptions.ColorScheme, InitialUsername = "MahApps", EnablePasswordPreview = true });
             if (result == null)
@@ -243,6 +243,20 @@ namespace MetroDemo
                 MessageDialogResult messageResult = await this.ShowMessageAsync("Authentication Information", String.Format("Username: {0}\nPassword: {1}", result.Username, result.Password));
             }
         }
+
+        private async void ShowLoginDialogOnlyPassword(object sender, RoutedEventArgs e)
+        {
+            LoginDialogData result = await this.ShowLoginAsync("Authentication", "Enter your password", new LoginDialogSettings { ColorScheme = this.MetroDialogOptions.ColorScheme, UsernameVisibility = Visibility.Collapsed });
+            if (result == null)
+            {
+                //User pressed cancel
+            }
+            else
+            {
+                MessageDialogResult messageResult = await this.ShowMessageAsync("Authentication Information", String.Format("Password: {0}", result.Password));
+            }
+        }
+
         private async void ShowProgressDialog(object sender, RoutedEventArgs e)
         {
             var controller = await this.ShowProgressAsync("Please wait...", "We are baking some cupcakes!");


### PR DESCRIPTION
The LoginDialog can now be shown like this to hide the username and only ask for a password:

```
var result = await this.ShowLoginAsync("Authentication", "Enter your password", 
                                       new LoginDialogSettings 
                                       { 
                                           UsernameVisibility = Visibility.Collapsed
                                       });
```

Closes #2229