### PR TITLE
flyout improvement caused by #2485

### DIFF
--- a/MahApps.Metro/Controls/CloseCommand.cs
+++ b/MahApps.Metro/Controls/CloseCommand.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace MahApps.Metro.Controls
+{
+    internal class CloseCommand : ICommand
+    {
+        private readonly Func<object, bool> canExecute;
+        private readonly Action<object> executeAction;
+
+        public CloseCommand(Func<object, bool> canExecute, Action<object> executeAction)
+        {
+            this.canExecute = canExecute;
+            this.executeAction = executeAction;
+        }
+
+        /// <summary>
+        /// Defines the method that determines whether the command can execute in its current state.
+        /// </summary>
+        /// <returns>
+        /// true if this command can be executed; otherwise, false.
+        /// </returns>
+        /// <param name="parameter">Data used by the command.  If the command does not require data to be passed, this object can be set to null.</param>
+        public bool CanExecute(object parameter)
+        {
+            return this.canExecute != null && this.canExecute(parameter);
+        }
+
+        /// <summary>
+        /// Defines the method to be called when the command is invoked.
+        /// </summary>
+        /// <param name="parameter">Data used by the command.  If the command does not require data to be passed, this object can be set to null.</param>
+        public void Execute(object parameter)
+        {
+            this.executeAction?.Invoke(parameter);
+        }
+
+        public event EventHandler CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+    }
+}

