### PR TITLE
fix ControlsHelper.ButtonWidth for combobox and other stuff

### DIFF
--- a/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
+++ b/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
@@ -33,6 +33,7 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty ButtonCommandProperty = DependencyProperty.RegisterAttached("ButtonCommand", typeof(ICommand), typeof(TextBoxHelper), new FrameworkPropertyMetadata(null, ButtonCommandOrClearTextChanged));
         public static readonly DependencyProperty ButtonCommandParameterProperty = DependencyProperty.RegisterAttached("ButtonCommandParameter", typeof(object), typeof(TextBoxHelper), new FrameworkPropertyMetadata(null));
         public static readonly DependencyProperty ButtonContentProperty = DependencyProperty.RegisterAttached("ButtonContent", typeof(object), typeof(TextBoxHelper), new FrameworkPropertyMetadata("r"));
+        public static readonly DependencyProperty ButtonContentTemplateProperty = DependencyProperty.RegisterAttached("ButtonContentTemplate", typeof(DataTemplate), typeof(TextBoxHelper), new FrameworkPropertyMetadata((DataTemplate)null));
         public static readonly DependencyProperty ButtonTemplateProperty = DependencyProperty.RegisterAttached("ButtonTemplate", typeof(ControlTemplate), typeof(TextBoxHelper), new FrameworkPropertyMetadata(null));
         public static readonly DependencyProperty ButtonFontFamilyProperty = DependencyProperty.RegisterAttached("ButtonFontFamily", typeof(FontFamily), typeof(TextBoxHelper), new FrameworkPropertyMetadata((new FontFamilyConverter()).ConvertFromString("Marlett")));
         
@@ -406,6 +407,20 @@ namespace MahApps.Metro.Controls
         public static void SetButtonContent(DependencyObject obj, object value)
         {
             obj.SetValue(ButtonContentProperty, value);
+        }
+
+        /// <summary> 
+        /// ButtonContentTemplate is the template used to display the content of the ClearText button. 
+        /// </summary>
+        [Category(AppName.MahApps)]
+        public static DataTemplate GetButtonContentTemplate(DependencyObject d)
+        {
+            return (DataTemplate)d.GetValue(ButtonContentTemplateProperty);
+        }
+
+        public static void SetButtonContentTemplate(DependencyObject obj, DataTemplate value)
+        {
+            obj.SetValue(ButtonContentTemplateProperty, value);
         }
 
         [Category(AppName.MahApps)]

--- a/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -159,7 +159,7 @@
         <Setter Property="Background" Value="{DynamicResource TransparentWhiteBrush}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="Padding" Value="1" />
+        <Setter Property="Padding" Value="0" />
         <Setter Property="Template" Value="{StaticResource ChromelessButtonTemplate}" />
     </Style>
 

--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -318,6 +318,7 @@
                                           Controls:ControlsHelper.CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.CornerRadius), Mode=OneWay}"
                                           Controls:TextBoxHelper.ButtonContent="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
                                           Controls:TextBoxHelper.ButtonContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
+                                          Controls:TextBoxHelper.ButtonFontFamily="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonFontFamily), Mode=OneWay}"
                                           Controls:TextBoxHelper.ClearTextButton="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
                                           IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                           KeyboardNavigation.IsTabStop="False"

--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -242,13 +242,14 @@
 
                                                 <Grid Margin="1">
                                                     <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*" />
-                                                        <ColumnDefinition Width="{Binding ElementName=ToggleButtonRootGrid, Path=ActualHeight, Mode=OneWay}" />
-                                                        <ColumnDefinition Width="{Binding ElementName=ToggleButtonRootGrid, Path=ActualHeight, Mode=OneWay}" />
+                                                        <ColumnDefinition x:Name="TextColumn" Width="*" />
+                                                        <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
+                                                        <ColumnDefinition x:Name="ToggleButtonColumn" Width="Auto" />
                                                     </Grid.ColumnDefinitions>
 
                                                     <Button x:Name="PART_ClearText"
                                                             Grid.Column="1"
+                                                            Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
                                                             Style="{DynamicResource ChromelessButtonStyle}"
                                                             Foreground="{TemplateBinding Foreground}"
                                                             FontFamily="Marlett"
@@ -258,28 +259,28 @@
                                                             ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                                             IsTabStop="False"
                                                             Visibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                                    <Rectangle x:Name="BtnArrowBackground"
-                                                               Grid.Column="2"
-                                                               Fill="Transparent"
-                                                               StrokeThickness="0" />
-                                                    <Path x:Name="BtnArrow"
+                                                    <Grid x:Name="BtnArrowBackground"
                                                           Grid.Column="2"
