### PR TITLE
MetroButtonPasswordBox / MetroButtonTextBox fixes for #2385 and #2220

### DIFF
--- a/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
+++ b/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
@@ -24,6 +24,7 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty UseFloatingWatermarkProperty = DependencyProperty.RegisterAttached("UseFloatingWatermark", typeof(bool), typeof(TextBoxHelper), new FrameworkPropertyMetadata(false, ButtonCommandOrClearTextChanged));
         public static readonly DependencyProperty TextLengthProperty = DependencyProperty.RegisterAttached("TextLength", typeof(int), typeof(TextBoxHelper), new UIPropertyMetadata(0));
         public static readonly DependencyProperty ClearTextButtonProperty = DependencyProperty.RegisterAttached("ClearTextButton", typeof(bool), typeof(TextBoxHelper), new FrameworkPropertyMetadata(false, ButtonCommandOrClearTextChanged));
+        public static readonly DependencyProperty TextButtonProperty = DependencyProperty.RegisterAttached("TextButton", typeof(bool), typeof(TextBoxHelper), new FrameworkPropertyMetadata(false, ButtonCommandOrClearTextChanged));
         public static readonly DependencyProperty ButtonsAlignmentProperty = DependencyProperty.RegisterAttached("ButtonsAlignment", typeof(ButtonsAlignment), typeof(TextBoxHelper), new FrameworkPropertyMetadata(ButtonsAlignment.Right, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure));
         /// <summary>
         /// The clear text button behavior property. It sets a click event to the button if the value is true.
@@ -329,15 +330,38 @@ namespace MahApps.Metro.Controls
             }
         }
 
+        /// <summary>
+        /// Gets the clear text button visibility / feature. Can be used to enable text deletion.
+        /// </summary>
         [Category(AppName.MahApps)]
         public static bool GetClearTextButton(DependencyObject d)
         {
             return (bool)d.GetValue(ClearTextButtonProperty);
         }
 
+        /// <summary>
+        /// Sets the clear text button visibility / feature. Can be used to enable text deletion.
+        /// </summary>
         public static void SetClearTextButton(DependencyObject obj, bool value)
         {
             obj.SetValue(ClearTextButtonProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the text button visibility.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        public static bool GetTextButton(DependencyObject d)
+        {
+            return (bool)d.GetValue(TextButtonProperty);
+        }
+
+        /// <summary>
+        /// Sets the text button visibility.
+        /// </summary>
+        public static void SetTextButton(DependencyObject obj, bool value)
+        {
+            obj.SetValue(TextButtonProperty, value);
         }
 
         /// <summary>

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -326,6 +326,7 @@
     <Style x:Key="MetroButtonPasswordBox"
            BasedOn="{StaticResource MetroPasswordBox}"
            TargetType="{x:Type PasswordBox}">
+        <Setter Property="Controls:TextBoxHelper.TextButton" Value="True" />
         <Setter Property="Controls:TextBoxHelper.ButtonTemplate" Value="{DynamicResource ChromelessButtonTemplate}" />
         <Setter Property="Template">
             <Setter.Value>
@@ -439,7 +440,8 @@
                                     Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
                                     ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                     IsTabStop="False"
-                                    Template="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonTemplate), Mode=OneWay}" />
+                                    Template="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonTemplate), Mode=OneWay}"
+                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.TextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource ControlsDisabledBrush}"

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -251,6 +251,7 @@
     <Style x:Key="MetroButtonTextBox"
            BasedOn="{StaticResource MetroTextBox}"
            TargetType="{x:Type TextBox}">
+        <Setter Property="Controls:TextBoxHelper.TextButton" Value="True" />
         <Setter Property="Controls:TextBoxHelper.ButtonTemplate" Value="{DynamicResource ChromelessButtonTemplate}" />
         <!--  change SnapsToDevicePixels to True to view a better border and validation error  -->
         <Setter Property="Template">
@@ -353,7 +354,8 @@
                                     Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContent), Mode=OneWay}"
                                     ContentTemplate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonContentTemplate), Mode=OneWay}"
                                     IsTabStop="False"
-                                    Template="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonTemplate), Mode=OneWay}" />
+                                    Template="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ButtonTemplate), Mode=OneWay}"
+                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.TextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource ControlsDisabledBrush}"
@@ -393,7 +395,7 @@
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.ButtonsAlignment)}" Value="Right" />
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.ClearTextButton)}" Value="False" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:TextBoxHelper.TextButton)}" Value="False" />
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="PART_ContentHost" Property="Grid.ColumnSpan" Value="2" />
                             <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />


### PR DESCRIPTION
## What changed?

- new attached dp `TextButton` in TextBoxHelper which handles the visibility of the Button in `MetroButtonPasswordBox` and `MetroButtonTextBox`
- fixed ButtonCommandMetroTextBox text displaid over icon

Closes #2385 ButtonCommandMetroTextBox text displaid over icon.
Closes #2220 Why in the MetroButtonTextBox the visibility of PART_ClearText is not managed as the MetroTextBox?
