### PR TITLE
Correction of lost SelectionIndex #2333

### DIFF
--- a/MahApps.Metro/Controls/FlipView.cs
+++ b/MahApps.Metro/Controls/FlipView.cs
@@ -57,8 +57,6 @@ namespace MahApps.Metro.Controls
         
         public FlipView()
         {
-            this.Unloaded += FlipView_Unloaded;
-            this.Loaded += FlipView_Loaded;
             this.MouseLeftButtonDown += FlipView_MouseLeftButtonDown;
         }
 
@@ -123,51 +121,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        void FlipView_Loaded(object sender, RoutedEventArgs e)
-        {
-            /* Loaded event fires twice if its a child of a TabControl.
-             * Once because the TabControl seems to initiali(z|s)e everything.
-             * And a second time when the Tab (housing the FlipView) is switched to. */
-
-            if (backButton == null || forwardButton == null) //OnApplyTemplate hasn't been called yet.
-                ApplyTemplate();
-
-            if (loaded) return; //Counteracts the double 'Loaded' event issue.
-
-            backButton.Click += backButton_Click;
-            forwardButton.Click += forwardButton_Click;
-            upButton.Click += upButton_Click;
-            downButton.Click += downButton_Click;
-
-            this.SelectionChanged += FlipView_SelectionChanged;
-            this.PreviewKeyDown += FlipView_PreviewKeyDown;
-
-            SelectedIndex = 0;
-
-            DetectControlButtonsStatus();
-
-            ShowBanner();
-
-            loaded = true;
-        }
-
-        void FlipView_Unloaded(object sender, RoutedEventArgs e)
-        {
-            this.Unloaded -= FlipView_Unloaded;
-            this.MouseLeftButtonDown -= FlipView_MouseLeftButtonDown;
-            this.SelectionChanged -= FlipView_SelectionChanged;
-
-            this.PreviewKeyDown -= FlipView_PreviewKeyDown;
-            backButton.Click -= backButton_Click;
-            forwardButton.Click -= forwardButton_Click;
-            upButton.Click -= upButton_Click;
-            downButton.Click -= downButton_Click;
-
-            if (hideControlStoryboardCompletedHandler != null)
-                hideControlStoryboard.Completed -= hideControlStoryboardCompletedHandler;
-
-            loaded = false;
-        }
+       
 
         void FlipView_PreviewKeyDown(object sender, KeyEventArgs e)
         {
@@ -206,6 +160,20 @@ namespace MahApps.Metro.Controls
             bannerLabel = GetTemplateChild(PART_BannerLabel) as Label;
 
             bannerLabel.Opacity = IsBannerEnabled ? 1.0 : 0.0;
+
+            backButton.Click += backButton_Click;
+            forwardButton.Click += forwardButton_Click;
+            upButton.Click += upButton_Click;
+            downButton.Click += downButton_Click;
+
+            this.SelectionChanged += FlipView_SelectionChanged;
+            this.PreviewKeyDown += FlipView_PreviewKeyDown;
+
+            SelectedIndex = 0;
+
+            DetectControlButtonsStatus();
+
+            ShowBanner();
         }
 
         protected override void OnItemsSourceChanged(System.Collections.IEnumerable oldValue, System.Collections.IEnumerable newValue)

--- a/MahApps.Metro/Controls/FlipView.cs
+++ b/MahApps.Metro/Controls/FlipView.cs
@@ -47,7 +47,6 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// To counteract the double Loaded event issue.
         /// </summary>
-        private bool loaded;
         private bool controlsVisibilityOverride;
 
         static FlipView()

--- a/MahApps.Metro/Controls/FlipView.cs
+++ b/MahApps.Metro/Controls/FlipView.cs
@@ -355,7 +355,7 @@ namespace MahApps.Metro.Controls
             {
                 var newValue = value ?? BannerText;
 
-                if (newValue == null) return;
+                if (newValue == null|| hideControlStoryboard==null) return;
 
                 if (hideControlStoryboardCompletedHandler != null)
                     hideControlStoryboard.Completed -= hideControlStoryboardCompletedHandler;


### PR DESCRIPTION
## What changed?

I got the same behavior described by @berkay2578 using the example he published on https://github.com/berkay2578/nfsw-server

It seems that the problem was related to bootstraping controls events and setting the SelecionIndex=0 in the Loaded event handler and then unsubscribing everything on the Unloaded event.

As described in the control comments and also in this stackoverflow question (http://stackoverflow.com/questions/6349695/removing-event-handlers-from-custom-controls-template-parts), when the control is inside a TabItem it can be loaded and unloaded multiple times, so everytime the control was unloaded and then loaded again, for example when the user changed tabs, it resetted the SelecionIndex to zero.

Now the event bootstrapping and initial setting of SelectionIndex occurs inside the OnApplyTemplate event. 

#2333