-                                                          Width="8"
-                                                          Height="4"
-                                                          HorizontalAlignment="Center"
-                                                          Fill="{DynamicResource GrayBrush1}"
-                                                          Data="F1 M 301.14,-189.041L 311.57,-189.041L 306.355,-182.942L 301.14,-189.041 Z "
-                                                          IsHitTestVisible="false"
-                                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                          Stretch="Uniform" />
+                                                          Background="Transparent"
+                                                          Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}">
+                                                        <Path x:Name="BtnArrow"
+                                                              Width="8"
+                                                              Height="4"
+                                                              HorizontalAlignment="Center"
+                                                              Fill="{DynamicResource GrayBrush1}"
+                                                              Data="F1 M 301.14,-189.041L 311.57,-189.041L 306.355,-182.942L 301.14,-189.041 Z "
+                                                              IsHitTestVisible="false"
+                                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                              Stretch="Uniform" />
+                                                    </Grid>
                                                 </Grid>
                                             </Grid>
                                             <ControlTemplate.Triggers>
                                                 <Trigger SourceName="BtnArrowBackground" Property="IsMouseOver" Value="True">
-                                                    <Setter TargetName="BtnArrowBackground" Property="Fill" Value="{DynamicResource GrayBrush5}" />
+                                                    <Setter TargetName="BtnArrowBackground" Property="Background" Value="{DynamicResource GrayBrush5}" />
                                                 </Trigger>
                                                 <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
-                                                    <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource GrayBrush8}" />
+                                                    <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource GrayBrush5}" />
                                                     <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
                                                 </Trigger>
                                                 <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
@@ -300,9 +301,9 @@
                         </Grid.Resources>
                         <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Grid}}, Path=ActualHeight, Mode=OneWay}" />
-                                <ColumnDefinition Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Grid}}, Path=ActualHeight, Mode=OneWay}" />
+                                <ColumnDefinition x:Name="TextColumn" Width="*" />
+                                <ColumnDefinition x:Name="ButtonColumn" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}" />
+                                <ColumnDefinition x:Name="ToggleButtonColumn" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}" />
                             </Grid.ColumnDefinitions>
 
                             <ToggleButton x:Name="PART_DropDownToggle"
@@ -314,12 +315,17 @@
                                           Foreground="{TemplateBinding Foreground}"
                                           BorderBrush="{TemplateBinding BorderBrush}"
                                           BorderThickness="{TemplateBinding BorderThickness}"
+                                          Controls:ControlsHelper.ButtonWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
+                                          Controls:TextBoxHelper.ButtonContent="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                          Controls:TextBoxHelper.ButtonContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
+                                          Controls:TextBoxHelper.ClearTextButton="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
                                           Controls:ControlsHelper.CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.CornerRadius), Mode=OneWay}"
                                           IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                           KeyboardNavigation.IsTabStop="False"
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
-                            <TextBox x:Name="PART_EditableTextBox"
+                            <TextBox Grid.Column="0"
+                                     x:Name="PART_EditableTextBox"
                                      Margin="1,1,0,-1"
                                      HorizontalAlignment="Stretch"
                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -341,7 +347,8 @@
                                      MaxLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ComboBoxHelper.MaxLength), Mode=OneWay}"
                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                      Visibility="Collapsed" />
-                            <TextBlock x:Name="PART_WatermarkMessage"
+                            <TextBlock Grid.Column="0"
+                                       x:Name="PART_WatermarkMessage"
                                        Margin="6,2,6,2"
                                        Padding="{TemplateBinding Padding}"
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -353,7 +360,8 @@
                                        IsHitTestVisible="False"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
-                            <Grid x:Name="ContentSite" Margin="7 0 4 0">
+                            <Grid Grid.Column="0"
+                                  x:Name="ContentSite" Margin="7 0 4 0">
                                 <ContentPresenter Margin="{TemplateBinding Padding}"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"

--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -182,7 +182,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
                     <Grid x:Name="ToggleButtonRootGrid">
-                        <Border x:Name="Background"
+                        <Border x:Name="PART_Background"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
@@ -229,18 +229,17 @@
                             <Setter TargetName="BtnArrowBackground" Property="Background" Value="{DynamicResource GrayBrush5}" />
                         </Trigger>
                         <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource GrayBrush5}" />
+                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource GrayBrush8}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
                         </Trigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True">
+                            <Setter TargetName="BtnArrowBackground" Property="Background" Value="{DynamicResource GrayBrush3}" />
+                            <Setter TargetName="PART_Background" Property="Background" Value="{DynamicResource GrayBrush7}" />
+                        </DataTrigger>
                         <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
                             <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource BlackBrush}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
