### PR TITLE
Allow showing title bar while showing dialog (Fixes #2109)

### DIFF
--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -53,6 +53,8 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty IconBitmapScalingModeProperty = DependencyProperty.Register("IconBitmapScalingMode", typeof(BitmapScalingMode), typeof(MetroWindow), new PropertyMetadata(BitmapScalingMode.HighQuality));
         public static readonly DependencyProperty ShowTitleBarProperty = DependencyProperty.Register("ShowTitleBar", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true, OnShowTitleBarPropertyChangedCallback, OnShowTitleBarCoerceValueCallback));
 
+        public static readonly DependencyProperty ShowDialogsOverTitleBarProperty = DependencyProperty.Register("ShowDialogsOverTitleBar", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true, OnShowDialogsOverTitleBarPropertyChangedCallback));
+
         public static readonly DependencyProperty ShowMinButtonProperty = DependencyProperty.Register("ShowMinButton", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
         public static readonly DependencyProperty ShowMaxRestoreButtonProperty = DependencyProperty.Register("ShowMaxRestoreButton", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
         public static readonly DependencyProperty ShowCloseButtonProperty = DependencyProperty.Register("ShowCloseButton", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
@@ -355,6 +357,33 @@ namespace MahApps.Metro.Controls
             if (e.NewValue != e.OldValue)
             {
                 window.SetVisibiltyForIcon();
+            }
+        }
+
+        /// <summary>
+        /// Get/sets whether dialogs show over the title bar.
+        /// </summary>
+        public bool ShowDialogsOverTitleBar
+        {
+            get { return (bool)GetValue(ShowDialogsOverTitleBarProperty); }
+            set { SetValue(ShowDialogsOverTitleBarProperty, value); }
+        }
+
+        private static void OnShowDialogsOverTitleBarPropertyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var window = (MetroWindow)d;
+            if (e.NewValue != e.OldValue)
+            {
+                window.UpdateDialogPlacement((bool)e.NewValue);
+            }
+        }
+
+        private void UpdateDialogPlacement(bool shouldShowOverTitleBar)
+        {
+            if (overlayBox != null)
+            {
+                int row = shouldShowOverTitleBar == true ? 0 : 1;
+                Grid.SetRow(overlayBox, row);
             }
         }
 
@@ -966,6 +995,7 @@ namespace MahApps.Metro.Controls
             this.flyoutModalDragMoveThumb = GetTemplateChild(PART_FlyoutModalDragMoveThumb) as Thumb;
 
             this.SetVisibiltyForAllTitleElements(this.TitlebarHeight > 0);
+            this.UpdateDialogPlacement(ShowDialogsOverTitleBar);
         }
 
         protected IntPtr CriticalHandle

--- a/samples/MetroDemo/MainWindow.xaml
+++ b/samples/MetroDemo/MainWindow.xaml
@@ -21,7 +21,8 @@
                       mc:Ignorable="d"
                       d:DesignHeight="600"
                       d:DesignWidth="800"
-                      d:DataContext="{d:DesignInstance MetroDemo:MainWindowViewModel}">
+                      d:DataContext="{d:DesignInstance MetroDemo:MainWindowViewModel}"
+                      ShowDialogsOverTitleBar="True">
     <!--
         if using DialogParticipation on Windows which open/close frequently you will get a
         memory leak unless you unregister.  The easiest way to do this is in your Closing/Unloaded
@@ -164,6 +165,10 @@
                               Header="Use Accent?"
                               IsCheckable="True"
                               IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=UseAccentForDialogs}" />
+                    <MenuItem x:Name="HideTitleBarForDialogsMenuItem"
+                              Header="Hide Title Bar When Displaying Dialog?"
+                              IsCheckable="True"
+                              IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=HideTitleBarForDialogs}" />
                     <Separator />
                     <MenuItem Click="ShowInputDialog" Header="Show InputDialog" />
                     <MenuItem Click="ShowLoginDialog" Header="Show LoginDialog" />

--- a/samples/MetroDemo/MainWindow.xaml.cs
+++ b/samples/MetroDemo/MainWindow.xaml.cs
@@ -88,6 +88,28 @@ namespace MetroDemo
             }
         }
 
+        public bool HideTitleBarForDialogs
+        {
+            get { return (bool)GetValue(HideTitleBarForDialogsProperty); }
+            set { SetValue(HideTitleBarForDialogsProperty, value); }
+        }
+
+        public static readonly DependencyProperty HideTitleBarForDialogsProperty =
+            DependencyProperty.Register("HideTitleBarForDialogs",
+                                        typeof(bool),
+                                        typeof(MainWindow),
+                                        new PropertyMetadata(true, ToggleHideTitleBarForDialogsPropertyChangedCallback));
+
+        private static void ToggleHideTitleBarForDialogsPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            var metroWindow = (MetroWindow)dependencyObject;
+            if (e.OldValue != e.NewValue)
+            {
+                var hideTitleBarForDialogs = (bool)e.NewValue;
+                metroWindow.ShowDialogsOverTitleBar = hideTitleBarForDialogs;
+            }
+        }
+
         public bool UseAccentForDialogs
         {
             get { return (bool)GetValue(UseAccentForDialogsProperty); }


### PR DESCRIPTION
## What changed?

Added `ShowDialogsOverTitleBar` property to MetroWindow to set whether dialogs show over (hide) the window's title bar or not. Defaults to `true` so that legacy applications are not affected.

Fixes #2109 

