### PR TITLE
[WIP] Fix PasswordBoxBindingBehavior and IsWaitingForData

### DIFF
--- a/MahApps.Metro/Behaviours/PasswordBoxBindingBehavior.cs
+++ b/MahApps.Metro/Behaviours/PasswordBoxBindingBehavior.cs
@@ -3,73 +3,110 @@
 //		For more information see : http://wpfsmartlibrary.codeplex.com/
 //		(by DotNetMastermind)
 //	--------------------------------------------------------------------
+
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interactivity;
+using System.Windows.Threading;
 
 namespace MahApps.Metro.Behaviours
 {
-    using System.ComponentModel;
-
     public class PasswordBoxBindingBehavior : Behavior<PasswordBox>
     {
-        #region Fields
-
-        private static bool IsUpdating;
-
-        #endregion
-
-        #region DependencyProperty - Password ("string")
+        /// <summary>
+        ///     Gets or sets the bindable Password property on the PasswordBox control. This is a dependency property.
+        /// </summary>
+        public static readonly DependencyProperty PasswordProperty
+            = DependencyProperty.RegisterAttached("Password", typeof(string),
+                                                  typeof(PasswordBoxBindingBehavior),
+                                                  new FrameworkPropertyMetadata(string.Empty, new PropertyChangedCallback(OnPasswordPropertyChanged)));
 
         [Category(AppName.MahApps)]
         public static string GetPassword(DependencyObject dpo)
         {
             return (string)dpo.GetValue(PasswordProperty);
         }
+
         public static void SetPassword(DependencyObject dpo, string value)
         {
             dpo.SetValue(PasswordProperty, value);
         }
+
         /// <summary>
-        /// Gets or sets the bindable Password property on the PasswordBox control. This is a dependency property.
-        /// </summary>
-        public static readonly DependencyProperty PasswordProperty =
-                    DependencyProperty.RegisterAttached("Password", typeof(string),
-                                                                     typeof(PasswordBoxBindingBehavior),
-                                                                     new FrameworkPropertyMetadata(String.Empty,
-                                                                     new PropertyChangedCallback(OnPasswordPropertyChanged)));
-        /// <summary>
-        /// Handles changes to the 'Password' attached property.
+        ///     Handles changes to the 'Password' attached property.
         /// </summary>
         private static void OnPasswordPropertyChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            PasswordBox targetPasswordBox = sender as PasswordBox;
+            var targetPasswordBox = sender as PasswordBox;
             if (targetPasswordBox != null)
             {
-                targetPasswordBox.PasswordChanged -= PasswordBox_PasswordChanged;
-                if (IsUpdating == false)
+                targetPasswordBox.PasswordChanged -= PasswordBoxPasswordChanged;
+                if (!GetIsChanging(targetPasswordBox))
                 {
                     targetPasswordBox.Password = (string)e.NewValue;
                 }
-                targetPasswordBox.PasswordChanged += PasswordBox_PasswordChanged;
+                targetPasswordBox.PasswordChanged += PasswordBoxPasswordChanged;
             }
         }
 
         /// <summary>
-        /// Handle the 'PasswordChanged'-event on the PasswordBox
+        ///     Handle the 'PasswordChanged'-event on the PasswordBox
         /// </summary>
-        private static void PasswordBox_PasswordChanged(object sender, RoutedEventArgs e)
+        private static void PasswordBoxPasswordChanged(object sender, RoutedEventArgs e)
         {
-            PasswordBox passwordBox = sender as PasswordBox;
-            IsUpdating = true;
+            var passwordBox = (PasswordBox)sender;
+            SetIsChanging(passwordBox, true);
             SetPassword(passwordBox, passwordBox.Password);
-            IsUpdating = false;
+            SetIsChanging(passwordBox, false);
         }
 
-        #endregion
+        /// <summary>
+        ///     Called after the behavior is attached to an AssociatedObject.
+        /// </summary>
+        /// <remarks>
+        ///     Override this to hook up functionality to the AssociatedObject.
+        /// </remarks>
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            this.AssociatedObject.PasswordChanged += PasswordBoxPasswordChanged;
+            this.Dispatcher.BeginInvoke(DispatcherPriority.Loaded,
+                                        new Action(() => {
+                                                       if (this.AssociatedObject != null)
+                                                       {
+                                                           SetPassword(this.AssociatedObject, this.AssociatedObject.Password);
+                                                       }
+                                                   }));
+        }
+
+        /// <summary>
+        ///     Called when the behavior is being detached from its AssociatedObject, but before it has actually occurred.
+        /// </summary>
+        /// <remarks>
+        ///     Override this to unhook functionality from the AssociatedObject.
+        /// </remarks>
+        protected override void OnDetaching()
+        {
+            this.AssociatedObject.PasswordChanged -= PasswordBoxPasswordChanged;
+            base.OnDetaching();
+        }
+
+        private static readonly DependencyProperty IsChangingProperty
+            = DependencyProperty.RegisterAttached("IsChanging",
+                                                  typeof(bool),
+                                                  typeof(PasswordBoxBindingBehavior),
+                                                  new UIPropertyMetadata(false));
+
+        private static bool GetIsChanging(DependencyObject obj)
+        {
+            return (bool)obj.GetValue(IsChangingProperty);
+        }
+
+        private static void SetIsChanging(DependencyObject obj, bool value)
+        {
+            obj.SetValue(IsChangingProperty, value);
+        }
     }
 }

