### PR TITLE
Fixes the HasDecimals property, broken before on commit bd6aa38e.

### DIFF
--- a/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1063,7 +1063,7 @@ namespace MahApps.Metro.Controls
         {
             _manualChange = true;
 
-            if (e.Key == Key.Decimal || e.Key == Key.OemPeriod)
+            if (HasDecimals == true && (e.Key == Key.Decimal || e.Key == Key.OemPeriod))
             {
                 TextBox textBox = sender as TextBox;
 


### PR DESCRIPTION
## What changed?

Fixed the `HasDecimals` property. It was broken on commit bd6aa38e which made the property stop working and decimals like ',' '.' were available when `HasDecimals = false`.

closes issue #2403. 