-                        </Trigger>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="Background" Property="Background" Value="{DynamicResource GrayBrush8}" />
-                        </Trigger>
-                        <Trigger Property="IsPressed" Value="True">
-                            <Setter TargetName="Background" Property="Background" Value="{DynamicResource GrayBrush7}" />
+                            <Setter TargetName="PART_Background" Property="Background" Value="{DynamicResource GrayBrush7}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -253,6 +252,7 @@
         <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Controls:ControlsHelper.ButtonWidth" Value="24" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource ComboBoxMouseOverInnerBorderBrush}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource TextBoxMouseOverBorderBrush}" />
         <Setter Property="FontFamily" Value="{DynamicResource ContentFontFamily}" />
@@ -480,12 +480,15 @@
                             <Setter TargetName="ContentSite" Property="Visibility" Value="Hidden" />
                             <Setter TargetName="PART_DropDownToggle" Property="Focusable" Value="False" />
                             <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
-                            <!-- #1037 : don't know why we set this to transparent ???
-                            <Setter TargetName="PART_DropDownToggle"
-                                    Property="Background"
-                                    Value="Transparent" />-->
                         </Trigger>
 
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEditable" Value="False" />
+                                <Condition Property="IsMouseOver" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="Background" Value="{DynamicResource GrayBrush9}" />
+                        </MultiTrigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="FocusBorder" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.MouseOverBorderBrush)}" />
                             <Setter TargetName="FocusBorder" Property="Visibility" Value="Visible" />

--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -79,8 +79,8 @@
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
-                                            Grid.Column="0"
                                             Grid.Row="0"
+                                            Grid.Column="0"
                                             Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
@@ -176,6 +176,78 @@
         </Setter>
     </Style>
 
+    <Style x:Key="MetroComboBoxDropDownToggleButtonStyle" TargetType="{x:Type ToggleButton}">
+        <Setter Property="Padding" Value="3" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Grid x:Name="ToggleButtonRootGrid">
+                        <Border x:Name="Background"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.CornerRadius), Mode=OneWay}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+
+                        <Grid Margin="1">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition x:Name="TextColumn" Width="*" />
+                                <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
+                                <ColumnDefinition x:Name="ToggleButtonColumn" Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <Button x:Name="PART_ClearText"
+                                    Grid.Column="1"
+                                    Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
+                                    Style="{DynamicResource ChromelessButtonStyle}"
+                                    Foreground="{TemplateBinding Foreground}"
+                                    FontFamily="Marlett"
+                                    FontSize="16"
+                                    Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
+                                    Content="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                    ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
+                                    IsTabStop="False"
+                                    Visibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" />
+                            <Grid x:Name="BtnArrowBackground"
+                                  Grid.Column="2"
+                                  Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
+                                  Background="Transparent">
+                                <Path x:Name="BtnArrow"
+                                      Width="8"
+                                      Height="4"
+                                      HorizontalAlignment="Center"
+                                      Fill="{DynamicResource GrayBrush1}"
+                                      Data="F1 M 301.14,-189.041L 311.57,-189.041L 306.355,-182.942L 301.14,-189.041 Z "
+                                      IsHitTestVisible="false"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                      Stretch="Uniform" />
+                            </Grid>
+                        </Grid>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger SourceName="BtnArrowBackground" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="BtnArrowBackground" Property="Background" Value="{DynamicResource GrayBrush5}" />
+                        </Trigger>
+                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource GrayBrush5}" />
+                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
+                        </Trigger>
+                        <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource BlackBrush}" />
+                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Background" Property="Background" Value="{DynamicResource GrayBrush8}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Background" Property="Background" Value="{DynamicResource GrayBrush7}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="MetroComboBox" TargetType="{x:Type ComboBox}">
         <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
         <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
