### PR TITLE
Remove BindsTwoWayByDefault from IsActiveProperty from ProgressRing

### DIFF
--- a/MahApps.Metro/Controls/ProgressRing.cs
+++ b/MahApps.Metro/Controls/ProgressRing.cs
@@ -15,7 +15,7 @@ namespace MahApps.Metro.Controls
     {
         public static readonly DependencyProperty BindableWidthProperty = DependencyProperty.Register("BindableWidth", typeof(double), typeof(ProgressRing), new PropertyMetadata(default(double), BindableWidthCallback));
 
-        public static readonly DependencyProperty IsActiveProperty = DependencyProperty.Register("IsActive", typeof(bool), typeof(ProgressRing), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, IsActiveChanged));
+        public static readonly DependencyProperty IsActiveProperty = DependencyProperty.Register("IsActive", typeof(bool), typeof(ProgressRing), new PropertyMetadata(true, IsActiveChanged));
 
         public static readonly DependencyProperty IsLargeProperty = DependencyProperty.Register("IsLarge", typeof(bool), typeof(ProgressRing), new PropertyMetadata(true, IsLargeChangedCallback));
 


### PR DESCRIPTION
## What changed?

Removed BindsTwoWayByDefault from IsActiveProperty. There is not need to apply TwoWay by default, because the GUI does not update the IsActive property in any parts of the code

# REMARKS

The only change is when **Visibility** changed.

In that case. Would it be important that when the visibility of ProgessRing changes that IsActive is reflected to the **bound property**?

As crossreference, IsIndeterminate has the same behavior
http://referencesource.microsoft.com/#PresentationFramework/src/Framework/System/Windows/Controls/ProgressBar.cs,60ee7d94e2137368,references