### PR TITLE
New MetroThumbContentControl for better experience

### DIFF
--- a/MahApps.Metro/Controls/ContentControlEx.cs
+++ b/MahApps.Metro/Controls/ContentControlEx.cs
@@ -15,7 +15,7 @@ namespace MahApps.Metro.Controls
                                         typeof(CharacterCasing),
                                         typeof(ContentControlEx),
                                         new FrameworkPropertyMetadata(CharacterCasing.Normal, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure),
-                                        new ValidateValueCallback(value => CharacterCasing.Normal <= (CharacterCasing)value && (CharacterCasing)value <= CharacterCasing.Upper));
+                                        value => CharacterCasing.Normal <= (CharacterCasing)value && (CharacterCasing)value <= CharacterCasing.Upper);
 
         /// <summary> 
         /// Character casing of the Content

--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -697,7 +697,7 @@ namespace MahApps.Metro.Controls
             var window = this.ParentWindow;
             if (window != null && this.Position != Position.Bottom)
             {
-                MetroWindow.DoWindowTitleThumbMoveOnDragDelta((Thumb)sender, window, dragDeltaEventArgs);
+                MetroWindow.DoWindowTitleThumbMoveOnDragDelta((IMetroThumb)sender, window, dragDeltaEventArgs);
             }
         }
 

--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -697,7 +697,7 @@ namespace MahApps.Metro.Controls
             var window = this.ParentWindow;
             if (window != null && this.Position != Position.Bottom)
             {
-                MetroWindow.DoWindowTitleThumbMoveOnDragDelta((IMetroThumb)sender, window, dragDeltaEventArgs);
+                MetroWindow.DoWindowTitleThumbMoveOnDragDelta(sender as IMetroThumb, window, dragDeltaEventArgs);
             }
         }
 

--- a/MahApps.Metro/Controls/IMetroThumb.cs
+++ b/MahApps.Metro/Controls/IMetroThumb.cs
@@ -1,0 +1,17 @@
+﻿using System.Windows;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+
+namespace MahApps.Metro.Controls
+{
+    public interface IMetroThumb : IInputElement
+    {
+        event DragStartedEventHandler DragStarted;
+
+        event DragDeltaEventHandler DragDelta;
+
+        event DragCompletedEventHandler DragCompleted;
+
+        event MouseButtonEventHandler MouseDoubleClick;
+    }
+}

