### PR TITLE
WindowButtonCommands enhancements

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -81,6 +81,7 @@ namespace MahApps.Metro.Controls
 
         public static readonly DependencyProperty LeftWindowCommandsProperty = DependencyProperty.Register("LeftWindowCommands", typeof(WindowCommands), typeof(MetroWindow), new PropertyMetadata(null));
         public static readonly DependencyProperty RightWindowCommandsProperty = DependencyProperty.Register("RightWindowCommands", typeof(WindowCommands), typeof(MetroWindow), new PropertyMetadata(null));
+        public static readonly DependencyProperty WindowButtonCommandsProperty = DependencyProperty.Register("WindowButtonCommands", typeof(WindowButtonCommands), typeof(MetroWindow), new PropertyMetadata(null));
 
         public static readonly DependencyProperty LeftWindowCommandsOverlayBehaviorProperty = DependencyProperty.Register("LeftWindowCommandsOverlayBehavior", typeof(WindowCommandsOverlayBehavior), typeof(MetroWindow), new PropertyMetadata(WindowCommandsOverlayBehavior.Always));
         public static readonly DependencyProperty RightWindowCommandsOverlayBehaviorProperty = DependencyProperty.Register("RightWindowCommandsOverlayBehavior", typeof(WindowCommandsOverlayBehavior), typeof(MetroWindow), new PropertyMetadata(WindowCommandsOverlayBehavior.Always));
@@ -107,7 +108,7 @@ namespace MahApps.Metro.Controls
         Thumb windowTitleThumb;
         internal ContentPresenter LeftWindowCommandsPresenter;
         internal ContentPresenter RightWindowCommandsPresenter;
-        internal WindowButtonCommands WindowButtonCommands;
+        internal ContentPresenter WindowButtonCommandsPresenter;
 
         internal Grid overlayBox;
         internal Grid metroActiveDialogContainer;
@@ -280,12 +281,13 @@ namespace MahApps.Metro.Controls
             set { SetValue(RightWindowCommandsProperty, value); }
         }
 
-        private static void WindowCommandsPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// Gets/sets the window button commands that hosts the min/max/close commands.
+        /// </summary>
+        public WindowButtonCommands WindowButtonCommands
         {
-            if (e.NewValue != e.OldValue && e.NewValue != null)
-            {
-                ((MetroWindow)dependencyObject).RightWindowCommands = (WindowCommands)e.NewValue;
-            }
+            get { return (WindowButtonCommands)GetValue(WindowButtonCommandsProperty); }
+            set { SetValue(WindowButtonCommandsProperty, value); }
         }
 
         /// <summary>
@@ -544,9 +546,9 @@ namespace MahApps.Metro.Controls
                 this.RightWindowCommandsPresenter.Visibility = this.RightWindowCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) ?
                     Visibility.Visible : newVisibility;
             }
-            if (this.WindowButtonCommands != null)
+            if (this.WindowButtonCommandsPresenter != null)
             {
-                this.WindowButtonCommands.Visibility = this.WindowButtonCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) ?
+                this.WindowButtonCommandsPresenter.Visibility = this.WindowButtonCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) ?
                     Visibility.Visible : newVisibility;
             }
 
@@ -873,18 +875,16 @@ namespace MahApps.Metro.Controls
                 LeftWindowCommands = new WindowCommands();
             if (RightWindowCommands == null)
                 RightWindowCommands = new WindowCommands();
+            if (WindowButtonCommands == null)
+                WindowButtonCommands = new WindowButtonCommands();
 
             LeftWindowCommands.ParentWindow = this;
             RightWindowCommands.ParentWindow = this;
+            WindowButtonCommands.ParentWindow = this;
 
             LeftWindowCommandsPresenter = GetTemplateChild(PART_LeftWindowCommands) as ContentPresenter;
             RightWindowCommandsPresenter = GetTemplateChild(PART_RightWindowCommands) as ContentPresenter;