@@ -226,79 +298,6 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
-                        <Grid.Resources>
-                            <Style x:Key="comboToggleStyle" TargetType="{x:Type ToggleButton}">
-                                <Setter Property="Padding" Value="3" />
-                                <Setter Property="Template">
-                                    <Setter.Value>
-                                        <ControlTemplate TargetType="{x:Type ToggleButton}">
-                                            <Grid x:Name="ToggleButtonRootGrid">
-                                                <Border x:Name="Background"
-                                                        Background="{TemplateBinding Background}"
-                                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                                        CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.CornerRadius), Mode=OneWay}"
-                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-
-                                                <Grid Margin="1">
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition x:Name="TextColumn" Width="*" />
-                                                        <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
-                                                        <ColumnDefinition x:Name="ToggleButtonColumn" Width="Auto" />
-                                                    </Grid.ColumnDefinitions>
-
-                                                    <Button x:Name="PART_ClearText"
-                                                            Grid.Column="1"
-                                                            Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
-                                                            Style="{DynamicResource ChromelessButtonStyle}"
-                                                            Foreground="{TemplateBinding Foreground}"
-                                                            FontFamily="Marlett"
-                                                            FontSize="16"
-                                                            Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
-                                                            Content="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
-                                                            ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
-                                                            IsTabStop="False"
-                                                            Visibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" />
-                                                    <Grid x:Name="BtnArrowBackground"
-                                                          Grid.Column="2"
-                                                          Background="Transparent"
-                                                          Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}">
-                                                        <Path x:Name="BtnArrow"
-                                                              Width="8"
-                                                              Height="4"
-                                                              HorizontalAlignment="Center"
-                                                              Fill="{DynamicResource GrayBrush1}"
-                                                              Data="F1 M 301.14,-189.041L 311.57,-189.041L 306.355,-182.942L 301.14,-189.041 Z "
-                                                              IsHitTestVisible="false"
-                                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                              Stretch="Uniform" />
-                                                    </Grid>
-                                                </Grid>
-                                            </Grid>
-                                            <ControlTemplate.Triggers>
-                                                <Trigger SourceName="BtnArrowBackground" Property="IsMouseOver" Value="True">
-                                                    <Setter TargetName="BtnArrowBackground" Property="Background" Value="{DynamicResource GrayBrush5}" />
-                                                </Trigger>
-                                                <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
-                                                    <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource GrayBrush5}" />
-                                                    <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
-                                                </Trigger>
-                                                <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
-                                                    <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource BlackBrush}" />
-                                                    <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
-                                                </Trigger>
-                                                <Trigger Property="IsMouseOver" Value="True">
-                                                    <Setter TargetName="Background" Property="Background" Value="{DynamicResource GrayBrush8}" />
-                                                </Trigger>
-                                                <Trigger Property="IsPressed" Value="True">
-                                                    <Setter TargetName="Background" Property="Background" Value="{DynamicResource GrayBrush7}" />
-                                                </Trigger>
-                                            </ControlTemplate.Triggers>
-                                        </ControlTemplate>
-                                    </Setter.Value>
-                                </Setter>
-                            </Style>
-                        </Grid.Resources>
                         <Grid>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="TextColumn" Width="*" />
@@ -310,23 +309,23 @@
                                           Grid.ColumnSpan="3"
                                           Margin="0"
                                           VerticalAlignment="Stretch"
-                                          Style="{DynamicResource comboToggleStyle}"
+                                          Style="{DynamicResource MetroComboBoxDropDownToggleButtonStyle}"
                                           Background="{TemplateBinding Background}"
                                           Foreground="{TemplateBinding Foreground}"
                                           BorderBrush="{TemplateBinding BorderBrush}"
                                           BorderThickness="{TemplateBinding BorderThickness}"
                                           Controls:ControlsHelper.ButtonWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
+                                          Controls:ControlsHelper.CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.CornerRadius), Mode=OneWay}"
                                           Controls:TextBoxHelper.ButtonContent="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
                                           Controls:TextBoxHelper.ButtonContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                           Controls:TextBoxHelper.ClearTextButton="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
-                                          Controls:ControlsHelper.CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.CornerRadius), Mode=OneWay}"
                                           IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                           KeyboardNavigation.IsTabStop="False"
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
-                            <TextBox Grid.Column="0"
-                                     x:Name="PART_EditableTextBox"
-                                     Margin="1,1,0,-1"
+                            <TextBox x:Name="PART_EditableTextBox"
+                                     Grid.Column="0"
+                                     Margin="1 1 0 -1"
                                      HorizontalAlignment="Stretch"
                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -347,9 +346,9 @@
                                      MaxLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ComboBoxHelper.MaxLength), Mode=OneWay}"
                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                      Visibility="Collapsed" />
-                            <TextBlock Grid.Column="0"
-                                       x:Name="PART_WatermarkMessage"
-                                       Margin="6,2,6,2"
+                            <TextBlock x:Name="PART_WatermarkMessage"
+                                       Grid.Column="0"
+                                       Margin="6 2 6 2"
                                        Padding="{TemplateBinding Padding}"
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -360,8 +359,9 @@
                                        IsHitTestVisible="False"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