--- a/MahApps.Metro/Controls/MetroThumb.cs
+++ b/MahApps.Metro/Controls/MetroThumb.cs
@@ -3,50 +3,50 @@ using System.Windows.Input;
 
 namespace MahApps.Metro.Controls
 {
-    public class MetroThumb : Thumb
+    public class MetroThumb : Thumb, IMetroThumb
     {
-        private TouchDevice _currentDevice = null;
+        private TouchDevice currentDevice = null;
 
         protected override void OnPreviewTouchDown(TouchEventArgs e)
         {
             // Release any previous capture
-            ReleaseCurrentDevice();
+            this.ReleaseCurrentDevice();
             // Capture the new touch
-            CaptureCurrentDevice(e);
+            this.CaptureCurrentDevice(e);
         }
 
         protected override void OnPreviewTouchUp(TouchEventArgs e)
         {
-            ReleaseCurrentDevice();
+            this.ReleaseCurrentDevice();
         }
 
         protected override void OnLostTouchCapture(TouchEventArgs e)
         {
             // Only re-capture if the reference is not null
             // This way we avoid re-capturing after calling ReleaseCurrentDevice()
-            if (_currentDevice != null)
+            if (this.currentDevice != null)
             {
-                CaptureCurrentDevice(e);
+                this.CaptureCurrentDevice(e);
             }
         }
 
         private void ReleaseCurrentDevice()
         {
-            if (_currentDevice != null)
+            if (this.currentDevice != null)
             {
                 // Set the reference to null so that we don't re-capture in the OnLostTouchCapture() method
-                var temp = _currentDevice;
-                _currentDevice = null;
-                ReleaseTouchCapture(temp);
+                var temp = this.currentDevice;
+                this.currentDevice = null;
+                this.ReleaseTouchCapture(temp);
             }
         }
 
         private void CaptureCurrentDevice(TouchEventArgs e)
         {
-            bool gotTouch = CaptureTouch(e.TouchDevice);
+            bool gotTouch = this.CaptureTouch(e.TouchDevice);
             if (gotTouch)
             {
-                _currentDevice = e.TouchDevice;
+                this.currentDevice = e.TouchDevice;
             }
         }
     }

--- a/MahApps.Metro/Controls/MetroThumbContentControl.cs
+++ b/MahApps.Metro/Controls/MetroThumbContentControl.cs
@@ -1,0 +1,280 @@
+using System.Windows.Controls.Primitives;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Input;
+
+namespace MahApps.Metro.Controls
+{
+    /// <summary>
+    /// The MetroThumbContentControl control can be used for titles or something else and enables basic drag movement functionality.
+    /// </summary>
+    public class MetroThumbContentControl : ContentControlEx, IMetroThumb
+    {
+        private TouchDevice currentDevice = null;
+        private Point startDragPoint;
+        private Point startDragScreenPoint;
+        private Point oldDragScreenPoint;
+
+        static MetroThumbContentControl()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(MetroThumbContentControl), new FrameworkPropertyMetadata(typeof(MetroThumbContentControl)));
+            FocusableProperty.OverrideMetadata(typeof(MetroThumbContentControl), new FrameworkPropertyMetadata(default(bool)));
+            EventManager.RegisterClassHandler(typeof(MetroThumbContentControl), Mouse.LostMouseCaptureEvent, new MouseEventHandler(OnLostMouseCapture));
+        }
+
+        public static readonly RoutedEvent DragStartedEvent
+            = EventManager.RegisterRoutedEvent("DragStarted",
+                                               RoutingStrategy.Bubble,
+                                               typeof(DragStartedEventHandler),
+                                               typeof(MetroThumbContentControl));
+
+        public static readonly RoutedEvent DragDeltaEvent
+            = EventManager.RegisterRoutedEvent("DragDelta",
+                                               RoutingStrategy.Bubble,
+                                               typeof(DragDeltaEventHandler),
+                                               typeof(MetroThumbContentControl));
+
+        public static readonly RoutedEvent DragCompletedEvent
+            = EventManager.RegisterRoutedEvent("DragCompleted",
+                                               RoutingStrategy.Bubble,
+                                               typeof(DragCompletedEventHandler),
+                                               typeof(MetroThumbContentControl));
+
+        /// <summary>
+        /// Adds or remove a DragStartedEvent handler
+        /// </summary>
+        public event DragStartedEventHandler DragStarted
+        {
+            add { this.AddHandler(DragStartedEvent, value); }
+            remove { this.RemoveHandler(DragStartedEvent, value); }
+        }
+
+        /// <summary>
+        /// Adds or remove a DragDeltaEvent handler
+        /// </summary>
+        public event DragDeltaEventHandler DragDelta
+        {
+            add { this.AddHandler(DragDeltaEvent, value); }
+            remove { this.RemoveHandler(DragDeltaEvent, value); }
+        }
+
+        /// <summary>
+        /// Adds or remove a DragCompletedEvent handler
+        /// </summary>
+        public event DragCompletedEventHandler DragCompleted
+        {
+            add { this.AddHandler(DragCompletedEvent, value); }
+            remove { this.RemoveHandler(DragCompletedEvent, value); }
+        }
+
+        public static readonly DependencyPropertyKey IsDraggingPropertyKey
+            = DependencyProperty.RegisterReadOnly("IsDragging",
+                                                  typeof(bool),
+                                                  typeof(MetroThumbContentControl),
+                                                  new FrameworkPropertyMetadata(default(bool)));
+
+        /// <summary>
+        /// DependencyProperty for the IsDragging property.
+        /// </summary>
+        public static readonly DependencyProperty IsDraggingProperty = IsDraggingPropertyKey.DependencyProperty;
+
+        /// <summary>
+        /// Indicates that the left mouse button is pressed and is over the MetroThumbContentControl.
+        /// </summary>
+        public bool IsDragging
+        {
+            get { return (bool)this.GetValue(IsDraggingProperty); }
+            protected set { this.SetValue(IsDraggingPropertyKey, value); }
+        }
+
+        public void CancelDragAction()
+        {
+            if (!this.IsDragging)
+            {
+                return;
+            }
+            if (this.IsMouseCaptured)
+            {
+                this.ReleaseMouseCapture();
+            }
+            this.ClearValue(IsDraggingPropertyKey);
+            var horizontalChange = this.oldDragScreenPoint.X - this.startDragScreenPoint.X;
+            var verticalChange = this.oldDragScreenPoint.Y - this.startDragScreenPoint.Y;
+            this.RaiseEvent(new MetroThumbContentControlDragCompletedEventArgs(horizontalChange, verticalChange, true));
+        }
+
+        protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+        {
+            if (!this.IsDragging)
+            {
+                e.Handled = true;
+                // focus me
+                this.Focus();
+                // now capture the mouse for the drag action
+                this.CaptureMouse();
+                // so now we are in dragging mode
+                this.SetValue(IsDraggingPropertyKey, true);
+                // get the mouse points
+                this.startDragPoint = e.GetPosition(this);
+                this.oldDragScreenPoint = this.startDragScreenPoint = this.PointToScreen(this.startDragPoint);
+                try
+                {
+                    this.RaiseEvent(new MetroThumbContentControlDragStartedEventArgs(this.startDragPoint.X, this.startDragPoint.Y));
+                }
+                catch
+                {
+                    this.CancelDragAction();
+                }
+            }
+
+            base.OnMouseLeftButtonDown(e);
+        }
+
+        protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
+        {
+            if (this.IsMouseCaptured && this.IsDragging)
+            {
+                e.Handled = true;
+                // now we are in normal mode
+                this.ClearValue(IsDraggingPropertyKey);
+                // release the captured mouse
+                this.ReleaseMouseCapture();
+                // get the current mouse position and call the completed event with the horizontal/vertical change
+                Point currentMouseScreenPoint = this.PointToScreen(e.MouseDevice.GetPosition(this));
+                var horizontalChange = currentMouseScreenPoint.X - this.startDragScreenPoint.X;
+                var verticalChange = currentMouseScreenPoint.Y - this.startDragScreenPoint.Y;
+                this.RaiseEvent(new MetroThumbContentControlDragCompletedEventArgs(horizontalChange, verticalChange, false));
+            }
+
+            base.OnMouseLeftButtonUp(e);
+        }
+
+        private static void OnLostMouseCapture(object sender, MouseEventArgs e)
+        {
+            // Cancel the drag action if we lost capture
+            MetroThumbContentControl thumb = (MetroThumbContentControl)sender;
+            if (Mouse.Captured != thumb)
+            {
+                thumb.CancelDragAction();
+            }
+        }
+
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            base.OnMouseMove(e);
+
+            if (!this.IsDragging)
+            {
+                return;
+            }
+            if (e.MouseDevice.LeftButton == MouseButtonState.Pressed)
+            {
+                Point currentDragPoint = e.GetPosition(this);
+                // Get client point and convert it to screen point
+                Point currentDragScreenPoint = this.PointToScreen(currentDragPoint);
+                if (currentDragScreenPoint != this.oldDragScreenPoint)
+                {
+                    this.oldDragScreenPoint = currentDragScreenPoint;
+                    e.Handled = true;
+                    var horizontalChange = currentDragPoint.X - this.startDragPoint.X;
+                    var verticalChange = currentDragPoint.Y - this.startDragPoint.Y;
+                    this.RaiseEvent(new DragDeltaEventArgs(horizontalChange, verticalChange) { RoutedEvent = MetroThumbContentControl.DragDeltaEvent });
+                }
+            }
+            else
+            {
+                // clear some saved stuff
+                if (e.MouseDevice.Captured == this)
+                {
+                    this.ReleaseMouseCapture();
+                }
+                this.ClearValue(IsDraggingPropertyKey);
+                this.startDragPoint.X = 0;
+                this.startDragPoint.Y = 0;
+            }
+        }
+
+        protected override void OnPreviewTouchDown(TouchEventArgs e)
+        {
+            // Release any previous capture
+            this.ReleaseCurrentDevice();
+            // Capture the new touch
+            this.CaptureCurrentDevice(e);
+        }
+
+        protected override void OnPreviewTouchUp(TouchEventArgs e)
+        {
+            this.ReleaseCurrentDevice();
+        }
+
+        protected override void OnLostTouchCapture(TouchEventArgs e)
+        {
+            // Only re-capture if the reference is not null
+            // This way we avoid re-capturing after calling ReleaseCurrentDevice()
+            if (this.currentDevice != null)
+            {
+                this.CaptureCurrentDevice(e);
+            }
+        }
+
+        private void ReleaseCurrentDevice()
+        {
+            if (this.currentDevice != null)
+            {
+                // Set the reference to null so that we don't re-capture in the OnLostTouchCapture() method
+                var temp = this.currentDevice;
+                this.currentDevice = null;
+                this.ReleaseTouchCapture(temp);
+            }
+        }
+
+        private void CaptureCurrentDevice(TouchEventArgs e)
+        {
+            bool gotTouch = this.CaptureTouch(e.TouchDevice);
+            if (gotTouch)
+            {
+                this.currentDevice = e.TouchDevice;
+            }
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new MetroThumbContentControlAutomationPeer(this);
+        }
+    }
+
+    public class MetroThumbContentControlDragStartedEventArgs : DragStartedEventArgs
+    {
+        public MetroThumbContentControlDragStartedEventArgs(double horizontalOffset, double verticalOffset)
+            : base(horizontalOffset, verticalOffset)
+        {
+            this.RoutedEvent = MetroThumbContentControl.DragStartedEvent;
+        }
+    }
+
+    public class MetroThumbContentControlDragCompletedEventArgs : DragCompletedEventArgs
+    {
+        public MetroThumbContentControlDragCompletedEventArgs(double horizontalOffset, double verticalOffset, bool canceled)
+            : base(horizontalOffset, verticalOffset, canceled)
+        {
+            this.RoutedEvent = MetroThumbContentControl.DragCompletedEvent;
+        }
+    }
+
+    public class MetroThumbContentControlAutomationPeer : FrameworkElementAutomationPeer
+    {
+        public MetroThumbContentControlAutomationPeer(FrameworkElement owner) : base(owner)
+        { }
+
+        protected override string GetClassNameCore()
+        {
+            return "MetroThumbContentControl";
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.Custom;
+        }
+    }
+}
+

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -813,16 +813,18 @@ namespace MahApps.Metro.Controls
         private void MetroWindow_SizeChanged(object sender, RoutedEventArgs e)
         {
             // this all works only for centered title
+            if (TitleAlignment != HorizontalAlignment.Center)
+            {
+                return;
+            }
 
-            var titleBarGrid = (Grid)titleBar;
-            var titleBarLabel = (Label)titleBarGrid.Children[0];
-            var titleControl = (ContentControl)titleBarLabel.Content;
+            var titleBarGrid = (ContentControl)this.titleBar;
             var iconContentControl = (ContentControl)icon;
 
             // Half of this MetroWindow
-            var halfDistance = this.Width / 2;
+            var halfDistance = this.ActualWidth / 2;
             // Distance between center and left/right
-            var distanceToCenter = titleControl.ActualWidth / 2;
+            var distanceToCenter = titleBarGrid.DesiredSize.Width / 2;
             // Distance between right edge from LeftWindowCommands to left window side
             var distanceFromLeft = iconContentControl.ActualWidth + LeftWindowCommands.ActualWidth;
             // Distance between left edge from RightWindowCommands to right window side
@@ -1021,7 +1023,8 @@ namespace MahApps.Metro.Controls
             }
 
             // handle size if we have a Grid for the title (e.g. clean window have a centered title)