-            WindowButtonCommands = GetTemplateChild(PART_WindowButtonCommands) as WindowButtonCommands;
-
-            if (WindowButtonCommands != null)
-            {
-                WindowButtonCommands.ParentWindow = this;
-            }
+            WindowButtonCommandsPresenter = GetTemplateChild(PART_WindowButtonCommands) as ContentPresenter;
 
             overlayBox = GetTemplateChild(PART_OverlayBox) as Grid;
             metroActiveDialogContainer = GetTemplateChild(PART_MetroActiveDialogContainer) as Grid;
@@ -1143,9 +1143,9 @@ namespace MahApps.Metro.Controls
                         this.RightWindowCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.Flyouts) ? zIndex : 1);
                 }
 
-                if (WindowButtonCommands != null)
+                if (WindowButtonCommandsPresenter != null)
                 {
-                    WindowButtonCommands.SetValue(Panel.ZIndexProperty,
+                    WindowButtonCommandsPresenter.SetValue(Panel.ZIndexProperty,
                         this.WindowButtonCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.Flyouts) ? zIndex : 1);
                 }
 

--- a/MahApps.Metro/Controls/WindowButtonCommands.cs
+++ b/MahApps.Metro/Controls/WindowButtonCommands.cs
@@ -220,7 +220,7 @@ namespace MahApps.Metro.Controls
             if (close != null)
             {
                 // TODO: Delete this if statement once WindowCloseButtonStyle property is deleted from MetroWindow!
-                if ((ParentWindow != null) && (ParentWindow.WindowCloseButtonStyle != null))
+                if (ParentWindow?.WindowCloseButtonStyle != null)
                 {
                     close.Style = ParentWindow.WindowCloseButtonStyle;
                 }
@@ -232,7 +232,7 @@ namespace MahApps.Metro.Controls
             if (max != null)
             {
                 // TODO: Delete this if statement once WindowMaxButtonStyle property is deleted from MetroWindow!
-                if ((ParentWindow != null) && (ParentWindow.WindowMaxButtonStyle != null))
+                if (ParentWindow?.WindowMaxButtonStyle != null)
                 {
                     max.Style = ParentWindow.WindowMaxButtonStyle;
                 }
@@ -244,7 +244,7 @@ namespace MahApps.Metro.Controls
             if (min != null)
             {
                 // TODO: Delete this if statement once WindowMinButtonStyle property is deleted from MetroWindow!
-                if ((ParentWindow != null) && (ParentWindow.WindowMinButtonStyle != null))
+                if (ParentWindow?.WindowMinButtonStyle != null)
                 {
                     min.Style = ParentWindow.WindowMinButtonStyle;
                 }

--- a/MahApps.Metro/Controls/WindowButtonCommands.cs
+++ b/MahApps.Metro/Controls/WindowButtonCommands.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Threading;
 using MahApps.Metro.Native;
 
 namespace MahApps.Metro.Controls
@@ -116,58 +117,58 @@ namespace MahApps.Metro.Controls
             ((WindowButtonCommands)d).ApplyTheme();
         }
 
+        public static readonly DependencyProperty MinimizeProperty =
+            DependencyProperty.Register("Minimize", typeof(string), typeof(WindowButtonCommands),
+                                        new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets the minimize button tooltip.
+        /// </summary>
         public string Minimize
         {
-            get
-            {
-                if (string.IsNullOrEmpty(minimize))
-                {
-                    minimize = GetCaption(900);
-                }
-                return minimize;
-            }
+            get { return (string)GetValue(MinimizeProperty); }
+            set { SetValue(MinimizeProperty, value); }
         }
 
+        public static readonly DependencyProperty MaximizeProperty =
+            DependencyProperty.Register("Maximize", typeof(string), typeof(WindowButtonCommands),
+                                        new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets the maximize button tooltip.
+        /// </summary>
         public string Maximize
         {
-            get
-            {
-                if (string.IsNullOrEmpty(maximize))
-                {
-                    maximize = GetCaption(901);
-                }
-                return maximize;
-            }
+            get { return (string)GetValue(MaximizeProperty); }
+            set { SetValue(MaximizeProperty, value); }
         }
 
+        public static readonly DependencyProperty CloseProperty =
+            DependencyProperty.Register("Close", typeof(string), typeof(WindowButtonCommands),
+                                        new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets the close button tooltip.
+        /// </summary>
         public string Close
         {
-            get
-            {
-                if (string.IsNullOrEmpty(closeText))
-                {
-                    closeText = GetCaption(905);
-                }
-                return closeText;
-            }
+            get { return (string)GetValue(CloseProperty); }
+            set { SetValue(CloseProperty, value); }
         }
 
+        public static readonly DependencyProperty RestoreProperty =
+            DependencyProperty.Register("Restore", typeof(string), typeof(WindowButtonCommands),
+                                        new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets the restore button tooltip.
+        /// </summary>
         public string Restore
         {
-            get
-            {
-                if (string.IsNullOrEmpty(restore))
-                {
-                    restore = GetCaption(903);
-                }
-                return restore;
-            }
+            get { return (string)GetValue(RestoreProperty); }
+            set { SetValue(RestoreProperty, value); }
         }
 
-        private static string minimize;
-        private static string maximize;
-        private static string closeText;
-        private static string restore;
         private Button min;
         private Button max;
         private Button close;
@@ -180,17 +181,25 @@ namespace MahApps.Metro.Controls
 
         public WindowButtonCommands()
         {
-            this.Loaded += WindowButtonCommands_Loaded;
-        }
-
-        private void WindowButtonCommands_Loaded(object sender, RoutedEventArgs e)
-        {
-            this.Loaded -= WindowButtonCommands_Loaded;
-            var parentWindow = this.ParentWindow;
-            if (null == parentWindow)
-            {
-                this.ParentWindow = this.TryFindParent<MetroWindow>();
-            }
+            this.Dispatcher.BeginInvoke(DispatcherPriority.Loaded,
+                                        new Action(() => {
+                                                       if (string.IsNullOrWhiteSpace(this.Minimize))
+                                                       {
+                                                           this.Minimize = GetCaption(900);
+                                                       }
+                                                       if (string.IsNullOrWhiteSpace(this.Maximize))
+                                                       {
+                                                           this.Maximize = GetCaption(901);
+                                                       }
+                                                       if (string.IsNullOrWhiteSpace(this.Close))
+                                                       {
+                                                           this.Close = GetCaption(905);
+                                                       }
+                                                       if (string.IsNullOrWhiteSpace(this.Restore))
+                                                       {
+                                                           this.Restore = GetCaption(903);
+                                                       }
+                                                   }));
         }
 
         private string GetCaption(int id)

--- a/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -223,6 +223,7 @@
     <!--  light button style for min, max and close window buttons  -->
     <Style x:Key="LightMetroWindowButtonStyle" BasedOn="{StaticResource BaseMetroWindowButtonStyle}" TargetType="{x:Type Button}">
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="Focusable" Value="False" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="MaxHeight" Value="34" />
         <Setter Property="Padding" Value="0" />

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -111,15 +111,16 @@
                                       Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                     <!--  the window button commands  -->
-                    <Controls:WindowButtonCommands x:Name="PART_WindowButtonCommands"
-                                                   Grid.Row="0"
-                                                   Grid.RowSpan="2"
-                                                   Grid.Column="4"
-                                                   Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                   VerticalAlignment="Top"
-                                                   Panel.ZIndex="1"
-                                                   Focusable="False"
-                                                   UseLayoutRounding="True" />
+                    <ContentPresenter x:Name="PART_WindowButtonCommands"
+                                      Grid.Row="0"
+                                      Grid.RowSpan="2"
+                                      Grid.Column="4"
+                                      Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                      VerticalAlignment="Top"
+                                      Panel.ZIndex="1"
+                                      Content="{Binding WindowButtonCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                      Focusable="False"
+                                      UseLayoutRounding="True" />
 
                     <!--  the main window content  -->
                     <Controls:MetroContentControl Grid.Row="1"
@@ -370,15 +371,16 @@
                                       Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                     <!--  the window button commands  -->
-                    <Controls:WindowButtonCommands x:Name="PART_WindowButtonCommands"
-                                                   Grid.Row="0"
-                                                   Grid.RowSpan="2"
-                                                   Grid.Column="4"
-                                                   Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                   VerticalAlignment="Top"
-                                                   Panel.ZIndex="1"
-                                                   Focusable="False"
-                                                   UseLayoutRounding="True" />
+                    <ContentPresenter x:Name="PART_WindowButtonCommands"
+                                      Grid.Row="0"
+                                      Grid.RowSpan="2"
+                                      Grid.Column="4"
+                                      Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                      VerticalAlignment="Top"
+                                      Panel.ZIndex="1"
+                                      Content="{Binding WindowButtonCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                      Focusable="False"
+                                      UseLayoutRounding="True" />
 
                     <!--  the main window content  -->
                     <Controls:MetroContentControl Grid.Row="1"

--- a/MahApps.Metro/Themes/WindowButtonCommands.xaml
+++ b/MahApps.Metro/Themes/WindowButtonCommands.xaml
@@ -83,6 +83,97 @@
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
+    <ControlTemplate x:Key="Win10WindowButtonCommandsTemplate" TargetType="{x:Type Controls:WindowButtonCommands}">
+        <StackPanel Orientation="Horizontal">
+            <Button x:Name="PART_Min"
+                    Focusable="False"
+                    IsEnabled="{Binding IsMinButtonEnabled, RelativeSource={RelativeSource AncestorType={x:Type Controls:MetroWindow}}}"
+                    ToolTip="{Binding Minimize, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                    UseLayoutRounding="True">
+                <Button.Visibility>
+                    <MultiBinding Converter="{x:Static Converters:ResizeModeMinMaxButtonVisibilityConverter.Instance}" ConverterParameter="MIN">
+                        <Binding RelativeSource="{RelativeSource AncestorType={x:Type Controls:MetroWindow}}"
+                                 Path="ShowMinButton"
+                                 Mode="OneWay" />
+                        <Binding RelativeSource="{RelativeSource AncestorType={x:Type Controls:MetroWindow}}"
+                                 Path="UseNoneWindowStyle"
+                                 Mode="OneWay" />
+                        <Binding RelativeSource="{RelativeSource AncestorType={x:Type Controls:MetroWindow}}"
+                                 Path="ResizeMode"
+                                 Mode="OneWay" />
+                    </MultiBinding>
+                </Button.Visibility>
+                <Path Width="10"
+                      Height="10"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      Fill="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                      Data="M0,39.984375L96,39.984375 96,48 0,48 0,39.984375z"
+                      SnapsToDevicePixels="True"
+                      Stretch="Uniform" />
+            </Button>
+            <Button x:Name="PART_Max"
+                    Focusable="False"
+                    IsEnabled="{Binding IsMaxRestoreButtonEnabled, RelativeSource={RelativeSource AncestorType={x:Type Controls:MetroWindow}}}"
+                    ToolTip="{Binding Maximize, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                    UseLayoutRounding="True">
+                <Button.Visibility>
+                    <MultiBinding Converter="{x:Static Converters:ResizeModeMinMaxButtonVisibilityConverter.Instance}" ConverterParameter="MAX">
+                        <Binding RelativeSource="{RelativeSource AncestorType={x:Type Controls:MetroWindow}}"
+                                 Path="ShowMaxRestoreButton"
+                                 Mode="OneWay" />
+                        <Binding RelativeSource="{RelativeSource AncestorType={x:Type Controls:MetroWindow}}"
+                                 Path="UseNoneWindowStyle"
+                                 Mode="OneWay" />
+                        <Binding RelativeSource="{RelativeSource AncestorType={x:Type Controls:MetroWindow}}"
+                                 Path="ResizeMode"
+                                 Mode="OneWay" />
+                    </MultiBinding>
+                </Button.Visibility>
+                <!--  normal state  -->
+                <Path x:Name="PART_MaxPath"
+                      Width="10"
+                      Height="10"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      Fill="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                      Data="M42.75,42.75L42.75,469.25 469.25,469.25 469.25,42.75 42.75,42.75z M0,0L512,0 512,512 0,512 0,0z"
+                      SnapsToDevicePixels="True"
+                      Stretch="Uniform" />
+            </Button>
+            <Button x:Name="PART_Close"
+                    Focusable="False"
+                    IsEnabled="{Binding IsCloseButtonEnabled, RelativeSource={RelativeSource AncestorType={x:Type Controls:MetroWindow}}}"
+                    ToolTip="{Binding Close, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                    UseLayoutRounding="True">
+                <Button.Visibility>
+                    <MultiBinding Converter="{x:Static Converters:ResizeModeMinMaxButtonVisibilityConverter.Instance}" ConverterParameter="CLOSE">
+                        <Binding RelativeSource="{RelativeSource AncestorType={x:Type Controls:MetroWindow}}"
+                                 Path="ShowCloseButton"
+                                 Mode="OneWay" />
+                        <Binding RelativeSource="{RelativeSource AncestorType={x:Type Controls:MetroWindow}}"
+                                 Path="UseNoneWindowStyle"
+                                 Mode="OneWay" />
+                    </MultiBinding>
+                </Button.Visibility>
+                <Path Width="10"
+                      Height="10"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      Fill="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Button}}}"
+                      Data="M51.25,28.75L240,217.5 428.75,28.75 451.25,51.25 262.5,240 451.25,428.75 428.75,451.25 240,262.5 51.25,451.25 28.75,428.75 217.5,240 28.75,51.25 51.25,28.75z"
+                      SnapsToDevicePixels="True"
+                      Stretch="Uniform" />
+            </Button>
+        </StackPanel>
+        <ControlTemplate.Triggers>
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:MetroWindow}}, Path=WindowState}" Value="Maximized">
+                <Setter TargetName="PART_Max" Property="ToolTip" Value="{Binding Restore, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+                <Setter TargetName="PART_MaxPath" Property="Data" Value="M42.75,128L42.75,469.25 384,469.25 384,128 42.75,128z M128,42.75L128,85.25 426.75,85.25 426.75,384 469.25,384 469.25,42.75 128,42.75z M85.25,0L512,0 512,426.75 426.75,426.75 426.75,512 0,512 0,85.25 85.25,85.25 85.25,0z" />
+            </DataTrigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
     <Style TargetType="{x:Type Controls:WindowButtonCommands}">
         <Setter Property="Background" Value="{DynamicResource TransparentWhiteBrush}" />
         <Setter Property="DarkCloseButtonStyle" Value="{StaticResource DarkMetroWindowButtonStyle}" />
@@ -94,7 +185,7 @@
         <Setter Property="LightCloseButtonStyle" Value="{StaticResource LightMetroWindowButtonStyle}" />
         <Setter Property="LightMaxButtonStyle" Value="{StaticResource LightMetroWindowButtonStyle}" />
         <Setter Property="LightMinButtonStyle" Value="{StaticResource LightMetroWindowButtonStyle}" />
-        <Setter Property="Template" Value="{StaticResource WindowButtonCommandsTemplate}" />
+        <Setter Property="Template" Value="{StaticResource Win10WindowButtonCommandsTemplate}" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding ParentWindow.ShowTitleBar, RelativeSource={RelativeSource Self}}" Value="True">

--- a/MahApps.Metro/Themes/WindowButtonCommands.xaml
+++ b/MahApps.Metro/Themes/WindowButtonCommands.xaml
@@ -96,7 +96,7 @@
         <Setter Property="LightMaxButtonStyle" Value="{StaticResource LightMetroWindowButtonStyle}" />
         <Setter Property="LightMinButtonStyle" Value="{StaticResource LightMetroWindowButtonStyle}" />
         <Setter Property="Template" Value="{StaticResource WindowButtonCommandsTemplate}" />
-        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding ParentWindow.ShowTitleBar, RelativeSource={RelativeSource Self}}" Value="True">
                 <Setter Property="Foreground" Value="{DynamicResource IdealForegroundColorBrush}" />

--- a/MahApps.Metro/Themes/WindowButtonCommands.xaml
+++ b/MahApps.Metro/Themes/WindowButtonCommands.xaml
@@ -185,7 +185,7 @@
         <Setter Property="LightCloseButtonStyle" Value="{StaticResource LightMetroWindowButtonStyle}" />
         <Setter Property="LightMaxButtonStyle" Value="{StaticResource LightMetroWindowButtonStyle}" />
         <Setter Property="LightMinButtonStyle" Value="{StaticResource LightMetroWindowButtonStyle}" />
-        <Setter Property="Template" Value="{StaticResource Win10WindowButtonCommandsTemplate}" />
+        <Setter Property="Template" Value="{StaticResource WindowButtonCommandsTemplate}" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding ParentWindow.ShowTitleBar, RelativeSource={RelativeSource Self}}" Value="True">

