### PR TITLE
Remove unnecessary usings im MahApps.Metro project

### DIFF
--- a/MahApps.Metro/Behaviours/StylizedBehaviors.cs
+++ b/MahApps.Metro/Behaviours/StylizedBehaviors.cs
@@ -4,7 +4,6 @@ using System.Windows.Interactivity;
 namespace MahApps.Metro.Behaviours
 {
     using System.ComponentModel;
-    using System.Windows.Threading;
 
     public class StylizedBehaviors
     {

--- a/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;

--- a/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 
 namespace MahApps.Metro.Controls.Dialogs
 {

--- a/MahApps.Metro/Controls/Dialogs/ProgressDialog.cs
+++ b/MahApps.Metro/Controls/Dialogs/ProgressDialog.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading;
+﻿using System.Threading;
 using System.Windows;
 using System.Windows.Media;
 

--- a/MahApps.Metro/Controls/MetroWindow.cs
+++ b/MahApps.Metro/Controls/MetroWindow.cs
@@ -11,7 +11,6 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Shapes;
 using System.Windows.Controls.Primitives;
-using System.Windows.Threading;
 using JetBrains.Annotations;
 using MahApps.Metro.Controls.Dialogs;
 using MahApps.Metro.Native;

--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/DoubleUtil.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/DoubleUtil.cs
@@ -1,7 +1,6 @@
 ﻿
 namespace Standard
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>

--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/DpiHelper.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/DpiHelper.cs
@@ -1,6 +1,5 @@
 ﻿namespace Standard
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Windows;
     using System.Windows.Media;

--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/NativeMethods.cs
@@ -8,7 +8,6 @@
     using System.Runtime.InteropServices;
     using System.Runtime.InteropServices.ComTypes;
     using System.Security;
-    using System.Security.Permissions;
     using System.Text;
     using Microsoft.Win32.SafeHandles;
 

--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/ShellProvider.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/ShellProvider.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
     using System.Runtime.InteropServices.ComTypes;
     using System.Text;

--- a/MahApps.Metro/Microsoft.Windows.Shell/Standard/Utilities.Wpf.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/Standard/Utilities.Wpf.cs
@@ -10,8 +10,6 @@ namespace Standard
     using System.ComponentModel;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
-    using System.Linq;
-    using System.Reflection;
     using System.Windows;
     using System.Windows.Media;
     using System.Windows.Media.Imaging;

--- a/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
+++ b/MahApps.Metro/Microsoft.Windows.Shell/WindowChromeWorker.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Windows.Shell
     using System.Runtime.InteropServices;
     using System.Security;
     using System.Security.Permissions;
-    using System.Threading;
     using System.Windows;
     using System.Windows.Interop;
     using System.Windows.Media;

--- a/MahApps.Metro/Models/Win32/HitTestValues.cs
+++ b/MahApps.Metro/Models/Win32/HitTestValues.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace MahApps.Metro.Models.Win32
+﻿namespace MahApps.Metro.Models.Win32
 {
     internal enum HitTestValues : int
 	{

--- a/MahApps.Metro/Native/UnsafeNativeMethods.cs
+++ b/MahApps.Metro/Native/UnsafeNativeMethods.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;

--- a/Mahapps.Metro.Tests/CleanWindowTest.cs
+++ b/Mahapps.Metro.Tests/CleanWindowTest.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using System.Windows.Media;
-using MahApps.Metro;
 using MahApps.Metro.Tests.TestHelpers;
 using Xunit;
 

--- a/Mahapps.Metro.Tests/Properties/AssemblyInfo.cs
+++ b/Mahapps.Metro.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/samples/Caliburn.Metro.Demo/ViewModels/Flyouts/Flyout3ViewModel.cs
+++ b/samples/Caliburn.Metro.Demo/ViewModels/Flyouts/Flyout3ViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Caliburn.Micro;
+﻿using Caliburn.Micro;
 using MahApps.Metro.Controls;
 using MetroDemo.Models;
 

--- a/samples/MetroDemo/App.xaml.cs
+++ b/samples/MetroDemo/App.xaml.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Windows;
+﻿using System.Windows;
 
 namespace MetroDemo
 {

--- a/samples/MetroDemo/ExampleViews/ButtonsExample.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/ButtonsExample.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace MetroDemo.ExampleViews
 {

--- a/samples/MetroDemo/ExampleViews/ColorExample.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/ColorExample.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace MetroDemo.ExampleViews
 {

--- a/samples/MetroDemo/ExampleViews/CustomDialogExample.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/CustomDialogExample.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace MetroDemo.ExampleViews
 {

--- a/samples/MetroDemo/ExampleViews/DataGridExamples.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/DataGridExamples.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace MetroDemo.ExampleViews
 {

--- a/samples/MetroDemo/ExampleViews/DateExamples.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/DateExamples.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace MetroDemo.ExampleViews
 {

--- a/samples/MetroDemo/ExampleViews/OtherExamples.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/OtherExamples.xaml.cs
@@ -1,16 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using System.Windows.Threading;
 using MahApps.Metro.Controls;
 

--- a/samples/MetroDemo/ExampleViews/SelectionExamples.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/SelectionExamples.xaml.cs
@@ -1,16 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace MetroDemo.ExampleViews
 {

--- a/samples/MetroDemo/ExampleViews/SliderProgressExamples.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/SliderProgressExamples.xaml.cs
@@ -1,17 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using MahApps.Metro.Controls;
 
 namespace MetroDemo.ExampleViews

--- a/samples/MetroDemo/ExampleViews/TabControlExamples.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/TabControlExamples.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 using MahApps.Metro.Controls;
 
 namespace MetroDemo.ExampleViews

--- a/samples/MetroDemo/ExampleViews/TextExamples.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/TextExamples.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace MetroDemo.ExampleViews
 {

--- a/samples/MetroDemo/ExampleViews/TilesExample.xaml.cs
+++ b/samples/MetroDemo/ExampleViews/TilesExample.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Windows.Controls;
+﻿using System.Windows.Controls;
 
 namespace MetroDemo.ExampleViews
 {

--- a/samples/MetroDemo/ExampleWindows/SizeToContentDemo.xaml.cs
+++ b/samples/MetroDemo/ExampleWindows/SizeToContentDemo.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using MahApps.Metro.Controls;
+﻿using MahApps.Metro.Controls;
 
 namespace MetroDemo.ExampleWindows
 {

--- a/samples/MetroDemo/Navigation/HomePage.xaml.cs
+++ b/samples/MetroDemo/Navigation/HomePage.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace MetroDemo.Navigation
 {

--- a/samples/MetroDemo/Navigation/InterestingPage.xaml.cs
+++ b/samples/MetroDemo/Navigation/InterestingPage.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace MetroDemo.Navigation
 {

--- a/samples/MetroDemo/Properties/AssemblyInfo.cs
+++ b/samples/MetroDemo/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 ﻿using System.Reflection;
-using System.Resources;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 


### PR DESCRIPTION
## What changed?

Removed using that were simply not needed by the code. Since unnecessary usings are explicitly shown as errors in ReSharper due to the distributed dotsettings file, they should be removed to focus on the real errors.

