### PR TITLE
Close SplitButton popup if it loses mouse capture

### DIFF
--- a/MahApps.Metro/Controls/SplitButton.cs
+++ b/MahApps.Metro/Controls/SplitButton.cs
@@ -353,12 +353,25 @@ namespace MahApps.Metro.Controls
         {
             Mouse.Capture(this, CaptureMode.SubTree);
             Mouse.AddPreviewMouseDownOutsideCapturedElementHandler(this, this.OutsideCapturedElementHandler);
+            Mouse.AddLostMouseCaptureHandler(this, this.LostMouseCaptureHandler);
+        }
+
+        private void RemoveMouseCaptureHandlers()
+        {
+            Mouse.RemovePreviewMouseDownOutsideCapturedElementHandler(this, this.OutsideCapturedElementHandler);
+            Mouse.RemoveLostMouseCaptureHandler(this, this.LostMouseCaptureHandler);
         }
 
         private void OutsideCapturedElementHandler(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
             this.IsExpanded = false;
-            Mouse.RemovePreviewMouseDownOutsideCapturedElementHandler(this, this.OutsideCapturedElementHandler);
+            this.RemoveMouseCaptureHandlers();
+        }
+
+        private void LostMouseCaptureHandler(object sender, MouseEventArgs e)
+        {
+            this.IsExpanded = false;
+            this.RemoveMouseCaptureHandlers();
         }
     }
 }


### PR DESCRIPTION
## What changed?

If the SplitButton loses mouse capture while its Popup is open, then close the popup.

Closes #2574 -- bug where Popup would stay open even when the window lost focus.