--- a/MahApps.Metro/Themes/WindowButtonCommands.xaml
+++ b/MahApps.Metro/Themes/WindowButtonCommands.xaml
@@ -12,7 +12,7 @@
             <Button x:Name="PART_Min"
                     Focusable="False"
                     IsEnabled="{Binding IsMinButtonEnabled, RelativeSource={RelativeSource AncestorType={x:Type Controls:MetroWindow}}}"
-                    ToolTip="{Binding Minimize, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowButtonCommands}}}">
+                    ToolTip="{Binding Minimize, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}">
                 <Button.Visibility>
                     <MultiBinding Converter="{x:Static Converters:ResizeModeMinMaxButtonVisibilityConverter.Instance}" ConverterParameter="MIN">
                         <Binding RelativeSource="{RelativeSource AncestorType={x:Type Controls:MetroWindow}}"
@@ -33,7 +33,7 @@
             <Button x:Name="PART_Max"
                     Focusable="False"
                     IsEnabled="{Binding IsMaxRestoreButtonEnabled, RelativeSource={RelativeSource AncestorType={x:Type Controls:MetroWindow}}}"
-                    ToolTip="{Binding Maximize, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowButtonCommands}}}">
+                    ToolTip="{Binding Maximize, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}">
                 <Button.Visibility>
                     <MultiBinding Converter="{x:Static Converters:ResizeModeMinMaxButtonVisibilityConverter.Instance}" ConverterParameter="MAX">
                         <Binding RelativeSource="{RelativeSource AncestorType={x:Type Controls:MetroWindow}}"
