### PR TITLE
Hotfix for DateTimePicker/TimePicker

### DIFF
--- a/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
+++ b/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
@@ -29,7 +29,7 @@
             typeof(EventHandler<TimePickerBaseSelectionChangedEventArgs<DateTime?>>),
             typeof(DateTimePicker));
 
-        public static readonly DependencyProperty SelectedDateProperty = DatePicker.SelectedDateProperty.AddOwner(typeof(DateTimePicker), new PropertyMetadata(OnSelectedDateChanged));
+        public static readonly DependencyProperty SelectedDateProperty = DatePicker.SelectedDateProperty.AddOwner(typeof(DateTimePicker), new FrameworkPropertyMetadata(default(DateTime?), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedDateChanged));
       
         private const string ElementCalendar = "PART_Calendar";
         private Calendar _calendar;

--- a/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
+++ b/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
@@ -4,6 +4,7 @@
     using System.ComponentModel;
     using System.Windows;
     using System.Windows.Controls;
+    using System.Windows.Controls.Primitives;
 
     /// <summary>
     ///     Represents a control that allows the user to select a date and a time.
@@ -32,7 +33,7 @@
         public static readonly DependencyProperty SelectedDateProperty = DatePicker.SelectedDateProperty.AddOwner(typeof(DateTimePicker), new FrameworkPropertyMetadata(default(DateTime?), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedDateChanged));
       
         private const string ElementCalendar = "PART_Calendar";
-        private Calendar _calendar;
+        private System.Windows.Controls.Calendar _calendar;
 
         static DateTimePicker()
         {
@@ -132,7 +133,7 @@
 
         public override void OnApplyTemplate()
         {
-            _calendar = GetTemplateChild(ElementCalendar) as Calendar;
+            _calendar = GetTemplateChild(ElementCalendar) as System.Windows.Controls.Calendar;
             base.OnApplyTemplate();
             _calendar = GetTemplateChild(ElementCalendar) as Calendar;
         }
@@ -164,11 +165,34 @@
             FirstDayOfWeek = SpecificCultureInfo.DateTimeFormat.FirstDayOfWeek;
         }
 
+        protected override string GetValueForTextBox()
+        {
+            return SelectedDate?.ToString();
+        }
+
         protected override void OnRangeBaseValueChanged(object sender, SelectionChangedEventArgs e)
         {
             base.OnRangeBaseValueChanged(sender, e);
             
             SetDatePartValues();
+        }
+
+        protected override void OnTextBoxLostFocus(object sender, RoutedEventArgs e)
+        {
+            DateTime ts;
+            if (DateTime.TryParse(((DatePickerTextBox)sender).Text, SpecificCultureInfo, System.Globalization.DateTimeStyles.None, out ts))
+            {
+                SelectedDate = ts;
+            }
+            else
+            {
+                if (SelectedDate == null)
+                {
+                    // if already null, overwrite wrong data in textbox
+                    WriteValueToTextBox();
+                }
+                SelectedDate = null;
+            }
         }
 
         protected override void SubscribeEvents()
@@ -220,6 +244,8 @@
             {
                 dateTimePicker.SetDefaultTimeOfDayValues();
             }
+
+            dateTimePicker.WriteValueToTextBox();
         }
 
         private void OnSelectedDatesChanged(object sender, SelectionChangedEventArgs e)

--- a/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
+++ b/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
@@ -168,9 +168,9 @@
         protected override string GetValueForTextBox()
         {
             var formatInfo = SpecificCultureInfo.DateTimeFormat;
-            var dateTimeFormat = $"{formatInfo.ShortDatePattern} {formatInfo.LongTimePattern}";
+            var dateTimeFormat = string.Intern($"{formatInfo.ShortDatePattern} {formatInfo.LongTimePattern}");
 
-            return SelectedDate?.ToString(string.Intern(dateTimeFormat), SpecificCultureInfo);
+            return SelectedDate?.ToString(dateTimeFormat, SpecificCultureInfo);
         }
 
         protected override void OnRangeBaseValueChanged(object sender, SelectionChangedEventArgs e)

