### PR TITLE
[RFC] Hotkey control

### DIFF
--- a/MahApps.Metro/Controls/HotKeyBox.cs
+++ b/MahApps.Metro/Controls/HotKeyBox.cs
@@ -8,7 +8,8 @@ using MahApps.Metro.Native;
 
 namespace MahApps.Metro.Controls {
     [TemplatePart(Name = PART_TextBox, Type = typeof(TextBox))]
-    public class HotKeyBox : Control {
+    public class HotKeyBox : Control
+    {
         private const string PART_TextBox = "PART_TextBox";
 
         public static readonly DependencyProperty HotKeyProperty = DependencyProperty.Register(
@@ -38,15 +39,18 @@ namespace MahApps.Metro.Controls {
 
         private TextBox _textBox;
 
-        static HotKeyBox() {
+        static HotKeyBox()
+        {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(HotKeyBox), new FrameworkPropertyMetadata(typeof(HotKeyBox)));
         }
 
-        public override void OnApplyTemplate() {
+        public override void OnApplyTemplate()
+        {
             base.OnApplyTemplate();
 
             _textBox = Template.FindName(PART_TextBox, this) as TextBox;
-            if (_textBox != null) {
+            if (_textBox != null)
+            {
                 _textBox.PreviewKeyDown += TextBoxOnPreviewKeyDown2;
                 _textBox.GotFocus += TextBoxOnGotFocus;
                 _textBox.LostFocus += TextBoxOnLostFocus;
@@ -60,7 +64,8 @@ namespace MahApps.Metro.Controls {
             ComponentDispatcher.ThreadPreprocessMessage += ComponentDispatcherOnThreadPreprocessMessage;
         }
 
-        private void ComponentDispatcherOnThreadPreprocessMessage(ref MSG msg, ref bool handled) {
+        private void ComponentDispatcherOnThreadPreprocessMessage(ref MSG msg, ref bool handled)
+        {
             if (msg.message == Constants.WM_HOTKEY)
             {
                 // swallow all hotkeys, so our control can catch the key strokes
@@ -73,9 +78,11 @@ namespace MahApps.Metro.Controls {
             ComponentDispatcher.ThreadPreprocessMessage -= ComponentDispatcherOnThreadPreprocessMessage;
         }
 
-        private void TextBoxOnPreviewKeyDown2(object sender, KeyEventArgs e) {
-            var key = (e.Key == Key.System ? e.SystemKey : e.Key);
-            switch (key) {
+        private void TextBoxOnPreviewKeyDown2(object sender, KeyEventArgs e)
+        {
+            var key = e.Key == Key.System ? e.SystemKey : e.Key;
+            switch (key)
+            {
                 case Key.Tab:
                 case Key.LeftShift:
                 case Key.RightShift:
@@ -103,30 +110,38 @@ namespace MahApps.Metro.Controls {
             UpdateText();
         }
 
-        private static ModifierKeys GetCurrentModifierKeys() {
+        private static ModifierKeys GetCurrentModifierKeys()
+        {
             var modifier = ModifierKeys.None;
-            if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl)) {
+            if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
+            {
                 modifier |= ModifierKeys.Control;
             }
-            if (Keyboard.IsKeyDown(Key.LeftAlt) || Keyboard.IsKeyDown(Key.RightAlt)) {
+            if (Keyboard.IsKeyDown(Key.LeftAlt) || Keyboard.IsKeyDown(Key.RightAlt))
+            {
                 modifier |= ModifierKeys.Alt;
             }
-            if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift)) {
+            if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
+            {
                 modifier |= ModifierKeys.Shift;
             }
-            if (Keyboard.IsKeyDown(Key.LWin) || Keyboard.IsKeyDown(Key.RWin)) {
+            if (Keyboard.IsKeyDown(Key.LWin) || Keyboard.IsKeyDown(Key.RWin))
+            {
                 modifier |= ModifierKeys.Windows;
             }
             return modifier;
         }
 
-        private void UpdateText() {
-            if (_textBox == null) {
+        private void UpdateText()
+        {
+            if (_textBox == null)
+            {
                 return;
             }
 
             var hotkey = HotKey;
-            if (hotkey == null || hotkey.Key == Key.None) {
+            if (hotkey == null || hotkey.Key == Key.None)
+            {
                 _textBox.Text = string.Empty;
                 return;
             }
@@ -174,7 +189,8 @@ namespace MahApps.Metro.Controls {
             return _key == other._key && _modifierKeys == other._modifierKeys;
         }
 
-        public override string ToString() {
+        public override string ToString()
+        {
             var sb = new StringBuilder();
             if ((_modifierKeys & ModifierKeys.Alt) == ModifierKeys.Alt)
             {

--- a/MahApps.Metro/Controls/HotKeyBox.cs
+++ b/MahApps.Metro/Controls/HotKeyBox.cs
@@ -37,6 +37,15 @@ namespace MahApps.Metro.Controls {
             set { SetValue(AreModifierKeysRequiredProperty, value); }
         }
 
+        public static readonly DependencyProperty WatermarkProperty = DependencyProperty.Register(
+            "Watermark", typeof(string), typeof(HotKeyBox), new PropertyMetadata(default(string)));
+
+        public string Watermark
+        {
+            get { return (string) GetValue(WatermarkProperty); }
+            set { SetValue(WatermarkProperty, value); }
+        }
+
         private TextBox _textBox;
 
         static HotKeyBox()
@@ -46,6 +55,14 @@ namespace MahApps.Metro.Controls {
 
         public override void OnApplyTemplate()
         {
+            if (_textBox != null)
+            {
+                _textBox.PreviewKeyDown -= TextBoxOnPreviewKeyDown2;
+                _textBox.GotFocus -= TextBoxOnGotFocus;
+                _textBox.LostFocus -= TextBoxOnLostFocus;
+                _textBox.TextChanged -= TextBoxOnTextChanged;
+            }
+
             base.OnApplyTemplate();
 
             _textBox = Template.FindName(PART_TextBox, this) as TextBox;
@@ -54,9 +71,14 @@ namespace MahApps.Metro.Controls {
                 _textBox.PreviewKeyDown += TextBoxOnPreviewKeyDown2;
                 _textBox.GotFocus += TextBoxOnGotFocus;
                 _textBox.LostFocus += TextBoxOnLostFocus;
-                _textBox.TextChanged += (sender, args) => _textBox.SelectionStart = _textBox.Text.Length;
+                _textBox.TextChanged += TextBoxOnTextChanged;
                 UpdateText();
             }
+        }
+
+        private void TextBoxOnTextChanged(object sender, TextChangedEventArgs args)
+        {
+            _textBox.SelectionStart = _textBox.Text.Length;
         }
 
         private void TextBoxOnGotFocus(object sender, RoutedEventArgs routedEventArgs)

--- a/MahApps.Metro/Controls/HotKeyBox.cs
+++ b/MahApps.Metro/Controls/HotKeyBox.cs
@@ -165,7 +165,8 @@ namespace MahApps.Metro.Controls {
             return modifier;
         }
 
-        private void UpdateText() {
+        private void UpdateText()
+        {
             var hotkey = HotKey;
             Text = hotkey == null || hotkey.Key == Key.None ? string.Empty : hotkey.ToString();
         }

--- a/MahApps.Metro/Controls/HotKeyBox.cs
+++ b/MahApps.Metro/Controls/HotKeyBox.cs
@@ -27,6 +27,15 @@ namespace MahApps.Metro.Controls {
             ctrl.UpdateText();
         }
 
+        public static readonly DependencyProperty AreModifierKeysRequiredProperty = DependencyProperty.Register(
+            "AreModifierKeysRequired", typeof(bool), typeof(HotKeyBox), new PropertyMetadata(default(bool)));
+
+        public bool AreModifierKeysRequired
+        {
+            get { return (bool) GetValue(AreModifierKeysRequiredProperty); }
+            set { SetValue(AreModifierKeysRequiredProperty, value); }
+        }
+
         private TextBox _textBox;
 
         static HotKeyBox() {
@@ -79,7 +88,13 @@ namespace MahApps.Metro.Controls {
             }
 
             e.Handled = true;
-            HotKey = new HotKey(key, GetCurrentModifierKeys());
+
+            var currentModifierKeys = GetCurrentModifierKeys();
+            if (currentModifierKeys != ModifierKeys.None || !AreModifierKeysRequired)
+            {
+                HotKey = new HotKey(key, currentModifierKeys);
+            }
+
             UpdateText();
         }
 

--- a/MahApps.Metro/Controls/HotKeyBox.cs
+++ b/MahApps.Metro/Controls/HotKeyBox.cs
@@ -46,6 +46,17 @@ namespace MahApps.Metro.Controls {
             set { SetValue(WatermarkProperty, value); }
         }
 
+        private static readonly DependencyPropertyKey TextPropertyKey = DependencyProperty.RegisterReadOnly(
+            "Text", typeof(string), typeof(HotKeyBox), new PropertyMetadata(default(string)));
+
+        public static readonly DependencyProperty TextProperty = TextPropertyKey.DependencyProperty;
+
+        public string Text
+        {
+            get { return (string) GetValue(TextProperty); }
+            private set { SetValue(TextPropertyKey, value); }
+        }
+
         private TextBox _textBox;
 
         static HotKeyBox()
@@ -154,21 +165,9 @@ namespace MahApps.Metro.Controls {
             return modifier;
         }
 
-        private void UpdateText()
-        {
-            if (_textBox == null)
-            {
-                return;
-            }
-
+        private void UpdateText() {
             var hotkey = HotKey;
-            if (hotkey == null || hotkey.Key == Key.None)
-            {
-                _textBox.Text = string.Empty;
-                return;
-            }
-
-            _textBox.Text = hotkey.ToString();
+            Text = hotkey == null || hotkey.Key == Key.None ? string.Empty : hotkey.ToString();
         }
     }
 

--- a/MahApps.Metro/Controls/HotKeyBox.cs
+++ b/MahApps.Metro/Controls/HotKeyBox.cs
@@ -50,6 +50,7 @@ namespace MahApps.Metro.Controls {
                 _textBox.PreviewKeyDown += TextBoxOnPreviewKeyDown2;
                 _textBox.GotFocus += TextBoxOnGotFocus;
                 _textBox.LostFocus += TextBoxOnLostFocus;
+                _textBox.TextChanged += (sender, args) => _textBox.SelectionStart = _textBox.Text.Length;
                 UpdateText();
             }
         }

--- a/MahApps.Metro/Controls/HotKeyBox.cs
+++ b/MahApps.Metro/Controls/HotKeyBox.cs
@@ -90,7 +90,11 @@ namespace MahApps.Metro.Controls {
             e.Handled = true;
 
             var currentModifierKeys = GetCurrentModifierKeys();
-            if (currentModifierKeys != ModifierKeys.None || !AreModifierKeysRequired)
+            if (currentModifierKeys == ModifierKeys.None && key == Key.Back)
+            {
+                HotKey = null;
+            }
+            else if (currentModifierKeys != ModifierKeys.None || !AreModifierKeysRequired)
             {
                 HotKey = new HotKey(key, currentModifierKeys);
             }
@@ -121,7 +125,7 @@ namespace MahApps.Metro.Controls {
             }
 
             var hotkey = HotKey;
-            if (hotkey.Key == Key.None) {
+            if (hotkey == null || hotkey.Key == Key.None) {
                 _textBox.Text = string.Empty;
                 return;
             }

--- a/MahApps.Metro/Controls/HotKeyBox.cs
+++ b/MahApps.Metro/Controls/HotKeyBox.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Text;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Interop;
+using System.Windows.Controls;
+using MahApps.Metro.Native;
+
+namespace MahApps.Metro.Controls {
+    [TemplatePart(Name = PART_TextBox, Type = typeof(TextBox))]
+    public class HotKeyBox : Control {
+        private const string PART_TextBox = "PART_TextBox";
+
+        public static readonly DependencyProperty HotKeyProperty = DependencyProperty.Register(
+            "HotKey", typeof(HotKey), typeof(HotKeyBox),
+            new FrameworkPropertyMetadata(default(HotKey), OnHotKeyChanged) { BindsTwoWayByDefault = true });
+
+        public HotKey HotKey
+        {
+            get { return (HotKey) GetValue(HotKeyProperty); }
+            set { SetValue(HotKeyProperty, value); }
+        }
+
+        private static void OnHotKeyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var ctrl = (HotKeyBox)d;
+            ctrl.UpdateText();
+        }
+
+        private TextBox _textBox;
+
+        static HotKeyBox() {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(HotKeyBox), new FrameworkPropertyMetadata(typeof(HotKeyBox)));
+        }
+
+        public override void OnApplyTemplate() {
+            base.OnApplyTemplate();
+
+            _textBox = Template.FindName(PART_TextBox, this) as TextBox;
+            if (_textBox != null) {
+                _textBox.PreviewKeyDown += TextBoxOnPreviewKeyDown2;
+                _textBox.GotFocus += TextBoxOnGotFocus;
+                _textBox.LostFocus += TextBoxOnLostFocus;
+                UpdateText();
+            }
+        }
+
+        private void TextBoxOnGotFocus(object sender, RoutedEventArgs routedEventArgs)
+        {
+            ComponentDispatcher.ThreadPreprocessMessage += ComponentDispatcherOnThreadPreprocessMessage;
+        }
+
+        private void ComponentDispatcherOnThreadPreprocessMessage(ref MSG msg, ref bool handled) {
+            if (msg.message == Constants.WM_HOTKEY)
+            {
+                // swallow all hotkeys, so our control can catch the key strokes
+                handled = true;
+            }
+        }
+
+        private void TextBoxOnLostFocus(object sender, RoutedEventArgs routedEventArgs)
+        {
+            ComponentDispatcher.ThreadPreprocessMessage -= ComponentDispatcherOnThreadPreprocessMessage;
+        }
+
+        private void TextBoxOnPreviewKeyDown2(object sender, KeyEventArgs e) {
+            var key = (e.Key == Key.System ? e.SystemKey : e.Key);
+            switch (key) {
+                case Key.Tab:
+                case Key.LeftShift:
+                case Key.RightShift:
+                case Key.LeftCtrl:
+                case Key.RightCtrl:
+                case Key.LeftAlt:
+                case Key.RightAlt:
+                case Key.RWin:
+                case Key.LWin:
+                    return;
+            }
+
+            e.Handled = true;
+            HotKey = new HotKey(key, GetCurrentModifierKeys());
+            UpdateText();
+        }
+
+        private static ModifierKeys GetCurrentModifierKeys() {
+            var modifier = ModifierKeys.None;
+            if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl)) {
+                modifier |= ModifierKeys.Control;
+            }
+            if (Keyboard.IsKeyDown(Key.LeftAlt) || Keyboard.IsKeyDown(Key.RightAlt)) {
+                modifier |= ModifierKeys.Alt;
+            }
+            if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift)) {
+                modifier |= ModifierKeys.Shift;
+            }
+            if (Keyboard.IsKeyDown(Key.LWin) || Keyboard.IsKeyDown(Key.RWin)) {
+                modifier |= ModifierKeys.Windows;
+            }
+            return modifier;
+        }
+
+        private void UpdateText() {
+            if (_textBox == null) {
+                return;
+            }
+
+            var hotkey = HotKey;
+            if (hotkey.Key == Key.None) {
+                _textBox.Text = string.Empty;
+                return;
+            }
+
+            _textBox.Text = hotkey.ToString();
+        }
+    }
+
+    public class HotKey : IEquatable<HotKey>
+    {
+        private readonly Key _key;
+        private readonly ModifierKeys _modifierKeys;
+
+        public HotKey(Key key, ModifierKeys modifierKeys)
+        {
+            _key = key;
+            _modifierKeys = modifierKeys;
+        }
+
+        public Key Key
+        {
+            get { return _key; }
+        }
+
+        public ModifierKeys ModifierKeys
+        {
+            get { return _modifierKeys; }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is HotKey && Equals((HotKey) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((int) _key*397) ^ (int) _modifierKeys;
+            }
+        }
+
+        public bool Equals(HotKey other)
+        {
+            return _key == other._key && _modifierKeys == other._modifierKeys;
+        }
+
+        public override string ToString() {
+            var sb = new StringBuilder();
+            if ((_modifierKeys & ModifierKeys.Alt) == ModifierKeys.Alt)
+            {
+                sb.Append(GetLocalizedKeyStringUnsafe(Constants.VK_MENU));
+                sb.Append("+");
+            }
+            if ((_modifierKeys & ModifierKeys.Control) == ModifierKeys.Control)
+            {
+                sb.Append(GetLocalizedKeyStringUnsafe(Constants.VK_CONTROL));
+                sb.Append("+");
+            }
+            if ((_modifierKeys & ModifierKeys.Shift) == ModifierKeys.Shift)
+            {
+                sb.Append(GetLocalizedKeyStringUnsafe(Constants.VK_SHIFT));
+                sb.Append("+");
+            }
+            if ((_modifierKeys & ModifierKeys.Windows) == ModifierKeys.Windows)
+            {
+                sb.Append("WINDOWS+");
+            }
+            sb.Append(GetLocalizedKeyStringUnsafe(KeyInterop.VirtualKeyFromKey(_key)).ToUpper());
+            return sb.ToString();
+        }
+
+        private static string GetLocalizedKeyStringUnsafe(int key)
+        {
+            // strip any modifier keys
+            long keyCode = key & 0xffff;
+
+            var sb = new StringBuilder(256);
+
+            long scanCode = UnsafeNativeMethods.MapVirtualKey((uint)keyCode, Constants.MAPVK_VK_TO_VSC);
+
+            // shift the scancode to the high word
+            scanCode = (scanCode << 16);
+            if (keyCode == 45 ||
+                keyCode == 46 ||
+                keyCode == 144 ||
+                (33 <= keyCode && keyCode <= 40))
+            {
+                // add the extended key flag
+                scanCode |= 0x1000000;
+            }
+
+            UnsafeNativeMethods.GetKeyNameText((int)scanCode, sb, 256);
+            return sb.ToString();
+        }
+
+    }
+}

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Controls\Helper\MouseWheelChange.cs" />
     <Compile Include="Controls\Helper\MouseWheelState.cs" />
     <Compile Include="Controls\Helper\SliderHelper.cs" />
+    <Compile Include="Controls\HotKeyBox.cs" />
     <Compile Include="Controls\Helper\VisibilityHelper.cs" />
     <Compile Include="Controls\MetroAnimatedSingleRowTabControl.cs" />
     <Compile Include="Controls\MetroAnimatedTabControl.cs" />
@@ -590,6 +591,10 @@
     <Page Include="Themes\Glow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Themes\HotKeyBox.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Themes\MetroAnimatedSingleRowTabControl.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Controls\Helper\TextBoxHelper.cs" />
     <Compile Include="Controls\Helper\ToggleButtonHelper.cs" />
     <Compile Include="Controls\Helper\VisibilityHelper.cs" />
+    <Compile Include="Controls\HotKeyBox.cs" />
     <Compile Include="Controls\LayoutInvalidationCatcher.cs" />
     <Compile Include="Controls\MetroAnimatedSingleRowTabControl.cs" />
     <Compile Include="Controls\MetroAnimatedTabControl.cs" />
@@ -537,6 +538,10 @@
     <Page Include="Themes\Dialogs\MessageDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Themes\HotKeyBox.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Themes\MetroAnimatedSingleRowTabControl.xaml">
       <SubType>Designer</SubType>

--- a/MahApps.Metro/Native/Constants.cs
+++ b/MahApps.Metro/Native/Constants.cs
@@ -167,5 +167,17 @@ namespace MahApps.Metro.Native
         public const int WM_MOVE = 0x0003;
 
         public const uint TOPMOST_FLAGS = SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSIZE | SWP_NOMOVE | SWP_NOREDRAW | SWP_NOSENDCHANGING;
+
+        public const int WM_HOTKEY = 0x0312;
+        public const int VK_SHIFT = 0x10;
+        public const int VK_CONTROL = 0x11;
+        public const int VK_MENU = 0x12;
+
+        /* used by UnsafeNativeMethods.MapVirtualKey */
+        public const uint MAPVK_VK_TO_VSC = 0x00;
+        public const uint MAPVK_VSC_TO_VK = 0x01;
+        public const uint MAPVK_VK_TO_CHAR = 0x02;
+        public const uint MAPVK_VSC_TO_VK_EX = 0x03;
+        public const uint MAPVK_VK_TO_VSC_EX = 0x04;
     }
 }

--- a/MahApps.Metro/Native/UnsafeNativeMethods.cs
+++ b/MahApps.Metro/Native/UnsafeNativeMethods.cs
@@ -12,7 +12,7 @@ namespace MahApps.Metro.Native
 
     /// <devdoc>http://msdn.microsoft.com/en-us/library/ms182161.aspx</devdoc>
     [SuppressUnmanagedCodeSecurity]
-    internal static class UnsafeNativeMethods 
+    internal static class UnsafeNativeMethods
     {
         /// <devdoc>http://msdn.microsoft.com/en-us/library/windows/desktop/aa969518%28v=vs.85%29.aspx</devdoc>
         [DllImport("dwmapi", PreserveSig = false, CallingConvention = CallingConvention.Winapi)]
@@ -227,6 +227,12 @@ namespace MahApps.Metro.Native
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         [DllImport("user32.dll", SetLastError = true)]
-        internal static extern bool RedrawWindow(IntPtr hWnd, IntPtr lprcUpdate, IntPtr hrgnUpdate, Constants.RedrawWindowFlags flags); 
+        internal static extern bool RedrawWindow(IntPtr hWnd, IntPtr lprcUpdate, IntPtr hrgnUpdate, Constants.RedrawWindowFlags flags);
+
+        [DllImport("user32.dll")]
+        internal static extern int MapVirtualKey(uint uCode, uint uMapType);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        internal static extern int GetKeyNameText(int lParam, [MarshalAs(UnmanagedType.LPWStr), Out] StringBuilder str, int size);
     }
 }

--- a/MahApps.Metro/Themes/Generic.xaml
+++ b/MahApps.Metro/Themes/Generic.xaml
@@ -30,6 +30,7 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/TransitioningContentControl.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/WindowButtonCommands.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/WindowCommands.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/HotKeyBox.xaml" />
 
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/Dialogs/BaseMetroDialog.xaml" />
     </ResourceDictionary.MergedDictionaries>

--- a/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
     <Style TargetType="{x:Type Controls:HotKeyBox}">
         <Setter Property="FontFamily" Value="{DynamicResource ContentFontFamily}" />
         <Setter Property="FontSize" Value="{DynamicResource ContentFontSize}" />
@@ -27,7 +28,19 @@
                              FontSize="{TemplateBinding FontSize}"
                              Foreground="{TemplateBinding Foreground}"
                              Padding="{TemplateBinding Padding}"
+                             Text="{TemplateBinding Text}"
                              Controls:TextBoxHelper.Watermark="{TemplateBinding Watermark}"/>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Normal">
+                            <Setter TargetName="PART_TextBox" Property="Text" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Text, Mode=OneWay}" />
+                        </Trigger>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Upper">
+                            <Setter TargetName="PART_TextBox" Property="Text" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Text, Converter={Converters:ToUpperConverter}, Mode=OneWay}" />
+                        </Trigger>
+                        <Trigger Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Lower">
+                            <Setter TargetName="PART_TextBox" Property="Text" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Text, Converter={Converters:ToLowerConverter}, Mode=OneWay}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -1,0 +1,34 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
+    <Style TargetType="{x:Type Controls:HotKeyBox}">
+        <Setter Property="FontFamily" Value="{DynamicResource ContentFontFamily}" />
+        <Setter Property="FontSize" Value="{DynamicResource ContentFontSize}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="MinHeight" Value="26" />
+        <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
+        <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource TextBoxFocusBorderBrush}" />
+        <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource TextBoxMouseOverBorderBrush}" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
+
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Controls:HotKeyBox}">
+                    <TextBox x:Name="PART_TextBox"
+                             MinHeight="{TemplateBinding MinHeight}"
+                             Background="{TemplateBinding Background}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             FontFamily="{TemplateBinding FontFamily}"
+                             FontSize="{TemplateBinding FontSize}"
+                             Foreground="{TemplateBinding Foreground}"
+                             Padding="{TemplateBinding Padding}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -26,7 +26,8 @@
                              FontFamily="{TemplateBinding FontFamily}"
                              FontSize="{TemplateBinding FontSize}"
                              Foreground="{TemplateBinding Foreground}"
-                             Padding="{TemplateBinding Padding}" />
+                             Padding="{TemplateBinding Padding}"
+                             Controls:TextBoxHelper.Watermark="{TemplateBinding Watermark}"/>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -180,6 +180,7 @@
                 <Label Content="HotKeyBox"
                        Style="{DynamicResource DescriptionHeaderStyle}" />
                 <Controls:HotKeyBox Margin="{StaticResource ControlMargin}"
+                                    Watermark="Enter hot key"
                                     HotKey="{Binding HotKey, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}"
                                     AreModifierKeysRequired="{Binding ElementName=ModifierKeysRequired, Path=IsChecked}"/>
                 <TextBlock Margin="{StaticResource ControlMargin}"

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -29,8 +29,12 @@
                 <ColumnDefinition />
                 <ColumnDefinition Width="1.5*" />
             </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-            <StackPanel Grid.Column="0"
+            <StackPanel Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
                         Margin="{StaticResource ColumnMargin}">
                 <Label Content="TextBox"
                        Style="{DynamicResource DescriptionHeaderStyle}" />
@@ -121,11 +125,9 @@
                 <TextBox Margin="{StaticResource ControlMargin}"
                          Controls:TextBoxHelper.SelectAllOnFocus="True"
                          Text="Select all on focus" />
-                <Controls:HotKeyBox Margin="{StaticResource ControlMargin}"
-                                    HotKey="{Binding HotKey}"/>
             </StackPanel>
 
-            <StackPanel Grid.Column="1"
+            <StackPanel Grid.Column="1" Grid.Row="0"
                         Margin="{StaticResource ColumnMargin}">
                 <Label Content="RichTextBox"
                        Style="{DynamicResource DescriptionHeaderStyle}" />
@@ -173,7 +175,15 @@
                 </RichTextBox>
             </StackPanel>
 
-            <StackPanel Grid.Column="2"
+            <StackPanel Grid.Column="1" Grid.Row="1"
+                        Margin="{StaticResource ColumnMargin}">
+                <Label Content="HotKeyBox"
+                       Style="{DynamicResource DescriptionHeaderStyle}" />
+                <Controls:HotKeyBox Margin="{StaticResource ControlMargin}"
+                                    HotKey="{Binding HotKey}"/>
+            </StackPanel>
+
+            <StackPanel Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
                         Margin="{StaticResource ColumnMargin}">
                 <Label Content="PasswordBox"
                        Style="{DynamicResource DescriptionHeaderStyle}" />
@@ -218,7 +228,7 @@
                              ToolTip="Select all on focus"/>
             </StackPanel>
 
-            <StackPanel Grid.Column="3"
+            <StackPanel Grid.Column="3" Grid.Row="0" Grid.RowSpan="2"
                         Grid.IsSharedSizeScope="True"
                         Margin="{StaticResource ColumnMargin}">
                 <Label Content="NumericUpDown"
@@ -321,4 +331,7 @@
     </AdornerDecorator>
 
 </UserControl>
+
+
+
 

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -121,6 +121,8 @@
                 <TextBox Margin="{StaticResource ControlMargin}"
                          Controls:TextBoxHelper.SelectAllOnFocus="True"
                          Text="Select all on focus" />
+                <Controls:HotKeyBox Margin="{StaticResource ControlMargin}"
+                                    HotKey="{Binding HotKey}"/>
             </StackPanel>
 
             <StackPanel Grid.Column="1"
@@ -223,9 +225,9 @@
                        Style="{DynamicResource DescriptionHeaderStyle}" />
 
                 <UniformGrid Columns="2">
-                    <CheckBox x:Name="ReadOnlyCheck"
-                              Content="IsReadOnly"
-                              Margin="1" />
+                <CheckBox x:Name="ReadOnlyCheck"
+                          Content="IsReadOnly"
+                          Margin="1" />
                     <CheckBox x:Name="HasDecimalsCheckBox"
                               Content="HasDecimals"
                               IsChecked="True"
@@ -240,7 +242,7 @@
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
                                         HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         Maximum="10" />
-             
+
                 <Label Content='Interval="5"' />
                 <Controls:NumericUpDown Value="5" IsTabStop="False"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
@@ -319,3 +321,4 @@
     </AdornerDecorator>
 
 </UserControl>
+

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -182,6 +182,7 @@
                 <Controls:HotKeyBox Margin="{StaticResource ControlMargin}"
                                     Watermark="Enter hot key"
                                     HotKey="{Binding HotKey, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}"
+                                    Controls:ControlsHelper.ContentCharacterCasing="Upper"
                                     AreModifierKeysRequired="{Binding ElementName=ModifierKeysRequired, Path=IsChecked}"/>
                 <TextBlock Margin="{StaticResource ControlMargin}"
                            Text="Try SHIFT+D to demonstrate validation"
@@ -264,7 +265,7 @@
                 <Label Content='Interval="5"' />
                 <Controls:NumericUpDown Value="5" IsTabStop="False"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
-                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"                                        
+                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         Controls:TextBoxHelper.ClearTextButton="True"
                                         ButtonsAlignment="Left"
                                         Interval="5" />
@@ -272,7 +273,7 @@
                 <Controls:NumericUpDown Margin="{StaticResource ControlMargin}"
                                         Controls:TextBoxHelper.Watermark="No Speedup when long pressed"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
-                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"                                        
+                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         Speedup="false" />
                 <Controls:NumericUpDown Margin="{StaticResource ControlMargin}"
                                         Controls:TextBoxHelper.Watermark="Speedup when pressed after 1000ms"
@@ -330,7 +331,7 @@
                 <Label Content="Select all on focus" />
                 <Controls:NumericUpDown Value="500" IsTabStop="False"
                                         IsReadOnly="{Binding ElementName=ReadOnlyCheck, Path=IsChecked, Mode=TwoWay}"
-                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"                                        
+                                        HasDecimals="{Binding ElementName=HasDecimalsCheckBox, Path=IsChecked, Mode=TwoWay}"
                                         Controls:TextBoxHelper.SelectAllOnFocus="True"
                                         ButtonsAlignment="Left"
                                         Interval="5" />

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -180,7 +180,11 @@
                 <Label Content="HotKeyBox"
                        Style="{DynamicResource DescriptionHeaderStyle}" />
                 <Controls:HotKeyBox Margin="{StaticResource ControlMargin}"
-                                    HotKey="{Binding HotKey}"/>
+                                    HotKey="{Binding HotKey}"
+                                    AreModifierKeysRequired="{Binding ElementName=ModifierKeysRequired, Path=IsChecked}"/>
+                <CheckBox Margin="{StaticResource ControlMargin}"
+                          x:Name="ModifierKeysRequired"
+                          Content="Require modifier keys"/>
             </StackPanel>
 
             <StackPanel Grid.Column="2" Grid.Row="0" Grid.RowSpan="2"
@@ -331,7 +335,3 @@
     </AdornerDecorator>
 
 </UserControl>
-
-
-
-

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -180,8 +180,11 @@
                 <Label Content="HotKeyBox"
                        Style="{DynamicResource DescriptionHeaderStyle}" />
                 <Controls:HotKeyBox Margin="{StaticResource ControlMargin}"
-                                    HotKey="{Binding HotKey}"
+                                    HotKey="{Binding HotKey, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}"
                                     AreModifierKeysRequired="{Binding ElementName=ModifierKeysRequired, Path=IsChecked}"/>
+                <TextBlock Margin="{StaticResource ControlMargin}"
+                           Text="Try SHIFT+D to demonstrate validation"
+                           Foreground="{DynamicResource DarkIdealForegroundDisabledBrush}"/>
                 <CheckBox Margin="{StaticResource ControlMargin}"
                           x:Name="ModifierKeysRequired"
                           Content="Require modifier keys"/>
@@ -335,3 +338,4 @@
     </AdornerDecorator>
 
 </UserControl>
+

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Controls.Dialogs;
 using MetroDemo.ExampleWindows;
@@ -31,6 +30,10 @@ namespace MetroDemo
                     if (!e.Cancel && flyoutDemo != null)
                     {
                         flyoutDemo.Dispose();
+                    }
+                    if (!e.Cancel)
+                    {
+                        _viewModel.Dispose();
                     }
                 };
         }

--- a/samples/MetroDemo/MainWindowViewModel.cs
+++ b/samples/MetroDemo/MainWindowViewModel.cs
@@ -444,7 +444,14 @@ namespace MetroDemo
                 if (_hotKey != value)
                 {
                     _hotKey = value;
-                    HotkeyManager.Current.AddOrReplace("demo", HotKey.Key, HotKey.ModifierKeys, (sender, e) => OnHotKey(sender, e));
+                    if (_hotKey != null && _hotKey.Key != Key.None)
+                    {
+                        HotkeyManager.Current.AddOrReplace("demo", HotKey.Key, HotKey.ModifierKeys, (sender, e) => OnHotKey(sender, e));
+                    }
+                    else
+                    {
+                        HotkeyManager.Current.Remove("demo");
+                    }
                     RaisePropertyChanged("HotKey");
                 }
             }

--- a/samples/MetroDemo/MainWindowViewModel.cs
+++ b/samples/MetroDemo/MainWindowViewModel.cs
@@ -14,6 +14,8 @@ using System.Windows.Input;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Controls.Dialogs;
 using MetroDemo.ExampleViews;
+using NHotkey;
+using NHotkey.Wpf;
 
 namespace MetroDemo
 {
@@ -48,7 +50,7 @@ namespace MetroDemo
         }
     }
 
-    public class MainWindowViewModel : INotifyPropertyChanged, IDataErrorInfo
+    public class MainWindowViewModel : INotifyPropertyChanged, IDataErrorInfo, IDisposable
     {
         private readonly IDialogCoordinator _dialogCoordinator;
         int? _integerGreater10Property;
@@ -91,6 +93,13 @@ namespace MetroDemo
             BrushResources = FindBrushResources();
 
             CultureInfos = CultureInfo.GetCultures(CultureTypes.InstalledWin32Cultures).ToList();
+
+            HotkeyManager.Current.AddOrReplace("demo", HotKey.Key, HotKey.ModifierKeys, (sender, e) => OnHotKey(sender, e));
+        }
+
+        public void Dispose()
+        {
+            HotkeyManager.Current.Remove("demo");
         }
 
         public string Title { get; set; }
@@ -367,7 +376,7 @@ namespace MetroDemo
             });
             customDialog.Content = new CustomDialogExample { DataContext = customDialogExampleContent};            
 
-            await _dialogCoordinator.ShowMetroDialogAsync(this, customDialog);            
+            await _dialogCoordinator.ShowMetroDialogAsync(this, customDialog);
         }
 
         public IEnumerable<string> BrushResources { get; private set; }
@@ -423,6 +432,29 @@ namespace MetroDemo
             {
                 return TemplateOne;
             }
+        }
+
+        private HotKey _hotKey = new HotKey(Key.Home, ModifierKeys.Control | ModifierKeys.Shift);
+
+        public HotKey HotKey
+        {
+            get { return _hotKey; }
+            set
+            {
+                if (_hotKey != value)
+                {
+                    _hotKey = value;
+                    HotkeyManager.Current.AddOrReplace("demo", HotKey.Key, HotKey.ModifierKeys, (sender, e) => OnHotKey(sender, e));
+                    RaisePropertyChanged("HotKey");
+                }
+            }
+        }
+
+        private async Task OnHotKey(object sender, HotkeyEventArgs e)
+        {
+            await ((MetroWindow)Application.Current.MainWindow).ShowMessageAsync(
+                "Hotkey pressed",
+                "You pressed the hotkey '" + HotKey + "' registered with the name '" + e.Name + "'");
         }
     }
 }

--- a/samples/MetroDemo/MainWindowViewModel.cs
+++ b/samples/MetroDemo/MainWindowViewModel.cs
@@ -244,6 +244,11 @@ namespace MetroDemo
                     return "No date given!";
                 }
 
+                if (columnName == "HotKey" && this.HotKey != null && this.HotKey.Key == Key.D && this.HotKey.ModifierKeys == ModifierKeys.Shift)
+                {
+                    return "SHIFT-D is not allowed";
+                }
+
                 return null;
             }
         }