--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -9,8 +9,6 @@ using System.Windows.Threading;
 
 namespace MahApps.Metro.Controls
 {
-    using ControlzEx;
-
     /// <summary>
     /// A sliding panel control that is hosted in a MetroWindow via a FlyoutsControl.
     /// <see cref="MetroWindow"/>

--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -9,6 +9,8 @@ using System.Windows.Threading;
 
 namespace MahApps.Metro.Controls
 {
+    using ControlzEx;
+
     /// <summary>
     /// A sliding panel control that is hosted in a MetroWindow via a FlyoutsControl.
     /// <see cref="MetroWindow"/>
@@ -18,8 +20,8 @@ namespace MahApps.Metro.Controls
     [TemplatePart(Name = "PART_BackHeaderText", Type = typeof(TextBlock))]
     [TemplatePart(Name = "PART_WindowTitleThumb", Type = typeof(Thumb))]
     [TemplatePart(Name = "PART_Root", Type = typeof(Grid))]
-    [TemplatePart(Name = "PART_Header", Type = typeof(ContentPresenter))]
-    [TemplatePart(Name = "PART_Content", Type = typeof(ContentPresenter))]
+    [TemplatePart(Name = "PART_Header", Type = typeof(FrameworkElement))]
+    [TemplatePart(Name = "PART_Content", Type = typeof(FrameworkElement))]
     public class Flyout : ContentControl
     {
         /// <summary>
@@ -59,6 +61,7 @@ namespace MahApps.Metro.Controls
 
         public static readonly DependencyProperty CloseCommandProperty = DependencyProperty.RegisterAttached("CloseCommand", typeof(ICommand), typeof(Flyout), new UIPropertyMetadata(null));
         public static readonly DependencyProperty CloseCommandParameterProperty = DependencyProperty.Register("CloseCommandParameter", typeof(object), typeof(Flyout), new PropertyMetadata(null));
+        internal static readonly DependencyProperty InternalCloseCommandProperty = DependencyProperty.Register("InternalCloseCommand", typeof(ICommand), typeof(Flyout));
 
         public static readonly DependencyProperty ThemeProperty = DependencyProperty.Register("Theme", typeof(FlyoutTheme), typeof(Flyout), new FrameworkPropertyMetadata(FlyoutTheme.Dark, ThemeChanged));
         public static readonly DependencyProperty ExternalCloseButtonProperty = DependencyProperty.Register("ExternalCloseButton", typeof(MouseButton), typeof(Flyout), new PropertyMetadata(MouseButton.Left));
@@ -124,6 +127,15 @@ namespace MahApps.Metro.Controls
         {
             get { return (object)GetValue(CloseCommandParameterProperty); }
             set { SetValue(CloseCommandParameterProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets/sets a command which will be executed if the close button was clicked.
+        /// </summary>
+        internal ICommand InternalCloseCommand
+        {
+            get { return (ICommand)GetValue(InternalCloseCommandProperty); }
+            set { SetValue(InternalCloseCommandProperty, value); }
         }
 
         /// <summary>
@@ -252,10 +264,41 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(AllowFocusElementProperty, value); }
         }
 
+        static Flyout()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(Flyout), new FrameworkPropertyMetadata(typeof(Flyout)));
+        }
+
         public Flyout()
         {
+            this.InternalCloseCommand = new CloseCommand(InternalCloseCommandCanExecute, InternalCloseCommandExecuteAction);
             this.Loaded += (sender, args) => this.UpdateFlyoutTheme();
             this.InitializeAutoCloseTimer();
+        }
+
+        private void InternalCloseCommandExecuteAction(object o)
+        {
+            var closeCommand = this.CloseCommand;
+            // close the Flyout only if there is no command
+            if (closeCommand == null)
+            {
+                this.IsOpen = false;
+            }
+            else
+            {
+                var closeCommandParameter = this.CloseCommandParameter ?? this;
+                if (closeCommand.CanExecute(closeCommandParameter))
+                {
+                    // force the command handler to run
+                    closeCommand.Execute(closeCommandParameter);
+                }
+            }
+        }
+
+        private bool InternalCloseCommandCanExecute(object o)
+        {
+            var closeCommand = this.CloseCommand;
+            return closeCommand == null || closeCommand.CanExecute(this.CloseCommandParameter ?? this);
         }
 
         private void InitializeAutoCloseTimer()
@@ -589,11 +632,6 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        static Flyout()
-        {
-            DefaultStyleKeyProperty.OverrideMetadata(typeof(Flyout), new FrameworkPropertyMetadata(typeof(Flyout)));
-        }
-
         DispatcherTimer autoCloseTimer;
         Grid flyoutRoot;
         Storyboard hideStoryboard;
@@ -602,10 +640,9 @@ namespace MahApps.Metro.Controls
         SplineDoubleKeyFrame showFrame;
         SplineDoubleKeyFrame showFrameY;
         SplineDoubleKeyFrame fadeOutFrame;
-        ContentPresenter flyoutHeader;
-        ContentPresenter flyoutContent;
+        FrameworkElement flyoutHeader;
+        FrameworkElement flyoutContent;
         Thumb windowTitleThumb;
-        Button backButton;
 
         public override void OnApplyTemplate()
         {
@@ -617,16 +654,9 @@ namespace MahApps.Metro.Controls
                 return;
             }
 
-            this.flyoutHeader = this.GetTemplateChild("PART_Header") as ContentPresenter;
-            this.flyoutContent = this.GetTemplateChild("PART_Content") as ContentPresenter;
-
+            this.flyoutHeader = this.GetTemplateChild("PART_Header") as FrameworkElement;
             this.flyoutHeader?.ApplyTemplate();
-            this.backButton = this.flyoutHeader?.FindChild<Button>("PART_BackButton");
-            if (this.backButton != null)
-            {
-                this.backButton.Click -= this.BackButtonClick;
-                this.backButton.Click += this.BackButtonClick;
-            }
+            this.flyoutContent = this.GetTemplateChild("PART_Content") as FrameworkElement;
 
             this.windowTitleThumb = this.GetTemplateChild("PART_WindowTitleThumb") as Thumb;
             if (this.windowTitleThumb != null)
@@ -659,10 +689,6 @@ namespace MahApps.Metro.Controls
 
         protected internal void CleanUp(FlyoutsControl flyoutsControl)
         {
-            if (this.backButton != null)
-            {
-                this.backButton.Click -= this.BackButtonClick;
-            }
             if (this.windowTitleThumb != null)
             {
                 this.windowTitleThumb.PreviewMouseLeftButtonUp -= this.WindowTitleThumbOnPreviewMouseLeftButtonUp;
@@ -671,16 +697,6 @@ namespace MahApps.Metro.Controls
                 this.windowTitleThumb.MouseRightButtonUp -= this.WindowTitleThumbSystemMenuOnMouseRightButtonUp;
             }
             this.parentWindow = null;
-        }
-
-        private void BackButtonClick(object sender, RoutedEventArgs e)
-        {
-            // close the Flyout only if there is no command
-            var closeCommand = this.CloseCommand;
-            if (closeCommand == null)
-            {
-                this.IsOpen = false;
-            }
         }
 
         private void WindowTitleThumbOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)

--- a/MahApps.Metro/Controls/Helper/ControlsHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ControlsHelper.cs
@@ -149,6 +149,22 @@ namespace MahApps.Metro.Controls
             element.SetValue(HeaderFontWeightProperty, value);
         }
 