-                            <Grid Grid.Column="0"
-                                  x:Name="ContentSite" Margin="7 0 4 0">
+                            <Grid x:Name="ContentSite"
+                                  Grid.Column="0"
+                                  Margin="7 0 4 0">
                                 <ContentPresenter Margin="{TemplateBinding Padding}"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"

--- a/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -50,19 +50,14 @@
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         <Grid x:Name="PART_InnerGrid" Margin="2">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition x:Name="ButtonColumn" Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}" />
+                                <ColumnDefinition x:Name="TextColumn" Width="*" />
+                                <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition x:Name="ButtonRow" Height="*" />
                             </Grid.RowDefinitions>
 
-                            <Border x:Name="ReadOnlyVisualElement"
-                                    Grid.Row="1"
-                                    Grid.ColumnSpan="2"
-                                    Background="{x:Null}"
-                                    Opacity="0" />
                             <ScrollViewer x:Name="PART_ContentHost"
                                           Grid.Row="1"
                                           Grid.Column="0"
@@ -85,6 +80,7 @@
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Column="0"
+                                            Grid.Row="0"
                                             Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
@@ -95,14 +91,17 @@
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
                             <Button x:Name="PART_ClearText"
+                                    Grid.Row="0"
                                     Grid.RowSpan="2"
                                     Grid.Column="1"
+                                    Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
                                     Style="{DynamicResource ChromelessButtonStyle}"
                                     Foreground="{TemplateBinding Foreground}"
                                     FontFamily="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonFontFamily), Mode=OneWay}"
                                     FontSize="16"
                                     Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
                                     Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                    ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                     IsTabStop="False"
                                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
@@ -125,15 +124,6 @@
                             </MultiDataTrigger.ExitActions>
                         </MultiDataTrigger>
 
-                        <!--  multiline textbox cannot bind to actual height so take the fallbach button width  -->
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="TextWrapping" Value="NoWrap" />
-                                <Condition Property="AcceptsReturn" Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="ButtonColumn" Property="Width" Value="{Binding ElementName=ButtonRow, Path=ActualHeight, Mode=OneWay}" />
-                        </MultiTrigger>
-
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.ClearTextButton)}" Value="False">
                             <Setter TargetName="PART_ContentHost" Property="Grid.ColumnSpan" Value="2" />
                             <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
@@ -143,7 +133,6 @@
                         </Trigger>
                         <Trigger Property="IsReadOnly" Value="True">
                             <Setter TargetName="PART_ClearText" Property="IsEnabled" Value="False" />
-                            <Setter TargetName="ReadOnlyVisualElement" Property="Opacity" Value="1" />
                         </Trigger>
                         <Trigger Property="IsFocused" Value="True">
                             <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderBrush)}" />
@@ -266,6 +255,7 @@
                                                             FontSize="16"
                                                             Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
                                                             Content="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                                            ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                                             IsTabStop="False"
                                                             Visibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" />
                                                     <Rectangle x:Name="BtnArrowBackground"
@@ -341,6 +331,7 @@
                                      FontFamily="{TemplateBinding FontFamily}"
                                      FontSize="{TemplateBinding FontSize}"
                                      Controls:TextBoxHelper.ButtonContent="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                     Controls:TextBoxHelper.ButtonContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                      Controls:TextBoxHelper.HasText="{TemplateBinding Controls:TextBoxHelper.HasText}"
                                      Controls:TextBoxHelper.UseFloatingWatermark="{TemplateBinding Controls:TextBoxHelper.UseFloatingWatermark}"
                                      Controls:TextBoxHelper.Watermark="{TemplateBinding Controls:TextBoxHelper.Watermark}"

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -222,6 +222,7 @@
                                     FontSize="16"
                                     Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
                                     Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                    ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                     IsTabStop="False"
                                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
@@ -436,6 +437,7 @@
                                     FontSize="16"
                                     Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="True"
                                     Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                    ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                     IsTabStop="False"
                                     Template="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonTemplate), Mode=OneWay}" />
                         </Grid>
@@ -672,6 +674,7 @@
                                     FontSize="16"
                                     Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
                                     Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                    ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                     IsTabStop="False"
                                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -129,6 +129,7 @@
                                     FontSize="16"
                                     Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay}"
                                     Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                    ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                     IsTabStop="False"
                                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
@@ -329,6 +330,7 @@
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Column="0"
+                                            Grid.Row="0"
                                             Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
@@ -339,6 +341,7 @@
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
                             <Button x:Name="PART_ClearText"
+                                    Grid.Row="0"
                                     Grid.RowSpan="2"
                                     Grid.Column="1"
                                     Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
