### PR TITLE
Floating watermarks now trigger better

### DIFF
--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -87,10 +87,10 @@
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                        Margin="4,2,2,2" />
-                            <Grid x:Name="PART_FloatingMessageContainer"
+                            <ContentControl x:Name="PART_FloatingMessageContainer"
                                   Grid.Column="0"
                                   Grid.ColumnSpan="2"
-                                  Height="0"
+                                  MaxHeight="0"
                                   IsHitTestVisible="False"
                                   Margin="5,0"
                                   Visibility="Visible">
@@ -100,12 +100,13 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Opacity="0.6"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                           Style="{DynamicResource MetroAutoCollapsingTextBlock}">
                                     <TextBlock.RenderTransform>
                                         <TranslateTransform />
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
-                            </Grid>
+                            </ContentControl>
                             <Button x:Name="PART_ClearText"
                                     Grid.Column="1"
                                     Grid.RowSpan="2"
@@ -127,36 +128,20 @@
                                     Value="Visible" />
                         </DataTrigger>
 
-                        <!--Sets the MiniMessage visibility (Watermark must not be "" and FloatWatermark must be true)-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.HasText)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}"
+                                           Value="True" />
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" 
+                                           Value="True"/>
+                            </MultiDataTrigger.Conditions>
+                            <MultiDataTrigger.EnterActions>
                                 <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override Watermark == ""-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.Watermark)}"
-                                     Value="">
-                            <DataTrigger.EnterActions>
+                            </MultiDataTrigger.EnterActions>
+                            <MultiDataTrigger.ExitActions>
                                 <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override TextBoxHelper.UseFloatingWatermark == false-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.UseFloatingWatermark)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
+                            </MultiDataTrigger.ExitActions>
+                        </MultiDataTrigger>
 
                         <!-- multiline textbox cannot bind to actual height so take the fallbach button width -->
                         <MultiTrigger>

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -349,10 +349,10 @@
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                        Margin="6,2,6,2" />
-                            <Grid x:Name="PART_FloatingMessageContainer"
+                            <ContentControl x:Name="PART_FloatingMessageContainer"
                                   Grid.Column="0"
                                   Grid.ColumnSpan="2"
-                                  Height="0"
+                                  MaxHeight="0"
                                   IsHitTestVisible="False"
                                   Margin="5,0"
                                   Visibility="Visible">
@@ -362,12 +362,13 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Opacity="0.6"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                           Style="{DynamicResource MetroAutoCollapsingTextBlock}">
                                     <TextBlock.RenderTransform>
                                         <TranslateTransform />
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
-                            </Grid>
+                            </ContentControl>
                             <Button x:Name="PART_ClearText"
                                     Grid.Column="2"
                                     Grid.RowSpan="2"
@@ -409,36 +410,20 @@
                                     Value="Visible" />
                         </DataTrigger>
 
-                        <!--Sets the MiniMessage visibility (Watermark must not be "" and FloatWatermark must be true)-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.HasText)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}"
+                                           Value="True" />
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" 
+                                           Value="True"/>
+                            </MultiDataTrigger.Conditions>
+                            <MultiDataTrigger.EnterActions>
                                 <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override Watermark == ""-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.Watermark)}"
-                                     Value="">
-                            <DataTrigger.EnterActions>
+                            </MultiDataTrigger.EnterActions>
+                            <MultiDataTrigger.ExitActions>
                                 <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override TextBoxHelper.UseFloatingWatermark == false-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.UseFloatingWatermark)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
+                            </MultiDataTrigger.ExitActions>
+                        </MultiDataTrigger>
 
                         <Trigger Property="IsMouseOver"
                                  Value="True">
@@ -593,10 +578,10 @@
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                        Margin="6,2,6,2" />
-                            <Grid x:Name="PART_FloatingMessageContainer"
+                            <ContentControl x:Name="PART_FloatingMessageContainer"
                                   Grid.Column="0"
                                   Grid.ColumnSpan="2"
-                                  Height="0"
+                                  MaxHeight="0"
                                   IsHitTestVisible="False"
                                   Margin="5,0"
                                   Visibility="Visible">
@@ -606,12 +591,13 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Opacity="0.6"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                           Style="{DynamicResource MetroAutoCollapsingTextBlock}">
                                     <TextBlock.RenderTransform>
                                         <TranslateTransform />
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
-                            </Grid>
+                            </ContentControl>
                             <Button x:Name="PART_ClearText"
                                     Grid.Column="2"
                                     Grid.RowSpan="2"
@@ -652,36 +638,20 @@
                                     Value="Visible" />
                         </DataTrigger>
 
-                        <!--Sets the MiniMessage visibility (Watermark must not be "" and FloatWatermark must be true)-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.HasText)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}"
+                                           Value="True" />
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" 
+                                           Value="True"/>
+                            </MultiDataTrigger.Conditions>
+                            <MultiDataTrigger.EnterActions>
                                 <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override Watermark == ""-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.Watermark)}"
