### PR TITLE
Async Dialog Cancellation Update

### DIFF
--- a/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
@@ -72,11 +72,11 @@ namespace MahApps.Metro.Controls.Dialogs
 
             KeyEventHandler escapeKeyHandler = null;
 
-            Action cleanUpHandlers = new Action(() => { });
+            Action cleanUpHandlers = null;
 
             var cancellationTokenRegistration = DialogSettings.CancellationToken.Register(() =>
             {
-                cleanUpHandlers();
+                cleanUpHandlers?.Invoke();
                 tcs.TrySetResult(ButtonStyle == MessageDialogStyle.Affirmative ? MessageDialogResult.Affirmative : MessageDialogResult.Negative);
             });
 


### PR DESCRIPTION
## What changed?

Assign empty lambda instead of null to cleanupHandlers to prevent null reference exception on early cancellation
_Closed issues._
#2420