### PR TITLE
[WIP] Win10 ToggleSwitch

### DIFF
--- a/MahApps.Metro/Controls/ToggleSwitch.cs
+++ b/MahApps.Metro/Controls/ToggleSwitch.cs
@@ -267,10 +267,13 @@ namespace MahApps.Metro.Controls
             }
         }
 
+        static ToggleSwitch()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(ToggleSwitch), new FrameworkPropertyMetadata(typeof(ToggleSwitch)));
+        }
+
         public ToggleSwitch()
         {
-            DefaultStyleKey = typeof(ToggleSwitch);
-
             PreviewKeyUp += ToggleSwitch_PreviewKeyUp;
             MouseUp += (sender, args) => Keyboard.Focus(this);
         }

--- a/MahApps.Metro/Controls/ToggleSwitchButton.cs
+++ b/MahApps.Metro/Controls/ToggleSwitchButton.cs
@@ -97,9 +97,13 @@ namespace MahApps.Metro.Controls
             set { SetValue(ThumbIndicatorWidthProperty, value); }
         }
 
+        static ToggleSwitchButton()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(ToggleSwitchButton), new FrameworkPropertyMetadata(typeof(ToggleSwitchButton)));
+        }
+
         public ToggleSwitchButton()
         {
-            DefaultStyleKey = typeof(ToggleSwitchButton);
             isCheckedPropertyChangeNotifier = new PropertyChangeNotifier(this, ToggleSwitchButton.IsCheckedProperty);
             isCheckedPropertyChangeNotifier.ValueChanged += IsCheckedPropertyChangeNotifierValueChanged;
         }

--- a/MahApps.Metro/Controls/ToggleSwitchButton.cs
+++ b/MahApps.Metro/Controls/ToggleSwitchButton.cs
@@ -4,7 +4,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
-using System.Windows.Shapes;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Data;
@@ -17,7 +16,7 @@ namespace MahApps.Metro.Controls
     [TemplatePart(Name = PART_BackgroundTranslate, Type = typeof(TranslateTransform))]
     [TemplatePart(Name = PART_DraggingThumb, Type = typeof(Thumb))]
     [TemplatePart(Name = PART_SwitchTrack, Type = typeof(Grid))]
-    [TemplatePart(Name = PART_ThumbIndicator, Type = typeof(Shape))]
+    [TemplatePart(Name = PART_ThumbIndicator, Type = typeof(FrameworkElement))]
     [TemplatePart(Name = PART_ThumbTranslate, Type = typeof(TranslateTransform))]
     public class ToggleSwitchButton : ToggleButton
     {
@@ -30,7 +29,7 @@ namespace MahApps.Metro.Controls
         private TranslateTransform _BackgroundTranslate;
         private Thumb _DraggingThumb;
         private Grid _SwitchTrack;
-        private Shape _ThumbIndicator;
+        private FrameworkElement _ThumbIndicator;
         private TranslateTransform _ThumbTranslate;
         private readonly PropertyChangeNotifier isCheckedPropertyChangeNotifier;
 
@@ -141,7 +140,7 @@ namespace MahApps.Metro.Controls
             _BackgroundTranslate = GetTemplateChild(PART_BackgroundTranslate) as TranslateTransform;
             _DraggingThumb = GetTemplateChild(PART_DraggingThumb) as Thumb;
             _SwitchTrack = GetTemplateChild(PART_SwitchTrack) as Grid;
-            _ThumbIndicator = GetTemplateChild(PART_ThumbIndicator) as Shape;
+            _ThumbIndicator = GetTemplateChild(PART_ThumbIndicator) as FrameworkElement;
             _ThumbTranslate = GetTemplateChild(PART_ThumbTranslate) as TranslateTransform;
 
             if (_ThumbIndicator != null && _ThumbTranslate != null && _BackgroundTranslate != null)

--- a/MahApps.Metro/Controls/ToggleSwitchButton.cs
+++ b/MahApps.Metro/Controls/ToggleSwitchButton.cs
@@ -112,7 +112,7 @@ namespace MahApps.Metro.Controls
         {
             if (_ThumbTranslate != null && _SwitchTrack != null && _ThumbIndicator != null)
             {
-                double destination = IsChecked.GetValueOrDefault() ? ActualWidth - (_SwitchTrack.Margin.Left + _SwitchTrack.Margin.Right + _ThumbIndicator.ActualWidth) : 0;
+                double destination = IsChecked.GetValueOrDefault() ? ActualWidth - (_SwitchTrack.Margin.Left + _SwitchTrack.Margin.Right + _ThumbIndicator.ActualWidth + _ThumbIndicator.Margin.Left + _ThumbIndicator.Margin.Right) : 0;
 
                 _thumbAnimation = new DoubleAnimation();
                 _thumbAnimation.To = destination;
@@ -172,7 +172,7 @@ namespace MahApps.Metro.Controls
             if (_ThumbTranslate != null)
             {
                 _ThumbTranslate.BeginAnimation(TranslateTransform.XProperty, null);
-                double destination = IsChecked.GetValueOrDefault() ? ActualWidth - (_SwitchTrack.Margin.Left + _SwitchTrack.Margin.Right + _ThumbIndicator.ActualWidth) : 0;
+                double destination = IsChecked.GetValueOrDefault() ? ActualWidth - (_SwitchTrack.Margin.Left + _SwitchTrack.Margin.Right + _ThumbIndicator.ActualWidth + _ThumbIndicator.Margin.Left + _ThumbIndicator.Margin.Right) : 0;
                 _ThumbTranslate.X = destination;
                 _thumbAnimation = null;
             }
@@ -189,7 +189,7 @@ namespace MahApps.Metro.Controls
                 if (_SwitchTrack != null && _ThumbIndicator != null)
                 {
                     double lastDragPosition = _lastDragPosition.Value;
-                    _ThumbTranslate.X = Math.Min(ActualWidth - (_SwitchTrack.Margin.Left + _SwitchTrack.Margin.Right + _ThumbIndicator.ActualWidth), Math.Max(0, lastDragPosition + e.HorizontalChange));
+                    _ThumbTranslate.X = Math.Min(ActualWidth - (_SwitchTrack.Margin.Left + _SwitchTrack.Margin.Right + _ThumbIndicator.ActualWidth + _ThumbIndicator.Margin.Left + _ThumbIndicator.Margin.Right), Math.Max(0, lastDragPosition + e.HorizontalChange));
                 }
             }
         }
@@ -219,7 +219,7 @@ namespace MahApps.Metro.Controls
         {
             if (_ThumbTranslate != null && _SwitchTrack != null && _ThumbIndicator != null)
             {
-                double destination = IsChecked.GetValueOrDefault() ? ActualWidth - (_SwitchTrack.Margin.Left + _SwitchTrack.Margin.Right + _ThumbIndicator.ActualWidth) : 0;
+                double destination = IsChecked.GetValueOrDefault() ? ActualWidth - (_SwitchTrack.Margin.Left + _SwitchTrack.Margin.Right + _ThumbIndicator.ActualWidth + _ThumbIndicator.Margin.Left + _ThumbIndicator.Margin.Right) : 0;
                 _ThumbTranslate.X = destination;
             }
         }

--- a/MahApps.Metro/Controls/ToggleSwitchButton.cs
+++ b/MahApps.Metro/Controls/ToggleSwitchButton.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Input;
 using System.Windows.Shapes;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -166,10 +168,24 @@ namespace MahApps.Metro.Controls
             }
         }
 
