### PR TITLE
Virtual Keyboard Service Pack

### DIFF
--- a/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
+++ b/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
@@ -24,7 +24,7 @@ namespace MahApps.Metro.Controls.Helper
             }
             else
             {
-                startInfo = new ProcessStartInfo(@"C:\Program Files (x86)\Common Files\Microsoft Shared\ink\TabTip32.exe");
+                startInfo = new ProcessStartInfo(@"C:\Program Files\Common Files\Microsoft Shared\ink\TabTip32.exe");
             }
             startInfo.WindowStyle = ProcessWindowStyle.Hidden;
 

--- a/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
+++ b/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
@@ -1,0 +1,102 @@
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System;
+
+namespace MahApps.Metro.Controls.Helper
+{
+    using System.Linq;
+    using System.Management;
+
+    public class VirtualKeyboardHelper
+    {
+        public static readonly DependencyProperty EnableVirtualKeyboardProperty = DependencyProperty.RegisterAttached(
+            "EnableVirtualKeyboard", typeof(bool), typeof(VirtualKeyboardHelper), new PropertyMetadata(default(bool), OnEnableVirtualKeyboardChanged));
+
+        private static void OnEnableVirtualKeyboardChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            UIElement tb = (UIElement)d;
+            if (tb != null)
+            {
+                tb.GotFocus += OnGotFocus;
+                tb.LostFocus += OnLostFocus;
+            }
+        }
+
+        public static bool GetEnableVirtualKeyboard(DependencyObject element)
+        {
+            return (bool)element.GetValue(EnableVirtualKeyboardProperty);
+        }
+
+        public static void SetEnableVirtualKeyboard(DependencyObject element, bool value)
+        {
+            element.SetValue(EnableVirtualKeyboardProperty, value);
+        }
+
+        private static DateTime lastCloseRequest;
+
+        public static void CloseVirtualKeyboard()
+        {
+            uint WM_SYSCOMMAND = 274;
+            uint SC_CLOSE = 61536;
+            IntPtr KeyboardWnd = FindWindow("IPTip_Main_Window", null);
+            PostMessage(KeyboardWnd.ToInt32(), WM_SYSCOMMAND, (int)SC_CLOSE, 0);
+        }
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr FindWindow(string sClassName, string sAppName);
+
+        public static void OpenVirtualKeyboard()
+        {
+            ProcessStartInfo startInfo;
+            if (Environment.Is64BitOperatingSystem)
+            {
+                startInfo = new ProcessStartInfo(@"C:\Program Files\Common Files\Microsoft Shared\ink\TabTip.exe");
+            }
+            else
+            {
+                startInfo = new ProcessStartInfo(@"C:\Program Files (x86)\Common Files\Microsoft Shared\ink\TabTip32.exe");
+            }
+            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            Process.Start(startInfo);
+        }
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern bool PostMessage(int hWnd, uint msg, int wParam, int lParam);
+
+        private static bool IsSurfaceKeyboardAttached()
+        {
+            SelectQuery Sq = new SelectQuery("Win32_Keyboard");
+            ManagementObjectSearcher objOSDetails = new ManagementObjectSearcher(Sq);
+            ManagementObjectCollection osDetailsCollection = objOSDetails.Get();
+            var amountExternalKeyboards = osDetailsCollection.Cast<ManagementObject>().Select(mo => (string)mo.GetPropertyValue("PNPDeviceID")).Count(i => i.StartsWith("USB"));
+            return amountExternalKeyboards > 0;
+        }
+
+        private static void OnGotFocus(object sender, RoutedEventArgs e)
+        {
+            lastCloseRequest = DateTime.MaxValue;
+            if (GetEnableVirtualKeyboard((DependencyObject)sender) && !IsSurfaceKeyboardAttached())
+            {
+                OpenVirtualKeyboard();
+            }
+        }
+
+        private static void OnLostFocus(object sender, RoutedEventArgs e)
+        {
+            lastCloseRequest = DateTime.Now;
+            Task.Factory
+                .StartNew(() => { Thread.Sleep(10); })
+                .ContinueWith(t =>
+                                  {
+                                      if ((DateTime.Now - lastCloseRequest) > TimeSpan.Zero)
+                                      {
+                                          CloseVirtualKeyboard();
+                                      }
+                                  });
+        }
+    }
+}