--- a/MahApps.Metro/Behaviours/StylizedBehaviors.cs
+++ b/MahApps.Metro/Behaviours/StylizedBehaviors.cs
@@ -4,16 +4,15 @@ using System.Windows.Interactivity;
 namespace MahApps.Metro.Behaviours
 {
     using System.ComponentModel;
+    using System.Windows.Threading;
 
     public class StylizedBehaviors
     {
-        private static readonly DependencyProperty OriginalBehaviorProperty = DependencyProperty.RegisterAttached(@"OriginalBehaviorInternal", typeof(Behavior), typeof(StylizedBehaviors), new UIPropertyMetadata(null));
-
-        public static readonly DependencyProperty BehaviorsProperty = DependencyProperty.RegisterAttached(
-            @"Behaviors",
-            typeof(StylizedBehaviorCollection),
-            typeof(StylizedBehaviors),
-            new FrameworkPropertyMetadata(null, OnPropertyChanged));
+        public static readonly DependencyProperty BehaviorsProperty
+            = DependencyProperty.RegisterAttached("Behaviors",
+                                                  typeof(StylizedBehaviorCollection),
+                                                  typeof(StylizedBehaviors),
+                                                  new FrameworkPropertyMetadata(null, OnPropertyChanged));
         
         [Category(AppName.MahApps)]
         public static StylizedBehaviorCollection GetBehaviors(DependencyObject uie)
@@ -26,66 +25,30 @@ namespace MahApps.Metro.Behaviours
             uie.SetValue(BehaviorsProperty, value);
         }
         
-        private static Behavior GetOriginalBehavior(DependencyObject obj)
-        {
-            return obj.GetValue(OriginalBehaviorProperty) as Behavior;
-        }
-
-        private static int GetIndexOf(BehaviorCollection itemBehaviors, Behavior behavior)
-        {
-            int index = -1;
-
-            Behavior orignalBehavior = GetOriginalBehavior(behavior);
-
-            for (int i = 0; i < itemBehaviors.Count; i++)
-            {
-                Behavior currentBehavior = itemBehaviors[i];
-
-                if (currentBehavior == behavior
-                    || currentBehavior == orignalBehavior)
-                {
-                    index = i;
-                    break;
-                }
-
-                Behavior currentOrignalBehavior = GetOriginalBehavior(currentBehavior);
-
-                if (currentOrignalBehavior == behavior
-                    || currentOrignalBehavior == orignalBehavior)
-                {
-                    index = i;
-                    break;
-                }
-            }
-
-            return index;
-        }
-
         private static void OnPropertyChanged(DependencyObject dpo, DependencyPropertyChangedEventArgs e)
         {
-            var uie = dpo as UIElement;
-
+            var uie = dpo as FrameworkElement;
             if (uie == null)
+            {
+                return;
+            }
+
+            var newBehaviors = e.NewValue as StylizedBehaviorCollection;
+            var oldBehaviors = e.OldValue as StylizedBehaviorCollection;
+            if (newBehaviors == oldBehaviors)
             {
                 return;
             }
 
             BehaviorCollection itemBehaviors = Interaction.GetBehaviors(uie);
 
-            var newBehaviors = e.NewValue as StylizedBehaviorCollection;
-            var oldBehaviors = e.OldValue as StylizedBehaviorCollection;
-
-            if (newBehaviors == oldBehaviors)
-            {
-                return;
-            }
+            uie.Unloaded -= FrameworkElementUnloaded;
 
             if (oldBehaviors != null)
             {
                 foreach (var behavior in oldBehaviors)
                 {
                     int index = GetIndexOf(itemBehaviors, behavior);
-
                     if (index >= 0)
                     {
                         itemBehaviors.RemoveAt(index);
@@ -98,7 +61,6 @@ namespace MahApps.Metro.Behaviours
                 foreach (var behavior in newBehaviors)
                 {
                     int index = GetIndexOf(itemBehaviors, behavior);
-
                     if (index < 0)
                     {
                         var clone = (Behavior)behavior.Clone();
@@ -107,6 +69,84 @@ namespace MahApps.Metro.Behaviours
                     }
                 }
             }
+
+            if (itemBehaviors.Count > 0)
+            {
+                uie.Unloaded += FrameworkElementUnloaded;
+            }
+            uie.Dispatcher.ShutdownStarted += Dispatcher_ShutdownStarted;
+        }
+
+        private static void Dispatcher_ShutdownStarted(object sender, System.EventArgs e)
+        {
+            var s = "";
+        }
+
+        private static void FrameworkElementUnloaded(object sender, RoutedEventArgs e)
+        {
+            // BehaviorCollection doesn't call Detach, so we do this
+            var uie = sender as FrameworkElement;
+            if (uie == null)
+            {
+                return;
+            }
+            BehaviorCollection itemBehaviors = Interaction.GetBehaviors(uie);
+            foreach (var behavior in itemBehaviors) {
+                behavior.Detach();
+            }
+            uie.Loaded += FrameworkElementLoaded;
+        }
+
+        private static void FrameworkElementLoaded(object sender, RoutedEventArgs e)
+        {
+            var uie = sender as FrameworkElement;
+            if (uie == null)
+            {
+                return;
+            }
+            uie.Loaded -= FrameworkElementLoaded;
+            BehaviorCollection itemBehaviors = Interaction.GetBehaviors(uie);
+            foreach (var behavior in itemBehaviors)
+            {
+                behavior.Attach(uie);
+            }
+        }
+
+        private static int GetIndexOf(BehaviorCollection itemBehaviors, Behavior behavior)
+        {
+            int index = -1;
+
+            Behavior orignalBehavior = GetOriginalBehavior(behavior);
+
+            for (int i = 0; i < itemBehaviors.Count; i++)
+            {
+                Behavior currentBehavior = itemBehaviors[i];
+                if (currentBehavior == behavior || currentBehavior == orignalBehavior)
+                {
+                    index = i;
+                    break;
+                }
+
+                Behavior currentOrignalBehavior = GetOriginalBehavior(currentBehavior);
+                if (currentOrignalBehavior == behavior || currentOrignalBehavior == orignalBehavior)
+                {
+                    index = i;
+                    break;
+                }
+            }
+
+            return index;
+        }
+
+        private static readonly DependencyProperty OriginalBehaviorProperty
+            = DependencyProperty.RegisterAttached("OriginalBehaviorInternal",
+                                                  typeof(Behavior),
+                                                  typeof(StylizedBehaviors),
+                                                  new UIPropertyMetadata(null));
+
+        private static Behavior GetOriginalBehavior(DependencyObject obj)
+        {
+            return obj.GetValue(OriginalBehaviorProperty) as Behavior;
         }
 
         private static void SetOriginalBehavior(DependencyObject obj, Behavior value)

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -718,6 +718,11 @@
       <SubType>Designer</SubType>
       <DependentUpon>Controls.xaml</DependentUpon>
     </Page>
+    <Page Include="Styles\Controls.Shadows.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <DependentUpon>Controls.xaml</DependentUpon>
+    </Page>
     <Page Include="Styles\Controls.Buttons.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -689,6 +689,11 @@
       <SubType>Designer</SubType>
       <DependentUpon>Controls.xaml</DependentUpon>
     </Page>
+    <Page Include="Styles\Controls.Shadows.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <DependentUpon>Controls.xaml</DependentUpon>
+    </Page>
     <Page Include="Styles\Controls.Buttons.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/MahApps.Metro/Styles/Colors.xaml
+++ b/MahApps.Metro/Styles/Colors.xaml
@@ -108,8 +108,6 @@
         <GradientStop Color="{DynamicResource AccentColor3}" Offset="1"/>
     </LinearGradientBrush>
 
-    <DropShadowEffect x:Key="DropShadowBrush" Direction="330" Opacity="0.3" ShadowDepth="0" BlurRadius="6"/>
-
     <SolidColorBrush x:Key="WindowBackgroundBrush" Color="{DynamicResource WhiteColor}" />
     <SolidColorBrush x:Key="SeperatorBrush" Color="#FFC4C4C5"/>
 

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -2,10 +2,12 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Behaviors="clr-namespace:MahApps.Metro.Behaviours"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
-                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters"
+                    xmlns:metro="clr-namespace:MahApps.Metro">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Buttons.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
@@ -13,6 +15,7 @@
     <Converters:StringToVisibilityConverter x:Key="StringToVisibilityConverter" />
     <Converters:StringToVisibilityConverter x:Key="StringToOppositeVisibilityConverter" OppositeStringValue="True" />
 
+    <!--  obsolete  -->
     <Grid x:Key="RevealButtonIcon"
           Width="16"
           Height="16"
@@ -35,37 +38,29 @@
     </Grid>
 
     <!--  Button Style for Win8MetroPasswordBox  -->
-    <Style x:Key="RevealButtonStyle" TargetType="{x:Type Button}">
+    <Style x:Key="RevealButtonStyle"
+           TargetType="{x:Type Button}"
+           BasedOn="{StaticResource ChromelessButtonStyle}">
         <Setter Property="Margin" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid>
-                        <Border x:Name="PasswordRevealIconEyeBorder"
-                                Margin="{TemplateBinding Margin}"
-                                Background="Transparent"
-                                BorderThickness="{TemplateBinding BorderThickness}">
-                            <Rectangle x:Name="IconEye"
-                                       Width="20"
-                                       Height="15"
-                                       Margin="0"
-                                       HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"
-                                       Fill="{Binding Path=Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Button}}}">
-                                <Rectangle.OpacityMask>
-                                    <VisualBrush Stretch="Fill" Visual="{StaticResource RevealButtonIcon}" />
-                                </Rectangle.OpacityMask>
-                            </Rectangle>
-                        </Border>
+                    <Grid Background="{TemplateBinding Background}">
+                        <metro:PackIconMaterial x:Name="PART_PackIcon"
+                                                Kind="Eye"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Padding="1"
+                                                Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
+                                                Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}" />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <DataTrigger Binding="{Binding ElementName=PasswordRevealIconEyeBorder, Path=IsMouseOver}" Value="True">
-                            <Setter TargetName="PasswordRevealIconEyeBorder" Property="Background" Value="Gainsboro" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True">
-                            <Setter TargetName="IconEye" Property="Fill" Value="{DynamicResource WhiteBrush}" />
-                            <Setter TargetName="PasswordRevealIconEyeBorder" Property="Background" Value="{DynamicResource BlackBrush}" />
-                        </DataTrigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="PART_PackIcon" Property="Opacity" Value="1" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="False">
+                            <Setter TargetName="PART_PackIcon" Property="Opacity" Value=".5" />
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -380,7 +375,7 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition x:Name="ButtonColumn" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}" />
+                                <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
@@ -434,6 +429,7 @@
                                     Grid.Row="0"
                                     Grid.RowSpan="2"
                                     Grid.Column="2"
+                                    Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
                                     Style="{DynamicResource ChromelessButtonStyle}"
                                     Foreground="{TemplateBinding Foreground}"
                                     FontFamily="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonFontFamily), Mode=OneWay}"
@@ -658,12 +654,10 @@
                                     Grid.RowSpan="2"
                                     Grid.Column="2"
                                     Margin="0"
-                                    BorderThickness="0"
                                     Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
                                     Style="{StaticResource RevealButtonStyle}"
                                     Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
-                                    SnapsToDevicePixels="True"
                                     Visibility="{Binding ElementName=RevealedPassword, Path=Text, Converter={StaticResource StringToVisibilityConverter}}" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -147,9 +147,16 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
-                        <Grid x:Name="PART_WaitingForDataEffectGrid"
-                              Style="{DynamicResource WaitingForDataEffectGridStyle}"
-                              Background="{TemplateBinding Background}" />
+                        <AdornerDecorator>
+                            <AdornerDecorator.CacheMode>
+                                <BitmapCache EnableClearType="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </AdornerDecorator.CacheMode>
+                            <Border x:Name="PART_WaitingForDataEffectGrid"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </AdornerDecorator>
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -293,22 +300,23 @@
                             </Trigger.ExitActions>
                         </Trigger>
                         
-                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="True">
-                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{DynamicResource WaitingForDataDropShadowEffect}" />
-                            <Trigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation AutoReverse="True"
-                                                         Duration="00:00:02"
-                                                         From="0"
-                                                         RepeatBehavior="Forever"
-                                                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
-                                                         Storyboard.TargetProperty="(Effect).Opacity"
-                                                         To="1" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.EnterActions>
-                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsVisible" Value="True" />
+                                <Condition Property="Controls:TextBoxHelper.IsWaitingForData" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect">
+                                <Setter.Value>
+                                    <DropShadowEffect Opacity="0"
+                                                      BlurRadius="10"
+                                                      ShadowDepth="0"
+                                                      Color="{DynamicResource BlackColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <MultiTrigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource WaitingForDataStoryboard}" />
+                            </MultiTrigger.EnterActions>
+                        </MultiTrigger>
                         <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="False">
                             <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{x:Null}" />
                         </Trigger>
@@ -353,9 +361,16 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
-                        <Grid x:Name="PART_WaitingForDataEffectGrid"
-                              Style="{DynamicResource WaitingForDataEffectGridStyle}"
-                              Background="{TemplateBinding Background}" />
+                        <AdornerDecorator>
+                            <AdornerDecorator.CacheMode>
+                                <BitmapCache EnableClearType="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </AdornerDecorator.CacheMode>
+                            <Border x:Name="PART_WaitingForDataEffectGrid"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </AdornerDecorator>
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -496,22 +511,24 @@
                                 <BeginStoryboard Storyboard="{StaticResource exitHasText}" />
                             </Trigger.ExitActions>
                         </Trigger>
-                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="True">
-                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{DynamicResource WaitingForDataDropShadowEffect}" />
-                            <Trigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation AutoReverse="True"
-                                                         Duration="00:00:02"
-                                                         From="0"
-                                                         RepeatBehavior="Forever"
-                                                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
-                                                         Storyboard.TargetProperty="(Effect).Opacity"
-                                                         To="1" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.EnterActions>
-                        </Trigger>
+
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsVisible" Value="True" />
+                                <Condition Property="Controls:TextBoxHelper.IsWaitingForData" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect">
+                                <Setter.Value>
+                                    <DropShadowEffect Opacity="0"
+                                                      BlurRadius="10"
+                                                      ShadowDepth="0"
+                                                      Color="{DynamicResource BlackColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <MultiTrigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource WaitingForDataStoryboard}" />
+                            </MultiTrigger.EnterActions>
+                        </MultiTrigger>
                         <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="False">
                             <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{x:Null}" />
                         </Trigger>
@@ -555,9 +572,16 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
-                        <Grid x:Name="PART_WaitingForDataEffectGrid"
-                              Style="{DynamicResource WaitingForDataEffectGridStyle}"
-                              Background="{TemplateBinding Background}" />
+                        <AdornerDecorator>
+                            <AdornerDecorator.CacheMode>
+                                <BitmapCache EnableClearType="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </AdornerDecorator.CacheMode>
+                            <Border x:Name="PART_WaitingForDataEffectGrid"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </AdornerDecorator>
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -712,22 +736,23 @@
                                 <BeginStoryboard Storyboard="{StaticResource exitHasText}" />
                             </Trigger.ExitActions>
                         </Trigger>
-                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="True">
-                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{DynamicResource WaitingForDataDropShadowEffect}" />
-                            <Trigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation AutoReverse="True"
-                                                         Duration="00:00:02"
-                                                         From="0"
-                                                         RepeatBehavior="Forever"
-                                                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
-                                                         Storyboard.TargetProperty="(Effect).Opacity"
-                                                         To="1" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.EnterActions>
-                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsVisible" Value="True" />
+                                <Condition Property="Controls:TextBoxHelper.IsWaitingForData" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect">
+                                <Setter.Value>
+                                    <DropShadowEffect Opacity="0"
+                                                      BlurRadius="10"
+                                                      ShadowDepth="0"
+                                                      Color="{DynamicResource BlackColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <MultiTrigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource WaitingForDataStoryboard}" />
+                            </MultiTrigger.EnterActions>
+                        </MultiTrigger>
                         <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="False">
                             <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{x:Null}" />
                         </Trigger>

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -36,18 +36,19 @@
 
     <!--  Button Style for Win8MetroPasswordBox  -->
     <Style x:Key="RevealButtonStyle" TargetType="{x:Type Button}">
+        <Setter Property="Margin" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
                     <Grid>
                         <Border x:Name="PasswordRevealIconEyeBorder"
-                                Margin="1 1 3 1"
+                                Margin="{TemplateBinding Margin}"
                                 Background="Transparent"
                                 BorderThickness="{TemplateBinding BorderThickness}">
                             <Rectangle x:Name="IconEye"
                                        Width="20"
                                        Height="15"
-                                       Margin="3 0"
+                                       Margin="0"
                                        HorizontalAlignment="Center"
                                        VerticalAlignment="Center"
                                        Fill="{Binding Path=Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Button}}}">
@@ -65,194 +66,6 @@
                             <Setter TargetName="IconEye" Property="Fill" Value="{DynamicResource WhiteBrush}" />
                             <Setter TargetName="PasswordRevealIconEyeBorder" Property="Background" Value="{DynamicResource BlackBrush}" />
                         </DataTrigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <!--  Win8MetroPasswordBox Style  -->
-    <Style x:Key="Win8MetroPasswordBox" TargetType="{x:Type PasswordBox}">
-        <Setter Property="AllowDrop" Value="true" />
-        <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
-        <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
-        <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="ContextMenu" Value="{DynamicResource TextBoxMetroContextMenu}" />
-        <Setter Property="Controls:ControlsHelper.ButtonWidth" Value="22" />
-        <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource TextBoxFocusBorderBrush}" />
-        <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource TextBoxMouseOverBorderBrush}" />
-        <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
-        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-        <Setter Property="FontFamily" Value="{DynamicResource ContentFontFamily}" />
-        <Setter Property="FontSize" Value="15" />
-        <Setter Property="HorizontalContentAlignment" Value="Left" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="MinHeight" Value="26" />
-        <Setter Property="Padding" Value="4 1 4 1" />
-        <Setter Property="PasswordChar" Value="●" />
-        <Setter Property="SelectionBrush" Value="{DynamicResource HighlightBrush}" />
-        <!--  change SnapsToDevicePixels to true to view a better border and validation error  -->
-        <Setter Property="SnapsToDevicePixels" Value="True" />
-        <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type PasswordBox}">
-                    <ControlTemplate.Resources>
-                        <Storyboard x:Key="enterGotFocus">
-                            <DoubleAnimation Duration="0:0:0.2"
-                                             Storyboard.TargetName="TextBoxHint"
-                                             Storyboard.TargetProperty="Opacity"
-                                             To=".2" />
-                        </Storyboard>
-                        <Storyboard x:Key="exitGotFocus">
-                            <DoubleAnimation Duration="0:0:0.2"
-                                             Storyboard.TargetName="TextBoxHint"
-                                             Storyboard.TargetProperty="Opacity" />
-                        </Storyboard>
-                        <Storyboard x:Key="enterHasText">
-                            <DoubleAnimation Duration="0:0:0.2"
-                                             From=".2"
-                                             Storyboard.TargetName="TextBoxHint"
-                                             Storyboard.TargetProperty="Opacity"
-                                             To="0" />
-                        </Storyboard>
-                        <Storyboard x:Key="exitHasText">
-                            <DoubleAnimation Duration="0:0:0.2"
-                                             Storyboard.TargetName="TextBoxHint"
-                                             Storyboard.TargetProperty="Opacity" />
-                        </Storyboard>
-                    </ControlTemplate.Resources>
-                    <Grid Margin="0" VerticalAlignment="Stretch">
-                        <Rectangle x:Name="Base"
-                                   Fill="{TemplateBinding Background}"
-                                   Stroke="{TemplateBinding BorderBrush}"
-                                   StrokeThickness="{TemplateBinding BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}}"
-                                   Opacity="1" />
-                        <Rectangle x:Name="FocusRectangle"
-                                   StrokeThickness="{TemplateBinding BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}}"
-                                   Visibility="Collapsed" />
-                        <Grid Margin="0" VerticalAlignment="Stretch">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
-                            <ScrollViewer x:Name="PART_ContentHost"
-                                          Margin="0"
-                                          Padding="0"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                            <TextBox x:Name="RevealedPassword"
-                                     Grid.Row="0"
-                                     Grid.Column="0"
-                                     Margin="1 1 1 1"
-                                     Padding="-1 1 1 1"
-                                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                     VerticalAlignment="Stretch"
-                                     VerticalContentAlignment="Stretch"
-                                     BorderBrush="Transparent"
-                                     BorderThickness="1"
-                                     FontSize="15"
-                                     IsReadOnly="True"
-                                     Text="{TemplateBinding Behaviors:PasswordBoxBindingBehavior.Password}"
-                                     Visibility="Hidden" />
-                            <TextBlock x:Name="TextBoxHint"
-                                       Grid.Row="0"
-                                       Grid.Column="0"
-                                       Margin="2 0 2 0"
-                                       Padding="6 0 6 0"
-                                       HorizontalAlignment="Stretch"
-                                       VerticalAlignment="Center"
-                                       Foreground="{TemplateBinding Foreground}"
-                                       Opacity="0.6"
-                                       FontSize="15"
-                                       Cursor="IBeam"
-                                       IsHitTestVisible="False"
-                                       Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
-                                       Visibility="{Binding ElementName=RevealedPassword, Path=Text, Converter={StaticResource StringToOppositeVisibilityConverter}}" />
-                            <Button x:Name="RevealButton"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Style="{StaticResource RevealButtonStyle}"
-                                    SnapsToDevicePixels="True"
-                                    Visibility="{Binding ElementName=RevealedPassword, Path=Text, Converter={StaticResource StringToVisibilityConverter}}" />
-                        </Grid>
-                        <Rectangle x:Name="DisabledVisualElement"
-                                   Fill="{DynamicResource ControlsDisabledBrush}"
-                                   Stroke="{DynamicResource ControlsDisabledBrush}"
-                                   StrokeThickness="{TemplateBinding BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}}"
-                                   Opacity="0"
-                                   IsHitTestVisible="False"
-                                   Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}" />
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" Value="false">
-                            <Setter Property="Foreground" Value="{StaticResource {x:Static SystemColors.GrayTextBrushKey}}" />
-                            <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
-                            <Setter TargetName="RevealButton" Property="Opacity" Value="0.5" />
-                            <Setter TargetName="TextBoxHint" Property="Text" Value="{}{disabled} " />
-                        </Trigger>
-                        <DataTrigger Binding="{Binding ElementName=RevealButton, Path=IsPressed}" Value="True">
-                            <Setter Property="Foreground" Value="Transparent" />
-                            <Setter Property="PasswordChar" Value=" " />
-                            <Setter TargetName="RevealedPassword" Property="Visibility" Value="Visible" />
-                        </DataTrigger>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="FocusRectangle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.MouseOverBorderBrush)}" />
-                            <Setter TargetName="FocusRectangle" Property="Visibility" Value="Visible" />
-                        </Trigger>
-                        <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="FocusRectangle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderBrush)}" />
-                            <Setter TargetName="FocusRectangle" Property="Visibility" Value="Visible" />
-                        </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Controls:TextBoxHelper.HasText" Value="False" />
-                                <Condition Property="IsFocused" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <MultiTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource enterGotFocus}" />
-                            </MultiTrigger.EnterActions>
-                            <MultiTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource exitGotFocus}" />
-                            </MultiTrigger.ExitActions>
-                        </MultiTrigger>
-                        <Trigger Property="Controls:TextBoxHelper.HasText" Value="True">
-                            <Trigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource enterHasText}" />
-                            </Trigger.EnterActions>
-                            <Trigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource exitHasText}" />
-                            </Trigger.ExitActions>
-                        </Trigger>
-                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="True">
-                            <Setter TargetName="Base" Property="Effect">
-                                <Setter.Value>
-                                    <DropShadowEffect Opacity="0"
-                                                      BlurRadius="10"
-                                                      ShadowDepth="0"
-                                                      Color="{DynamicResource BlackColor}" />
-                                </Setter.Value>
-                            </Setter>
-                            <Trigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation AutoReverse="True"
-                                                         Duration="00:00:02"
-                                                         From="0"
-                                                         RepeatBehavior="Forever"
-                                                         Storyboard.TargetName="Base"
-                                                         Storyboard.TargetProperty="(Effect).Opacity"
-                                                         To="1" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.EnterActions>
-                        </Trigger>
-                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="False">
-                            <Setter TargetName="Base" Property="Effect" Value="{x:Null}" />
-                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -297,6 +110,13 @@
         <!--  change SnapsToDevicePixels to true to view a better border and validation error  -->
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
+        <Setter Property="Behaviors:StylizedBehaviors.Behaviors">
+            <Setter.Value>
+                <Behaviors:StylizedBehaviorCollection>
+                    <Behaviors:PasswordBoxBindingBehavior />
+                </Behaviors:StylizedBehaviorCollection>
+            </Setter.Value>
+        </Setter>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type PasswordBox}">
@@ -327,6 +147,9 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
+                        <Grid x:Name="PART_WaitingForDataEffectGrid"
+                              Style="{DynamicResource WaitingForDataEffectGridStyle}"
+                              Background="{TemplateBinding Background}" />
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -365,6 +188,7 @@
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Column="0"
+                                            Grid.Row="0"
                                             Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