-            if (titleBar != null && titleBar.GetType() == typeof(Grid))
+            //if (titleBar != null && titleBar.GetType() == typeof(Grid))
+            if (titleBar != null && TitleAlignment == HorizontalAlignment.Center)
             {
                 SizeChanged += MetroWindow_SizeChanged;
             }

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -1075,7 +1075,7 @@ namespace MahApps.Metro.Controls
 
         private void WindowTitleThumbMoveOnDragDelta(object sender, DragDeltaEventArgs dragDeltaEventArgs)
         {
-            DoWindowTitleThumbMoveOnDragDelta((IMetroThumb)sender, this, dragDeltaEventArgs);
+            DoWindowTitleThumbMoveOnDragDelta(sender as IMetroThumb, this, dragDeltaEventArgs);
         }
 
         private void WindowTitleThumbChangeWindowStateOnMouseDoubleClick(object sender, MouseButtonEventArgs mouseButtonEventArgs)
@@ -1096,7 +1096,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        internal static void DoWindowTitleThumbMoveOnDragDelta([NotNull] IMetroThumb thumb, [NotNull] MetroWindow window, DragDeltaEventArgs dragDeltaEventArgs)
+        internal static void DoWindowTitleThumbMoveOnDragDelta(IMetroThumb thumb, [NotNull] MetroWindow window, DragDeltaEventArgs dragDeltaEventArgs)
         {
             if (thumb == null)
             {
@@ -1130,18 +1130,19 @@ namespace MahApps.Metro.Controls
             // for the touch usage
             UnsafeNativeMethods.ReleaseCapture();
 
-            if (windowIsMaximized) {
+            if (windowIsMaximized)
+            {
                 window.Top = 2;
                 window.Left = Math.Max(cursorPos.x - window.RestoreBounds.Width / 2, 0);
                 EventHandler windowOnStateChanged = null;
                 windowOnStateChanged = (sender, args) =>
-                {
-                    window.StateChanged -= windowOnStateChanged;
-                    if (window.WindowState == WindowState.Normal)
                     {
-                        Mouse.Capture(thumb, CaptureMode.Element);
-                    }
-                };
+                        window.StateChanged -= windowOnStateChanged;
+                        if (window.WindowState == WindowState.Normal)
+                        {
+                            Mouse.Capture(thumb, CaptureMode.Element);
+                        }
+                    };
                 window.StateChanged += windowOnStateChanged;
             }
 

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -1048,7 +1048,10 @@ namespace MahApps.Metro.Controls
 
         internal static void DoWindowTitleThumbOnPreviewMouseLeftButtonUp(MetroWindow window, MouseButtonEventArgs mouseButtonEventArgs)
         {
-            Mouse.Capture(null);
+            if (mouseButtonEventArgs.Source == mouseButtonEventArgs.OriginalSource)
+            {
+                Mouse.Capture(null);
+            }
         }
 
         internal static void DoWindowTitleThumbMoveOnDragDelta([NotNull] Thumb thumb, [NotNull] MetroWindow window, DragDeltaEventArgs dragDeltaEventArgs)

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -959,14 +959,22 @@ namespace MahApps.Metro.Controls
             // clear all event handlers first:
             if (this.windowTitleThumb != null)
             {
-                this.windowTitleThumb.PreviewMouseLeftButtonUp -= WindowTitleThumbOnPreviewMouseLeftButtonUp;
+                this.windowTitleThumb.PreviewMouseLeftButtonUp -= this.WindowTitleThumbOnPreviewMouseLeftButtonUp;
                 this.windowTitleThumb.DragDelta -= this.WindowTitleThumbMoveOnDragDelta;
                 this.windowTitleThumb.MouseDoubleClick -= this.WindowTitleThumbChangeWindowStateOnMouseDoubleClick;
                 this.windowTitleThumb.MouseRightButtonUp -= this.WindowTitleThumbSystemMenuOnMouseRightButtonUp;
             }
+            var thumbContentControl = this.titleBar as IMetroThumb;
+            if (thumbContentControl != null)
+            {
+                thumbContentControl.PreviewMouseLeftButtonUp -= this.WindowTitleThumbOnPreviewMouseLeftButtonUp;
+                thumbContentControl.DragDelta -= this.WindowTitleThumbMoveOnDragDelta;
+                thumbContentControl.MouseDoubleClick -= this.WindowTitleThumbChangeWindowStateOnMouseDoubleClick;
+                thumbContentControl.MouseRightButtonUp -= this.WindowTitleThumbSystemMenuOnMouseRightButtonUp;
+            }
             if (this.flyoutModalDragMoveThumb != null)
             {
-                this.flyoutModalDragMoveThumb.PreviewMouseLeftButtonUp -= WindowTitleThumbOnPreviewMouseLeftButtonUp;
+                this.flyoutModalDragMoveThumb.PreviewMouseLeftButtonUp -= this.WindowTitleThumbOnPreviewMouseLeftButtonUp;
                 this.flyoutModalDragMoveThumb.DragDelta -= this.WindowTitleThumbMoveOnDragDelta;
                 this.flyoutModalDragMoveThumb.MouseDoubleClick -= this.WindowTitleThumbChangeWindowStateOnMouseDoubleClick;
                 this.flyoutModalDragMoveThumb.MouseRightButtonUp -= this.WindowTitleThumbSystemMenuOnMouseRightButtonUp;
@@ -995,6 +1003,14 @@ namespace MahApps.Metro.Controls
                 this.windowTitleThumb.DragDelta += this.WindowTitleThumbMoveOnDragDelta;
                 this.windowTitleThumb.MouseDoubleClick += this.WindowTitleThumbChangeWindowStateOnMouseDoubleClick;
                 this.windowTitleThumb.MouseRightButtonUp += this.WindowTitleThumbSystemMenuOnMouseRightButtonUp;
+            }
+            var thumbContentControl = this.titleBar as IMetroThumb;
+            if (thumbContentControl != null)
+            {
+                thumbContentControl.PreviewMouseLeftButtonUp += WindowTitleThumbOnPreviewMouseLeftButtonUp;
+                thumbContentControl.DragDelta += this.WindowTitleThumbMoveOnDragDelta;
+                thumbContentControl.MouseDoubleClick += this.WindowTitleThumbChangeWindowStateOnMouseDoubleClick;
+                thumbContentControl.MouseRightButtonUp += this.WindowTitleThumbSystemMenuOnMouseRightButtonUp;
             }
             if (this.flyoutModalDragMoveThumb != null)
             {
@@ -1033,7 +1049,7 @@ namespace MahApps.Metro.Controls
 
         private void WindowTitleThumbMoveOnDragDelta(object sender, DragDeltaEventArgs dragDeltaEventArgs)
         {
-            DoWindowTitleThumbMoveOnDragDelta((Thumb)sender, this, dragDeltaEventArgs);
+            DoWindowTitleThumbMoveOnDragDelta((IMetroThumb)sender, this, dragDeltaEventArgs);
         }
 
         private void WindowTitleThumbChangeWindowStateOnMouseDoubleClick(object sender, MouseButtonEventArgs mouseButtonEventArgs)
@@ -1054,7 +1070,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        internal static void DoWindowTitleThumbMoveOnDragDelta([NotNull] Thumb thumb, [NotNull] MetroWindow window, DragDeltaEventArgs dragDeltaEventArgs)
+        internal static void DoWindowTitleThumbMoveOnDragDelta([NotNull] IMetroThumb thumb, [NotNull] MetroWindow window, DragDeltaEventArgs dragDeltaEventArgs)
         {
             if (thumb == null)
             {

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -64,7 +64,9 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty ShowSystemMenuOnRightClickProperty = DependencyProperty.Register("ShowSystemMenuOnRightClick", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
 
         public static readonly DependencyProperty TitlebarHeightProperty = DependencyProperty.Register("TitlebarHeight", typeof(int), typeof(MetroWindow), new PropertyMetadata(30, TitlebarHeightPropertyChangedCallback));
-        public static readonly DependencyProperty TitleCapsProperty = DependencyProperty.Register("TitleCaps", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
+        [Obsolete(@"This property will be deleted in the next release. You should use the new TitleCharacterCasing dependency property.")]
+        public static readonly DependencyProperty TitleCapsProperty = DependencyProperty.Register("TitleCaps", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true, (o, e) => ((MetroWindow)o).TitleCharacterCasing = (bool)e.NewValue ? CharacterCasing.Upper : CharacterCasing.Normal));
+        public static readonly DependencyProperty TitleCharacterCasingProperty = DependencyProperty.Register("TitleCharacterCasing", typeof(CharacterCasing), typeof(MetroWindow), new FrameworkPropertyMetadata(CharacterCasing.Upper, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure), value => CharacterCasing.Normal <= (CharacterCasing)value && (CharacterCasing)value <= CharacterCasing.Upper);
         public static readonly DependencyProperty TitleAlignmentProperty = DependencyProperty.Register("TitleAlignment", typeof(HorizontalAlignment), typeof(MetroWindow), new PropertyMetadata(HorizontalAlignment.Stretch, PropertyChangedCallback));
 
         public static readonly DependencyProperty SaveWindowPositionProperty = DependencyProperty.Register("SaveWindowPosition", typeof(bool), typeof(MetroWindow), new PropertyMetadata(false));
@@ -565,10 +567,20 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Gets/sets if the TitleBar's text is automatically capitalized.
         /// </summary>
+        [Obsolete(@"This property will be deleted in the next release. You should use the new TitleCharacterCasing dependency property.")]
         public bool TitleCaps
         {
             get { return (bool)GetValue(TitleCapsProperty); }
             set { SetValue(TitleCapsProperty, value); }
+        }
+
+        /// <summary> 
+        /// Character casing of the title
+        /// </summary> 
+        public CharacterCasing TitleCharacterCasing
+        {
+            get { return (CharacterCasing)GetValue(TitleCharacterCasingProperty); }
+            set { SetValue(TitleCharacterCasingProperty, value); }
         }
 
         /// <summary>
@@ -638,9 +650,7 @@ namespace MahApps.Metro.Controls
             set { SetValue(NonActiveWindowTitleBrushProperty, value); }
         }
 
-        /// <summary>
-        /// Gets/sets the TitleBar/Window's Text.
-        /// </summary>
+        [Obsolete("This property will be deleted in the next release.")]
         public string WindowTitle
         {
             get { return TitleCaps ? Title.ToUpper() : Title; }

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -145,6 +145,8 @@
     <Compile Include="Controls\IconPacks\PackIconModern.cs" />
     <Compile Include="Controls\IconPacks\PackIconModernDataFactory.cs" />
     <Compile Include="Controls\IconPacks\PackIconModernKind.cs" />
+    <Compile Include="Controls\IMetroThumb.cs" />
+    <Compile Include="Controls\MetroThumbContentControl.cs" />
     <Compile Include="Controls\TimePartVisibility.cs" />
     <Compile Include="Controls\DateTimePicker.cs" />
     <Compile Include="Controls\Dialogs\DialogCoordinator.cs" />

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -576,6 +576,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Themes\ContentControlEx.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Themes\DateTimePicker.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Controls\IconPacks\PackIconModern.cs" />
     <Compile Include="Controls\IconPacks\PackIconModernDataFactory.cs" />
     <Compile Include="Controls\IconPacks\PackIconModernKind.cs" />
+    <Compile Include="Controls\IMetroThumb.cs" />
     <Compile Include="Controls\LayoutInvalidationCatcher.cs" />
     <Compile Include="Controls\MetroAnimatedSingleRowTabControl.cs" />
     <Compile Include="Controls\MetroAnimatedTabControl.cs" />
@@ -171,6 +172,7 @@
     <Compile Include="Controls\ScrollViewerOffsetMediator.cs" />
     <Compile Include="Controls\SplitButton.cs" />
     <Compile Include="Controls\Theme.cs" />
+    <Compile Include="Controls\MetroThumbContentControl.cs" />
     <Compile Include="Controls\TimePartVisibility.cs" />
     <Compile Include="Controls\WindowButtonCommands.cs" />
     <Compile Include="Controls\WindowCommands.cs">

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -527,6 +527,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Themes\ContentControlEx.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Themes\DateTimePicker.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/MahApps.Metro/Themes/ContentControlEx.xaml
+++ b/MahApps.Metro/Themes/ContentControlEx.xaml
@@ -1,0 +1,50 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:converters="clr-namespace:MahApps.Metro.Converters">
+
+    <Style x:Key="MahApps.Metro.Styles.ContentControlEx" TargetType="{x:Type controls:ContentControlEx}">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type controls:ContentControlEx}">
+                    <Grid Background="Transparent">
+                        <ContentPresenter x:Name="PART_ContentPresenter"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                          RecognizesAccessKey="{TemplateBinding RecognizesAccessKey}"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          UseLayoutRounding="{TemplateBinding UseLayoutRounding}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="ContentCharacterCasing" Value="Normal">
+                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content}" />
+                        </Trigger>
+                        <Trigger Property="ContentCharacterCasing" Value="Upper">
+                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={converters:ToUpperConverter}}" />
+                        </Trigger>
+                        <Trigger Property="ContentCharacterCasing" Value="Lower">
+                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={converters:ToLowerConverter}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="MahApps.Metro.Styles.MetroThumbContentControl"
+           TargetType="{x:Type controls:MetroThumbContentControl}"
+           BasedOn="{StaticResource MahApps.Metro.Styles.ContentControlEx}" />
+
+</ResourceDictionary>

--- a/MahApps.Metro/Themes/Generic.xaml
+++ b/MahApps.Metro/Themes/Generic.xaml
@@ -32,6 +32,8 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/WindowCommands.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/HotKeyBox.xaml" />
 
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/ContentControlEx.xaml" />
+
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/Dialogs/BaseMetroDialog.xaml" />
     </ResourceDictionary.MergedDictionaries>
     
@@ -39,85 +41,8 @@
     <Style TargetType="{x:Type controls:ToggleSwitchButton}" BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitchButton}" />
     <Style TargetType="{x:Type controls:ToggleSwitch}" BasedOn="{StaticResource MahApps.Metro.Styles.ToggleSwitch}" />
 
-    <Style TargetType="{x:Type controls:ContentControlEx}">
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Focusable" Value="False" />
-        <Setter Property="HorizontalAlignment" Value="Stretch" />
-        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="VerticalAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Stretch" />
-        <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type controls:ContentControlEx}">
-                    <Grid Background="Transparent">
-                        <ContentPresenter x:Name="PART_ContentPresenter"
-                                          Margin="{TemplateBinding Padding}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          Content="{TemplateBinding Content}"
-                                          ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                                          ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                          RecognizesAccessKey="{TemplateBinding RecognizesAccessKey}"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                          UseLayoutRounding="{TemplateBinding UseLayoutRounding}" />
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="ContentCharacterCasing" Value="Normal">
-                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content}" />
-                        </Trigger>
-                        <Trigger Property="ContentCharacterCasing" Value="Upper">
-                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={converters:ToUpperConverter}}" />
-                        </Trigger>
-                        <Trigger Property="ContentCharacterCasing" Value="Lower">
-                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={converters:ToLowerConverter}}" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <Style TargetType="{x:Type controls:MetroThumbContentControl}">
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Focusable" Value="False" />
-        <Setter Property="HorizontalAlignment" Value="Stretch" />
-        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="VerticalAlignment" Value="Stretch" />
-        <Setter Property="VerticalContentAlignment" Value="Stretch" />
-        <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type controls:MetroThumbContentControl}">
-                    <Grid Background="Transparent">
-                        <ContentPresenter x:Name="PART_ContentPresenter"
-                                          Margin="{TemplateBinding Padding}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          Content="{TemplateBinding Content}"
-                                          ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                                          ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                          RecognizesAccessKey="{TemplateBinding RecognizesAccessKey}"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                          UseLayoutRounding="{TemplateBinding UseLayoutRounding}" />
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="ContentCharacterCasing" Value="Normal">
-                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content}" />
-                        </Trigger>
-                        <Trigger Property="ContentCharacterCasing" Value="Upper">
-                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={converters:ToUpperConverter}}" />
-                        </Trigger>
-                        <Trigger Property="ContentCharacterCasing" Value="Lower">
-                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={converters:ToLowerConverter}}" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+    <Style TargetType="{x:Type controls:ContentControlEx}" BasedOn="{StaticResource MahApps.Metro.Styles.ContentControlEx}" />
+    <Style TargetType="{x:Type controls:MetroThumbContentControl}" BasedOn="{StaticResource MahApps.Metro.Styles.MetroThumbContentControl}" />
 
     <Style TargetType="{x:Type controls:PackIconMaterial}">
         <Setter Property="Height" Value="16" />