+        public static readonly DependencyProperty HeaderMarginProperty =
+            DependencyProperty.RegisterAttached("HeaderMargin", typeof(Thickness), typeof(ControlsHelper), new UIPropertyMetadata(new Thickness()));
+
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(Flyout))]
+        public static Thickness GetHeaderMargin(UIElement element)
+        {
+            return (Thickness)element.GetValue(HeaderMarginProperty);
+        }
+
+        public static void SetHeaderMargin(UIElement element, Thickness value)
+        {
+            element.SetValue(HeaderMarginProperty, value);
+        }
+
         /// <summary>
         /// This property can be used to set the button width (PART_ClearText) of TextBox, PasswordBox, ComboBox, NumericUpDown
         /// </summary>

--- a/MahApps.Metro/Controls/Helper/ControlsHelper.cs
+++ b/MahApps.Metro/Controls/Helper/ControlsHelper.cs
@@ -106,6 +106,7 @@ namespace MahApps.Metro.Controls
 
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(Flyout))]
         public static double GetHeaderFontSize(UIElement element)
         {
             return (double)element.GetValue(HeaderFontSizeProperty);
@@ -121,6 +122,7 @@ namespace MahApps.Metro.Controls
 
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(Flyout))]
         public static FontStretch GetHeaderFontStretch(UIElement element)
         {
             return (FontStretch)element.GetValue(HeaderFontStretchProperty);
@@ -136,6 +138,7 @@ namespace MahApps.Metro.Controls
 
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(Flyout))]
         public static FontWeight GetHeaderFontWeight(UIElement element)
         {
             return (FontWeight)element.GetValue(HeaderFontWeightProperty);

--- a/MahApps.Metro/Controls/MetroTabItem.cs
+++ b/MahApps.Metro/Controls/MetroTabItem.cs
@@ -1,49 +1,9 @@
-﻿using System;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 
 namespace MahApps.Metro.Controls
 {
-    internal class MetroTabItemCloseCommand : ICommand
-    {
-        private readonly Func<object, bool> canExecute;
-        private readonly Action<object> executeAction;
-
-        public MetroTabItemCloseCommand(Func<object, bool> canExecute, Action<object> executeAction)
-        {
-            this.canExecute = canExecute;
-            this.executeAction = executeAction;
-        }
-
-        /// <summary>
-        /// Defines the method that determines whether the command can execute in its current state.
-        /// </summary>
-        /// <returns>
-        /// true if this command can be executed; otherwise, false.
-        /// </returns>
-        /// <param name="parameter">Data used by the command.  If the command does not require data to be passed, this object can be set to null.</param>
-        public bool CanExecute(object parameter)
-        {
-            return this.canExecute != null && this.canExecute(parameter);
-        }
-
-        /// <summary>
-        /// Defines the method to be called when the command is invoked.
-        /// </summary>
-        /// <param name="parameter">Data used by the command.  If the command does not require data to be passed, this object can be set to null.</param>
-        public void Execute(object parameter)
-        {
-            this.executeAction?.Invoke(parameter);
-        }
-
-        public event EventHandler CanExecuteChanged
-        {
-            add { CommandManager.RequerySuggested += value; }
-            remove { CommandManager.RequerySuggested -= value; }
-        }
-    }
-
     /// <summary>
     /// An extended TabItem with a metro style.
     /// </summary>
@@ -52,7 +12,7 @@ namespace MahApps.Metro.Controls
         public MetroTabItem()
         {
             DefaultStyleKey = typeof(MetroTabItem);
-            this.InternalCloseTabCommand = new MetroTabItemCloseCommand(InternalCloseTabCommandCanExecute, InternalCloseTabCommandExecuteAction);
+            this.InternalCloseTabCommand = new CloseCommand(InternalCloseTabCommandCanExecute, InternalCloseTabCommandExecuteAction);
         }
 
         private void InternalCloseTabCommandExecuteAction(object o)

--- a/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Behaviours\TabControlSelectFirstVisibleTabBehavior.cs" />
     <Compile Include="Behaviours\WindowsSettingBehaviour.cs" />
     <Compile Include="Controls\ButtonsAlignment.cs" />
+    <Compile Include="Controls\CloseCommand.cs" />
     <Compile Include="Controls\ContentControlEx.cs" />
     <Compile Include="Controls\Extensions.cs" />
     <Compile Include="Controls\IconPacks\PackIconMaterial.cs" />

--- a/MahApps.Metro/MahApps.Metro.csproj
+++ b/MahApps.Metro/MahApps.Metro.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Actions\SetFlyoutOpenAction.cs" />
     <Compile Include="Behaviours\BindableResourceBehavior.cs" />
     <Compile Include="Behaviours\BorderlessWindowBehavior.cs" />
+    <Compile Include="Controls\CloseCommand.cs" />
     <Compile Include="Controls\Extensions.cs" />
     <Compile Include="Controls\Helper\AmPmComparer.cs" />
     <Compile Include="Controls\ButtonsAlignment.cs" />

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -10,7 +10,7 @@
 
     <DataTemplate x:Key="HeaderTemplate" x:Shared="False">
         <DockPanel x:Name="dpHeader"
-                   Margin="10 25 10 10"
+                   Margin="10"
                    VerticalAlignment="Center"
                    LastChildFill="True">
             <Button x:Name="PART_BackButton"
@@ -67,7 +67,6 @@
                 </Setter>
             </DataTrigger>
             <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}}" Value="Top">