@@ -374,18 +198,6 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
-                            <Button x:Name="PART_ClearText"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="2"
-                                    Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
-                                    Style="{DynamicResource ChromelessButtonStyle}"
-                                    Foreground="{TemplateBinding Foreground}"
-                                    FontFamily="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonFontFamily), Mode=OneWay}"
-                                    FontSize="16"
-                                    Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
-                                    Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
-                                    IsTabStop="False"
-                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"
                                               Grid.RowSpan="2"
@@ -397,6 +209,19 @@
                                               TextBlock.Foreground="{DynamicResource ControlsValidationBrush}"
                                               ToolTip="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:PasswordBoxHelper.CapsLockWarningToolTip), Mode=OneWay}"
                                               Visibility="Collapsed" />
+                            <Button x:Name="PART_ClearText"
+                                    Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="2"
+                                    Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
+                                    Style="{DynamicResource ChromelessButtonStyle}"
+                                    Foreground="{TemplateBinding Foreground}"
+                                    FontFamily="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonFontFamily), Mode=OneWay}"
+                                    FontSize="16"
+                                    Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
+                                    Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                    IsTabStop="False"
+                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource ControlsDisabledBrush}"
@@ -466,6 +291,26 @@
                             <Trigger.ExitActions>
                                 <BeginStoryboard Storyboard="{StaticResource exitHasText}" />
                             </Trigger.ExitActions>
