### PR TITLE
Dialog Font Sizes Setting Implementation #2380

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -19,6 +19,8 @@ namespace MahApps.Metro.Controls.Dialogs
         public static readonly DependencyProperty TitleProperty = DependencyProperty.Register("Title", typeof(string), typeof(BaseMetroDialog), new PropertyMetadata(default(string)));
         public static readonly DependencyProperty DialogTopProperty = DependencyProperty.Register("DialogTop", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
         public static readonly DependencyProperty DialogBottomProperty = DependencyProperty.Register("DialogBottom", typeof(object), typeof(BaseMetroDialog), new PropertyMetadata(null));
+        public static readonly DependencyProperty DialogTitleFontSizeProperty = DependencyProperty.Register("DialogTitleFontSize", typeof(double), typeof(BaseMetroDialog), new PropertyMetadata(26D));
+        public static readonly DependencyProperty DialogMessageFontSizeProperty = DependencyProperty.Register("DialogMessageFontSize", typeof(double), typeof(BaseMetroDialog), new PropertyMetadata(15D));
 
         public MetroDialogSettings DialogSettings { get; private set; }
 
@@ -47,6 +49,18 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             get { return GetValue(DialogBottomProperty); }
             set { SetValue(DialogBottomProperty, value); }
+        }
+
+        public double DialogTitleFontSize
+        {
+            get { return (double)GetValue(DialogTitleFontSizeProperty); }
+            set { SetValue(DialogTitleFontSizeProperty, value); }
+        }
+
+        public double DialogMessageFontSize
+        {
+            get { return (double)GetValue(DialogMessageFontSizeProperty); }
+            set { SetValue(DialogMessageFontSizeProperty, value); }
         }
 
         internal SizeChangedEventHandler SizeChangedHandler { get; set; }
@@ -356,6 +370,9 @@ namespace MahApps.Metro.Controls.Dialogs
             DefaultText = "";
             DefaultButtonFocus = MessageDialogResult.Negative;
             CancellationToken = CancellationToken.None;
+            DialogTitleFontSize = Double.NaN;
+            DialogMessageFontSize = Double.NaN;
+
         }
 
         /// <summary>
@@ -417,6 +434,15 @@ namespace MahApps.Metro.Controls.Dialogs
         /// If set, stops standard resource dictionaries being applied to the dialog.
         /// </summary>
         public bool SuppressDefaultResources { get; set; }
+
+        /// <summary>
+        /// Gets/sets the font size for the title.
+        /// </summary>
+        public double DialogTitleFontSize { get; set; }
+        /// <summary>
+        /// Gets/sets the font size for the text.
+        /// </summary>
+        public double DialogMessageFontSize { get; set; }
     }
 
     /// <summary>

--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -111,6 +111,18 @@ namespace MahApps.Metro.Controls.Dialogs
                 this.Resources.MergedDictionaries.Add(DialogSettings.CustomResourceDictionary);
             }
 
+            var titleFontSizeResource = TryFindResource("DialogTitleFontSize") as double?;
+            if(titleFontSizeResource.HasValue)
+            {
+                this.DialogTitleFontSize = titleFontSizeResource.Value;
+            }
+            var messageFontSizeResource = TryFindResource("DialogMessageFontSize") as double?;
+            if (messageFontSizeResource.HasValue)
+            {
+                this.DialogMessageFontSize = messageFontSizeResource.Value;
+            }
+
+
             this.Loaded += (sender, args) =>
             {
                 OnLoaded();

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -35,7 +35,7 @@ namespace MahApps.Metro.Controls.Dialogs
                         Title = title,
                         Message = message
                     };
-
+                    SetDialogFontSizes(settings, dialog);
                     SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                     dialog.SizeChangedHandler = sizeHandler;
 
@@ -99,8 +99,12 @@ namespace MahApps.Metro.Controls.Dialogs
                     {
                         Title = title,
                         Message = message,
-                        Input = settings.DefaultText
+                        Input = settings.DefaultText,
+
+
                     };
+
+                    SetDialogFontSizes(settings, dialog);
 
                     SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                     dialog.SizeChangedHandler = sizeHandler;
@@ -140,6 +144,8 @@ namespace MahApps.Metro.Controls.Dialogs
                 }));
             }).Unwrap();
         }
+
+       
         /// <summary>
         /// Creates a MessageDialog inside of the current window.
         /// </summary>
@@ -168,6 +174,8 @@ namespace MahApps.Metro.Controls.Dialogs
                         Title = title,
                         ButtonStyle = style
                     };
+                    SetDialogFontSizes(settings, dialog);
+
 
                     SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                     dialog.SizeChangedHandler = sizeHandler;
@@ -231,7 +239,7 @@ namespace MahApps.Metro.Controls.Dialogs
                         Title = title,
                         IsCancelable = isCancelable
                     };
