### PR TITLE
Proposal - Dont focus flyout on close

### DIFF
--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -8,9 +8,7 @@ using System.Windows.Media.Animation;
 using System.Windows.Threading;
 
 namespace MahApps.Metro.Controls
-{
-    using System.Linq;
-
+{    
     /// <summary>
     /// A sliding panel control that is hosted in a MetroWindow via a FlyoutsControl.
     /// <see cref="MetroWindow"/>

--- a/MahApps.Metro/Controls/Flyout.cs
+++ b/MahApps.Metro/Controls/Flyout.cs
@@ -9,6 +9,8 @@ using System.Windows.Threading;
 
 namespace MahApps.Metro.Controls
 {
+    using System.Linq;
+
     /// <summary>
     /// A sliding panel control that is hosted in a MetroWindow via a FlyoutsControl.
     /// <see cref="MetroWindow"/>
@@ -452,9 +454,7 @@ namespace MahApps.Metro.Controls
                             }
                         }
                         else
-                        {
-                            // focus the Flyout itself to avoid nasty FocusVisual painting (it's visible until the Flyout is closed)
-                            flyout.Focus();
+                        {                            
                             flyout.StopAutoCloseTimer();
                             if (flyout.hideStoryboard != null)
                             {
@@ -480,8 +480,6 @@ namespace MahApps.Metro.Controls
                         }
                         else
                         {
-                            // focus the Flyout itself to avoid nasty FocusVisual painting (it's visible until the Flyout is closed)
-                            flyout.Focus();
                             flyout.StopAutoCloseTimer();
                             flyout.Hide();
                         }


### PR DESCRIPTION
### Background

I have multiple windows, and i'm using flyouts to show an alert condition in the application.  When the user dismisses the alert all flyouts are closed via my application code.

### The problem

This line causes the last Window my where my code closes the flyout to receive focus , bringing that window to the front, interrupting the users activity:

```
// focus the Flyout itself to avoid nasty FocusVisual painting (it's visible until the Flyout is closed)		
flyout.Focus();
```

### Remarks

I understand there is a specific comment here regarding this line to perform some visual trickery.  However, it's not logically correct.  I have experimented, removed the line, and I can't see any display issues in _my_ application.

Maybe someone / @punker76 ,  with some background on this line can comment?

Another option would be to make the code a bit more specific; only run the focus if the current Window is active, something like:

```
if (Window.GetWindow(flyout) == Application.Windows.OfType<Window>().FirstOrDefault(w => w.IsActive))
    flyout.Focus();
```