--- a/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
+++ b/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
@@ -167,7 +167,10 @@
 
         protected override string GetValueForTextBox()
         {
-            return SelectedDate?.ToString();
+            var formatInfo = SpecificCultureInfo.DateTimeFormat;
+            var dateTimeFormat = $"{formatInfo.ShortDatePattern} {formatInfo.LongTimePattern}";
+
+            return SelectedDate?.ToString(string.Intern(dateTimeFormat), SpecificCultureInfo);
         }
 
         protected override void OnRangeBaseValueChanged(object sender, SelectionChangedEventArgs e)

--- a/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
+++ b/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
@@ -33,7 +33,7 @@
         public static readonly DependencyProperty SelectedDateProperty = DatePicker.SelectedDateProperty.AddOwner(typeof(DateTimePicker), new FrameworkPropertyMetadata(default(DateTime?), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedDateChanged));
       
         private const string ElementCalendar = "PART_Calendar";
-        private System.Windows.Controls.Calendar _calendar;
+        private Calendar _calendar;
 
         static DateTimePicker()
         {

--- a/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
+++ b/MahApps.Metro/Controls/TimePicker/DateTimePicker.cs
@@ -5,6 +5,7 @@
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Controls.Primitives;
+    using Standard;
 
     /// <summary>
     ///     Represents a control that allows the user to select a date and a time.
@@ -252,7 +253,8 @@
 
         private DateTime? GetSelectedDateTimeFromGUI()
         {
-            var selectedDate = _calendar?.SelectedDate;
+            // Because Calendar.SelectedDate is bound to this.SelectedDate return this.SelectedDate
+            var selectedDate = SelectedDate;
 
             if (selectedDate != null)
             {

--- a/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
+++ b/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
@@ -430,7 +430,7 @@ namespace MahApps.Metro.Controls
 
         protected virtual string GetValueForTextBox()
         {
-            return SelectedTime?.ToString(SpecificCultureInfo.DateTimeFormat.LongTimePattern, SpecificCultureInfo);
+            return (DateTime.MinValue + SelectedTime)?.ToString(string.Intern(SpecificCultureInfo.DateTimeFormat.LongTimePattern), SpecificCultureInfo);
         }
 
         protected virtual void OnTextBoxLostFocus(object sender, RoutedEventArgs e)

--- a/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
+++ b/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
@@ -555,7 +555,7 @@ namespace MahApps.Metro.Controls
                 {
                     return hourList.Where(i => i > 0 && i <= 12).OrderBy(i => i, new AmPmComparer());
                 }
-                return hourList.Where(i => i > 0 && i <= 24);
+                return hourList.Where(i => i >= 0 && i < 24);
             }
             return Enumerable.Empty<int>();
         }

--- a/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
+++ b/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
@@ -381,6 +381,8 @@ namespace MahApps.Metro.Controls
             SubscribeEvents();
             ApplyCulture();
             ApplyBindings();
+
+            WriteValueToTextBox();
         }
 
         protected virtual void ApplyBindings()
@@ -428,7 +430,7 @@ namespace MahApps.Metro.Controls
 
         protected virtual string GetValueForTextBox()
         {
-            return SelectedTime?.ToString();
+            return SelectedTime?.ToString(SpecificCultureInfo.DateTimeFormat.LongTimePattern, SpecificCultureInfo);
         }
 
         protected virtual void OnTextBoxLostFocus(object sender, RoutedEventArgs e)

--- a/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -148,7 +148,6 @@
                                                    x:Name="PART_TextBox"
                                                    Grid.Row="1"
                                                    IsReadOnly="{Binding Path=IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}"
-                                                   Text="{Binding Path=SelectedTime, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TimeSpanToStringConverter}}" 
                                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                                    Foreground="{TemplateBinding Foreground}"
@@ -358,7 +357,7 @@
                         <Trigger Property="IsDatePickerVisible" Value="True">
                             <Setter TargetName="PART_Calendar" Property="Visibility" Value="Visible" />
                             <Setter TargetName="StackPanel" Property="Orientation" Value="{Binding Path=Orientation, RelativeSource={RelativeSource TemplatedParent}}" />