--- a/samples/MetroDemo/MetroDemo.NET45.csproj
+++ b/samples/MetroDemo/MetroDemo.NET45.csproj
@@ -66,6 +66,14 @@
     <Reference Include="Microsoft.Threading.Tasks">
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
     </Reference>
+    <Reference Include="NHotkey, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NHotkey.1.2.1\lib\net20\NHotkey.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NHotkey.Wpf, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NHotkey.Wpf.1.2.1\lib\net35\NHotkey.Wpf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationFramework.Aero" />
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/samples/MetroDemo/MetroDemo.csproj
+++ b/samples/MetroDemo/MetroDemo.csproj
@@ -72,6 +72,14 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
+    <Reference Include="NHotkey, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NHotkey.1.2.1\lib\net20\NHotkey.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NHotkey.Wpf, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NHotkey.Wpf.1.2.1\lib\net35\NHotkey.Wpf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationFramework.Aero" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -295,7 +303,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
     <None Include="Properties\app.manifest" />
     <None Include="Properties\Settings.settings">

--- a/samples/MetroDemo/packages.config
+++ b/samples/MetroDemo/packages.config
@@ -3,4 +3,6 @@
   <package id="Microsoft.Bcl" version="1.0.19" targetFramework="net40-Client" />
   <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="net40-Client" />
   <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net40-Client" />