@@ -348,6 +351,7 @@
                                     FontSize="16"
                                     Controls:TextBoxHelper.IsClearTextButtonBehaviorEnabled="True"
                                     Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
+                                    ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                     IsTabStop="False"
                                     Template="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonTemplate), Mode=OneWay}" />
                         </Grid>
@@ -386,14 +390,14 @@
                             </MultiDataTrigger.ExitActions>
                         </MultiDataTrigger>
 
-                        <!--  multiline textbox cannot bind to actual height so take the fallbach button width  -->
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="TextWrapping" Value="NoWrap" />
-                                <Condition Property="AcceptsReturn" Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_ClearText" Property="Width" Value="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight, Mode=OneWay}" />
-                        </MultiTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.ButtonsAlignment)}" Value="Right" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.ClearTextButton)}" Value="False" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_ContentHost" Property="Grid.ColumnSpan" Value="2" />
+                            <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
+                        </MultiDataTrigger>
 
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.MouseOverBorderBrush)}" />
@@ -417,7 +421,7 @@
                             <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource BlackBrush}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
                         </Trigger>
-                        
+
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="IsVisible" Value="True" />
@@ -451,28 +455,17 @@
     <Style x:Key="SearchMetroTextBox"
            BasedOn="{StaticResource MetroButtonTextBox}"
            TargetType="{x:Type TextBox}">
-        <Setter Property="Controls:TextBoxHelper.ButtonTemplate">
+        <Setter Property="Controls:TextBoxHelper.ButtonContentTemplate">
             <Setter.Value>
-                <ControlTemplate TargetType="{x:Type Button}">
-                    <Grid Background="{TemplateBinding Background}">
-                        <metro:PackIconModern x:Name="PART_PackIcon"
-                                              Kind="Magnify"
-                                              Opacity="0.75"
-                                              HorizontalAlignment="Center"
-                                              VerticalAlignment="Center"
-                                              Padding="-6"
-                                              Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
-                                              Height="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}" />
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_PackIcon" Property="Opacity" Value="1" />
-                        </Trigger>
-                        <Trigger Property="IsMouseOver" Value="False">
-                            <Setter TargetName="PART_PackIcon" Property="Opacity" Value=".5" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
+                <DataTemplate>
+                    <metro:PackIconModern x:Name="PART_PackIcon"
+                                          Kind="Magnify"
+                                          Padding="-6"
+                                          HorizontalAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          Width="{Binding RelativeSource={RelativeSource AncestorType=TextBox}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}"
+                                          Height="{Binding RelativeSource={RelativeSource AncestorType=TextBox}, Path=(Controls:ControlsHelper.ButtonWidth), Mode=OneWay}" />
+                </DataTemplate>
             </Setter.Value>
         </Setter>
     </Style>

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -86,11 +86,6 @@
                                 <RowDefinition x:Name="ButtonRow" Height="*" />
                             </Grid.RowDefinitions>
 
-                            <Border x:Name="ReadOnlyVisualElement"
-                                    Grid.Row="1"
-                                    Grid.ColumnSpan="2"
-                                    Background="{x:Null}"
-                                    Opacity="0" />
                             <ScrollViewer x:Name="PART_ContentHost"
                                           Grid.Row="1"
                                           Grid.Column="0"
@@ -189,7 +184,6 @@
                         </Trigger>
                         <Trigger Property="IsReadOnly" Value="True">
                             <Setter TargetName="PART_ClearText" Property="IsEnabled" Value="False" />
-                            <Setter TargetName="ReadOnlyVisualElement" Property="Opacity" Value="1" />
                         </Trigger>
                         <Trigger Property="IsFocused" Value="True">
                             <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderBrush)}" />
@@ -313,11 +307,6 @@
                                 <RowDefinition x:Name="ButtonRow" Height="*" />
                             </Grid.RowDefinitions>
 
-                            <Border x:Name="ReadOnlyVisualElement"
-                                    Grid.Row="1"
-                                    Grid.ColumnSpan="2"
-                                    Background="{x:Null}"
-                                    Opacity="0" />
                             <ScrollViewer x:Name="PART_ContentHost"
                                           Grid.Row="1"
                                           Grid.Column="0"
@@ -413,7 +402,7 @@
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
                         </Trigger>
                         <Trigger Property="IsReadOnly" Value="True">
-                            <Setter TargetName="ReadOnlyVisualElement" Property="Opacity" Value="1" />
+                            <Setter TargetName="PART_ClearText" Property="IsEnabled" Value="False" />
                         </Trigger>
                         <Trigger Property="IsFocused" Value="True">
                             <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderBrush)}" />

