### PR TITLE
Fixed broken links to CONTRIBUTING.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,11 +48,11 @@ Did you stumble upon a bug? Before reporting it to us, please check out the [FAQ
 
 If you've improved MahApps.Metro and think that other people would enjoy it, submit a pull request. Anyone and everyone is welcome to contribute.
 
-Please take a moment to review the [guidelines for contributing](CONTRIBUTING.md).
+Please take a moment to review the [guidelines for contributing](.github/CONTRIBUTING.md).
 
-* [Bug reports](CONTRIBUTING.md#bugs)
-* [Feature requests](CONTRIBUTING.md#features)
-* [Pull requests](CONTRIBUTING.md#pull-requests)
+* [Bug reports](.github/CONTRIBUTING.md#bugs)
+* [Feature requests](.github/CONTRIBUTING.md#features)
+* [Pull requests](.github/CONTRIBUTING.md#pull-requests)
 
 You need [Visual Studio 2015 Community Edition](<https://www.visualstudio.com/>) to build the solution (comes with [#2330](https://github.com/MahApps/MahApps.Metro/pull/2330)), so we can use the new C# 6 features. You can use the [dev-vc2013](<https://github.com/MahApps/MahApps.Metro/tree/dev-vc2013>) branch if you still have the Visual Studio 2013, but no new feature or fix will be added in this branch by me™.
 


### PR DESCRIPTION
## What changed?

Links in `README.md` to `CONTRIBUTING.md` were broken, when the latter was moved to the `.github` subfolder. This PR fixes the links.

This fixes #2425.