-                <Setter TargetName="dpHeader" Property="Margin" Value="10" />
                 <Setter TargetName="PART_BackButton" Property="LayoutTransform">
                     <Setter.Value>
                         <RotateTransform Angle="-90" />
@@ -75,7 +74,6 @@
                 </Setter>
             </DataTrigger>
             <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}}" Value="Bottom">
-                <Setter TargetName="dpHeader" Property="Margin" Value="10" />
                 <Setter TargetName="PART_BackButton" Property="LayoutTransform">
                     <Setter.Value>
                         <RotateTransform Angle="90" />
@@ -210,15 +208,35 @@
             </VisualStateManager.VisualStateGroups>
         </Grid>
         <ControlTemplate.Triggers>
-            <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource Self}}" Value="Top">
+            <Trigger Property="Position" Value="Right">
+                <Setter TargetName="PART_Header" Property="Margin" Value="0 20 0 0" />
+            </Trigger>
+            <Trigger Property="Position" Value="Left">
+                <Setter TargetName="PART_Header" Property="Margin" Value="0 20 0 0" />
+            </Trigger>
+            <Trigger Property="Position" Value="Top">
                 <Setter TargetName="PART_Content" Property="DockPanel.Dock" Value="Right" />
                 <Setter TargetName="PART_Header" Property="DockPanel.Dock" Value="Left" />
-            </DataTrigger>
-            <DataTrigger Binding="{Binding Position, RelativeSource={RelativeSource Self}}" Value="Bottom">
+            </Trigger>
+            <Trigger Property="Position" Value="Bottom">
                 <Setter TargetName="PART_Content" Property="DockPanel.Dock" Value="Right" />
                 <Setter TargetName="PART_Header" Property="DockPanel.Dock" Value="Left" />
                 <Setter TargetName="PART_WindowTitleThumb" Property="Visibility" Value="Collapsed" />