--- a/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -14,6 +14,8 @@
         <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="UpDownButtonsWidth" Value="22" />
+        <Setter Property="Controls:ControlsHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource TextBoxFocusBorderBrush}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource TextBoxMouseOverBorderBrush}" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
@@ -60,6 +62,7 @@
                             <TextBox x:Name="PART_TextBox"
                                      Grid.Row="1"
                                      Grid.Column="0"
+                                     Margin="0 0 -2 0"
                                      MinWidth="20"
                                      MinHeight="{TemplateBinding MinHeight}"
                                      HorizontalAlignment="Stretch"
@@ -71,6 +74,10 @@
                                      FontFamily="{TemplateBinding FontFamily}"
                                      FontSize="{TemplateBinding FontSize}"
                                      Controls:ControlsHelper.DisabledVisualElementVisibility="Collapsed"
+                                     Controls:ControlsHelper.ButtonWidth="{TemplateBinding Controls:ControlsHelper.ButtonWidth}"
+                                     Controls:TextBoxHelper.ButtonContent="{TemplateBinding Controls:TextBoxHelper.ButtonContent}"
+                                     Controls:TextBoxHelper.ButtonContentTemplate="{TemplateBinding Controls:TextBoxHelper.ButtonContentTemplate}"
+                                     Controls:TextBoxHelper.ButtonFontFamily="{TemplateBinding Controls:TextBoxHelper.ButtonFontFamily}"
                                      Controls:TextBoxHelper.ButtonsAlignment="{TemplateBinding ButtonsAlignment}"
                                      Controls:TextBoxHelper.ClearTextButton="{TemplateBinding Controls:TextBoxHelper.ClearTextButton}"
                                      Controls:TextBoxHelper.Watermark="{TemplateBinding Controls:TextBoxHelper.Watermark}"
@@ -86,7 +93,7 @@
                                           Grid.RowSpan="2"
                                           Grid.Column="1"
                                           Width="{TemplateBinding UpDownButtonsWidth}"
-                                          Margin="2 2 0 2"
+                                          Margin="0 2 0 2"
                                           Style="{DynamicResource ChromelessButtonStyle}"
                                           Foreground="{TemplateBinding Foreground}"
                                           Delay="{TemplateBinding Delay}"
@@ -141,12 +148,13 @@
 
                         <Trigger Property="ButtonsAlignment" Value="Left">
                             <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="0 2 2 2" />
+                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="0 2 0 2" />
                             <Setter TargetName="PART_NumericDownColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="0" />
                             <Setter TargetName="PART_NumericUp" Property="Margin" Value="2 2 0 2" />
                             <Setter TargetName="PART_NumericUpColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="2" />
+                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
                             <Setter TargetName="PART_TextBoxColumn" Property="Width" Value="Auto" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">

--- a/docs/release-notes/1.3.0.md
+++ b/docs/release-notes/1.3.0.md
@@ -2,7 +2,7 @@
 
 MahApps.Metro v1.3.0 bug fix and feature release.
 
-# Features / Changes
+# Features / Changes (and Fixes)
 
 - New Hotkey control `HotKeyBox` #2322 (@thoemmi)
 - New 'Remember' CheckBox in `LoginDialog` #2308 #2305 (@manekovskiy)
@@ -20,14 +20,20 @@ MahApps.Metro v1.3.0 bug fix and feature release.
 - New `Auto Close` feature for `Flyout` #2228 #1710 (@Sikta)
     + Enable this by set `IsAutoCloseEnabled` to true
     + Time changable by `AutoCloseInterval` (default 5000 ms)
-- Fix PasswordBoxBindingBehavior and IsWaitingForData #2355
-    + Fixed: Behaviors in StylizedBehaviors should be detached on unload
-    + Fixed: PasswordBoxBindingBehavior, it doesn't work e.g. in TabControl TabItems
-    + IsWaitingForData for MetroButtonTextBox, MetroPasswordBox, MetroButtonPasswordBox, MetroButtonRevealedPasswordBox
-    + PackIconMaterial `Eye` and ClearTextButton feature for MetroButtonRevealedPasswordBox
-- Added ContentStringFormat TemplateBinding to ToolTip #2359 (@nrpog) #2363
+- Fix `PasswordBoxBindingBehavior` and `IsWaitingForData` #2355
+    + Fixed: Behaviors in `StylizedBehaviors` should be detached on unload
+    + Fixed: `PasswordBoxBindingBehavior`, it doesn't work e.g. in TabControl TabItems
+    + `IsWaitingForData` for `MetroButtonTextBox`, `MetroPasswordBox`, `MetroButtonPasswordBox`, `MetroButtonRevealedPasswordBox`
+    + PackIconMaterial `Eye` and ClearTextButton feature for `MetroButtonRevealedPasswordBox`
+- Added `ContentStringFormat` TemplateBinding to ToolTip #2359 (@nrpog) #2363
+- `ControlsHelper.ButtonWidth` for `ComboBox` and other stuff #2365
+	+ set `ChromelessButtonStyle` Padding to 0
+	+ new DependencyProperty `ButtonContentTemplate` in `TextBoxHelper`
+	+ fix width of ClearText button if height change, e.g. by floating watermark
+	+ fix background state colors (`IsPressed`, `IsMouseOver`)
+	+ new sytle `MetroComboBoxDropDownToggleButtonStyle` for `ComboBox` toggle button
 