+                        </Trigger>
+                        
+                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="True">
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{DynamicResource WaitingForDataDropShadowEffect}" />
+                            <Trigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation AutoReverse="True"
+                                                         Duration="00:00:02"
+                                                         From="0"
+                                                         RepeatBehavior="Forever"
+                                                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
+                                                         Storyboard.TargetProperty="(Effect).Opacity"
+                                                         To="1" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.EnterActions>
+                        </Trigger>
+                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="False">
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{x:Null}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -508,6 +353,9 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
+                        <Grid x:Name="PART_WaitingForDataEffectGrid"
+                              Style="{DynamicResource WaitingForDataEffectGridStyle}"
+                              Background="{TemplateBinding Background}" />
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -545,6 +393,7 @@
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
+                                            Grid.Row="0"
                                             Grid.Column="0"
                                             Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
@@ -555,17 +404,6 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
-                            <Button x:Name="PART_ClearText"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="2"
-                                    Style="{DynamicResource ChromelessButtonStyle}"
-                                    Foreground="{TemplateBinding Foreground}"
-                                    FontFamily="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonFontFamily), Mode=OneWay}"
-                                    FontSize="16"
-                                    Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="True"
-                                    Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
-                                    IsTabStop="False"
-                                    Template="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonTemplate), Mode=OneWay}" />
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"
                                               Grid.RowSpan="2"