+  <package id="NHotkey" version="1.2.1" targetFramework="net45" />
+  <package id="NHotkey.Wpf" version="1.2.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR adds a `HotKeyBox` to MahApps.Metro with following features:
* handles all hotkeys except <kbd>Tab</kbd>, <kbd>Shift+Tab</kbd> (used for navigation) and <kbd>Back</kbd> (clears the hotkey)
* optionally modifier keys (<kbd>Ctrl</kbd>, <kbd>Alt</kbd>, <kbd>Shift</kbd>, or <kbd>Win</kbd>) are required
* supports watermark
* validation works
* templating support
* uses Win API [`GetKeyNameText`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646300%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396) to get a textual representation of the keys. No localization is required, as it only depends on the keyboard layout as configured in Windows. (I have a German keyboard, therefore you see `STRG+UMSCHALT+POS1` in the screenshot; with an English layout it would say `CTRL+SHIFT+HOME`)
* supports `ControlsHelper.ContentCharacterCasing`. The reason was that Windows is not consistent about what `GetKeyNameText` returns. E.g. on my machine with an English keyboard layout it returns normal-cased modifier keys, but upper-case function keys, which results in `Ctrl+Shift+HOME`. You may attach `Controls:ControlsHelper.ContentCharacterCasing="Upper"` to get consistent output.

![image](https://cloud.githubusercontent.com/assets/73690/12340240/f96fe7ca-bb19-11e5-8e93-be7fcdc99c0b.png)

**The only purpose of `HotKeyBox` is to enable the user to *enter* a hotkey. Registering and handling hotkeys is out of its scope.** I have added the control to the sample app and use [**NHotkey**](https://github.com/thomaslevesque/NHotkey) ([NuGet](https://www.nuget.org/packages/NHotkey.Wpf/)) for the handling.