+        private void SetIsPressed(bool pressed)
+        {
+            // we can't use readonly IsPressedProperty
+            typeof(ToggleButton).GetMethod("set_IsPressed", BindingFlags.Instance | BindingFlags.NonPublic)
+                                .Invoke(this, new object[] { pressed });
+        }
+
         private double? _lastDragPosition;
         private bool _isDragging;
         void _DraggingThumb_DragStarted(object sender, DragStartedEventArgs e)
         {
+            if (Mouse.LeftButton == MouseButtonState.Pressed)
+            {
+                if (!IsPressed)
+                {
+                    SetIsPressed(true);
+                }
+            }
             if (_ThumbTranslate != null)
             {
                 _ThumbTranslate.BeginAnimation(TranslateTransform.XProperty, null);
@@ -197,6 +213,7 @@ namespace MahApps.Metro.Controls
 
         void _DraggingThumb_DragCompleted(object sender, DragCompletedEventArgs e)
         {
+            SetIsPressed(false);
             _lastDragPosition = null;
             if (!_isDragging)
             {

--- a/MahApps.Metro/Converters/RectangleHeightToRadiusConverter.cs
+++ b/MahApps.Metro/Converters/RectangleHeightToRadiusConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace MahApps.Metro.Converters
+{
+    [ValueConversion(typeof(double), typeof(double))]
+    [MarkupExtensionReturnType(typeof(RectangleHeightToRadiusConverter))]
+    public class RectangleHeightToRadiusConverter : MarkupConverter
+    {
+        private static RectangleHeightToRadiusConverter _instance;
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static RectangleHeightToRadiusConverter()
+        {
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance ?? (_instance = new RectangleHeightToRadiusConverter());
+        }
+
+        protected override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var height = value as double?;
+            return height.GetValueOrDefault(0) / 2d;
+        }
+
+        protected override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return DependencyProperty.UnsetValue;
+        }
+    }
+}

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Controls\VisualStates.cs" />
     <Compile Include="Controls\WindowCommands.cs" />
     <Compile Include="Converters\NullToUnsetValueConverter.cs" />
+    <Compile Include="Converters\RectangleHeightToRadiusConverter.cs" />
     <Compile Include="Converters\ResizeModeMinMaxButtonVisibilityConverter.cs" />
     <Compile Include="Converters\StringToVisibilityConverter.cs" />
     <Compile Include="Converters\ThicknessBindingConverter.cs" />

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -500,6 +500,11 @@
       <Generator>MSBuild:Compile</Generator>
       <DependentUpon>Controls.xaml</DependentUpon>
     </Page>
+    <Page Include="Styles\Controls.ToggleSwitch.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+      <DependentUpon>Controls.xaml</DependentUpon>
+    </Page>
     <Page Include="Styles\Controls.Toolbar.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -451,6 +451,11 @@
       <Generator>MSBuild:Compile</Generator>
       <DependentUpon>Controls.xaml</DependentUpon>
     </Page>
+    <Page Include="Styles\Controls.ToggleSwitch.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+      <DependentUpon>Controls.xaml</DependentUpon>
+    </Page>
     <Page Include="Styles\Controls.Toolbar.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Converters\BackgroundToForegroundConverter.cs" />
     <Compile Include="Converters\ClockDegreeConverter.cs" />
     <Compile Include="Converters\NullToUnsetValueConverter.cs" />
+    <Compile Include="Converters\RectangleHeightToRadiusConverter.cs" />
     <Compile Include="Converters\ThicknessBindingConverter.cs" />
     <Compile Include="Converters\IsNullConverter.cs" />
     <Compile Include="Converters\FontSizeOffsetConverter.cs" />

--- a/MahApps.Metro/Styles/Accents/Amber.xaml
+++ b/MahApps.Metro/Styles/Accents/Amber.xaml
@@ -3,8 +3,11 @@
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     mc:Ignorable="options">
+
     <Color x:Key="HighlightColor">#FFB17807</Color>
-    
+
+    <Color x:Key="AccentBaseColor">#FFF0A30A</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CCF0A30A</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99F0A30A</Color>
@@ -13,7 +16,9 @@
     <!--20%-->
     <Color x:Key="AccentColor4">#33F0A30A</Color>
 
+    <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -41,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/BaseDark.xaml
+++ b/MahApps.Metro/Styles/Accents/BaseDark.xaml
@@ -85,4 +85,15 @@
 
     <!-- DataGrid brushes -->
     <SolidColorBrush x:Key="MetroDataGrid.DisabledHighlightBrush" Color="{StaticResource Gray7}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.PressedBrush.Win10" Color="#FF999999" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffBorderBrush.Win10" Color="#FFCCCCCC" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffMouseOverBorderBrush.Win10" Color="#FFFFFFFF" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffDisabledBorderBrush.Win10" Color="#FF666666" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchDisabledBrush.Win10" Color="#FF444444" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorBrush.Win10" Color="#FFCCCCCC" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorMouseOverBrush.Win10" Color="#FFFFFFFF" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorPressedBrush.Win10" Color="#FFFFFFFF" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorDisabledBrush.Win10" Color="#FF666666" options:Freeze="True" />
+
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/BaseLight.xaml
+++ b/MahApps.Metro/Styles/Accents/BaseLight.xaml
@@ -85,4 +85,15 @@
 
     <!-- DataGrid brushes -->
     <SolidColorBrush x:Key="MetroDataGrid.DisabledHighlightBrush" Color="{StaticResource Gray7}" options:Freeze="True" />
+    
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.PressedBrush.Win10" Color="#FF666666" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffBorderBrush.Win10" Color="#FF333333" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffMouseOverBorderBrush.Win10" Color="#FF000000" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffDisabledBorderBrush.Win10" Color="#FF999999" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchDisabledBrush.Win10" Color="#FFCCCCCC" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorBrush.Win10" Color="#FF333333" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorMouseOverBrush.Win10" Color="#FF000000" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorPressedBrush.Win10" Color="#FFFFFFFF" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorDisabledBrush.Win10" Color="#FF999999" options:Freeze="True" />
+
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Blue.xaml
+++ b/MahApps.Metro/Styles/Accents/Blue.xaml
@@ -3,9 +3,10 @@
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     mc:Ignorable="options">
-    <!--ACCENT COLORS-->
+
     <Color x:Key="HighlightColor">#FF086F9E</Color>
-        
+
+    <Color x:Key="AccentBaseColor">#FF119EDA</Color>
     <!--80%-->
     <Color x:Key="AccentColor">#CC119EDA</Color>
     <!--60%-->
@@ -15,7 +16,9 @@
     <!--20%-->
     <Color x:Key="AccentColor4">#33119EDA</Color>
 
+    <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Brown.xaml
+++ b/MahApps.Metro/Styles/Accents/Brown.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF604220</Color>
     
+    <Color x:Key="AccentBaseColor">#FF825A2C</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC825A2C</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99825A2C</Color>
@@ -14,7 +16,9 @@
     <!--20%-->
     <Color x:Key="AccentColor4">#33825A2C</Color>
 
+    <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -42,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Cobalt.xaml
+++ b/MahApps.Metro/Styles/Accents/Cobalt.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF003BB0</Color>
     
+    <Color x:Key="AccentBaseColor">#FF0050EF</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC0050EF</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#990050EF</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Crimson.xaml
+++ b/MahApps.Metro/Styles/Accents/Crimson.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF77001B</Color>
     
+    <Color x:Key="AccentBaseColor">#FFA20025</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CCA20025</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99A20025</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Cyan.xaml
+++ b/MahApps.Metro/Styles/Accents/Cyan.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF1377A7</Color>
     
+    <Color x:Key="AccentBaseColor">#FF1BA1E2</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC1BA1E2</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#991BA1E2</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Emerald.xaml
+++ b/MahApps.Metro/Styles/Accents/Emerald.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF006600</Color>
     
+    <Color x:Key="AccentBaseColor">#FF008A00</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC008A00</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99008A00</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Green.xaml
+++ b/MahApps.Metro/Styles/Accents/Green.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF477D11</Color>
     
+    <Color x:Key="AccentBaseColor">#FF60A917</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC60A917</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#9960A917</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Indigo.xaml
+++ b/MahApps.Metro/Styles/Accents/Indigo.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF4E00BC</Color>
     
+    <Color x:Key="AccentBaseColor">#FF6A00FF</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC6A00FF</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#996A00FF</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Lime.xaml
+++ b/MahApps.Metro/Styles/Accents/Lime.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF799100</Color>
     
+    <Color x:Key="AccentBaseColor">#FFA4C400</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CCA4C400</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99A4C400</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Magenta.xaml
+++ b/MahApps.Metro/Styles/Accents/Magenta.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF9F0055</Color>
     
+    <Color x:Key="AccentBaseColor">#FFD80073</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CCD80073</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99D80073</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Mauve.xaml
+++ b/MahApps.Metro/Styles/Accents/Mauve.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF574766</Color>
     
+    <Color x:Key="AccentBaseColor">#FF76608A</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC76608A</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#9976608A</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Olive.xaml
+++ b/MahApps.Metro/Styles/Accents/Olive.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF50634A</Color>
     
+    <Color x:Key="AccentBaseColor">#FF6D8764</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC6D8764</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#996D8764</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Orange.xaml
+++ b/MahApps.Metro/Styles/Accents/Orange.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FFB94C00</Color>
     
+    <Color x:Key="AccentBaseColor">#FFFA6800</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CCFA6800</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99FA6800</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Pink.xaml
+++ b/MahApps.Metro/Styles/Accents/Pink.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FFB45499</Color>
     
+    <Color x:Key="AccentBaseColor">#FFF472D0</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CCF472D0</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99F472D0</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Purple.xaml
+++ b/MahApps.Metro/Styles/Accents/Purple.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF5133AB</Color>
 
+    <Color x:Key="AccentBaseColor">#FF6459DF</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC6459DF</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#996459DF</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Red.xaml
+++ b/MahApps.Metro/Styles/Accents/Red.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FFA90E00</Color>
     
+    <Color x:Key="AccentBaseColor">#FFE51400</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CCE51400</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99E51400</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Sienna.xaml
+++ b/MahApps.Metro/Styles/Accents/Sienna.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF763C21</Color>
     
+    <Color x:Key="AccentBaseColor">#FFA0522D</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CCA0522D</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99A0522D</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Steel.xaml
+++ b/MahApps.Metro/Styles/Accents/Steel.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF4A5763</Color>
     
+    <Color x:Key="AccentBaseColor">#FF647687</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC647687</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99647687</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Taupe.xaml
+++ b/MahApps.Metro/Styles/Accents/Taupe.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF635939</Color>
     
+    <Color x:Key="AccentBaseColor">#FF87794E</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC87794E</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#9987794E</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Teal.xaml
+++ b/MahApps.Metro/Styles/Accents/Teal.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF007E7D</Color>
     
+    <Color x:Key="AccentBaseColor">#FF00ABA9</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CC00ABA9</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#9900ABA9</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Violet.xaml
+++ b/MahApps.Metro/Styles/Accents/Violet.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FF7D00BC</Color>
     
+    <Color x:Key="AccentBaseColor">#FFAA00FF</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CCAA00FF</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99AA00FF</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Accents/Yellow.xaml
+++ b/MahApps.Metro/Styles/Accents/Yellow.xaml
@@ -6,6 +6,8 @@
 
     <Color x:Key="HighlightColor">#FFBBA404</Color>
     
+    <Color x:Key="AccentBaseColor">#FFFEDE06</Color>
+    <!--80%-->
     <Color x:Key="AccentColor">#CCFEDE06</Color>
     <!--60%-->
     <Color x:Key="AccentColor2">#99FEDE06</Color>
@@ -16,6 +18,7 @@
 
     <!-- re-set brushes too -->
     <SolidColorBrush x:Key="HighlightBrush" Color="{StaticResource HighlightColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{StaticResource AccentBaseColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{StaticResource AccentColor3}" options:Freeze="True" />
@@ -43,4 +46,8 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Colors.xaml
+++ b/MahApps.Metro/Styles/Colors.xaml
@@ -10,6 +10,7 @@
 
     <!--ACCENT COLORS-->
     <Color x:Key="HighlightColor">#FF086F9E</Color>
+    <Color x:Key="AccentBaseColor">#FF119EDA</Color>
     <!--80%-->
     <Color x:Key="AccentColor">#CC119EDA</Color>
     <!--60%-->
@@ -61,6 +62,7 @@
     <SolidColorBrush x:Key="SemiTransparentGreyBrush" Color="#40808080"/>
     <SolidColorBrush x:Key="ControlsDisabledBrush" Color="#A5FFFFFF" />
 
+    <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{DynamicResource AccentBaseColor}"/>
     <SolidColorBrush x:Key="AccentColorBrush" Color="{DynamicResource AccentColor}"/>
     <SolidColorBrush x:Key="AccentColorBrush2" Color="{DynamicResource AccentColor2}"/>
     <SolidColorBrush x:Key="AccentColorBrush3" Color="{DynamicResource AccentColor3}"/>
@@ -176,4 +178,19 @@
     <SolidColorBrush x:Key="MetroDataGrid.FocusBorderBrush" Color="{StaticResource AccentColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightBrush" Color="{StaticResource AccentColor2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MetroDataGrid.InactiveSelectionHighlightTextBrush" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.PressedBrush.Win10" Color="#FF999999" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffBorderBrush.Win10" Color="#FF333333" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffMouseOverBorderBrush.Win10" Color="#FF000000" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffDisabledBorderBrush.Win10" Color="#FF999999" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OffSwitchBrush.Win10" Color="Transparent" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{StaticResource AccentColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchDisabledBrush.Win10" Color="#FFCCCCCC" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{StaticResource AccentColor2}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorBrush.Win10" Color="#FF333333" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorMouseOverBrush.Win10" Color="#FF000000" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{StaticResource IdealForegroundColor}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorPressedBrush.Win10" Color="#FFFFFFFF" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorDisabledBrush.Win10" Color="#FF999999" options:Freeze="True" />
+    
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
+++ b/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
@@ -3,14 +3,20 @@
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
                     xmlns:converters="clr-namespace:MahApps.Metro.Converters">
 
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/ToggleSwitch.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
     <!--  Metro style  -->
 
+    <!--  obsolete  -->
     <Style x:Key="MetroToggleSwitchButton"
-           BasedOn="{StaticResource {x:Type Controls:ToggleSwitchButton}}"
+           BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitchButton}"
            TargetType="{x:Type Controls:ToggleSwitchButton}" />
 
+    <!--  obsolete  -->
     <Style x:Key="MetroToggleSwitch"
-           BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}"
+           BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitch}"
            TargetType="{x:Type Controls:ToggleSwitch}" />
 
     <!--  Win10 style  -->