--- a/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
+++ b/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
@@ -4,16 +4,22 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System;
+using System.Linq;
+using System.Management;
 
 namespace MahApps.Metro.Controls.Helper
 {
-    using System.Linq;
-    using System.Management;
-
     public class VirtualKeyboardHelper
     {
+        private const uint SC_CLOSE = 61536;
+        private const uint WM_SYSCOMMAND = 274;
+        private static DateTime lastCloseRequest;
+
         public static readonly DependencyProperty EnableVirtualKeyboardProperty = DependencyProperty.RegisterAttached(
-            "EnableVirtualKeyboard", typeof(bool), typeof(VirtualKeyboardHelper), new PropertyMetadata(default(bool), OnEnableVirtualKeyboardChanged));
+            "EnableVirtualKeyboard",
+            typeof(bool),
+            typeof(VirtualKeyboardHelper),
+            new PropertyMetadata(default(bool), OnEnableVirtualKeyboardChanged));
 
         private static void OnEnableVirtualKeyboardChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -35,45 +41,28 @@ namespace MahApps.Metro.Controls.Helper
             element.SetValue(EnableVirtualKeyboardProperty, value);
         }
 
-        private static DateTime lastCloseRequest;
-
-        public static void CloseVirtualKeyboard()
+        private static void CloseVirtualKeyboard()
         {
-            uint WM_SYSCOMMAND = 274;
-            uint SC_CLOSE = 61536;
-            IntPtr KeyboardWnd = FindWindow("IPTip_Main_Window", null);
-            PostMessage(KeyboardWnd.ToInt32(), WM_SYSCOMMAND, (int)SC_CLOSE, 0);
+            IntPtr keyboardWnd = FindWindow("IPTip_Main_Window", null);
+            PostMessage(keyboardWnd.ToInt32(), WM_SYSCOMMAND, (int)SC_CLOSE, 0);
         }
 
         [DllImport("user32.dll")]
-        public static extern IntPtr FindWindow(string sClassName, string sAppName);
-
-        public static void OpenVirtualKeyboard()
-        {
-            ProcessStartInfo startInfo;
-            if (Environment.Is64BitOperatingSystem)
-            {
-                startInfo = new ProcessStartInfo(@"C:\Program Files\Common Files\Microsoft Shared\ink\TabTip.exe");
-            }
-            else
-            {
-                startInfo = new ProcessStartInfo(@"C:\Program Files (x86)\Common Files\Microsoft Shared\ink\TabTip32.exe");
-            }
-            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            Process.Start(startInfo);
-        }
-
-        [return: MarshalAs(UnmanagedType.Bool)]
-        [DllImport("user32.dll", SetLastError = true)]
-        public static extern bool PostMessage(int hWnd, uint msg, int wParam, int lParam);
+        private static extern IntPtr FindWindow(string sClassName, string sAppName);
 
         private static bool IsSurfaceKeyboardAttached()
         {
-            SelectQuery Sq = new SelectQuery("Win32_Keyboard");
-            ManagementObjectSearcher objOSDetails = new ManagementObjectSearcher(Sq);
-            ManagementObjectCollection osDetailsCollection = objOSDetails.Get();
-            var amountExternalKeyboards = osDetailsCollection.Cast<ManagementObject>().Select(mo => (string)mo.GetPropertyValue("PNPDeviceID")).Count(i => i.StartsWith("USB"));
-            return amountExternalKeyboards > 0;
+            using (var objOsDetails = new ManagementObjectSearcher("Win32_Keyboard"))
+            {
+                using (var osDetailsCollection = objOsDetails.Get())
+                {
+                    var amountExternalKeyboards = osDetailsCollection.Cast<ManagementObject>()
+                                                                     .Select(mo => (string)mo.GetPropertyValue("PNPDeviceID"))
+                                                                     .Count(i => i.StartsWith("USB"));
+
+                    return amountExternalKeyboards > 0;
+                }
+            }
         }
 
         private static void OnGotFocus(object sender, RoutedEventArgs e)