-                            <Setter TargetName="PART_TextBox" Property="Text" Value="{Binding Path=SelectedDate, RelativeSource={RelativeSource TemplatedParent}}" />
+                            <!--<Setter TargetName="PART_TextBox" Property="Text" Value="{Binding Path=SelectedDate, RelativeSource={RelativeSource TemplatedParent}}" />-->
                         </Trigger>
                         
                         <MultiDataTrigger>

--- a/Mahapps.Metro.Tests/DateAndTimePickerWindow.xaml
+++ b/Mahapps.Metro.Tests/DateAndTimePickerWindow.xaml
@@ -9,5 +9,7 @@
                       d:DesignWidth="300">
     <StackPanel>
         <controls:DateTimePicker x:Name="TheDateTimePicker" Culture="pt-BR" SelectedDate="08/31/2016 14:00:01" />
+        <controls:TimePicker x:Name="TheTimePickerDe" Culture="de-de" SelectedTime="14:00:01" />
+        <controls:TimePicker x:Name="TheTimePickerUs" Culture="en-us" SelectedTime="14:00:01" />
     </StackPanel>
 </controls:MetroWindow>

--- a/Mahapps.Metro.Tests/DateTimePickerTests.cs
+++ b/Mahapps.Metro.Tests/DateTimePickerTests.cs
@@ -16,12 +16,42 @@
 
             var window = await WindowHelpers.CreateInvisibleWindowAsync<DateAndTimePickerWindow>().ConfigureAwait(false);
             window.Invoke(() =>
-                {
-                    Assert.NotNull(window.TheDateTimePicker.SelectedDate);
-                    Assert.NotNull(window.TheDateTimePicker.Culture);
-                    Assert.Equal("pt-BR", window.TheDateTimePicker.Culture.IetfLanguageTag);
-                    Assert.Equal("31/08/2016 14:00:01", window.TheDateTimePicker.FindChild<DatePickerTextBox>(string.Empty).Text);
-                });
+                              {
+                                  Assert.NotNull(window.TheDateTimePicker.SelectedDate);
+                                  Assert.NotNull(window.TheDateTimePicker.Culture);
+                                  Assert.Equal("pt-BR", window.TheDateTimePicker.Culture.IetfLanguageTag);
+                                  Assert.Equal("31/08/2016 14:00:01", window.TheDateTimePicker.FindChild<DatePickerTextBox>(string.Empty).Text);
+                              });
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task TimePickerCultureDeTest()
+        {
+            await TestHost.SwitchToAppThread();
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DateAndTimePickerWindow>().ConfigureAwait(false);
+            window.Invoke(() =>
+                              {
+                                  Assert.NotNull(window.TheTimePickerDe.SelectedTime);
+                                  Assert.NotNull(window.TheTimePickerDe.Culture);
+                                  Assert.Equal("de-DE", window.TheTimePickerDe.Culture.IetfLanguageTag);
+                                  Assert.Equal("14:00:01", window.TheTimePickerDe.FindChild<DatePickerTextBox>(string.Empty).Text);
+                              });
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task TimePickerCultureUsTest()
+        {
+            await TestHost.SwitchToAppThread();
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DateAndTimePickerWindow>().ConfigureAwait(false);
+            window.Invoke(() =>
+                              {
+                                  Assert.NotNull(window.TheTimePickerUs.SelectedTime);
+                                  Assert.NotNull(window.TheTimePickerUs.Culture);
+                                  Assert.Equal("en-US", window.TheTimePickerUs.Culture.IetfLanguageTag);
+                                  Assert.Equal("2:00:01 PM", window.TheTimePickerUs.FindChild<DatePickerTextBox>(string.Empty).Text);
+                              });
         }
     }
 }


### PR DESCRIPTION
The reason is that we do not have to use Mode=TwoWay explicit, and DatePicker.SelectedDate has BindsTwoWayByDefault too.

 - [x] Change DateTimePicker.SelectedDate to BindsTwoWayByDefault
 - [x] [Fix] Issue where Binding issues on DateTimePicker/TimePicker are shown on the output window
 - [x] [Fix] Issue where Hour 0 is not shown when using 24h clock
 - [x] Fix issue where clearing text does not immediately set value to `null` but `00:00:00` and `0001.01.01 00.00.00` respectively