@@ -577,6 +415,18 @@
                                               TextBlock.Foreground="{DynamicResource ControlsValidationBrush}"
                                               ToolTip="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:PasswordBoxHelper.CapsLockWarningToolTip), Mode=OneWay}"
                                               Visibility="Collapsed" />
+                            <Button x:Name="PART_ClearText"
+                                    Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="2"
+                                    Style="{DynamicResource ChromelessButtonStyle}"
+                                    Foreground="{TemplateBinding Foreground}"
+                                    FontFamily="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonFontFamily), Mode=OneWay}"
+                                    FontSize="16"
+                                    Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="True"
+                                    Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                    IsTabStop="False"
+                                    Template="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonTemplate), Mode=OneWay}" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource ControlsDisabledBrush}"
@@ -637,7 +487,6 @@
                                 <BeginStoryboard Storyboard="{StaticResource exitGotFocus}" />
                             </MultiTrigger.ExitActions>
                         </MultiTrigger>
-
                         <Trigger Property="Controls:TextBoxHelper.HasText" Value="True">
                             <Setter TargetName="PART_Message" Property="Visibility" Value="Visible" />
                             <Trigger.EnterActions>
@@ -646,6 +495,25 @@
                             <Trigger.ExitActions>
                                 <BeginStoryboard Storyboard="{StaticResource exitHasText}" />
                             </Trigger.ExitActions>