@@ -92,11 +81,30 @@ namespace MahApps.Metro.Controls.Helper
                 .StartNew(() => { Thread.Sleep(10); })
                 .ContinueWith(t =>
                                   {
-                                      if ((DateTime.Now - lastCloseRequest) > TimeSpan.Zero)
+                                      if (DateTime.Now - lastCloseRequest > TimeSpan.Zero)
                                       {
                                           CloseVirtualKeyboard();
                                       }
                                   });
         }
+
+        private static void OpenVirtualKeyboard()
+        {
+            ProcessStartInfo startInfo;
+            if (Environment.Is64BitOperatingSystem)
+            {
+                startInfo = new ProcessStartInfo(@"C:\Program Files\Common Files\Microsoft Shared\ink\TabTip.exe");
+            }
+            else
+            {
+                startInfo = new ProcessStartInfo(@"C:\Program Files (x86)\Common Files\Microsoft Shared\ink\TabTip32.exe");
+            }
+            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            Process.Start(startInfo);
+        }
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool PostMessage(int hWnd, uint msg, int wParam, int lParam);
     }
 }

--- a/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
+++ b/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
@@ -50,7 +50,7 @@ namespace MahApps.Metro.Controls.Helper
         [DllImport("user32.dll")]
         private static extern IntPtr FindWindow(string sClassName, string sAppName);
 