@@ -18,7 +24,7 @@
     <converters:ThicknessToDoubleConverter x:Key="ThicknessToDouble" />
 
     <Style x:Key="MahApps.Metro.Styles.ToggleSwitchButton.Win10"
-           BasedOn="{StaticResource MetroToggleSwitchButton}"
+           BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitchButton}"
            TargetType="{x:Type Controls:ToggleSwitchButton}">
         <Setter Property="Width" Value="44" />
         <Setter Property="Height" Value="20" />
@@ -141,7 +147,7 @@
     </Style>
 
     <Style x:Key="MahApps.Metro.Styles.ToggleSwitch.Win10"
-           BasedOn="{StaticResource MetroToggleSwitch}"
+           BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitch}"
            TargetType="{x:Type Controls:ToggleSwitch}">
         <Setter Property="OffSwitchBrush" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.OffSwitchBrush.Win10}" />
         <Setter Property="OnSwitchBrush" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10}" />

--- a/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
+++ b/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
@@ -1,0 +1,162 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
+
+    <Style x:Key="MetroToggleSwitchButton"
+           BasedOn="{StaticResource {x:Type Controls:ToggleSwitchButton}}"
+           TargetType="{x:Type Controls:ToggleSwitchButton}" />
+
+    <Style x:Key="MetroToggleSwitch"
+           BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}"
+           TargetType="{x:Type Controls:ToggleSwitch}" />
+
+    <Style x:Key="MahApps.Metro.Styles.ToggleSwitchButton.Win10"
+           BasedOn="{StaticResource {x:Type Controls:ToggleSwitchButton}}"
+           TargetType="{x:Type Controls:ToggleSwitchButton}">
+        <Setter Property="BorderBrush" Value="{DynamicResource GrayBrush4}" />
+        <Setter Property="BorderThickness" Value="2" />
+        <Setter Property="Height" Value="20" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="OffSwitchBrush" Value="{DynamicResource GrayBrush4}" />
+        <Setter Property="OnSwitchBrush" Value="{DynamicResource AccentColorBrush}" />
+        <Setter Property="Padding" Value="2" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Controls:ToggleSwitchButton}">
+                    <Grid>
+                        <Grid x:Name="PART_SwitchTrack"
+                              SnapsToDevicePixels="True"
+                              UseLayoutRounding="False">
+                            <Border Background="Gray"
+                                    BorderThickness="0"
+                                    CornerRadius="10"
+                                    SnapsToDevicePixels="False">
+                                <Grid>
+                                    <Border x:Name="PART_SwitchBrushBorder"
+                                            Margin="2"
+                                            Background="White"
+                                            BorderThickness="0"
+                                            CornerRadius="8"
+                                            SnapsToDevicePixels="False" />
+                                    <Ellipse x:Name="PART_ThumbIndicator"
+                                             Width="10"
+                                             Height="10"
+                                             Margin="5 0"
+                                             HorizontalAlignment="Left"
+                                             Fill="Black"
+                                             Stroke="Transparent"
+                                             StrokeThickness="0">
+                                        <Ellipse.RenderTransform>
+                                            <TranslateTransform x:Name="PART_ThumbTranslate" />
+                                        </Ellipse.RenderTransform>
+                                    </Ellipse>
+                                </Grid>
+                            </Border>
+                            <!--  <Border Background="Transparent"  -->
+                            <!--  BorderThickness="0"  -->
+                            <!--  CornerRadius="10"  -->
+                            <!--  ClipToBounds="True"  -->
+                            <!--  SnapsToDevicePixels="False">  -->
+                            <!--  <Ellipse x:Name="PART_ThumbIndicator"  -->
+                            <!--  Width="10"  -->
+                            <!--  Height="10"  -->
+                            <!--  Margin="0"  -->
+                            <!--  HorizontalAlignment="Left"  -->
+                            <!--  Fill="Black"  -->
+                            <!--  Stroke="Transparent"  -->
+                            <!--  StrokeThickness="0">  -->
+                            <!--                                    <Ellipse.RenderTransform>-->
+                            <!--                                        <TranslateTransform x:Name="PART_ThumbTranslate" />-->
+                            <!--                                    </Ellipse.RenderTransform>-->
+                            <!--                                </Ellipse>-->
+                            <!--                            </Border>-->
+                            <Border x:Name="PART_BackgroundOverlay"
+                                    Background="{DynamicResource WhiteBrush}"
+                                    BorderThickness="0"
+                                    Opacity="0"
+                                    CornerRadius="10"
+                                    SnapsToDevicePixels="False" />
+
+                            <!--  <Border Background="{TemplateBinding Background}"  -->
+                            <!--  BorderBrush="{TemplateBinding BorderBrush}"  -->
+                            <!--  BorderThickness="{TemplateBinding BorderThickness}">  -->
+                            <!--                                <Grid Margin="{TemplateBinding Padding}" ClipToBounds="True">-->
+                            <!--                                    <Rectangle Fill="{TemplateBinding OnSwitchBrush}" />-->
+                            <!--                                    <Rectangle Fill="{TemplateBinding OffSwitchBrush}" RenderTransformOrigin="0.5,0.5">-->
+                            <!--                                        <Rectangle.RenderTransform>-->
+                            <!--                                            <TranslateTransform x:Name="PART_BackgroundTranslate" />-->
+                            <!--                                        </Rectangle.RenderTransform>-->
+                            <!--                                    </Rectangle>-->
+                            <!--  <Rectangle x:Name="PART_BackgroundOverlay"  -->
+                            <!--  Fill="{DynamicResource WhiteBrush}"  -->
+                            <!--  Opacity="0" />  -->
+                            <!--                                </Grid>-->
+                            <!--                            </Border>-->
+                            <!--  <Rectangle x:Name="PART_ThumbIndicator"  -->
+                            <!--  Width="{TemplateBinding ThumbIndicatorWidth}"  -->
+                            <!--  HorizontalAlignment="Left"  -->
+                            <!--  Fill="{TemplateBinding ThumbIndicatorBrush}">  -->
+                            <!--                                <Rectangle.RenderTransform>-->
+                            <!--                                    <TranslateTransform x:Name="PART_ThumbTranslate" />-->
+                            <!--                                </Rectangle.RenderTransform>-->
+                            <!--                            </Rectangle>-->
+                        </Grid>
+                        <Thumb x:Name="PART_DraggingThumb">
+                            <Thumb.Template>
+                                <ControlTemplate>
+                                    <Rectangle Fill="Transparent" />
+                                </ControlTemplate>
+                            </Thumb.Template>
+                        </Thumb>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="Disabled">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_BackgroundOverlay" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.5" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="MouseOver">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_BackgroundOverlay" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.2" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Pressed">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_BackgroundOverlay" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.4" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="PART_SwitchBrushBorder" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=OnSwitchBrush, Mode=OneWay}" />
+                            <Setter TargetName="PART_ThumbIndicator" Property="Fill" Value="White" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter TargetName="PART_ThumbIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ThumbIndicatorDisabledBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource BlackBrush}" />
+        <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource GrayBrush4}" />
+        <Setter Property="ThumbIndicatorWidth" Value="13" />
+        <Setter Property="Width" Value="50" />
+    </Style>
+
+    <Style x:Key="MahApps.Metro.Styles.ToggleSwitch.Win10"
+           BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}"
+           TargetType="{x:Type Controls:ToggleSwitch}">
+        <Setter Property="ToggleSwitchButtonStyle" Value="{StaticResource MahApps.Metro.Styles.ToggleSwitchButton.Win10}" />
+    </Style>
+
+</ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
+++ b/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
@@ -45,25 +45,25 @@
                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                               UseLayoutRounding="False">
                             <Rectangle x:Name="PART_SwitchBrushOuterBorder"