@@ -55,12 +55,11 @@
                       Data="F1M0,0L0,9 9,9 9,0 0,0 0,3 8,3 8,8 1,8 1,3z"
                       SnapsToDevicePixels="True" />
             </Button>
-            <!--  Style="{Binding CloseButtonStyle, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowButtonCommands}}}"  -->
             <Button x:Name="PART_Close"
                     Focusable="False"
                     IsEnabled="{Binding IsCloseButtonEnabled, RelativeSource={RelativeSource AncestorType={x:Type Controls:MetroWindow}}}"
                     RenderOptions.EdgeMode="Aliased"
-                    ToolTip="{Binding Close, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowButtonCommands}}}">
+                    ToolTip="{Binding Close, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}">
                 <Button.Visibility>
                     <MultiBinding Converter="{x:Static Converters:ResizeModeMinMaxButtonVisibilityConverter.Instance}" ConverterParameter="CLOSE">
                         <Binding RelativeSource="{RelativeSource AncestorType={x:Type Controls:MetroWindow}}"
@@ -78,7 +77,7 @@
         </StackPanel>
         <ControlTemplate.Triggers>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:MetroWindow}}, Path=WindowState}" Value="Maximized">
-                <Setter TargetName="PART_Max" Property="ToolTip" Value="{Binding Restore, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowButtonCommands}}}" />
+                <Setter TargetName="PART_Max" Property="ToolTip" Value="{Binding Restore, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
                 <Setter TargetName="PART_MaxPath" Property="Data" Value="F1M0,10L0,3 3,3 3,0 10,0 10,2 4,2 4,3 7,3 7,6 6,6 6,5 1,5 1,10z M1,10L7,10 7,7 10,7 10,2 9,2 9,6 6,6 6,9 1,9z" />
             </DataTrigger>
         </ControlTemplate.Triggers>

