### PR TITLE
AutomationId based on name fix

### DIFF
--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -20,6 +20,7 @@
                     Height="40"
                     VerticalAlignment="Bottom"
                     Style="{DynamicResource MetroCircleButtonStyle}"
+                     AutomationProperties.AutomationId="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Name,  StringFormat='nav{0}' , Mode=OneWay }"
                     Foreground="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=Foreground}"
                     FontFamily="Segoe UI Symbol"
                     FontSize="16"

--- a/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -73,6 +73,7 @@
                                      BorderThickness="0"
                                      FontFamily="{TemplateBinding FontFamily}"
                                      FontSize="{TemplateBinding FontSize}"
+                                     AutomationProperties.AutomationId="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Name,  StringFormat='PART_TextBox{0}' , Mode=OneWay }"
                                      Controls:ControlsHelper.DisabledVisualElementVisibility="Collapsed"
                                      Controls:ControlsHelper.ButtonWidth="{TemplateBinding Controls:ControlsHelper.ButtonWidth}"
                                      Controls:TextBoxHelper.ButtonContent="{TemplateBinding Controls:TextBoxHelper.ButtonContent}"
@@ -95,6 +96,7 @@
                                           Width="{TemplateBinding UpDownButtonsWidth}"
                                           Margin="0 2 0 2"
                                           Style="{DynamicResource ChromelessButtonStyle}"
+                                          AutomationProperties.AutomationId="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Name,  StringFormat='PART_NumericUp{0}' , Mode=OneWay }"
                                           Foreground="{TemplateBinding Foreground}"
                                           Delay="{TemplateBinding Delay}"
                                           IsTabStop="False">
@@ -110,6 +112,7 @@
                                           Grid.Column="2"
                                           Width="{TemplateBinding UpDownButtonsWidth}"
                                           Margin="0 2 2 2"
+                                          AutomationProperties.AutomationId="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Name,  StringFormat='PART_NumericDown{0}' , Mode=OneWay }"
                                           VerticalContentAlignment="Center"
                                           Style="{DynamicResource ChromelessButtonStyle}"
                                           Foreground="{TemplateBinding Foreground}"


### PR DESCRIPTION
## Set AutomationId based on x:Name property

Now the AutomationId property is set according to the control x:Name property.

For NumericUpDown:

- Textbox: "PART_TextBox{x:Name value}"
- DownButton : "PART_NumericDown{x:Name value}"
- UpButton: "PART_NumericUp{x:Name value}"

For Flyout:

-NavButton: "nav{x:Name value}"

#2166