-                                       Height="20"
-                                       RadiusX="10"
-                                       RadiusY="10"
+                                       Height="{TemplateBinding Height}"
+                                       RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={converters:RectangleHeightToRadiusConverter}, Mode=OneWay}"
+                                       RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={converters:RectangleHeightToRadiusConverter}, Mode=OneWay}"
                                        Fill="{TemplateBinding OffSwitchBrush}"
                                        Stroke="{TemplateBinding BorderBrush}"
                                        StrokeThickness="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessToDouble}}"
-                                       Width="44" />
+                                       Width="{TemplateBinding Width}" />
                             <Rectangle x:Name="PART_SwitchBrushBorder"
                                        Fill="{TemplateBinding OnSwitchBrush}"
                                        Opacity="0"
-                                       Height="20"
-                                       RadiusX="10"
-                                       RadiusY="10"
+                                       Height="{TemplateBinding Height}"
+                                       RadiusX="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={converters:RectangleHeightToRadiusConverter}, Mode=OneWay}"
+                                       RadiusY="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Height, Converter={converters:RectangleHeightToRadiusConverter}, Mode=OneWay}"
                                        StrokeThickness="0"
-                                       Width="44" />
+                                       Width="{TemplateBinding Width}" />
                             <Grid x:Name="PART_ThumbIndicator"
                                   HorizontalAlignment="Left"