-            </DataTrigger>
+            </Trigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="CloseButtonVisibility" Value="Collapsed" />
+                    <Condition Property="TitleVisibility" Value="Collapsed" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Header" Property="Visibility" Value="Collapsed" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="CloseButtonVisibility" Value="Hidden" />
+                    <Condition Property="TitleVisibility" Value="Hidden" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="PART_Header" Property="Visibility" Value="Collapsed" />
+            </MultiTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
@@ -237,3 +255,4 @@
         <Setter Property="Visibility" Value="Hidden" />
     </Style>
 </ResourceDictionary>
+

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -99,6 +99,7 @@
                                                FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
                                                Content="{TemplateBinding Header}"
                                                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                               ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
                                                RecognizesAccessKey="True"
                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     <ContentPresenter x:Name="PART_Content" DockPanel.Dock="Bottom" />

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -10,7 +10,6 @@
 
     <DataTemplate x:Key="HeaderTemplate" x:Shared="False">
         <DockPanel x:Name="dpHeader"
-                   Margin="10"
                    VerticalAlignment="Center"
                    LastChildFill="True">
             <Button x:Name="PART_BackButton"
@@ -93,6 +92,7 @@
             <AdornerDecorator>
                 <DockPanel FocusVisualStyle="{x:Null}" Focusable="False">
                     <Controls:ContentControlEx x:Name="PART_Header"
+                                               Padding="{TemplateBinding Controls:ControlsHelper.HeaderMargin}"
                                                DockPanel.Dock="Top"
                                                FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
                                                FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
@@ -140,7 +140,7 @@
                         </Storyboard>
                     </VisualState>
                     <VisualState x:Name="Show">
-                        <Storyboard>
+                        <Storyboard x:Name="ShowStoryboard">
                             <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
                                                            Storyboard.TargetName="PART_Root"
                                                            Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.X)">
@@ -241,10 +241,12 @@
     </ControlTemplate>
 
     <Style TargetType="{x:Type Controls:Flyout}">
+<!--        <Setter Property="TextOptions.TextFormattingMode" Value="Display" />-->
         <Setter Property="Foreground" Value="{DynamicResource FlyoutForegroundBrush}" />
         <Setter Property="Background" Value="{DynamicResource FlyoutBackgroundBrush}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource FlyoutHeaderFontSize}" />
+        <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="10" />
         <Setter Property="HeaderTemplate" Value="{StaticResource HeaderTemplate}" />
         <Setter Property="KeyboardNavigation.ControlTabNavigation" Value="Cycle" />
         <Setter Property="KeyboardNavigation.DirectionalNavigation" Value="Cycle" />

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -208,12 +208,6 @@
             </VisualStateManager.VisualStateGroups>
         </Grid>
         <ControlTemplate.Triggers>
-            <Trigger Property="Position" Value="Right">
-                <Setter TargetName="PART_Header" Property="Margin" Value="0 20 0 0" />
-            </Trigger>
-            <Trigger Property="Position" Value="Left">
-                <Setter TargetName="PART_Header" Property="Margin" Value="0 20 0 0" />
-            </Trigger>
             <Trigger Property="Position" Value="Top">
                 <Setter TargetName="PART_Content" Property="DockPanel.Dock" Value="Right" />
                 <Setter TargetName="PART_Header" Property="DockPanel.Dock" Value="Left" />
@@ -241,7 +235,6 @@
     </ControlTemplate>
 
     <Style TargetType="{x:Type Controls:Flyout}">
-<!--        <Setter Property="TextOptions.TextFormattingMode" Value="Display" />-->
         <Setter Property="Foreground" Value="{DynamicResource FlyoutForegroundBrush}" />
         <Setter Property="Background" Value="{DynamicResource FlyoutBackgroundBrush}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -255,6 +248,14 @@
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="Visibility" Value="Hidden" />
+        <Style.Triggers>
+            <Trigger Property="Position" Value="Right">
+                <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="10 25 10 10" />
+            </Trigger>
+            <Trigger Property="Position" Value="Left">
+                <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="10 25 10 10" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 </ResourceDictionary>
 

--- a/MahApps.Metro/Themes/Flyout.xaml
+++ b/MahApps.Metro/Themes/Flyout.xaml
@@ -14,7 +14,7 @@
                    VerticalAlignment="Center"
                    LastChildFill="True">
             <Button x:Name="PART_BackButton"
