### PR TITLE
Fix for issue 2674: Null Reference Exception in BorderlessWindowBehav…

### DIFF
--- a/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
+++ b/MahApps.Metro/Behaviours/BorderlessWindowBehavior.cs
@@ -122,7 +122,10 @@ namespace MahApps.Metro.Behaviours
 
         private void TopMostChangeNotifierOnValueChanged(object sender, EventArgs e)
         {
-            this.savedTopMost = this.AssociatedObject.Topmost;
+            if (this.AssociatedObject != null)
+            {
+                this.savedTopMost = this.AssociatedObject.Topmost;
+            }
         }
 
         private void UseNoneWindowStylePropertyChangedCallback(object sender, EventArgs e)


### PR DESCRIPTION
## What changed?

Checks Associated Object to make sure it is not null before using it.

_Closed issues._

2674: Null Reference Exception in BorderlessWindowBehavior.TopMostChangeNotifierOnValueChanged