-                                  Height="20"
-                                  Width="20">
+                                  Height="{TemplateBinding Height}"
+                                  Width="{TemplateBinding Height}">
                                 <Grid.RenderTransform>
                                     <TranslateTransform x:Name="PART_ThumbTranslate" />
                                 </Grid.RenderTransform>

--- a/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
+++ b/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
@@ -1,6 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
+    
+    <!--  Metro style  -->
 
     <Style x:Key="MetroToggleSwitchButton"
            BasedOn="{StaticResource {x:Type Controls:ToggleSwitchButton}}"
@@ -10,16 +12,22 @@
            BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}"
            TargetType="{x:Type Controls:ToggleSwitch}" />
 
+    <!--  Win10 style  -->
+
     <Style x:Key="MahApps.Metro.Styles.ToggleSwitchButton.Win10"
-           BasedOn="{StaticResource {x:Type Controls:ToggleSwitchButton}}"
+           BasedOn="{StaticResource MetroToggleSwitchButton}"
            TargetType="{x:Type Controls:ToggleSwitchButton}">
+        <Setter Property="Width" Value="50" />
+        <Setter Property="Height" Value="20" />
         <Setter Property="BorderBrush" Value="{DynamicResource GrayBrush4}" />
         <Setter Property="BorderThickness" Value="2" />
-        <Setter Property="Height" Value="20" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="OffSwitchBrush" Value="{DynamicResource GrayBrush4}" />
         <Setter Property="OnSwitchBrush" Value="{DynamicResource AccentColorBrush}" />
         <Setter Property="Padding" Value="2" />
+        <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource BlackBrush}" />
+        <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource GrayBrush4}" />
+        <Setter Property="ThumbIndicatorWidth" Value="10" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Controls:ToggleSwitchButton}">
@@ -126,11 +134,11 @@
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
-                                    <Storyboard>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_BackgroundOverlay" Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.4" />
-                                        </DoubleAnimationUsingKeyFrames>
-                                    </Storyboard>
+<!--                                    <Storyboard>-->
+<!--                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_BackgroundOverlay" Storyboard.TargetProperty="(UIElement.Opacity)">-->
+<!--                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.4" />-->
+<!--                                        </DoubleAnimationUsingKeyFrames>-->
+<!--                                    </Storyboard>-->
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
@@ -147,14 +155,10 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource BlackBrush}" />
-        <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource GrayBrush4}" />
-        <Setter Property="ThumbIndicatorWidth" Value="13" />
-        <Setter Property="Width" Value="50" />
     </Style>
 
     <Style x:Key="MahApps.Metro.Styles.ToggleSwitch.Win10"
-           BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}"
+           BasedOn="{StaticResource MetroToggleSwitch}"
            TargetType="{x:Type Controls:ToggleSwitch}">
         <Setter Property="ToggleSwitchButtonStyle" Value="{StaticResource MahApps.Metro.Styles.ToggleSwitchButton.Win10}" />
     </Style>

--- a/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
+++ b/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
-    
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:converters="clr-namespace:MahApps.Metro.Converters">
+
     <!--  Metro style  -->
 
     <Style x:Key="MetroToggleSwitchButton"
@@ -13,82 +14,58 @@
            TargetType="{x:Type Controls:ToggleSwitch}" />
 
     <!--  Win10 style  -->
+    
+    <converters:ThicknessToDoubleConverter x:Key="ThicknessToDouble" />
 
     <Style x:Key="MahApps.Metro.Styles.ToggleSwitchButton.Win10"
            BasedOn="{StaticResource MetroToggleSwitchButton}"
            TargetType="{x:Type Controls:ToggleSwitchButton}">
-        <Setter Property="Width" Value="50" />
+        <Setter Property="Width" Value="44" />
         <Setter Property="Height" Value="20" />
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="Padding" Value="2" />
-        <Setter Property="BorderBrush" Value="{DynamicResource BlackBrush}" />
-        <Setter Property="OffSwitchBrush" Value="{DynamicResource WhiteBrush}" />
-        <Setter Property="OnSwitchBrush" Value="{DynamicResource AccentColorBrush}" />
-        <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource BlackBrush}" />
-        <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource GrayBrush4}" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.OffBorderBrush.Win10}" />
+        <Setter Property="OffSwitchBrush" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.OffSwitchBrush.Win10}" />
+        <Setter Property="OnSwitchBrush" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10}" />
+        <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorBrush.Win10}" />
+        <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorDisabledBrush.Win10}" />
         <Setter Property="ThumbIndicatorWidth" Value="10" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Controls:ToggleSwitchButton}">
                     <Grid>
                         <Grid x:Name="PART_SwitchTrack"
