### PR TITLE
Added ContentStringFormat TemplateBinding to ToolTip

### DIFF
--- a/MahApps.Metro/Styles/Controls.Tooltip.xaml
+++ b/MahApps.Metro/Styles/Controls.Tooltip.xaml
@@ -59,6 +59,7 @@
                                           TextElement.FontSize="{DynamicResource ContentFontSize}"
                                           Cursor="{TemplateBinding Cursor}"
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                           Content="{TemplateBinding Content}"
                                           Margin="{TemplateBinding Padding}" />
                     </Border>


### PR DESCRIPTION
Fixed a bug in the ToolTip style where the ContentStringFormat was being ignored.