### PR TITLE
Issue Winhost "hanging" after transition #1835

### DIFF
--- a/MahApps.Metro/Controls/MetroContentControl.cs
+++ b/MahApps.Metro/Controls/MetroContentControl.cs
@@ -1,5 +1,7 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media.Animation;
 
 namespace MahApps.Metro.Controls
 {
@@ -40,6 +42,18 @@ namespace MahApps.Metro.Controls
 
             Loaded += MetroContentControlLoaded;
             Unloaded += MetroContentControlUnloaded;
+        }
+
+        public override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+            var sb = ((Storyboard)GetTemplateChild("AfterLoadedStoryBoard"));
+            sb.Completed += Sb_Completed;
+        }
+
+        private void Sb_Completed(object sender, EventArgs e)
+        {
+            this.InvalidateVisual();
         }
 
         void MetroContentControlIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
@@ -109,5 +123,6 @@ namespace MahApps.Metro.Controls
             }
 
         }
+      
     }
 }

--- a/MahApps.Metro/Controls/MetroContentControl.cs
+++ b/MahApps.Metro/Controls/MetroContentControl.cs
@@ -48,12 +48,7 @@ namespace MahApps.Metro.Controls
         {
             base.OnApplyTemplate();
             var sb = ((Storyboard)GetTemplateChild("AfterLoadedStoryBoard"));
-            sb.Completed += Sb_Completed;
-        }
-
-        private void Sb_Completed(object sender, EventArgs e)
-        {
-            this.InvalidateVisual();
+            sb.Completed += (s, e) => { InvalidateVisual(); };
         }
 
         void MetroContentControlIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)

--- a/MahApps.Metro/Themes/MetroContentControl.xaml
+++ b/MahApps.Metro/Themes/MetroContentControl.xaml
@@ -29,7 +29,7 @@
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="LayoutStates">
                                 <VisualState x:Name="AfterLoaded">
-                                    <Storyboard>
+                                    <Storyboard x:Name="AfterLoadedStoryBoard">
                                         <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                                        Storyboard.TargetName="root"
                                                                        Storyboard.TargetProperty="(UIElement.Opacity)">


### PR DESCRIPTION
## What changed?

I found a StackOverflow post (https://stackoverflow.com/questions/12465357/force-redraw-after-storyboard-with-windowsformshost-wpf/12748181#12748181) with the same problem and implemented a fix using de solution provided (calling InvalidateVisual() when the transition is completed to force a redraw of the Winform Host).

I believe a more elegant solution would be to have events for when the transition animation is starting or completing so that the developer can decide if it is better to hide the Winform host until the transition is completed, avoiding that the user seeing the winform control abrupty moving to another position when the transition is completed. 

These new events would have to be created in MetroContentControl and MetroWindow controls.
I can do this, but  I´d like to ask if this is something the project maintainers think is a good idea.
#1835