-                                     Value="">
-                            <DataTrigger.EnterActions>
+                            </MultiDataTrigger.EnterActions>
+                            <MultiDataTrigger.ExitActions>
                                 <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override TextBoxHelper.FloatingWatermark == false-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.UseFloatingWatermark)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
+                            </MultiDataTrigger.ExitActions>
+                        </MultiDataTrigger>
 
                         <Trigger Property="IsMouseOver"
                                  Value="True">
@@ -842,10 +812,10 @@
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                        Margin="6,2,6,2" />
-                            <Grid x:Name="PART_FloatingMessageContainer"
+                            <ContentControl x:Name="PART_FloatingMessageContainer"
                                   Grid.Column="0"
                                   Grid.ColumnSpan="2"
-                                  Height="0"
+                                  MaxHeight="0"
                                   IsHitTestVisible="False"
                                   Margin="5,0"
                                   Visibility="Visible">
@@ -855,12 +825,13 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Opacity="0.6"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                           Style="{DynamicResource MetroAutoCollapsingTextBlock}">
                                     <TextBlock.RenderTransform>
                                         <TranslateTransform />
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
-                            </Grid>
+                            </ContentControl>
                             <Button x:Name="PART_RevealButton"
 									Grid.Column="2" Grid.RowSpan="2"
                                     Style="{StaticResource RevealButtonStyle}"
@@ -902,36 +873,22 @@
                             <Setter Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
                             <Setter Property="PasswordChar" Value=" " />
                         </DataTrigger>
-                        <!--Sets the MiniMessage visibility (Watermark must not be "" and FloatWatermark must be true)-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.HasText)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
+
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}"
+                                           Value="True" />
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" 
+                                           Value="True"/>
+                            </MultiDataTrigger.Conditions>
+                            <MultiDataTrigger.EnterActions>
                                 <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override Watermark == ""-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.Watermark)}"
-                                     Value="">
-                            <DataTrigger.EnterActions>
+                            </MultiDataTrigger.EnterActions>
+                            <MultiDataTrigger.ExitActions>
                                 <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override TextBoxHelper.FloatingWatermark == false-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.UseFloatingWatermark)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
+                            </MultiDataTrigger.ExitActions>
+                        </MultiDataTrigger>
+
                         <Trigger Property="IsMouseOver"
                                  Value="True">
                             <Setter TargetName="Base"

--- a/MahApps.Metro/Styles/Controls.TextBlock.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBlock.xaml
@@ -11,4 +11,16 @@
                 Value="{DynamicResource LabelTextBrush}" />-->
     </Style>
 
+    <Style TargetType="{x:Type TextBlock}"
+           x:Key="MetroAutoCollapsingTextBlock"
+           BasedOn="{StaticResource MetroTextBlock}">
+        <Style.Triggers>
+            <Trigger Property="Text"
+                     Value="">
+                <Setter Property="Visibility" 
+                        Value="Collapsed"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -121,10 +121,10 @@
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                        Margin="6,2,6,2" />
-                            <Grid x:Name="PART_FloatingMessageContainer"
+                            <ContentControl x:Name="PART_FloatingMessageContainer"
                                   Grid.Column="0"
                                   Grid.ColumnSpan="2"
-                                  Height="0"
+                                  MaxHeight="0"
                                   IsHitTestVisible="False"
                                   Margin="5,0"
                                   Visibility="Visible">
@@ -134,12 +134,13 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Opacity="0.6"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                           Style="{DynamicResource MetroAutoCollapsingTextBlock}">
                                     <TextBlock.RenderTransform>
                                         <TranslateTransform />
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
-                            </Grid>
+                            </ContentControl>
                             <Button x:Name="PART_ClearText"
                                     Grid.Column="1"
                                     Grid.RowSpan="2"
@@ -189,49 +190,20 @@
                                     Value="Visible" />
                         </DataTrigger>
 
-                        <!--Sets the MiniMessage visibility (Watermark must not be "" and FloatWatermark must be true)-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.HasText)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}"
+                                           Value="True" />
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" 
+                                           Value="True"/>
+                            </MultiDataTrigger.Conditions>
+                            <MultiDataTrigger.EnterActions>
                                 <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override Watermark == ""-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.Watermark)}"
-                                     Value="">
-                            <DataTrigger.EnterActions>
+                            </MultiDataTrigger.EnterActions>
+                            <MultiDataTrigger.ExitActions>
                                 <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override TextBoxHelper.UseFloatingWatermark == false-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.UseFloatingWatermark)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-
-                        <!-- multiline textbox cannot bind to actual height so take the fallbach button width -->
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="TextWrapping"
-                                           Value="NoWrap" />
-                                <Condition Property="AcceptsReturn"
-                                           Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_ClearText"
-                                    Property="Width"
-                                    Value="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight, Mode=OneWay}" />
-                        </MultiTrigger>
+                            </MultiDataTrigger.ExitActions>
+                        </MultiDataTrigger>
 
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
@@ -444,10 +416,10 @@
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                        Margin="6,2,6,2" />
-                            <Grid x:Name="PART_FloatingMessageContainer"
+                            <ContentControl x:Name="PART_FloatingMessageContainer"
                                   Grid.Column="0"
                                   Grid.ColumnSpan="2"
