### PR TITLE
Fix Window Title Thumb Drag

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -982,7 +982,7 @@ namespace MahApps.Metro.Controls
 
             // if the window is maximized dragging is only allowed on title bar (also if not visible)
             var windowIsMaximized = window.WindowState == WindowState.Maximized;
-            var isMouseOnTitlebar = cursorPos.y <= window.TitlebarHeight && window.TitlebarHeight > 0;
+            var isMouseOnTitlebar = Mouse.GetPosition(window.windowTitleThumb).Y <= window.TitlebarHeight && window.TitlebarHeight > 0;
             if (!isMouseOnTitlebar && windowIsMaximized)
             {
                 return;


### PR DESCRIPTION
I've got a 3 monitor setup, all different resolutions and orientations.  Native.GetCursorPos reports .y as 200+ something on one monitor, even though the Window is maximised, and thus you can't drag-to-restore.  This seems to be a more robust solution.