--- a/MahApps.Metro/Themes/Generic.xaml
+++ b/MahApps.Metro/Themes/Generic.xaml
@@ -79,6 +79,46 @@
         </Setter>
     </Style>
 
+    <Style TargetType="{x:Type controls:MetroThumbContentControl}">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type controls:MetroThumbContentControl}">
+                    <Grid Background="Transparent">
+                        <ContentPresenter x:Name="PART_ContentPresenter"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                          RecognizesAccessKey="{TemplateBinding RecognizesAccessKey}"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          UseLayoutRounding="{TemplateBinding UseLayoutRounding}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="ContentCharacterCasing" Value="Normal">
+                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content}" />
+                        </Trigger>
+                        <Trigger Property="ContentCharacterCasing" Value="Upper">
+                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={converters:ToUpperConverter}}" />
+                        </Trigger>
+                        <Trigger Property="ContentCharacterCasing" Value="Lower">
+                            <Setter TargetName="PART_ContentPresenter" Property="Content" Value="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Content, Converter={converters:ToLowerConverter}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style TargetType="{x:Type controls:PackIconMaterial}">
         <Setter Property="Height" Value="16" />
         <Setter Property="Width" Value="16" />

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -77,6 +77,7 @@
                     <Controls:MetroThumbContentControl x:Name="PART_TitleBar"
                                                        Grid.Row="0"
                                                        Grid.Column="2"
