### PR TITLE
Set Opacity to .55 if SplitButton/DropDownButton is disabled

### DIFF
--- a/MahApps.Metro/Themes/DropDownButton.xaml
+++ b/MahApps.Metro/Themes/DropDownButton.xaml
@@ -333,6 +333,11 @@
                 <Setter Property="BorderBrush"
                         Value="{DynamicResource AccentColorBrush}" />
             </Trigger>
+            <Trigger Property="IsEnabled"
+                     Value="False">
+                <Setter Property="Opacity"
+                        Value=".55"/>
+            </Trigger>
         </Style.Triggers>
     </Style>
 

--- a/MahApps.Metro/Themes/SplitButton.xaml
+++ b/MahApps.Metro/Themes/SplitButton.xaml
@@ -306,6 +306,11 @@
                 <Setter Property="BorderBrush"
                         Value="{DynamicResource AccentColorBrush}" />
             </Trigger>
+            <Trigger Property="IsEnabled"
+                     Value="False">
+                <Setter Property="Opacity"
+                        Value=".55"/>
+            </Trigger>
         </Style.Triggers>
     </Style>
 


### PR DESCRIPTION
**Default Style for enabled and disabled SplitButton/DropDownButton are the same**
![enabled](https://cloud.githubusercontent.com/assets/14271763/11831901/0c4a9c7a-a3ee-11e5-8bff-aaa2f0b92df5.jpg)

**Disabled style (Set opacity to 0.55)**
![disabled](https://cloud.githubusercontent.com/assets/14271763/11831900/0c451d40-a3ee-11e5-978e-d56338ccbcd5.jpg)

This resolves #2127