### PR TITLE
Paste over selection for a NumericUpDown control

### DIFF
--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1161,7 +1161,7 @@ namespace MahApps.Metro.Controls
 
             var text = e.SourceDataObject.GetData(DataFormats.Text) as string;
 
-            string newText = string.Concat(textPresent.Substring(0, textBox.SelectionStart), text, textPresent.Substring(textBox.SelectionStart));
+            string newText = string.Concat(textPresent.Substring(0, textBox.SelectionStart), text, textPresent.Substring(textBox.SelectionStart + textBox.SelectionLength));
             double number;
             if (!ValidateText(newText, out number))
             {


### PR DESCRIPTION
When pasting into a NumericUpDown control any selected text is now replaced with the pasted text.

Closes Issue #2370 

Fixed up the pasting into the NumericUpDown control so that selected text is replaced.