+                        </Trigger>
+                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="True">
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{DynamicResource WaitingForDataDropShadowEffect}" />
+                            <Trigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation AutoReverse="True"
+                                                         Duration="00:00:02"
+                                                         From="0"
+                                                         RepeatBehavior="Forever"
+                                                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
+                                                         Storyboard.TargetProperty="(Effect).Opacity"
+                                                         To="1" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.EnterActions>
+                        </Trigger>
+                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="False">
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{x:Null}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -657,7 +525,6 @@
     <Style x:Key="MetroButtonRevealedPasswordBox"
            BasedOn="{StaticResource MetroPasswordBox}"
            TargetType="{x:Type PasswordBox}">
-        <Setter Property="Controls:TextBoxHelper.ButtonTemplate" Value="{DynamicResource ChromelessButtonTemplate}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type PasswordBox}">
@@ -688,6 +555,9 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
+                        <Grid x:Name="PART_WaitingForDataEffectGrid"
+                              Style="{DynamicResource WaitingForDataEffectGridStyle}"
+                              Background="{TemplateBinding Background}" />
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -712,14 +582,18 @@
                                           Background="{x:Null}"
                                           BorderThickness="0"
                                           IsTabStop="False" />
-                            <TextBox x:Name="RevealedPassword"
-                                     Grid.Row="1"
-                                     Grid.Column="0"
-                                     BorderBrush="Transparent"
-                                     BorderThickness="1"
-                                     IsReadOnly="True"
-                                     Text="{TemplateBinding Behaviors:PasswordBoxBindingBehavior.Password}"
-                                     Visibility="Collapsed" />
+                            <TextBlock x:Name="RevealedPassword"
+                                       Grid.Row="1"
+                                       Grid.Column="0"
+                                       Margin="4 2 4 2"
+                                       Padding="{TemplateBinding Padding}"
+                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                       Foreground="{TemplateBinding Foreground}"
+                                       FontSize="{TemplateBinding FontSize}"
+                                       IsHitTestVisible="False"
+                                       Text="{TemplateBinding Behaviors:PasswordBoxBindingBehavior.Password}"
+                                       Visibility="Collapsed" />
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
                                        Grid.Column="0"
@@ -733,6 +607,7 @@
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
+                                            Grid.Row="0"
                                             Grid.Column="0"
                                             Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
@@ -743,14 +618,6 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
-                            <Button x:Name="PART_RevealButton"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="2"
-                                    Style="{StaticResource RevealButtonStyle}"
-                                    Foreground="{TemplateBinding Foreground}"
-                                    IsTabStop="False"
-                                    SnapsToDevicePixels="True"
-                                    Visibility="{Binding ElementName=RevealedPassword, Path=Text, Converter={StaticResource StringToVisibilityConverter}}" />
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"
                                               Grid.RowSpan="2"
@@ -762,6 +629,18 @@
                                               TextBlock.Foreground="{DynamicResource ControlsValidationBrush}"
                                               ToolTip="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:PasswordBoxHelper.CapsLockWarningToolTip), Mode=OneWay}"
                                               Visibility="Collapsed" />
+                            <Button x:Name="PART_RevealButton"
+                                    Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="2"
+                                    Margin="0"
+                                    BorderThickness="0"
+                                    Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
+                                    Style="{StaticResource RevealButtonStyle}"
+                                    Foreground="{TemplateBinding Foreground}"
+                                    IsTabStop="False"
+                                    SnapsToDevicePixels="True"
+                                    Visibility="{Binding ElementName=RevealedPassword, Path=Text, Converter={StaticResource StringToVisibilityConverter}}" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource ControlsDisabledBrush}"
@@ -775,11 +654,6 @@
                     <ControlTemplate.Triggers>
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Password, Mode=OneWay}" Value="">
                             <Setter TargetName="PART_Message" Property="Visibility" Value="Visible" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding ElementName=PART_RevealButton, Path=IsPressed}" Value="True">
-                            <Setter Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
-                            <Setter Property="PasswordChar" Value=" " />
-                            <Setter TargetName="RevealedPassword" Property="Visibility" Value="Visible" />
                         </DataTrigger>
 
                         <MultiDataTrigger>
@@ -811,6 +685,9 @@
                             <Setter TargetName="PART_RevealButton" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
                         </Trigger>
                         <Trigger SourceName="PART_RevealButton" Property="IsPressed" Value="True">
+                            <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
+                            <Setter Property="PasswordChar" Value=" " />
+                            <Setter TargetName="RevealedPassword" Property="Visibility" Value="Visible" />
                             <Setter TargetName="PART_RevealButton" Property="Background" Value="{DynamicResource BlackBrush}" />
                             <Setter TargetName="PART_RevealButton" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
                         </Trigger>
@@ -835,9 +712,38 @@
                                 <BeginStoryboard Storyboard="{StaticResource exitHasText}" />
                             </Trigger.ExitActions>
                         </Trigger>
+                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="True">
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{DynamicResource WaitingForDataDropShadowEffect}" />
+                            <Trigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation AutoReverse="True"
+                                                         Duration="00:00:02"
+                                                         From="0"
+                                                         RepeatBehavior="Forever"
+                                                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
+                                                         Storyboard.TargetProperty="(Effect).Opacity"
+                                                         To="1" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.EnterActions>
+                        </Trigger>
+                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="False">
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{x:Null}" />
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
+    
+    <!--  Win8MetroPasswordBox Style  -->
+    <Style x:Key="Win8MetroPasswordBox"
+           TargetType="{x:Type PasswordBox}"
+           BasedOn="{StaticResource MetroButtonRevealedPasswordBox}">
+        <Setter Property="AllowDrop" Value="true" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="FontSize" Value="15" />
+    </Style>
+    
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -538,6 +538,7 @@
     <Style x:Key="MetroButtonRevealedPasswordBox"
            BasedOn="{StaticResource MetroPasswordBox}"
            TargetType="{x:Type PasswordBox}">
+        <Setter Property="Controls:TextBoxHelper.ButtonTemplate" Value="{DynamicResource ChromelessButtonTemplate}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type PasswordBox}">
@@ -587,6 +588,7 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition x:Name="RevealButtonColumn" Width="Auto" />
                                 <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
