### PR TITLE
Added EllipseDiameterScale (issue #2204)

### DIFF
--- a/MahApps.Metro/Controls/ProgressRing.cs
+++ b/MahApps.Metro/Controls/ProgressRing.cs
@@ -25,6 +25,8 @@ namespace MahApps.Metro.Controls
 
         public static readonly DependencyProperty EllipseOffsetProperty = DependencyProperty.Register("EllipseOffset", typeof(Thickness), typeof(ProgressRing), new PropertyMetadata(default(Thickness)));
 
+        public static readonly DependencyProperty EllipseDiameterScaleProperty = DependencyProperty.Register("EllipseDiameterScale", typeof(double), typeof(ProgressRing), new PropertyMetadata(1D));
+
         private List<Action> _deferredActions = new List<Action>();
 
         static ProgressRing()
@@ -65,6 +67,12 @@ namespace MahApps.Metro.Controls
             private set { SetValue(EllipseDiameterProperty, value); }
         }
 
+        public double EllipseDiameterScale
+        {
+            get { return (double)GetValue(EllipseDiameterScaleProperty); }
+            set { SetValue(EllipseDiameterScaleProperty, value); }
+        }
+
         public Thickness EllipseOffset
         {
             get { return (Thickness)GetValue(EllipseOffsetProperty); }
@@ -97,6 +105,7 @@ namespace MahApps.Metro.Controls
 
             var action = new Action(() =>
             {
+
                 ring.SetEllipseDiameter(
                     (double) dependencyPropertyChangedEventArgs.NewValue);
                 ring.SetEllipseOffset(
@@ -118,7 +127,7 @@ namespace MahApps.Metro.Controls
 
         private void SetEllipseDiameter(double width)
         {
-            EllipseDiameter = width / 8;
+            EllipseDiameter =(width / 8)*EllipseDiameterScale;
         }
 
         private void SetEllipseOffset(double width)


### PR DESCRIPTION
## Added EllipseDiameterScale (issue #2204)

Added EllipseDiameterScale property as a multiplier for Ellipse Size, below the scaling of 1.0 (default), 0.5 (smaller) and 1.5 larger values for this property are shown.

This solves issue #2204 as now it is possible do manually ajust the size of the Ellipse. In the control the Ellipse size is calculated using the formula below:

EllipseDiameter =(width / 8)*EllipseDiameterScale;

![ring0_5](https://cloud.githubusercontent.com/assets/778016/13406475/7a57eb88-df02-11e5-941f-eb73f2c408ee.png)
![ring1](https://cloud.githubusercontent.com/assets/778016/13406476/7a5da9f6-df02-11e5-88a1-15f8379da424.png)
![ring1_5](https://cloud.githubusercontent.com/assets/778016/13406477/7a61ba0a-df02-11e5-9e0f-19bf391920e2.png)