+                                                       ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
                                                        Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                        HorizontalAlignment="{TemplateBinding TitleAlignment}"
                                                        HorizontalContentAlignment="Stretch"
@@ -340,6 +341,7 @@
                                                        Grid.Row="0"
                                                        Grid.Column="0"
                                                        Grid.ColumnSpan="5"
+                                                       ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
                                                        Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                        HorizontalAlignment="{TemplateBinding TitleAlignment}"
                                                        HorizontalContentAlignment="Center"
@@ -567,20 +569,6 @@
         </Setter>
         <Setter Property="WindowTitleBrush" Value="{DynamicResource WindowTitleColorBrush}" />
         <Style.Triggers>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=TitleCaps, Mode=OneWay}" Value="True">
-                <Setter Property="TitleTemplate">
-                    <Setter.Value>
-                        <DataTemplate>
-                            <TextBlock Margin="8 -1 0 0"
-                                       VerticalAlignment="Center"
-                                       FontFamily="{DynamicResource HeaderFontFamily}"
-                                       FontSize="{DynamicResource WindowTitleFontSize}"
-                                       Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content, Converter={Converters:ToUpperConverter}}"
-                                       TextTrimming="CharacterEllipsis" />
-                        </DataTemplate>
-                    </Setter.Value>
-                </Setter>
-            </DataTrigger>
             <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Icon, Mode=OneWay, Converter={x:Static Converters:IsNullConverter.Instance}}" Value="False">
                 <Setter Property="IconTemplate">
                     <Setter.Value>

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -336,33 +336,29 @@
                                          Grid.ColumnSpan="5"
                                          Style="{StaticResource WindowTitleThumbStyle}" />
                     <!--  the title bar  -->