-        private static bool IsSurfaceKeyboardAttached()
+        private static bool IsHardwareKeyboardAttached()
         {
             using (var objOsDetails = new ManagementObjectSearcher(new SelectQuery("Win32_Keyboard")))
             {
@@ -68,7 +68,7 @@ namespace MahApps.Metro.Controls.Helper
         private static void OnGotFocus(object sender, RoutedEventArgs e)
         {
             lastCloseRequest = DateTime.MaxValue;
-            if (GetEnableVirtualKeyboard((DependencyObject)sender) && !IsSurfaceKeyboardAttached())
+            if (GetEnableVirtualKeyboard((DependencyObject)sender) && !IsHardwareKeyboardAttached())
             {
                 OpenVirtualKeyboard();
             }

--- a/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
+++ b/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
@@ -9,6 +9,8 @@ using System.Management;
 
 namespace MahApps.Metro.Controls.Helper
 {
+    using System.IO;
+
     public class VirtualKeyboardHelper
     {
         private const uint SC_CLOSE = 61536;
@@ -17,18 +19,18 @@ namespace MahApps.Metro.Controls.Helper
 
         private static readonly Lazy<ProcessStartInfo> StartInfo = new Lazy<ProcessStartInfo>(() =>
         {
-            ProcessStartInfo startInfo;
-            if (Environment.Is64BitOperatingSystem)
+            string tabTipExe = "TabTip.exe";
+            if (!Environment.Is64BitProcess)
             {
-                startInfo = new ProcessStartInfo(@"C:\Program Files\Common Files\Microsoft Shared\ink\TabTip.exe");
+                tabTipExe = "TabTip32.exe";
             }
-            else
-            {
-                startInfo = new ProcessStartInfo(@"C:\Program Files\Common Files\Microsoft Shared\ink\TabTip32.exe");
-            }
-            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
 
-            return startInfo;
+            var fileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "ink", tabTipExe);
+
+            return new ProcessStartInfo(fileName)
+                   {
+                       WindowStyle = ProcessWindowStyle.Hidden
+                   };
         });
 
         public static readonly DependencyProperty EnableVirtualKeyboardProperty = DependencyProperty.RegisterAttached(

--- a/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
+++ b/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
@@ -15,6 +15,22 @@ namespace MahApps.Metro.Controls.Helper
         private const uint WM_SYSCOMMAND = 274;
         private static DateTime lastCloseRequest;
 
+        private static readonly Lazy<ProcessStartInfo> StartInfo = new Lazy<ProcessStartInfo>(() =>
+        {
+            ProcessStartInfo startInfo;
+            if (Environment.Is64BitOperatingSystem)
+            {
+                startInfo = new ProcessStartInfo(@"C:\Program Files\Common Files\Microsoft Shared\ink\TabTip.exe");
+            }
+            else
+            {
+                startInfo = new ProcessStartInfo(@"C:\Program Files (x86)\Common Files\Microsoft Shared\ink\TabTip32.exe");
+            }
+            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
+
+            return startInfo;
+        });
+
         public static readonly DependencyProperty EnableVirtualKeyboardProperty = DependencyProperty.RegisterAttached(
             "EnableVirtualKeyboard",
             typeof(bool),
@@ -90,17 +106,7 @@ namespace MahApps.Metro.Controls.Helper
 
         private static void OpenVirtualKeyboard()
         {
-            ProcessStartInfo startInfo;
-            if (Environment.Is64BitOperatingSystem)
-            {
-                startInfo = new ProcessStartInfo(@"C:\Program Files\Common Files\Microsoft Shared\ink\TabTip.exe");
-            }
-            else
-            {
-                startInfo = new ProcessStartInfo(@"C:\Program Files (x86)\Common Files\Microsoft Shared\ink\TabTip32.exe");
-            }
-            startInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            Process.Start(startInfo);
+            Process.Start(StartInfo.Value);
         }
 
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
+++ b/MahApps.Metro/Controls/Helper/VirtualKeyboardHelper.cs
@@ -52,7 +52,7 @@ namespace MahApps.Metro.Controls.Helper
 
         private static bool IsSurfaceKeyboardAttached()
         {
-            using (var objOsDetails = new ManagementObjectSearcher("Win32_Keyboard"))
+            using (var objOsDetails = new ManagementObjectSearcher(new SelectQuery("Win32_Keyboard")))
             {
                 using (var osDetailsCollection = objOsDetails.Get())
                 {

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -111,6 +111,7 @@
     </Compile>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Lib\NET45\System.Windows.Interactivity.dll</HintPath>
@@ -138,6 +139,7 @@
     <Compile Include="Behaviours\WindowsSettingBehaviour.cs" />
     <Compile Include="Controls\ButtonsAlignment.cs" />
     <Compile Include="Controls\ContentControlEx.cs" />
+    <Compile Include="Controls\Helper\VirtualKeyboardHelper.cs" />
     <Compile Include="Controls\IconPacks\PackIconMaterial.cs" />
     <Compile Include="Controls\IconPacks\PackIconMaterialDataFactory.cs" />
     <Compile Include="Controls\IconPacks\PackIconMaterialKind.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -73,6 +73,7 @@
     </Compile>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Lib\NET40\System.Windows.Interactivity.dll</HintPath>
@@ -140,6 +141,7 @@
     <Compile Include="Controls\Helper\TabControlHelper.cs" />
     <Compile Include="Controls\Helper\TextBoxHelper.cs" />
     <Compile Include="Controls\Helper\ToggleButtonHelper.cs" />
+    <Compile Include="Controls\Helper\VirtualKeyboardHelper.cs" />
     <Compile Include="Controls\Helper\VisibilityHelper.cs" />
     <Compile Include="Controls\HotKeyBox.cs" />
     <Compile Include="Controls\IconPacks\PackIconMaterial.cs" />

--- a/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -25,7 +25,6 @@
         <Setter Property="SelectedDateFormat" Value="Short" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
-        <Setter Property="helper:VirtualKeyboardHelper.EnableVirtualKeyboard" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">
@@ -132,6 +131,7 @@
         <Setter Property="FontSize" Value="{DynamicResource ContentFontSize}" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="helper:VirtualKeyboardHelper.EnableVirtualKeyboard" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePickerTextBox}">

--- a/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -25,6 +25,7 @@
         <Setter Property="SelectedDateFormat" Value="Short" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
+        <Setter Property="InputScope" Value="Date" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">

--- a/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters"
-                    xmlns:System="clr-namespace:System;assembly=mscorlib">
+                    xmlns:System="clr-namespace:System;assembly=mscorlib"
+                    xmlns:helper="clr-namespace:MahApps.Metro.Controls.Helper">
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     <Converters:ThicknessToDoubleConverter x:Key="ThicknessToDoubleConverter" />
@@ -24,6 +25,7 @@
         <Setter Property="SelectedDateFormat" Value="Short" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
+        <Setter Property="helper:VirtualKeyboardHelper.EnableVirtualKeyboard" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DatePicker}">

--- a/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Behaviors="clr-namespace:MahApps.Metro.Behaviours"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
-                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters"
+                    xmlns:helper="clr-namespace:MahApps.Metro.Controls.Helper">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
@@ -104,6 +105,7 @@
         <!--  change SnapsToDevicePixels to true to view a better border and validation error  -->
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
+        <Setter Property="helper:VirtualKeyboardHelper.EnableVirtualKeyboard" Value="True" />
         <Setter Property="Behaviors:StylizedBehaviors.Behaviors">
             <Setter.Value>
                 <Behaviors:StylizedBehaviorCollection>

--- a/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
-                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters"
+                    xmlns:helper="clr-namespace:MahApps.Metro.Controls.Helper">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
@@ -30,6 +31,7 @@
         <!--  change SnapsToDevicePixels to True to view a better border and validation error  -->
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
+        <Setter Property="helper:VirtualKeyboardHelper.EnableVirtualKeyboard" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}">

--- a/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="clr-namespace:MahApps.Metro.Controls"
                     xmlns:converters="clr-namespace:MahApps.Metro.Converters"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+                    xmlns:system="clr-namespace:System;assembly=mscorlib"
+                    xmlns:helper="clr-namespace:MahApps.Metro.Controls.Helper">
 
     <converters:ClockDegreeConverter x:Key="ClockDegreeConverter" TotalParts="60" />
     <converters:ClockDegreeConverter x:Key="HourDegreeConverter" TotalParts="12" />
@@ -119,6 +120,8 @@
         <Setter Property="controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="controls:TextBoxHelper.Watermark" Value="Select a date" />
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
+        <Setter Property="helper:VirtualKeyboardHelper.EnableVirtualKeyboard" Value="True" />
+        <Setter Property="InputScope" Value="Date" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:DateTimePicker}">


### PR DESCRIPTION
## What changed?

A new feature is introduced that shows the **[Windows integrated Virtual Keyboard (VK)](https://www.google.it/search?q=windows+virtual+keyboard&source=lnms&tbm=isch)** on devices without an attached keyboard but with existing touch screen.
## How?

Introduced a new Attached Property `VirtualKeyboardHelper.EnableVirtualKeyboard` and added this as setter to the style definition of `TextBox`, `PasswordBox`, `DatePicker`, `DateTimePicker`.

Use `InputScope` on `Controls` to define the default keyboard open style
## TODO
- [x] Fix issue with non opening VK on DatePicker
- [x] Testing: On the fly detaching/attaching of USB Keyboard
- [ ] Testing on Surface Pro 4
  - [ ] Testing: On the fly detaching/attaching of Surface Keyboard
  - [ ] Testing: Fold back of Surface Keyboard
- [ ] Open VK in **handwriting-view** when stylus is present
- [x] ~~Fix issue with too many open keyboard processes~~