-                              SnapsToDevicePixels="True"
+                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                               UseLayoutRounding="False">
-                            <Border Background="{TemplateBinding BorderBrush}"
-                                    BorderThickness="0"
-                                    CornerRadius="10"
-                                    SnapsToDevicePixels="False">
-                                <Grid>
-                                    <Border x:Name="PART_SwitchBrushBorder"
-                                            Margin="{TemplateBinding BorderThickness}"
-                                            Background="{TemplateBinding OffSwitchBrush}"
-                                            BorderThickness="0"
-                                            CornerRadius="8"
-                                            SnapsToDevicePixels="False" />
-                                    <Ellipse x:Name="PART_ThumbIndicator"
-                                             Width="{TemplateBinding ThumbIndicatorWidth}"
-                                             Height="{TemplateBinding ThumbIndicatorWidth}"
-                                             Margin="5 0"
-                                             HorizontalAlignment="Left"
-                                             Fill="{TemplateBinding ThumbIndicatorBrush}"
-                                             Stroke="Transparent"
-                                             StrokeThickness="0">
-                                        <Ellipse.RenderTransform>
-                                            <TranslateTransform x:Name="PART_ThumbTranslate" />
-                                        </Ellipse.RenderTransform>
-                                    </Ellipse>
-                                </Grid>
-                            </Border>
-                            <Border x:Name="PART_BackgroundOverlay"
-                                    Background="{DynamicResource WhiteBrush}"
-                                    BorderThickness="0"
-                                    Opacity="0"
-                                    CornerRadius="10"
-                                    SnapsToDevicePixels="False" />
-                            <!--  <Border Background="{TemplateBinding Background}"  -->
-                            <!--  BorderBrush="{TemplateBinding BorderBrush}"  -->
-                            <!--  BorderThickness="{TemplateBinding BorderThickness}">  -->
-                            <!--                                <Grid Margin="{TemplateBinding Padding}" ClipToBounds="True">-->
-                            <!--                                    <Rectangle Fill="{TemplateBinding OnSwitchBrush}" />-->
-                            <!--                                    <Rectangle Fill="{TemplateBinding OffSwitchBrush}" RenderTransformOrigin="0.5,0.5">-->
-                            <!--                                        <Rectangle.RenderTransform>-->
-                            <!--                                            <TranslateTransform x:Name="PART_BackgroundTranslate" />-->
-                            <!--                                        </Rectangle.RenderTransform>-->
-                            <!--                                    </Rectangle>-->
-                            <!--  <Rectangle x:Name="PART_BackgroundOverlay"  -->
-                            <!--  Fill="{DynamicResource WhiteBrush}"  -->
-                            <!--  Opacity="0" />  -->
-                            <!--                                </Grid>-->
-                            <!--                            </Border>-->
-                            <!--  <Rectangle x:Name="PART_ThumbIndicator"  -->
-                            <!--  Width="{TemplateBinding ThumbIndicatorWidth}"  -->
-                            <!--  HorizontalAlignment="Left"  -->
-                            <!--  Fill="{TemplateBinding ThumbIndicatorBrush}">  -->
-                            <!--                                <Rectangle.RenderTransform>-->
-                            <!--                                    <TranslateTransform x:Name="PART_ThumbTranslate" />-->
-                            <!--                                </Rectangle.RenderTransform>-->
-                            <!--                            </Rectangle>-->
+                            <Rectangle x:Name="PART_SwitchBrushOuterBorder"
+                                       Height="20"
+                                       RadiusX="10"
+                                       RadiusY="10"
+                                       Fill="{TemplateBinding OffSwitchBrush}"
+                                       Stroke="{TemplateBinding BorderBrush}"
+                                       StrokeThickness="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessToDouble}}"
+                                       Width="44" />
+                            <Rectangle x:Name="PART_SwitchBrushBorder"
+                                       Fill="{TemplateBinding OnSwitchBrush}"
+                                       Opacity="0"
+                                       Height="20"
+                                       RadiusX="10"
+                                       RadiusY="10"
+                                       StrokeThickness="0"
+                                       Width="44" />
+                            <Grid x:Name="PART_ThumbIndicator"
+                                  HorizontalAlignment="Left"
+                                  Height="20"
+                                  Width="20">
+                                <Grid.RenderTransform>
+                                    <TranslateTransform x:Name="PART_ThumbTranslate" />
+                                </Grid.RenderTransform>
+                                <Ellipse x:Name="PART_ThumbIndicatorInner"
+                                         Fill="{TemplateBinding ThumbIndicatorBrush}"
+                                         Height="{TemplateBinding ThumbIndicatorWidth}"
+                                         Width="{TemplateBinding ThumbIndicatorWidth}" />
+                            </Grid>
                         </Grid>
                         <Thumb x:Name="PART_DraggingThumb">
                             <Thumb.Template>
@@ -100,39 +77,63 @@
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />
-                                <VisualState x:Name="Disabled">
-                                    <Storyboard>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_BackgroundOverlay" Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.5" />
-                                        </DoubleAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="MouseOver">
-                                    <Storyboard>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_BackgroundOverlay" Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.2" />
-                                        </DoubleAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="Pressed">
-                                    <Storyboard>
-                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_BackgroundOverlay" Storyboard.TargetProperty="(UIElement.Opacity)">
-                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.4" />
-                                        </DoubleAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
+                                <VisualState x:Name="Disabled" />
+                                <VisualState x:Name="MouseOver" />
+                                <VisualState x:Name="Pressed" />
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="ToggleButton.IsChecked" Value="True">
-                            <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=OnSwitchBrush, Mode=OneWay}" />
-                            <Setter TargetName="PART_SwitchBrushBorder" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="PART_ThumbIndicator" Property="Fill" Value="{DynamicResource WhiteBrush}" />
+                        <!--  Checked  -->
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="PART_SwitchBrushOuterBorder" Property="Opacity" Value="0" />
+                            <Setter TargetName="PART_SwitchBrushBorder" Property="Opacity" Value="1" />
+                            <Setter TargetName="PART_ThumbIndicatorInner" Property="Fill" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10}" />
                         </Trigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="PART_ThumbIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ThumbIndicatorDisabledBrush}" />
+                        <!--  MouseOver  -->
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="IsChecked" Value="False" />
+                                <Condition Property="IsEnabled" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_SwitchBrushOuterBorder" Property="Stroke" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.OffMouseOverBorderBrush.Win10}" />
+                            <Setter TargetName="PART_ThumbIndicatorInner" Property="Fill" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorMouseOverBrush.Win10}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="IsChecked" Value="True" />
+                                <Condition Property="IsEnabled" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_SwitchBrushBorder" Property="Fill" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10}" />
+                        </MultiTrigger>
+                        <!--  Pressed  -->
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="PART_SwitchBrushOuterBorder" Property="Opacity" Value="0" />
+                            <Setter TargetName="PART_SwitchBrushBorder" Property="Opacity" Value="1" />
+                            <Setter TargetName="PART_SwitchBrushBorder" Property="Fill" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.PressedBrush.Win10}" />
+                            <Setter TargetName="PART_ThumbIndicatorInner" Property="Fill" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorPressedBrush.Win10}" />
                         </Trigger>
+                        <!--  Disabled  -->
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEnabled" Value="False" />
+                                <Condition Property="IsChecked" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_SwitchBrushOuterBorder" Property="Opacity" Value="0" />
+                            <Setter TargetName="PART_SwitchBrushBorder" Property="Opacity" Value="1" />
+                            <Setter TargetName="PART_SwitchBrushBorder" Property="Fill" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchDisabledBrush.Win10}" />
+                            <Setter TargetName="PART_ThumbIndicatorInner" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ThumbIndicatorDisabledBrush}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEnabled" Value="False" />
+                                <Condition Property="IsChecked" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_SwitchBrushOuterBorder" Property="Stroke" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.OffDisabledBorderBrush.Win10}" />
+                            <Setter TargetName="PART_ThumbIndicatorInner" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ThumbIndicatorDisabledBrush}" />
+                        </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -142,12 +143,12 @@
     <Style x:Key="MahApps.Metro.Styles.ToggleSwitch.Win10"
            BasedOn="{StaticResource MetroToggleSwitch}"
            TargetType="{x:Type Controls:ToggleSwitch}">
-        <Setter Property="OffSwitchBrush" Value="{DynamicResource WhiteBrush}" />
-        <Setter Property="OnSwitchBrush" Value="{DynamicResource AccentColorBrush}" />
-        <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource BlackBrush}" />
-        <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource GrayBrush4}" />
+        <Setter Property="OffSwitchBrush" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.OffSwitchBrush.Win10}" />
+        <Setter Property="OnSwitchBrush" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10}" />
+        <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorBrush.Win10}" />
+        <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorDisabledBrush.Win10}" />
         <Setter Property="ThumbIndicatorWidth" Value="10" />
         <Setter Property="ToggleSwitchButtonStyle" Value="{StaticResource MahApps.Metro.Styles.ToggleSwitchButton.Win10}" />
     </Style>
-    
+
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
+++ b/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
@@ -19,12 +19,12 @@
            TargetType="{x:Type Controls:ToggleSwitchButton}">
         <Setter Property="Width" Value="50" />
         <Setter Property="Height" Value="20" />
-        <Setter Property="BorderBrush" Value="{DynamicResource GrayBrush4}" />
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="OffSwitchBrush" Value="{DynamicResource GrayBrush4}" />
-        <Setter Property="OnSwitchBrush" Value="{DynamicResource AccentColorBrush}" />
         <Setter Property="Padding" Value="2" />