-
+                    SetDialogFontSizes(settings, dialog);
                     if (settings == null)
                     {
                         settings = window.MetroDialogOptions;
@@ -512,6 +520,22 @@ namespace MahApps.Metro.Controls.Dialogs
             win.Closed += closedHandler;
 
             return win;
+        }
+
+        private static void SetDialogFontSizes(MetroDialogSettings settings, BaseMetroDialog dialog)
+        {
+            if (settings == null)
+            {
+                return;
+            }
+            if (!double.IsNaN(settings.DialogTitleFontSize))
+            {
+                dialog.DialogTitleFontSize = settings.DialogTitleFontSize;
+            }
+            if (!double.IsNaN(settings.DialogMessageFontSize))
+            {
+                dialog.DialogMessageFontSize = settings.DialogMessageFontSize;
+            }
         }
 
         public static event EventHandler<DialogStateChangedEventArgs> DialogOpened;

--- a/MahApps.Metro/Styles/Fonts.xaml
+++ b/MahApps.Metro/Styles/Fonts.xaml
@@ -25,9 +25,6 @@
 
     <System:Double x:Key="StatusBarFontSize">12</System:Double>
 
-    <System:Double x:Key="DialogTitleFontSize">26</System:Double>
-    <System:Double x:Key="DialogMessageFontSize">15</System:Double>
-
     <System:Double x:Key="FlyoutHeaderFontSize">20</System:Double>
 
     <System:Double x:Key="ToggleSwitchFontSize">14.667</System:Double>

--- a/MahApps.Metro/Styles/Fonts.xaml
+++ b/MahApps.Metro/Styles/Fonts.xaml
@@ -19,11 +19,12 @@
     <System:Double x:Key="FloatingWatermarkFontSize">10</System:Double>
 
     <System:Double x:Key="TooltipFontSize">12</System:Double>
-
     <System:Double x:Key="MenuFontSize">14</System:Double>
     <System:Double x:Key="ContextMenuFontSize">14</System:Double>
 
     <System:Double x:Key="StatusBarFontSize">12</System:Double>
+    <System:Double x:Key="DialogTitleFontSize">26</System:Double>
+    <System:Double x:Key="DialogMessageFontSize">15</System:Double>
 
     <System:Double x:Key="FlyoutHeaderFontSize">20</System:Double>
 

--- a/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -62,7 +62,7 @@
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
                             <TextBlock Grid.Row="0"
-                                       FontSize="{DynamicResource DialogTitleFontSize}"
+                                       FontSize="{TemplateBinding DialogTitleFontSize}"
                                        Foreground="{TemplateBinding Foreground}"
                                        Text="{TemplateBinding Title}"
                                        TextWrapping="Wrap" />

--- a/MahApps.Metro/Themes/Dialogs/InputDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/InputDialog.xaml
@@ -11,14 +11,14 @@
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0"
                    Margin="0 5 0 0"
-                   FontSize="{DynamicResource DialogMessageFontSize}"
+                   FontSize="{Binding DialogMessageFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                    Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                    TextWrapping="Wrap" />
         <TextBox x:Name="PART_TextBox"
                  Grid.Row="1"
                  Margin="0 5 0 0"
-                 FontSize="{DynamicResource DialogMessageFontSize}"
+                 FontSize="{Binding DialogMessageFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  Text="{Binding Input, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  TextWrapping="Wrap"

--- a/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/LoginDialog.xaml
@@ -15,7 +15,7 @@
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0"
                    Margin="0 5 0 0"
-                   FontSize="{DynamicResource DialogMessageFontSize}"
+                   FontSize="{Binding DialogMessageFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                    Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                    TextWrapping="Wrap" />

--- a/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/MessageDialog.xaml
@@ -15,7 +15,7 @@
                       VerticalScrollBarVisibility="Auto">
             <TextBlock x:Name="PART_MessageTextBlock"
                        Margin="0 5 0 0"
-                       FontSize="{DynamicResource DialogMessageFontSize}"
+                       FontSize="{Binding DialogMessageFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                        Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                        TextWrapping="Wrap" />

--- a/MahApps.Metro/Themes/Dialogs/ProgressDialog.xaml
+++ b/MahApps.Metro/Themes/Dialogs/ProgressDialog.xaml
@@ -12,7 +12,7 @@
             </Grid.RowDefinitions>
             <TextBlock Grid.Row="0"
                        Margin="0 5 0 0"
-                       FontSize="{DynamicResource DialogMessageFontSize}"
+                       FontSize="{Binding DialogMessageFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:ProgressDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                        Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:ProgressDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                        Text="{Binding Message, RelativeSource={RelativeSource AncestorType=Dialogs:ProgressDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                        TextWrapping="Wrap" />


### PR DESCRIPTION
## Implementation of the option to set Dialog Font sizes using MetroDialogSettings object.

The size of the fonts for the Title and Message of a Dialog, can be set using a MetroDialogSettings object and passing it as a parameter.

Example:

`var controller = await this.ShowProgressAsync("Please wait...", "We are baking some cupcakes!", false, new MetroDialogSettings() { DialogMessageFontSize = 25, DialogTitleFontSize = 50 });`

 #2380 