-                                  Height="0"
+                                  MaxHeight="0"
                                   IsHitTestVisible="False"
                                   Margin="5,0"
                                   Visibility="Visible">
@@ -457,12 +429,13 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Opacity="0.6"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                           Style="{DynamicResource MetroAutoCollapsingTextBlock}">
                                     <TextBlock.RenderTransform>
                                         <TranslateTransform />
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
-                            </Grid>
+                            </ContentControl>
                             <Button x:Name="PART_ClearText"
                                     Grid.Column="1"
                                     Grid.RowSpan="2"
@@ -512,36 +485,20 @@
                                     Value="Visible" />
                         </DataTrigger>
 
-                        <!--Sets the MiniMessage visibility (Watermark must not be "" and FloatWatermark must be true)-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.HasText)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}"
+                                           Value="True" />
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" 
+                                           Value="True"/>
+                            </MultiDataTrigger.Conditions>
+                            <MultiDataTrigger.EnterActions>
                                 <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override Watermark == ""-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.Watermark)}"
-                                     Value="">
-                            <DataTrigger.EnterActions>
+                            </MultiDataTrigger.EnterActions>
+                            <MultiDataTrigger.ExitActions>
                                 <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
-                        <!--To override TextBoxHelper.UseFloatingWatermark == false-->
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.UseFloatingWatermark)}"
-                                     Value="False">
-                            <DataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource HideFloatingMessageStoryboard}" />
-                            </DataTrigger.EnterActions>
-                            <DataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
-                            </DataTrigger.ExitActions>
-                        </DataTrigger>
+                            </MultiDataTrigger.ExitActions>
+                        </MultiDataTrigger>
 
                         <!-- multiline textbox cannot bind to actual height so take the fallbach button width -->
                         <MultiTrigger>

--- a/MahApps.Metro/Styles/Shared.xaml
+++ b/MahApps.Metro/Styles/Shared.xaml
@@ -5,12 +5,12 @@
     <ExponentialEase Exponent="2" EasingMode="EaseInOut" x:Key="ExpoEaseInOut" />
 
     <Storyboard x:Key="HideFloatingMessageStoryboard">
-        <DoubleAnimation EasingFunction="{StaticResource ExpoEaseInOut}" Storyboard.TargetName="PART_FloatingMessageContainer" Storyboard.TargetProperty="Height" To="0" Duration="0:0:.2" />
+        <DoubleAnimation EasingFunction="{StaticResource ExpoEaseInOut}" Storyboard.TargetName="PART_FloatingMessageContainer" Storyboard.TargetProperty="MaxHeight" To="0" Duration="0:0:.2" />
         <DoubleAnimation Storyboard.TargetName="PART_FloatingMessageContainer" Storyboard.TargetProperty="Opacity" To="0" Duration="0:0:.2" />
         <DoubleAnimation EasingFunction="{StaticResource ExpoEaseIn}" Storyboard.TargetName="PART_FloatingMessage" Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)" To="20" Duration="0:0:.2" />
     </Storyboard>
     <Storyboard x:Key="ShowFloatingMessageStoryboard">
-        <DoubleAnimation EasingFunction="{StaticResource ExpoEaseInOut}" Storyboard.TargetName="PART_FloatingMessageContainer" Storyboard.TargetProperty="Height" To="15" Duration="0:0:.2" />
+        <DoubleAnimation EasingFunction="{StaticResource ExpoEaseInOut}" Storyboard.TargetName="PART_FloatingMessageContainer" Storyboard.TargetProperty="MaxHeight" To="15" Duration="0:0:.2" />
         <DoubleAnimation Storyboard.TargetName="PART_FloatingMessageContainer" Storyboard.TargetProperty="Opacity" Duration="0:0:.2" />
         <DoubleAnimation EasingFunction="{StaticResource ExpoEaseOut}" Storyboard.TargetName="PART_FloatingMessage" Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)" To="0" Duration="0:0:.2" />
     </Storyboard>


### PR DESCRIPTION
Fixes #2225

List of changes:
- The `PART_FloatingMessageContainer` grid is now a `ContentControl` because the layout system for ContentControl is way simpler and therefore faster. Also, the grid wasn't necessary.
- The triggers that active the hide/show of the floating watermark are no longer three separate `DataTrigger`s. This system now consists of a `MultiDataTrigger` with two conditions, which both must be satisfied:
  - Whether the input box should have a floating watermark
  - Whether the input box has text
  - The third one, whether the input box actually has a value for `TextBoxHelper.Watermark` has been dropped, because there are no 'negative' DataTriggers. This brings me to the next change:
- The animated property is no longer `Height`; it is now `MaxHeight`. If the watermark is not set, the TextBlock will not take any space because it uses an added `MetroAutoCollapsingTextBlock` style, which is based on `MetroTextBlock` and will automatically collapse when the text property is empty.