### PR TITLE
MVVM dialog unregister instructions. Fixes #2241

### DIFF
--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -20,8 +20,15 @@
                       d:DesignHeight="600"
                       d:DesignWidth="800"
                       d:DataContext="{d:DesignInstance MetroDemo:MainWindowViewModel}"
-                      Closing="MetroWindow_Closing"
-                      Dialog:DialogParticipation.Register="{Binding}">
+                      Closing="MetroWindow_Closing"                      
+                      Dialog:DialogParticipation.Register="{Binding}">    
+    <!-- 
+    if using DialogParticipation on Windows which open/close frequently you will get a
+    memory leak unless you unregister.  The easiest way to do this is in your Closing/Unloaded 
+    event, as so:
+       
+        DialogParticipation.SetRegister(this, null);
+    -->    
 
     <Window.Resources>
         <ResourceDictionary>


### PR DESCRIPTION
...just some notes in the XAML to stop people falling into a memory leak trap.