+        <Setter Property="BorderBrush" Value="{DynamicResource BlackBrush}" />
+        <Setter Property="OffSwitchBrush" Value="{DynamicResource WhiteBrush}" />
+        <Setter Property="OnSwitchBrush" Value="{DynamicResource AccentColorBrush}" />
         <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource BlackBrush}" />
         <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource GrayBrush4}" />
         <Setter Property="ThumbIndicatorWidth" Value="10" />
@@ -35,23 +35,23 @@
                         <Grid x:Name="PART_SwitchTrack"
                               SnapsToDevicePixels="True"
                               UseLayoutRounding="False">
-                            <Border Background="Gray"
+                            <Border Background="{TemplateBinding BorderBrush}"
                                     BorderThickness="0"
                                     CornerRadius="10"
                                     SnapsToDevicePixels="False">
                                 <Grid>
                                     <Border x:Name="PART_SwitchBrushBorder"
-                                            Margin="2"
-                                            Background="White"
+                                            Margin="{TemplateBinding BorderThickness}"
+                                            Background="{TemplateBinding OffSwitchBrush}"
                                             BorderThickness="0"
                                             CornerRadius="8"
                                             SnapsToDevicePixels="False" />
                                     <Ellipse x:Name="PART_ThumbIndicator"
-                                             Width="10"
-                                             Height="10"
+                                             Width="{TemplateBinding ThumbIndicatorWidth}"
+                                             Height="{TemplateBinding ThumbIndicatorWidth}"
                                              Margin="5 0"
                                              HorizontalAlignment="Left"
-                                             Fill="Black"
+                                             Fill="{TemplateBinding ThumbIndicatorBrush}"
                                              Stroke="Transparent"
                                              StrokeThickness="0">
                                         <Ellipse.RenderTransform>
@@ -60,31 +60,12 @@
                                     </Ellipse>
                                 </Grid>
                             </Border>
-                            <!--  <Border Background="Transparent"  -->
-                            <!--  BorderThickness="0"  -->
-                            <!--  CornerRadius="10"  -->
-                            <!--  ClipToBounds="True"  -->
-                            <!--  SnapsToDevicePixels="False">  -->
-                            <!--  <Ellipse x:Name="PART_ThumbIndicator"  -->
-                            <!--  Width="10"  -->
-                            <!--  Height="10"  -->
-                            <!--  Margin="0"  -->
-                            <!--  HorizontalAlignment="Left"  -->
-                            <!--  Fill="Black"  -->
-                            <!--  Stroke="Transparent"  -->
-                            <!--  StrokeThickness="0">  -->
-                            <!--                                    <Ellipse.RenderTransform>-->
-                            <!--                                        <TranslateTransform x:Name="PART_ThumbTranslate" />-->
-                            <!--                                    </Ellipse.RenderTransform>-->
-                            <!--                                </Ellipse>-->
-                            <!--                            </Border>-->
                             <Border x:Name="PART_BackgroundOverlay"
                                     Background="{DynamicResource WhiteBrush}"
                                     BorderThickness="0"
                                     Opacity="0"
                                     CornerRadius="10"
                                     SnapsToDevicePixels="False" />
-
                             <!--  <Border Background="{TemplateBinding Background}"  -->
                             <!--  BorderBrush="{TemplateBinding BorderBrush}"  -->
                             <!--  BorderThickness="{TemplateBinding BorderThickness}">  -->
@@ -134,19 +115,20 @@
                                     </Storyboard>
                                 </VisualState>
                                 <VisualState x:Name="Pressed">
-<!--                                    <Storyboard>-->
-<!--                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_BackgroundOverlay" Storyboard.TargetProperty="(UIElement.Opacity)">-->
-<!--                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.4" />-->
-<!--                                        </DoubleAnimationUsingKeyFrames>-->
-<!--                                    </Storyboard>-->
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="PART_BackgroundOverlay" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <DiscreteDoubleKeyFrame KeyTime="0" Value="0.4" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsChecked" Value="True">
-                            <Setter TargetName="PART_SwitchBrushBorder" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=OnSwitchBrush, Mode=OneWay}" />
-                            <Setter TargetName="PART_ThumbIndicator" Property="Fill" Value="White" />
+                        <Trigger Property="ToggleButton.IsChecked" Value="True">
+                            <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=OnSwitchBrush, Mode=OneWay}" />
+                            <Setter TargetName="PART_SwitchBrushBorder" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_ThumbIndicator" Property="Fill" Value="{DynamicResource WhiteBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="PART_ThumbIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ThumbIndicatorDisabledBrush}" />
@@ -160,7 +142,12 @@
     <Style x:Key="MahApps.Metro.Styles.ToggleSwitch.Win10"
            BasedOn="{StaticResource MetroToggleSwitch}"
            TargetType="{x:Type Controls:ToggleSwitch}">
+        <Setter Property="OffSwitchBrush" Value="{DynamicResource WhiteBrush}" />
+        <Setter Property="OnSwitchBrush" Value="{DynamicResource AccentColorBrush}" />
+        <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource BlackBrush}" />
+        <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource GrayBrush4}" />
+        <Setter Property="ThumbIndicatorWidth" Value="10" />
         <Setter Property="ToggleSwitchButtonStyle" Value="{StaticResource MahApps.Metro.Styles.ToggleSwitchButton.Win10}" />
     </Style>
-
+    
 </ResourceDictionary>

--- a/MahApps.Metro/Styles/Controls.xaml
+++ b/MahApps.Metro/Styles/Controls.xaml
@@ -32,6 +32,8 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.ToolBar.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TreeView.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.StatusBar.xaml" />
+
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.ToggleSwitch.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="FloatingMessageContainerStyle" TargetType="{x:Type ContentControl}">
@@ -42,13 +44,6 @@
         <Setter Property="MaxHeight" Value="0" />
         <Setter Property="Visibility" Value="Visible" />
     </Style>
-
-    <Style x:Key="MetroToggleSwitchButton"
-           BasedOn="{StaticResource {x:Type Controls:ToggleSwitchButton}}"
-           TargetType="{x:Type Controls:ToggleSwitchButton}" />
-    <Style x:Key="MetroToggleSwitch"
-           BasedOn="{StaticResource {x:Type Controls:ToggleSwitch}}"
-           TargetType="{x:Type Controls:ToggleSwitch}" />
 
     <!--  note: default style for textblock is now in MetroWindow !!!  -->
 

--- a/MahApps.Metro/Themes/Generic.xaml
+++ b/MahApps.Metro/Themes/Generic.xaml
@@ -35,6 +35,10 @@
 
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/Dialogs/BaseMetroDialog.xaml" />
     </ResourceDictionary.MergedDictionaries>
+    
+    <!--  set up default styles for our custom controls  -->
+    <Style TargetType="{x:Type controls:ToggleSwitchButton}" BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitchButton}" />
+    <Style TargetType="{x:Type controls:ToggleSwitch}" BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitch}" />
 
     <Style TargetType="{x:Type controls:ContentControlEx}">
         <Setter Property="Background" Value="Transparent" />

--- a/MahApps.Metro/Themes/ToggleSwitch.xaml
+++ b/MahApps.Metro/Themes/ToggleSwitch.xaml
@@ -11,6 +11,7 @@
         <Setter Property="OffSwitchBrush" Value="{DynamicResource GrayBrush4}" />
         <Setter Property="OnSwitchBrush" Value="{DynamicResource AccentColorBrush}" />
         <Setter Property="Padding" Value="2" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource BlackBrush}" />
         <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource GrayBrush4}" />
         <Setter Property="ThumbIndicatorWidth" Value="13" />