-# Bugfixes / Closed issues
+# Closed Issues
 
 - #2003 "VisualButton" That makes working with the XAML icons easier
 - #2114 Icon color not changing on theme change (as #1029)
@@ -35,3 +41,4 @@ MahApps.Metro v1.3.0 bug fix and feature release.
 - #1710 New "Auto Close" feature for Flyouts
 - #2354 TextBoxHelper.ButtonClicked should pass ButtonCommandParameter to ButtonCommand.CanExecute
 - #2343 Win8MetroPasswordBox Preview does not work with Tabcontrol (item > 1)
+- #2352 Can't set ComboBox buttons width with ControlsHelper.ButtonWidth

--- a/samples/MetroDemo/ExampleViews/SelectionExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/SelectionExamples.xaml
@@ -131,6 +131,8 @@
                 <ComboBox Width="200"
                           Margin="0, 10, 0, 0"
                           Controls:TextBoxHelper.ClearTextButton="True"
+                          Controls:TextBoxHelper.Watermark="Editable..."
+                          Controls:TextBoxHelper.UseFloatingWatermark="True"
                           IsEditable="True"
                           SelectedIndex="0">
                     <ComboBoxItem Content="Item 1" />

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml
@@ -44,6 +44,7 @@
                          Text="Enabled" />
                 <TextBox Margin="{StaticResource ControlMargin}"
                          Controls:TextBoxHelper.IsWaitingForData="True"
+                         Controls:TextBoxHelper.ClearTextButton="True"
                          Controls:TextBoxHelper.UseFloatingWatermark="True"
                          Controls:TextBoxHelper.Watermark="Watermark"
                          ToolTip="Default alignment" />
@@ -74,7 +75,8 @@
                         <Style BasedOn="{StaticResource SearchMetroTextBox}" TargetType="{x:Type TextBox}">
                             <Style.Triggers>
                                 <Trigger Property="Controls:TextBoxHelper.HasText" Value="True">
-                                    <Setter Property="Controls:TextBoxHelper.ButtonTemplate" Value="{DynamicResource ChromelessButtonTemplate}" />
+                                    <Setter Property="Controls:TextBoxHelper.ButtonContentTemplate" Value="{x:Null}" />
+                                    <Setter Property="Controls:TextBoxHelper.ButtonContent" Value="r" />
                                 </Trigger>
                             </Style.Triggers>
                         </Style>

--- a/samples/MetroDemo/MainWindowViewModel.cs
+++ b/samples/MetroDemo/MainWindowViewModel.cs
@@ -94,7 +94,14 @@ namespace MetroDemo
 
             CultureInfos = CultureInfo.GetCultures(CultureTypes.InstalledWin32Cultures).ToList();
 
-            HotkeyManager.Current.AddOrReplace("demo", HotKey.Key, HotKey.ModifierKeys, (sender, e) => OnHotKey(sender, e));
+            try
+            {
+                HotkeyManager.Current.AddOrReplace("demo", HotKey.Key, HotKey.ModifierKeys, (sender, e) => OnHotKey(sender, e));
+            }
+            catch (HotkeyAlreadyRegisteredException exception)
+            {
+                System.Diagnostics.Trace.TraceWarning("Uups, the hotkey {0} is already registered!", exception.Name);
+            }
         }
 
         public void Dispose()


### PR DESCRIPTION
- remove unnecessary ReadOnlyVisualElement
- set ChromelessButtonStyle Padding to 0
- new DependencyProperty ButtonContentTemplate
- fix width of ClearText button if height change, e.g. by floating watermark
- new MetroComboBoxDropDownToggleButtonStyle
- fix background state colors
- catch HotkeyAlreadyRegisteredException /cc @thoemmi 

Closes #2352 Can't set ComboBox buttons width with ControlsHelper.ButtonWidth