-                    <Grid x:Name="PART_TitleBar"
-                          Grid.Row="0"
-                          Grid.Column="0"
-                          Grid.ColumnSpan="5"
-                          Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                          Focusable="False"
-                          Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <!--  this element is used so that everything still responds to drag  -->
-                        <Label HorizontalContentAlignment="Center" VerticalContentAlignment="Center">
-                            <ContentControl x:Name="TitleControl"
-                                            HorizontalAlignment="Center"
-                                            Content="{TemplateBinding Title}"
-                                            ContentTemplate="{TemplateBinding TitleTemplate}"
-                                            Focusable="False">
-                                <ContentControl.Foreground>
-                                    <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
-                                        <Binding ElementName="PART_WindowTitleBackground"
-                                                 Path="Fill"
-                                                 Mode="OneWay" />
-                                        <Binding RelativeSource="{RelativeSource TemplatedParent}"
-                                                 Path="TitleForeground"
-                                                 Mode="OneWay" />
-                                    </MultiBinding>
-                                </ContentControl.Foreground>
-                            </ContentControl>
-                        </Label>
-                    </Grid>
+                    <Controls:MetroThumbContentControl x:Name="PART_TitleBar"
+                                                       Grid.Row="0"
+                                                       Grid.Column="0"
+                                                       Grid.ColumnSpan="5"
+                                                       Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                       HorizontalAlignment="{TemplateBinding TitleAlignment}"
+                                                       HorizontalContentAlignment="Center"
+                                                       VerticalContentAlignment="Center"
+                                                       Content="{TemplateBinding Title}"
+                                                       ContentTemplate="{TemplateBinding TitleTemplate}"
+                                                       Focusable="False"
+                                                       Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <ContentControl.Foreground>
+                            <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
+                                <Binding ElementName="PART_WindowTitleBackground"
+                                         Path="Fill"
+                                         Mode="OneWay" />
+                                <Binding RelativeSource="{RelativeSource TemplatedParent}"
+                                         Path="TitleForeground"
+                                         Mode="OneWay" />
+                            </MultiBinding>
+                        </ContentControl.Foreground>
+                    </Controls:MetroThumbContentControl>
 
                     <!--  the right window commands  -->
                     <ContentPresenter x:Name="PART_RightWindowCommands"