-                    Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=CloseCommand, Mode=OneWay}"
+                    Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=InternalCloseCommand, Mode=OneWay}"
                     CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=CloseCommandParameter, Mode=OneWay}"
                     Width="40"
                     Height="40"
@@ -52,7 +52,6 @@
             <TextBlock x:Name="PART_BackHeaderText"
                        Margin="15 0 0 0"
                        VerticalAlignment="Center"
-                       FontSize="{StaticResource FlyoutHeaderFontSize}"
                        Text="{Binding}"
                        Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:Flyout}}, Path=TitleVisibility}" />
         </DockPanel>
@@ -95,10 +94,15 @@
             </Grid.RenderTransform>
             <AdornerDecorator>
                 <DockPanel FocusVisualStyle="{x:Null}" Focusable="False">
-                    <ContentPresenter x:Name="PART_Header"
-                                      ContentSource="Header"
-                                      ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                      DockPanel.Dock="Top" />
+                    <Controls:ContentControlEx x:Name="PART_Header"
+                                               DockPanel.Dock="Top"
+                                               FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
+                                               FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
+                                               FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
+                                               Content="{TemplateBinding Header}"
+                                               ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                               RecognizesAccessKey="True"
+                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     <ContentPresenter x:Name="PART_Content" DockPanel.Dock="Bottom" />
                 </DockPanel>
             </AdornerDecorator>
@@ -222,6 +226,7 @@
         <Setter Property="Foreground" Value="{DynamicResource FlyoutForegroundBrush}" />
         <Setter Property="Background" Value="{DynamicResource FlyoutBackgroundBrush}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource FlyoutHeaderFontSize}" />
         <Setter Property="HeaderTemplate" Value="{StaticResource HeaderTemplate}" />
         <Setter Property="KeyboardNavigation.ControlTabNavigation" Value="Cycle" />
         <Setter Property="KeyboardNavigation.DirectionalNavigation" Value="Cycle" />

--- a/Mahapps.Metro.Tests/FlyoutTest.cs
+++ b/Mahapps.Metro.Tests/FlyoutTest.cs
@@ -187,17 +187,14 @@ namespace MahApps.Metro.Tests
                                 });
         }
 
-        public class ColorTest
+        [Fact]
+        public async Task DefaultFlyoutThemeIsDark()
         {
-            [Fact]
-            public async Task DefaultFlyoutThemeIsDark()
-            {
-                await TestHost.SwitchToAppThread();
+            await TestHost.SwitchToAppThread();
 
-                var window = await WindowHelpers.CreateInvisibleWindowAsync<FlyoutWindow>();
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<FlyoutWindow>();
 
-                Assert.Equal(FlyoutTheme.Dark, window.DefaultFlyout.Theme);
-            }
+            Assert.Equal(FlyoutTheme.Dark, window.DefaultFlyout.Theme);
         }
     }
 }

--- a/docs/release-notes/1.3.0.md
+++ b/docs/release-notes/1.3.0.md
@@ -80,6 +80,9 @@ MahApps.Metro v1.3.0 bug fix and feature release.
 	+ It's now possible again to have title templates with clickable controls
 	+ Replaced `TitleCaps` with `TitleCharacterCasing` (marked as obsolete). Now title can be `Upper`, `Lower` or `Normal`
 	+ Add new styles `MahApps.Metro.Styles.ContentControlEx` and `MahApps.Metro.Styles.MetroThumbContentControl`
+- `Flyout` improvement caused by #2485 #2523
+	+ use `ContentControlEx` for header, so it's now possible to use `ControlsHelper` attached properties `ContentCharacterCasing`, `HeaderFontSize`, `HeaderFontWeight` and `HeaderFontStretch`
+	+ new attached property `ControlsHelper.HeaderMargin` to handle the Margin from Flyout side
 
 # Closed Issues
 
@@ -133,3 +136,4 @@ MahApps.Metro v1.3.0 bug fix and feature release.
 - #2495 Default for ControlsHelper.HeaderFontSizeProperty should be SystemFonts.MessageFontSize
 - #2479 DefaultButtonFocus Not Working As Expected PR #2505
 - #2514 NumericUpDown UseFloatingWatermark Issue
