### PR TITLE
ToggleSwitch "Click" event not triggered #2415

### DIFF
--- a/MahApps.Metro/Controls/ToggleSwitch.cs
+++ b/MahApps.Metro/Controls/ToggleSwitch.cs
@@ -12,7 +12,6 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
-using MahApps.Metro.Converters;
 
 namespace MahApps.Metro.Controls
 {

--- a/MahApps.Metro/Themes/ToggleSwitch.xaml
+++ b/MahApps.Metro/Themes/ToggleSwitch.xaml
@@ -69,10 +69,10 @@
                                 </Rectangle.RenderTransform>
                             </Rectangle>
                         </Grid>
-                        <Thumb x:Name="PART_DraggingThumb">
+                        <Thumb x:Name="PART_DraggingThumb" Background="Transparent">
                             <Thumb.Template>
                                 <ControlTemplate>
-                                    <Rectangle Fill="Transparent" />
+                                    <Grid Background="{TemplateBinding Background}" />
                                 </ControlTemplate>
                             </Thumb.Template>
                         </Thumb>


### PR DESCRIPTION
## What changed?

- fix click action by using the OnClick instead only OnToggle method
- and use the PropertyChangeNotifier for IsCheckedProperty to update the thumb

Closes #2415 ToggleSwitch "Click" event not triggered

and use the PropertyChangeNotifier for IsCheckedProperty to update the thumb