--- a/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/MahApps.Metro/Themes/MetroWindow.xaml
@@ -68,18 +68,23 @@
                                       Focusable="False"
                                       Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
+                    <Controls:MetroThumb x:Name="PART_WindowTitleThumb"
+                                         Grid.Row="0"
+                                         Grid.Column="0"
+                                         Grid.ColumnSpan="5"
+                                         Style="{StaticResource WindowTitleThumbStyle}" />
                     <!--  the title bar  -->
-                    <ContentControl x:Name="PART_TitleBar"
-                                    Grid.Row="0"
-                                    Grid.Column="2"
-                                    Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                    HorizontalAlignment="{TemplateBinding TitleAlignment}"
-                                    HorizontalContentAlignment="Stretch"
-                                    VerticalContentAlignment="Stretch"
-                                    Content="{TemplateBinding Title}"
-                                    ContentTemplate="{TemplateBinding TitleTemplate}"
-                                    Focusable="False"
-                                    Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Controls:MetroThumbContentControl x:Name="PART_TitleBar"
+                                                       Grid.Row="0"
+                                                       Grid.Column="2"
+                                                       Height="{Binding TitlebarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                       HorizontalAlignment="{TemplateBinding TitleAlignment}"
+                                                       HorizontalContentAlignment="Stretch"
+                                                       VerticalContentAlignment="Stretch"
+                                                       Content="{TemplateBinding Title}"
+                                                       ContentTemplate="{TemplateBinding TitleTemplate}"
+                                                       Focusable="False"
+                                                       Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <ContentControl.Foreground>
                             <MultiBinding Converter="{x:Static Converters:BackgroundToForegroundConverter.Instance}">
                                 <Binding ElementName="PART_WindowTitleBackground"
@@ -90,13 +95,7 @@
                                          Mode="OneWay" />
                             </MultiBinding>
                         </ContentControl.Foreground>
-                    </ContentControl>
-
-                    <Controls:MetroThumb x:Name="PART_WindowTitleThumb"
-                                         Grid.Row="0"
-                                         Grid.Column="0"
-                                         Grid.ColumnSpan="5"
-                                         Style="{StaticResource WindowTitleThumbStyle}" />
+                    </Controls:MetroThumbContentControl>
 
                     <!--  the right window commands  -->
                     <ContentPresenter x:Name="PART_RightWindowCommands"
@@ -331,6 +330,11 @@
                                       Focusable="False"
                                       Visibility="{TemplateBinding ShowTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
+                    <Controls:MetroThumb x:Name="PART_WindowTitleThumb"
+                                         Grid.Row="0"
+                                         Grid.Column="0"
+                                         Grid.ColumnSpan="5"
+                                         Style="{StaticResource WindowTitleThumbStyle}" />
                     <!--  the title bar  -->
                     <Grid x:Name="PART_TitleBar"
                           Grid.Row="0"
@@ -359,12 +363,6 @@
                             </ContentControl>
                         </Label>
                     </Grid>
-
-                    <Controls:MetroThumb x:Name="PART_WindowTitleThumb"
-                                         Grid.Row="0"
-                                         Grid.Column="0"
-                                         Grid.ColumnSpan="5"
-                                         Style="{StaticResource WindowTitleThumbStyle}" />
 
                     <!--  the right window commands  -->
                     <ContentPresenter x:Name="PART_RightWindowCommands"

--- a/Mahapps.Metro.Tests/MetroWindowTest.cs
+++ b/Mahapps.Metro.Tests/MetroWindowTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Tests.TestHelpers;
 using Xunit;
@@ -280,6 +281,54 @@ namespace MahApps.Metro.Tests
             var settings = window.GetWindowPlacementSettings();
             Assert.NotNull(settings);
             Assert.Equal(true, settings.UpgradeSettings);
+        }
+
+        [Fact]
+        public async Task TestTitleCapsProperty()
+        {
+            await TestHost.SwitchToAppThread();
+
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<MetroWindow>(w => w.Title = "Test");
+            var titleBar = window.FindChild<ContentControl>("PART_TitleBar");
+            var titleBarContent = titleBar.FindChild<ContentPresenter>("PART_ContentPresenter");
+
+            var be = BindingOperations.GetBindingExpression(titleBarContent, ContentControl.ContentProperty);
+            Assert.NotNull(be);
+            be.UpdateTarget();
+
+            // default should be UPPER
+            Assert.Equal(true, window.TitleCaps);
+            Assert.Equal("TEST", titleBarContent.Content);
+
+            window.TitleCaps = false;
+            be.UpdateTarget();
+            Assert.Equal("Test", titleBarContent.Content);
+        }
+
+        [Fact]
+        public async Task TestTitleCharacterCasingProperty()
+        {
+            await TestHost.SwitchToAppThread();
+
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<MetroWindow>(w => w.Title = "Test");
+            var titleBar = window.FindChild<ContentControl>("PART_TitleBar");
+            var titleBarContent = titleBar.FindChild<ContentPresenter>("PART_ContentPresenter");
+
+            var be = BindingOperations.GetBindingExpression(titleBarContent, ContentControl.ContentProperty);
+            Assert.NotNull(be);
+            be.UpdateTarget();
+
+            // default should be UPPER
+            Assert.Equal(CharacterCasing.Upper, window.TitleCharacterCasing);
+            Assert.Equal("TEST", titleBarContent.Content);
+
+            window.TitleCharacterCasing = CharacterCasing.Lower;
+            be.UpdateTarget();
+            Assert.Equal("test", titleBarContent.Content);
+
+            window.TitleCharacterCasing = CharacterCasing.Normal;
+            be.UpdateTarget();
+            Assert.Equal("Test", titleBarContent.Content);
         }
     }
 }