--- a/MahApps.Metro/Themes/ToggleSwitch.xaml
+++ b/MahApps.Metro/Themes/ToggleSwitch.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
-    <Style TargetType="{x:Type Controls:ToggleSwitchButton}">
+    <Style x:Key="MahApps.Metro.Styles.ToggleSwitchButton" TargetType="{x:Type Controls:ToggleSwitchButton}">
         <Setter Property="Width" Value="70" />
         <Setter Property="Height" Value="35" />
         <Setter Property="BorderBrush" Value="{DynamicResource GrayBrush4}" />
@@ -88,7 +88,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="{x:Type Controls:ToggleSwitch}">
+    <Style x:Key="MahApps.Metro.Styles.ToggleSwitch" TargetType="{x:Type Controls:ToggleSwitch}">
         <Setter Property="FontFamily" Value="{DynamicResource ToggleSwitchFontFamily}" />
         <Setter Property="FontSize" Value="{DynamicResource ToggleSwitchFontSize}" />
         <Setter Property="Foreground" Value="{DynamicResource BlackBrush}" />
@@ -101,7 +101,7 @@
         <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource BlackBrush}" />
         <Setter Property="ThumbIndicatorDisabledBrush" Value="{DynamicResource GrayBrush4}" />
         <Setter Property="ThumbIndicatorWidth" Value="13" />
-        <Setter Property="ToggleSwitchButtonStyle" Value="{StaticResource {x:Type Controls:ToggleSwitchButton}}" />
+        <Setter Property="ToggleSwitchButtonStyle" Value="{DynamicResource MahApps.Metro.Styles.ToggleSwitchButton}" />
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
         <Setter Property="HeaderTemplate">
             <Setter.Value>

--- a/docs/release-notes/1.3.0.md
+++ b/docs/release-notes/1.3.0.md
@@ -42,6 +42,25 @@ MahApps.Metro v1.3.0 bug fix and feature release.
 - Dialog font sizes setting implementation #2380 #2383 (@petvetbr, @punker76)
 	+ changable via `DialogTitleFontSize` and `DialogMessageFontSize`
 - New attached dependency property `TextButton` in TextBoxHelper which handles the visibility of the button in `MetroButtonPasswordBox` and `MetroButtonTextBox`styles #2387
+- Win10 ToggleSwitch #2410
+  + new Win10 toggle switch styles: `MahApps.Metro.Styles.ToggleSwitchButton.Win10` and `MahApps.Metro.Styles.ToggleSwitch.Win10`
+  + new Metro toggle switch styles `MahApps.Metro.Styles.ToggleSwitchButton` and `MahApps.Metro.Styles.ToggleSwitch`
+  + fixed broken `IsPressed` state
+  + new brushes for the Win10 style  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.PressedBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.OffBorderBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.OffMouseOverBorderBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.OffDisabledBorderBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.OffSwitchBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchDisabledBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorMouseOverBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorPressedBrush.Win10`  
+  `MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorDisabledBrush.Win10`
+  + new keys for all accent colors: `AccentBaseColor` and `AccentBaseColorBrush` (full color)
 
 # Closed Issues
 

--- a/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
+++ b/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
@@ -158,14 +158,14 @@
                     HorizontalAlignment="Center">
             <StackPanel.Resources>
                 <Style x:Key="CustomMetroToggleSwitch"
-                       BasedOn="{StaticResource MetroToggleSwitch}"
+                       BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitch}"
                        TargetType="{x:Type Controls:ToggleSwitch}">
                     <Setter Property="OffLabel" Value="False" />
                     <Setter Property="OnLabel" Value="True" />
                     <Setter Property="SwitchForeground" Value="Red" />
                 </Style>
                 <Style x:Key="CustomMetroToggleSwitchButton"
-                       BasedOn="{StaticResource MetroToggleSwitchButton}"
+                       BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitchButton}"
                        TargetType="{x:Type Controls:ToggleSwitchButton}">
                     <Setter Property="SwitchForeground" Value="YellowGreen" />
                 </Style>

--- a/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
+++ b/samples/MetroDemo/ExampleViews/ButtonsExample.xaml
@@ -192,16 +192,30 @@
             </StackPanel.Resources>
             <Label Content="Enable / Visible" Style="{DynamicResource DescriptionHeaderStyle}" />
             <Controls:ToggleSwitch x:Name="enabledSwitch"
+                                   Style="{StaticResource MahApps.Metro.Styles.ToggleSwitch.Win10}"
                                    Margin="{StaticResource ControlMargin}"
                                    IsChecked="True"
                                    OffLabel="Disabled"
                                    OnLabel="Enabled" />
             <Controls:ToggleSwitch x:Name="visibleSwitch"
+                                   Style="{StaticResource MahApps.Metro.Styles.ToggleSwitch.Win10}"
                                    Margin="{StaticResource ControlMargin}"
                                    IsChecked="False"
                                    OffLabel="Collapsed"
                                    OnLabel="Visible" />
-            <Controls:ToggleSwitch IsEnabled="{Binding ElementName=enabledSwitch, Path=IsChecked}" Visibility="{Binding ElementName=visibleSwitch, Path=IsChecked, Converter={StaticResource btv}}" />
+            <Controls:ToggleSwitch Style="{StaticResource MahApps.Metro.Styles.ToggleSwitch.Win10}"
+                                   IsEnabled="{Binding ElementName=enabledSwitch, Path=IsChecked}"
+                                   Margin="{StaticResource ControlMargin}"
+                                   Visibility="{Binding ElementName=visibleSwitch, Path=IsChecked, Converter={StaticResource btv}}" />
+
+            <Controls:ToggleSwitch Style="{StaticResource MahApps.Metro.Styles.ToggleSwitch.Win10}"
+                                   Margin="{StaticResource ControlMargin}"
+                                   IsChecked="True"
+                                   IsEnabled="False" />
+            <Controls:ToggleSwitch Style="{StaticResource MahApps.Metro.Styles.ToggleSwitch.Win10}"
+                                   Margin="{StaticResource ControlMargin}"
+                                   IsChecked="False"
+                                   IsEnabled="False" />
         </StackPanel>
 
         <StackPanel Grid.Row="1"


### PR DESCRIPTION
## What changed?

- new win10 toggle switch styles: `MahApps.Metro.Styles.ToggleSwitchButton.Win10` and `MahApps.Metro.Styles.ToggleSwitch.Win10`
- new metro toggle switch styles `MahApps.Metro.Styles.ToggleSwitchButton` and `MahApps.Metro.Styles.ToggleSwitch`
- fixed broken `IsPressed` state
- new brushes for the Win10 style  
`MahApps.Metro.Brushes.ToggleSwitchButton.PressedBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.OffBorderBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.OffMouseOverBorderBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.OffDisabledBorderBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.OffSwitchBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchDisabledBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorMouseOverBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorPressedBrush.Win10`  
`MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorDisabledBrush.Win10`  
- new keys for all accent colors: `AccentBaseColor` and `AccentBaseColorBrush` (full color)

![2016-03-10_23h21_25](https://cloud.githubusercontent.com/assets/658431/13686773/d019335c-e717-11e5-9cc5-586ae4628854.png)
![2016-03-10_23h21_38](https://cloud.githubusercontent.com/assets/658431/13686777/d3e43978-e717-11e5-91e0-3e990fdf7ece.png)
![2016-03-10_23h22_04](https://cloud.githubusercontent.com/assets/658431/13686779/d6638e24-e717-11e5-83d4-7dbda3a4455a.png)
![2016-03-10_23h22_28](https://cloud.githubusercontent.com/assets/658431/13686782/d86bbe80-e717-11e5-85a2-69e5dc26cf42.png)

![toggleswitchwin10_finished](https://cloud.githubusercontent.com/assets/658431/13674064/55adf87c-e6dc-11e5-9d94-30f33b398a8c.gif)