@@ -659,6 +661,19 @@
                                     Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
                                     Visibility="{Binding ElementName=RevealedPassword, Path=Text, Converter={StaticResource StringToVisibilityConverter}}" />
+                            <Button x:Name="PART_ClearText"
+                                    Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="3"
+                                    Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
+                                    Style="{DynamicResource ChromelessButtonStyle}"
+                                    Foreground="{TemplateBinding Foreground}"
+                                    FontFamily="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonFontFamily), Mode=OneWay}"
+                                    FontSize="16"
+                                    Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
+                                    Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                    IsTabStop="False"
+                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource ControlsDisabledBrush}"
@@ -709,6 +724,15 @@
                             <Setter TargetName="PART_RevealButton" Property="Background" Value="{DynamicResource BlackBrush}" />
                             <Setter TargetName="PART_RevealButton" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
                         </Trigger>
+                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource GrayBrush8}" />
+                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
+                        </Trigger>
+                        <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource BlackBrush}" />
+                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
+                        </Trigger>
+
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="Controls:TextBoxHelper.HasText" Value="False" />

--- a/MahApps.Metro/Styles/Controls.Shadows.xaml
+++ b/MahApps.Metro/Styles/Controls.Shadows.xaml
@@ -1,0 +1,21 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
+
+    <DropShadowEffect x:Key="DropShadowBrush"
+                      Opacity="0.3"
+                      po:Freeze="True"
+                      BlurRadius="6"
+                      Direction="330"
+                      ShadowDepth="0" />
+
+    <DropShadowEffect x:Key="WaitingForDataDropShadowEffect"
+                      Opacity="0"
+                      po:Freeze="True"
+                      x:Shared="False"
+                      BlurRadius="8" Direction="360"
+                      ShadowDepth="0"
+                      Color="{DynamicResource BlackColor}" />
+
+
+</ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.Shadows.xaml
+++ b/MahApps.Metro/Styles/Controls.Shadows.xaml
@@ -9,13 +9,4 @@
                       Direction="330"
                       ShadowDepth="0" />
 
-    <DropShadowEffect x:Key="WaitingForDataDropShadowEffect"
-                      Opacity="0"
-                      po:Freeze="True"
-                      x:Shared="False"
-                      BlurRadius="8" Direction="360"
-                      ShadowDepth="0"
-                      Color="{DynamicResource BlackColor}" />
-
-
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -61,6 +61,9 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
+                        <Grid x:Name="PART_WaitingForDataEffectGrid"
+                              Style="{DynamicResource WaitingForDataEffectGridStyle}"
+                              Background="{TemplateBinding Background}" />
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -103,6 +106,7 @@
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Column="0"
+                                            Grid.Row="0"
                                             Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
@@ -113,6 +117,7 @@
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
                             <Button x:Name="PART_ClearText"
+                                    Grid.Row="0"
                                     Grid.RowSpan="2"
                                     Grid.Column="1"
                                     Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
@@ -216,14 +221,7 @@
                         </Trigger>
 
                         <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="True">
-                            <Setter TargetName="Base" Property="Effect">
-                                <Setter.Value>
-                                    <DropShadowEffect Opacity="0"
-                                                      BlurRadius="10"
-                                                      ShadowDepth="0"
-                                                      Color="{DynamicResource BlackColor}" />
-                                </Setter.Value>
-                            </Setter>
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{DynamicResource WaitingForDataDropShadowEffect}" />
                             <Trigger.EnterActions>
                                 <BeginStoryboard>
                                     <Storyboard>
@@ -231,7 +229,7 @@
                                                          Duration="00:00:02"
                                                          From="0"
                                                          RepeatBehavior="Forever"
-                                                         Storyboard.TargetName="Base"
+                                                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
                                                          Storyboard.TargetProperty="(Effect).Opacity"
                                                          To="1" />
                                     </Storyboard>
@@ -239,7 +237,7 @@
                             </Trigger.EnterActions>
                         </Trigger>
                         <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="False">
-                            <Setter TargetName="Base" Property="Effect" Value="{x:Null}" />
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{x:Null}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -282,6 +280,9 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
+                        <Grid x:Name="PART_WaitingForDataEffectGrid"
+                              Style="{DynamicResource WaitingForDataEffectGridStyle}"
+                              Background="{TemplateBinding Background}" />
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -411,6 +412,26 @@
                         <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
                             <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource BlackBrush}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
+                        </Trigger>
+                        
+                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="True">
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{DynamicResource WaitingForDataDropShadowEffect}" />
+                            <Trigger.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation AutoReverse="True"
+                                                         Duration="00:00:02"
+                                                         From="0"
+                                                         RepeatBehavior="Forever"
+                                                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
+                                                         Storyboard.TargetProperty="(Effect).Opacity"
+                                                         To="1" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </Trigger.EnterActions>
+                        </Trigger>
+                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="False">
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{x:Null}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -61,9 +61,16 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
-                        <Grid x:Name="PART_WaitingForDataEffectGrid"
-                              Style="{DynamicResource WaitingForDataEffectGridStyle}"
-                              Background="{TemplateBinding Background}" />
+                        <AdornerDecorator>
+                            <AdornerDecorator.CacheMode>
+                                <BitmapCache EnableClearType="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </AdornerDecorator.CacheMode>
+                            <Border x:Name="PART_WaitingForDataEffectGrid"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </AdornerDecorator>
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -220,22 +227,23 @@
                             </Trigger.ExitActions>
                         </Trigger>
 
-                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="True">
-                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{DynamicResource WaitingForDataDropShadowEffect}" />
-                            <Trigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation AutoReverse="True"
-                                                         Duration="00:00:02"
-                                                         From="0"
-                                                         RepeatBehavior="Forever"
-                                                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
-                                                         Storyboard.TargetProperty="(Effect).Opacity"
-                                                         To="1" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.EnterActions>
-                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsVisible" Value="True" />
+                                <Condition Property="Controls:TextBoxHelper.IsWaitingForData" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect">
+                                <Setter.Value>
+                                    <DropShadowEffect Opacity="0"
+                                                      BlurRadius="10"
+                                                      ShadowDepth="0"
+                                                      Color="{DynamicResource BlackColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <MultiTrigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource WaitingForDataStoryboard}" />
+                            </MultiTrigger.EnterActions>
+                        </MultiTrigger>
                         <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="False">
                             <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{x:Null}" />
                         </Trigger>
@@ -280,9 +288,16 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
-                        <Grid x:Name="PART_WaitingForDataEffectGrid"
-                              Style="{DynamicResource WaitingForDataEffectGridStyle}"
-                              Background="{TemplateBinding Background}" />
+                        <AdornerDecorator>
+                            <AdornerDecorator.CacheMode>
+                                <BitmapCache EnableClearType="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </AdornerDecorator.CacheMode>
+                            <Border x:Name="PART_WaitingForDataEffectGrid"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </AdornerDecorator>
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -414,22 +429,23 @@
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
                         </Trigger>
                         