--- a/Mahapps.Metro.Tests/FlyoutTest.cs
+++ b/Mahapps.Metro.Tests/FlyoutTest.cs
@@ -148,7 +148,7 @@ namespace MahApps.Metro.Tests
             var window = await WindowHelpers.CreateInvisibleWindowAsync<FlyoutWindow>();
             window.RightFlyout.IsOpen = true;
 
-            int windowCommandsZIndex = Panel.GetZIndex(window.FindChild<WindowButtonCommands>("PART_WindowButtonCommands"));
+            int windowCommandsZIndex = Panel.GetZIndex(window.WindowButtonCommands.TryFindParent<ContentPresenter>());
             int flyoutindex = Panel.GetZIndex(window.RightFlyout);
 
             Assert.True(windowCommandsZIndex > flyoutindex);

--- a/Mahapps.Metro.Tests/MetroWindowTest.cs
+++ b/Mahapps.Metro.Tests/MetroWindowTest.cs
@@ -26,7 +26,7 @@ namespace MahApps.Metro.Tests
 
             Assert.Equal(window, window.LeftWindowCommands.ParentWindow);
             Assert.Equal(window, window.RightWindowCommands.ParentWindow);
-            Assert.Equal(window, window.FindChild<WindowButtonCommands>("PART_WindowButtonCommands").ParentWindow);
+            Assert.Equal(window, window.WindowButtonCommands.ParentWindow);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace MahApps.Metro.Tests
 
         private Button GetButton(MetroWindow window, string buttonName)
         {
-            var windowButtonCommands = window.FindChild<WindowButtonCommands>("PART_WindowButtonCommands");
+            var windowButtonCommands = window.WindowButtonCommands;
             Assert.NotNull(windowButtonCommands);
 
             var button = windowButtonCommands.Template.FindName(buttonName, windowButtonCommands) as Button;

--- a/Mahapps.Metro.Tests/TestHelpers/WindowHelpers.cs
+++ b/Mahapps.Metro.Tests/TestHelpers/WindowHelpers.cs
@@ -45,7 +45,7 @@ namespace MahApps.Metro.Tests.TestHelpers
         public static void AssertWindowCommandsColor(this MetroWindow window, Color color)
         {
             Assert.True(window.RightWindowCommands.Items.Cast<Button>().Select(x => ((SolidColorBrush)x.Foreground).Color).All(x => x == color));
-            Assert.Equal(color, ((SolidColorBrush)window.FindChild<WindowButtonCommands>("PART_WindowButtonCommands").Foreground).Color);
+            Assert.Equal(color, ((SolidColorBrush)window.WindowButtonCommands.Foreground).Color);
         }
     }
 }


### PR DESCRIPTION
## What changed?

- use ContentPresenter to show the WindowButtonCommands, so it's now possible easier to change the min/max/close button styles
- enable changing min/max/restore/close button tooltip
- new Win10WindowButtonCommandsTemplate

![2016-02-29_23h49_58](https://cloud.githubusercontent.com/assets/658431/13411765/5b8e7248-df3f-11e5-93d1-a1eea678c3fa.png)

Closes #1972 Changing Close button icon.