### PR TITLE
Revert #2575 and fix problem in a way that doesn't break the SplitBut…

### DIFF
--- a/MahApps.Metro/Controls/SplitButton.cs
+++ b/MahApps.Metro/Controls/SplitButton.cs
@@ -347,31 +347,20 @@ namespace MahApps.Metro.Controls
         {
             this.ReleaseMouseCapture();
             this._expander?.Focus();
+            this._popup.StaysOpen = true; // if we don't set this back to true, then the popup will never show again
         }
 
         private void PopupOpened(object sender, EventArgs e)
         {
             Mouse.Capture(this, CaptureMode.SubTree);
             Mouse.AddPreviewMouseDownOutsideCapturedElementHandler(this, this.OutsideCapturedElementHandler);
-            Mouse.AddLostMouseCaptureHandler(this, this.LostMouseCaptureHandler);
-        }
-
-        private void RemoveMouseCaptureHandlers()
-        {
-            Mouse.RemovePreviewMouseDownOutsideCapturedElementHandler(this, this.OutsideCapturedElementHandler);
-            Mouse.RemoveLostMouseCaptureHandler(this, this.LostMouseCaptureHandler);
+            this._popup.StaysOpen = false; // hides popup on alt+tab
         }
 
         private void OutsideCapturedElementHandler(object sender, MouseButtonEventArgs mouseButtonEventArgs)
         {
             this.IsExpanded = false;
-            this.RemoveMouseCaptureHandlers();
-        }
-
-        private void LostMouseCaptureHandler(object sender, MouseEventArgs e)
-        {
-            this.IsExpanded = false;
-            this.RemoveMouseCaptureHandlers();
+            Mouse.RemovePreviewMouseDownOutsideCapturedElementHandler(this, this.OutsideCapturedElementHandler);
         }
     }
 }

--- a/MahApps.Metro/Controls/SplitButton.cs
+++ b/MahApps.Metro/Controls/SplitButton.cs
@@ -329,7 +329,7 @@ namespace MahApps.Metro.Controls
             this._popup.Closed += this.PopupClosed;
         }
 
-        //Make popup close even if no selectionchanged event fired (case when user select the save item as before)
+        //Make popup close even if no selectionchanged event fired (case when user select the same item as before)
         private void ListBoxPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             var source = e.OriginalSource as DependencyObject;


### PR DESCRIPTION
...ton's popup menu.

## What changed?

#2575 closed the SplitButton's popup if you clicked the scroll bar. Totally my fault and lack of testing there. I apologize.

This pull request fixes #2574 (popup stays open if you Alt+Tab) in a different way that also keeps the scroll bar mouse down working. Things seem to work as expected again.