### PR TITLE
2396 show metro dialog async dialog opened fix

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -322,24 +322,27 @@ namespace MahApps.Metro.Controls.Dialogs
 
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
             {
-                dialog.Dispatcher.Invoke(new Action(() =>
+                return (Task)window.Dispatcher.Invoke(new Func<Task>(() =>
                 {
+                    settings = settings ?? window.MetroDialogOptions;
+
+                    SetDialogFontSizes(settings, dialog);
+
                     SizeChangedEventHandler sizeHandler = SetupAndOpenDialog(window, dialog);
                     dialog.SizeChangedHandler = sizeHandler;
-                }));
-            }).ContinueWith(y =>
-                ((Task)dialog.Dispatcher.Invoke(new Func<Task>(() => dialog.WaitForLoadAsync().ContinueWith(x =>
-                {
-                    dialog.OnShown();
 
-                    if (DialogOpened != null)
+                    return dialog.WaitForLoadAsync().ContinueWith(x =>
                     {
-                        DialogOpened(window, new DialogStateChangedEventArgs());
-                    }
-                })))));
+                        dialog.OnShown();
+
+                        if (DialogOpened != null)
+                        {
+                            window.Dispatcher.BeginInvoke(new Action(() => DialogOpened(window, new DialogStateChangedEventArgs())));
+                        }
+                    });
+                }));
+            }).Unwrap();
         }
-
-
 
         /// <summary>
         /// Hides a visible Metro Dialog instance.

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -223,12 +223,25 @@ namespace MetroDemo
 
         private async void ShowAwaitCustomDialog(object sender, RoutedEventArgs e)
         {
+            EventHandler<DialogStateChangedEventArgs> dialogManagerOnDialogOpened = null;
+            dialogManagerOnDialogOpened = (o, args) => {
+                                              DialogManager.DialogOpened -= dialogManagerOnDialogOpened;
+                                              Console.WriteLine("Custom Dialog opened!");
+                                          };
+            DialogManager.DialogOpened += dialogManagerOnDialogOpened;
+
+            EventHandler<DialogStateChangedEventArgs> dialogManagerOnDialogClosed = null;
+            dialogManagerOnDialogClosed = async (o, args) => {
+                                                    DialogManager.DialogClosed -= dialogManagerOnDialogClosed;
+                                                    Console.WriteLine("Custom Dialog closed!");
+                                                    await this.ShowMessageAsync("Dialog gone", "The custom dialog has closed");
+                                                };
+            DialogManager.DialogClosed += dialogManagerOnDialogClosed;
+
             var dialog = (BaseMetroDialog)this.Resources["CustomCloseDialogTest"];
 
             await this.ShowMetroDialogAsync(dialog);
             await dialog.WaitUntilUnloadedAsync();
-
-            await this.ShowMessageAsync("Dialog gone", "The custom dialog has closed");
         }
 
         private async void CloseCustomDialog(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## What changed?

- use Dispatcher in ShowMetroDialogAsync like in the other methods

Closes  #2396 ShowMetroDialogAsync does not raise DialogManager.DialogOpened event.