--- a/docs/release-notes/1.3.0.md
+++ b/docs/release-notes/1.3.0.md
@@ -75,6 +75,10 @@ MahApps.Metro v1.3.0 bug fix and feature release.
 - New dependency properties for `Tile` control: `HorizontalTitleAlignment` and `VerticalTitleAlignment` #2293
 - New attached dependency properties `TextBoxHelper.ButtonFontSize` #2345
 - Added a `MetroFlatToggleButton` style like MetroFlatButton #2481 (@Koopakiller)
+- New `MetroThumbContentControl` for `MetroWindow` title #2487
+	+ It's now possible again to have title templates with clickable controls
+	+ Replaced `TitleCaps` with `TitleCharacterCasing` (marked as obsolete). Now title can be `Upper`, `Lower` or `Normal`
+	+ Add new styles `MahApps.Metro.Styles.ContentControlEx` and `MahApps.Metro.Styles.MetroThumbContentControl`
 
 # Closed Issues
 
@@ -123,3 +127,5 @@ MahApps.Metro v1.3.0 bug fix and feature release.
 - #2474 right to left DatePicker
 - #2476 MetroWindow OnClosing exception (.Net 4.0)
 - #2339 The Glow border does not follow the window is is used the UseNoneWindowStyle property!
+- #2477 Create a custom Thumb for the title DragMove
+- #2449 Visual bug while using RightWindowCommands

--- a/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
+++ b/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
@@ -54,13 +54,17 @@
 
     <Controls:MetroWindow.TitleTemplate>
         <DataTemplate>
-            <TextBlock Margin="0 -1 8 0"
+            <StackPanel Orientation="Horizontal">
+                <Button Content="Click Me..." Margin="1" />
+
+                <TextBlock Margin="0 -1 8 0"
                        HorizontalAlignment="Right"
                        VerticalAlignment="Center"
                        FontFamily="{DynamicResource HeaderFontFamily}"
                        FontSize="{DynamicResource WindowTitleFontSize}"
                        Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content, Converter={converters:ToUpperConverter}}"
                        TextTrimming="CharacterEllipsis" />
+            </StackPanel>
         </DataTemplate>
     </Controls:MetroWindow.TitleTemplate>
 

--- a/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
+++ b/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
@@ -2,13 +2,13 @@
                       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
-                      xmlns:converters="http://metro.mahapps.com/winfx/xaml/shared"
                       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                       xmlns:exampleWindows="clr-namespace:MetroDemo.ExampleWindows"
                       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                       xmlns:metroDemo="clr-namespace:MetroDemo"
                       x:Name="flyoutsDemo"
                       Title="Flyouts Demo"
+                      TitleCharacterCasing="Normal"
                       Width="700"
                       Height="500"
                       MinWidth="700"
@@ -59,7 +59,7 @@
                            VerticalAlignment="Center"
                            FontFamily="{DynamicResource HeaderFontFamily}"
                            FontSize="{DynamicResource WindowTitleFontSize}"
-                           Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content, Converter={converters:ToUpperConverter}}"
+                           Text="{TemplateBinding Content}"
                            TextTrimming="CharacterEllipsis" />
                 <Button Content="Click Me..." Margin="1" Click="ClickMeOnClick" />
             </StackPanel>

--- a/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
+++ b/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
@@ -54,16 +54,14 @@
 
     <Controls:MetroWindow.TitleTemplate>
         <DataTemplate>
-            <StackPanel Orientation="Horizontal">
-                <Button Content="Click Me..." Margin="1" />
-
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                 <TextBlock Margin="0 -1 8 0"
-                       HorizontalAlignment="Right"
-                       VerticalAlignment="Center"
-                       FontFamily="{DynamicResource HeaderFontFamily}"
-                       FontSize="{DynamicResource WindowTitleFontSize}"
-                       Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content, Converter={converters:ToUpperConverter}}"
-                       TextTrimming="CharacterEllipsis" />
+                           VerticalAlignment="Center"
+                           FontFamily="{DynamicResource HeaderFontFamily}"
+                           FontSize="{DynamicResource WindowTitleFontSize}"
+                           Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content, Converter={converters:ToUpperConverter}}"
+                           TextTrimming="CharacterEllipsis" />
+                <Button Content="Click Me..." Margin="1" Click="ClickMeOnClick" />
             </StackPanel>
         </DataTemplate>
     </Controls:MetroWindow.TitleTemplate>

--- a/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml.cs
+++ b/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml.cs
@@ -182,5 +182,10 @@ namespace MetroDemo.ExampleWindows
         {
             this.ToggleFlyout(12);
         }
+
+        private async void ClickMeOnClick(object sender, RoutedEventArgs e)
+        {
+            await this.ShowMessageAsync("Title Template Test", "Thx for using MahApps.Metro!!!");
+        }
     }
 }


### PR DESCRIPTION
## What changed?

Add and use a new `MetroThumbContentControl`. This will be used for all title bar stuff, so we can drag&move the window **and** allow custom title templates with Buttons or Menus.

![clickablecontrolsontitle](https://cloud.githubusercontent.com/assets/658431/14887138/b87d448c-0d54-11e6-9638-9bdd297f6606.gif)

Closes #2477 Create a custom Thumb for the title DragMove
Closes #2449 Visual bug while using RightWindowCommands