+- #2485 Hiding close button and title leaves blank space in top-positioned flyouts #2485

--- a/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
+++ b/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
@@ -17,6 +17,10 @@
                       BorderThickness="1"
                       SaveWindowPosition="True"
                       WindowStartupLocation="CenterScreen"
+                      IconOverlayBehavior="Never"
+                      LeftWindowCommandsOverlayBehavior="Never"
+                      RightWindowCommandsOverlayBehavior="Never"
+                      WindowButtonCommandsOverlayBehavior="Always"
                       mc:Ignorable="d"
                       d:DataContext="{d:DesignInstance metroDemo:MainWindowViewModel}">
 
@@ -229,24 +233,28 @@
                     </ComboBox>
                 </StackPanel>
             </Controls:Flyout>
-            <Controls:Flyout Header="Top" Position="Top">
-                <StackPanel Height="100"
-                            Margin="5,5,5,5"
-                            HorizontalAlignment="Right"
-                            Orientation="Horizontal">
-                    <Button Width="40"
-                            Height="40"
-                            FontFamily="Segoe UI Symbol"
-                            FontSize="16"
-                            Style="{DynamicResource MetroCircleButtonStyle}">
-                        <Rectangle Width="20" Height="20">
-                            <Rectangle.Fill>
-                                <VisualBrush Stretch="Fill" Visual="{DynamicResource appbar_add}" />
-                            </Rectangle.Fill>
-                        </Rectangle>
-                    </Button>
-                </StackPanel>
+
+            <Controls:Flyout Header="Top"
+                             Position="Top"
+                             Theme="Light"
+                             IsModal="True"
+                             Margin="50 0 50 0"
+                             TitleVisibility="Collapsed"
+                             CloseButtonVisibility="Collapsed">
+                <Grid Height="150">
+                    <TextBlock Text="Flyout on the top..." FontSize="22" Margin="10" />
+                    <Grid VerticalAlignment="Bottom" Background="{DynamicResource AccentColorBrush2}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Button Grid.Column="1" Style="{DynamicResource MetroFlatButton}" Margin="5" Content="_Save" IsEnabled="False" />
+                        <Button Grid.Column="2" Style="{DynamicResource MetroFlatButton}" Margin="5" IsCancel="True" Content="_Close" Click="TopFlyoutCloseButtonOnClick" />
+                    </Grid>
+                </Grid>
             </Controls:Flyout>
+
             <Controls:Flyout Header="Bottom" Position="Bottom">
                 <StackPanel Height="80"
                             Margin="5,5,5,5"

--- a/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
+++ b/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml
@@ -92,6 +92,7 @@
     <Controls:MetroWindow.Flyouts>
         <Controls:FlyoutsControl x:Name="flyoutsControl">
             <Controls:Flyout x:Name="settingsFlyout"
+                             Controls:ControlsHelper.ContentCharacterCasing="Upper"
                              Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Controls:MetroWindow}, Path=ActualWidth}"
                              Margin="100 0 0 0"
                              AreAnimationsEnabled="False"

--- a/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml.cs
+++ b/samples/MetroDemo/ExampleWindows/FlyoutDemo.xaml.cs
@@ -187,5 +187,10 @@ namespace MetroDemo.ExampleWindows
         {
             await this.ShowMessageAsync("Title Template Test", "Thx for using MahApps.Metro!!!");
         }
+
+        private void TopFlyoutCloseButtonOnClick(object sender, RoutedEventArgs e)
+        {
+            this.ToggleFlyout(8);
+        }
     }
 }


### PR DESCRIPTION
## What changed?

- use ContentControlEx for header
- use internal command handling for close button
- use ControlsHelper attaches proeprties `HeaderFontSize`, `HeaderFontWeight` and `HeaderFontStretch`
- new attached property `ControlsHelper.HeaderMargin`

![image](https://cloud.githubusercontent.com/assets/658431/15726258/298c3546-2850-11e6-90ed-078c09e3234a.png)

_Closed issues._

Closes #2485 Hiding close button and title leaves blank space in top-positioned flyouts