-                        <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="True">
-                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{DynamicResource WaitingForDataDropShadowEffect}" />
-                            <Trigger.EnterActions>
-                                <BeginStoryboard>
-                                    <Storyboard>
-                                        <DoubleAnimation AutoReverse="True"
-                                                         Duration="00:00:02"
-                                                         From="0"
-                                                         RepeatBehavior="Forever"
-                                                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
-                                                         Storyboard.TargetProperty="(Effect).Opacity"
-                                                         To="1" />
-                                    </Storyboard>
-                                </BeginStoryboard>
-                            </Trigger.EnterActions>
-                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsVisible" Value="True" />
+                                <Condition Property="Controls:TextBoxHelper.IsWaitingForData" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect">
+                                <Setter.Value>
+                                    <DropShadowEffect Opacity="0"
+                                                      BlurRadius="10"
+                                                      ShadowDepth="0"
+                                                      Color="{DynamicResource BlackColor}" />
+                                </Setter.Value>
+                            </Setter>
+                            <MultiTrigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource WaitingForDataStoryboard}" />
+                            </MultiTrigger.EnterActions>
+                        </MultiTrigger>
                         <Trigger Property="Controls:TextBoxHelper.IsWaitingForData" Value="False">
                             <Setter TargetName="PART_WaitingForDataEffectGrid" Property="Effect" Value="{x:Null}" />
                         </Trigger>

--- a/MahApps.Metro/Styles/Controls.xaml
+++ b/MahApps.Metro/Styles/Controls.xaml
@@ -4,6 +4,7 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Sizes.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Shadows.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Page.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/ValidationErrorTemplate.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Scrollbars.xaml" />

--- a/MahApps.Metro/Styles/Controls.xaml
+++ b/MahApps.Metro/Styles/Controls.xaml
@@ -42,6 +42,10 @@
         <Setter Property="Visibility" Value="Visible" />
     </Style>
 
+    <Style x:Key="WaitingForDataEffectGridStyle" TargetType="{x:Type Grid}">
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+    </Style>
+
     <Style x:Key="MetroToggleSwitchButton" TargetType="{x:Type Controls:ToggleSwitchButton}" BasedOn="{StaticResource {x:Type Controls:ToggleSwitchButton}}" />
     <Style x:Key="MetroToggleSwitch" TargetType="{x:Type Controls:ToggleSwitch}" BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}" />
 

--- a/MahApps.Metro/Styles/Controls.xaml
+++ b/MahApps.Metro/Styles/Controls.xaml
@@ -42,10 +42,6 @@
         <Setter Property="Visibility" Value="Visible" />
     </Style>
 
-    <Style x:Key="WaitingForDataEffectGridStyle" TargetType="{x:Type Grid}">
-        <Setter Property="SnapsToDevicePixels" Value="True" />
-    </Style>
-
     <Style x:Key="MetroToggleSwitchButton" TargetType="{x:Type Controls:ToggleSwitchButton}" BasedOn="{StaticResource {x:Type Controls:ToggleSwitchButton}}" />
     <Style x:Key="MetroToggleSwitch" TargetType="{x:Type Controls:ToggleSwitch}" BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}" />
 

--- a/MahApps.Metro/Styles/Shared.xaml
+++ b/MahApps.Metro/Styles/Shared.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
 
     <ExponentialEase x:Key="ExpoEaseIn"
                      EasingMode="EaseIn"
@@ -10,6 +11,17 @@
     <ExponentialEase x:Key="ExpoEaseInOut"
                      EasingMode="EaseInOut"
                      Exponent="2" />
+
+    <Storyboard x:Key="WaitingForDataStoryboard" po:Freeze="True">
+        <DoubleAnimation AutoReverse="True"
+                         Duration="00:00:02"
+                         From="0"
+                         RepeatBehavior="Forever"
+                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
+                         Storyboard.TargetProperty="(Effect).Opacity"
+                         Timeline.DesiredFrameRate="30"
+                         To="1" />
+    </Storyboard>
 
     <Storyboard x:Key="HideFloatingMessageStoryboard">
         <DoubleAnimation Duration="0:0:.2"

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -25,9 +25,9 @@
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
-                <ColumnDefinition Width="1.5*" />
                 <ColumnDefinition />
-                <ColumnDefinition Width="1.5*" />
+                <ColumnDefinition />
+                <ColumnDefinition />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -180,8 +180,9 @@
                              Controls:TextBoxHelper.UseFloatingWatermark="True"
                              Password="Win8" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"
-                             Controls:TextBoxHelper.IsWaitingForData="True"
                              Style="{StaticResource MetroButtonRevealedPasswordBox}"
+                             Controls:TextBoxHelper.ClearTextButton="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.HasText), Mode=OneWay}"
+                             Controls:TextBoxHelper.IsWaitingForData="True"
                              Controls:TextBoxHelper.Watermark="Revealed PasswordBox"
                              Controls:TextBoxHelper.UseFloatingWatermark="True" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -175,6 +175,16 @@
                              Controls:TextBoxHelper.Watermark="Password"
                              Password="Password" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"
+                             Style="{StaticResource Win8MetroPasswordBox}"
+                             Controls:TextBoxHelper.Watermark="Win8"
+                             Controls:TextBoxHelper.UseFloatingWatermark="True"
+                             Password="Win8" />
+                <PasswordBox Margin="{StaticResource ControlMargin}"
+                             Controls:TextBoxHelper.IsWaitingForData="True"
+                             Style="{StaticResource MetroButtonRevealedPasswordBox}"
+                             Controls:TextBoxHelper.Watermark="Revealed PasswordBox"
+                             Controls:TextBoxHelper.UseFloatingWatermark="True" />
+                <PasswordBox Margin="{StaticResource ControlMargin}"
                              Controls:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
                              Controls:TextBoxHelper.ClearTextButton="True"
                              Controls:TextBoxHelper.UseFloatingWatermark="True"


### PR DESCRIPTION
- add sample for Win8 PasswordBox
- add Shadows resource dictionary , e.g. for IsWaitingForData
- Fixed: Behaviors in StylizedBehaviors should be detached on unload
- Fixed: PasswordBoxBindingBehavior, it doesn't work e.g. in TabControl TabItems
- use new WaitingForDataDropShadowEffect and fix blurry effect
- IsWaitingForData for MetroButtonTextBox, MetroPasswordBox, MetroButtonPasswordBox, MetroButtonRevealedPasswordBox
- remove Win8MetroPasswordBox boilerplate code
- PackIconMaterial `Eye` for `MetroButtonRevealedPasswordBox`
- `ClearTextButton` feature for `MetroButtonRevealedPasswordBox`

Closes #2343 Win8MetroPasswordBox Preview does not work with Tabcontrol (item > 1)