### PR TITLE
Hotfix for DateTimePicker/TimePicker

### DIFF
--- a/docs/release-notes/1.4.0.md
+++ b/docs/release-notes/1.4.0.md
@@ -16,6 +16,11 @@ MahApps.Metro v1.4.0 bug fix and feature release.
 		* `MultiFrameImageMode.NoScaleSmallerFrame`  
 		It takes the largest frame from the window which has equal or smaller size than the window's icon template. The frame is rendered centered if it's smaller.  
 		![image](https://cloud.githubusercontent.com/assets/73690/11567646/3bb8e1fc-99e8-11e5-90f5-682d3d87527d.png)
+- Changes for `DateTimePicker` and `TimePicker` [#2710](https://github.com/MahApps/MahApps.Metro/pull/2710)
+	+ Change `DateTimePicker.SelectedDate` to `BindsTwoWayByDefault`. The reason is that we do not have to use Mode=TwoWay explicit, and DatePicker.SelectedDate has BindsTwoWayByDefault too.
+	+ [Fix] Issue where Binding issues on DateTimePicker/TimePicker are shown on the output window
+	+ [Fix] Issue where Hour 0 is not shown when using 24h clock
+	+ Fix issue where clearing text does not immediately set value to `null` but `00:00:00` and `0001.01.01 00.00.00` respectively
 
 # Closed Issues / PRs
 

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
@@ -267,10 +267,13 @@
         private void SetDatePartValues()
         {
             var dateTime = GetSelectedDateTimeFromGUI();
-            DisplayDate = dateTime != DateTime.MinValue ? dateTime : DateTime.Today;
-            if (SelectedDate != DisplayDate || (Popup != null && Popup.IsOpen))
+            if (dateTime != null)
             {
-                SelectedDate = DisplayDate;
+                DisplayDate = dateTime != DateTime.MinValue ? dateTime : DateTime.Today;
+                if (SelectedDate != DisplayDate || (Popup != null && Popup.IsOpen))
+                {
+                    SelectedDate = DisplayDate;
+                }
             }
         }
     }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
@@ -136,6 +136,7 @@
         {
             _calendar = GetTemplateChild(ElementCalendar) as Calendar;
             base.OnApplyTemplate();
+            SetDatePartValues();
         }
 
         protected virtual void OnSelectedDateChanged(TimePickerBaseSelectionChangedEventArgs<DateTime?> e)

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
@@ -4,6 +4,7 @@
     using System.ComponentModel;
     using System.Windows;
     using System.Windows.Controls;
+    using System.Windows.Controls.Primitives;
 
     /// <summary>
     ///     Represents a control that allows the user to select a date and a time.
@@ -29,10 +30,11 @@
             typeof(EventHandler<TimePickerBaseSelectionChangedEventArgs<DateTime?>>),
             typeof(DateTimePicker));
 
-        public static readonly DependencyProperty SelectedDateProperty = DatePicker.SelectedDateProperty.AddOwner(typeof(DateTimePicker), new PropertyMetadata(OnSelectedDateChanged));
+        public static readonly DependencyProperty SelectedDateProperty = DatePicker.SelectedDateProperty.AddOwner(typeof(DateTimePicker), new FrameworkPropertyMetadata(default(DateTime?), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedDateChanged));
       
         private const string ElementCalendar = "PART_Calendar";
         private Calendar _calendar;
+        private bool _deactivateWriteValueToTextBox;
 
         static DateTimePicker()
         {
@@ -134,7 +136,6 @@
         {
             _calendar = GetTemplateChild(ElementCalendar) as Calendar;
             base.OnApplyTemplate();
-            _calendar = GetTemplateChild(ElementCalendar) as Calendar;
         }
 
         protected virtual void OnSelectedDateChanged(TimePickerBaseSelectionChangedEventArgs<DateTime?> e)
@@ -154,6 +155,7 @@
                 _calendar.SetBinding(Calendar.FirstDayOfWeekProperty, GetBinding(FirstDayOfWeekProperty));
                 _calendar.SetBinding(Calendar.IsTodayHighlightedProperty, GetBinding(IsTodayHighlightedProperty));
                 _calendar.SetBinding(FlowDirectionProperty, GetBinding(FlowDirectionProperty));
+                _calendar.SetBinding(Calendar.SelectedDateProperty, GetBinding(SelectedDateProperty));
             }
         }
 
@@ -164,6 +166,16 @@
             FirstDayOfWeek = SpecificCultureInfo.DateTimeFormat.FirstDayOfWeek;
         }
 
+        protected override string GetValueForTextBox()
+        {
+            var formatInfo = SpecificCultureInfo.DateTimeFormat;
+            var dateTimeFormat = string.Intern($"{formatInfo.ShortDatePattern} {formatInfo.LongTimePattern}");
+
+            var selectedDateTimeFromGui = this.GetSelectedDateTimeFromGUI();
+            var valueForTextBox = selectedDateTimeFromGui?.ToString(dateTimeFormat, this.SpecificCultureInfo);
+            return valueForTextBox;
+        }
+
         protected override void OnRangeBaseValueChanged(object sender, SelectionChangedEventArgs e)
         {
             base.OnRangeBaseValueChanged(sender, e);
@@ -171,23 +183,29 @@
             SetDatePartValues();
         }
 
-        protected override void SubscribeEvents()
+        protected override void OnTextBoxLostFocus(object sender, RoutedEventArgs e)
         {
-            base.SubscribeEvents();
-
-            if (_calendar != null)
+            DateTime ts;
+            if (DateTime.TryParse(((DatePickerTextBox)sender).Text, SpecificCultureInfo, System.Globalization.DateTimeStyles.None, out ts))
             {
-                _calendar.SelectedDatesChanged += OnSelectedDatesChanged;
+                SelectedDate = ts;
+            }
+            else
+            {
+                if (SelectedDate == null)
+                {
+                    // if already null, overwrite wrong data in textbox
+                    WriteValueToTextBox();
+                }
+                SelectedDate = null;
             }
         }
 
-        protected override void UnSubscribeEvents()
+        protected override void WriteValueToTextBox()
         {
-            base.UnSubscribeEvents();
-
-            if (_calendar != null)
+            if (!_deactivateWriteValueToTextBox)
             {
-                _calendar.SelectedDatesChanged -= OnSelectedDatesChanged;
+                base.WriteValueToTextBox();
             }
         }
 
@@ -210,6 +228,12 @@
         {
             var dateTimePicker = (DateTimePicker)d;
 
+            /* Without deactivating changing SelectedTime would callbase.OnSelectedTimeChanged.
+             * This would write too and this would result in duplicate writing.
+             * More problematic would be instead that a short amount of time SelectedTime would be as value in TextBox
+             */
+            dateTimePicker._deactivateWriteValueToTextBox = true; 
+
             var dt = (DateTime?)e.NewValue;
             if (dt.HasValue)
             {
@@ -220,26 +244,28 @@
             {
                 dateTimePicker.SetDefaultTimeOfDayValues();
             }
+
+            dateTimePicker._deactivateWriteValueToTextBox = false;
+
+            dateTimePicker.WriteValueToTextBox();
         }
 
-        private void OnSelectedDatesChanged(object sender, SelectionChangedEventArgs e)
+        private DateTime? GetSelectedDateTimeFromGUI()
         {
-            if (e.AddedItems != null)
+            // Because Calendar.SelectedDate is bound to this.SelectedDate return this.SelectedDate
+            var selectedDate = SelectedDate;
+
+            if (selectedDate != null)
             {
-                var dt = (DateTime)e.AddedItems[0];
-                dt = dt.Add(SelectedTime.GetValueOrDefault());
-                SelectedDate = dt;
+                return selectedDate.Value.Date + GetSelectedTimeFromGUI().GetValueOrDefault();
             }
-        }
 
-        private DateTime GetCorrectDateTime()
-        {
-            return SelectedDate.GetValueOrDefault(DateTime.Today).Date + SelectedTime.GetValueOrDefault();
+            return null;
         }
 
         private void SetDatePartValues()
         {
-            var dateTime = GetCorrectDateTime();
+            var dateTime = GetSelectedDateTimeFromGUI();
             DisplayDate = dateTime != DateTime.MinValue ? dateTime : DateTime.Today;
             if (SelectedDate != DisplayDate || (Popup != null && Popup.IsOpen))
             {

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
@@ -161,6 +161,8 @@ namespace MahApps.Metro.Controls
         private Selector _ampmSwitcher;
         private Button _button;
         private bool _deactivateRangeBaseEvent;
+        private bool _deactivateTextChangedEvent;
+        private bool _textInputChanged;
         private UIElement _hourHand;
         private Selector _hourInput;
         private UIElement _minuteHand;
@@ -168,7 +170,7 @@ namespace MahApps.Metro.Controls
         private Popup _popup;
         private UIElement _secondHand;
         private Selector _secondInput;
-        private DatePickerTextBox _textBox;
+        protected DatePickerTextBox _textBox;
 
         static TimePickerBase()
         {
@@ -372,6 +374,7 @@ namespace MahApps.Metro.Controls
             _secondHand = GetTemplateChild(ElementSecondHand) as FrameworkElement;
             _textBox = GetTemplateChild(ElementTextBox) as DatePickerTextBox;
 
+
             SetHandVisibility(HandVisibility);
             SetPickerVisibility(PickerVisibility);
 
@@ -379,13 +382,15 @@ namespace MahApps.Metro.Controls
             SubscribeEvents();
             ApplyCulture();
             ApplyBindings();
+
+            WriteValueToTextBox();
         }
 
         protected virtual void ApplyBindings()
         {
-            if (this.Popup != null)
+            if (Popup != null)
             {
-                this.Popup.SetBinding(Popup.IsOpenProperty, GetBinding(IsDropDownOpenProperty));
+                Popup.SetBinding(Popup.IsOpenProperty, GetBinding(IsDropDownOpenProperty));
             }
         }
 
@@ -424,14 +429,33 @@ namespace MahApps.Metro.Controls
             return new Binding(property.Name) { Source = this };
         }
 
+        protected virtual string GetValueForTextBox()
+        {
+            var valueForTextBox = (DateTime.MinValue + SelectedTime)?.ToString(string.Intern(SpecificCultureInfo.DateTimeFormat.LongTimePattern), SpecificCultureInfo);
+            return valueForTextBox;
+        }
+
+        protected virtual void OnTextBoxLostFocus(object sender, RoutedEventArgs e)
+        {
+            TimeSpan ts;
+            if (TimeSpan.TryParse(((DatePickerTextBox)sender).Text, SpecificCultureInfo, out ts))
+            {
+                SelectedTime = ts;
+            }
+            else
+            {
+                if (SelectedTime == null)
+                {
+                    // if already null, overwrite wrong data in textbox
+                    WriteValueToTextBox();
+                }
+                SelectedTime = null;
+            }
+        }
+
         protected virtual void OnRangeBaseValueChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_deactivateRangeBaseEvent)
-            {
-                return;
-            }
-
-            SelectedTime = this.GetTimeOfDayFromClockHands();
+            SelectedTime = this.GetSelectedTimeFromGUI();
         }
 
         protected virtual void OnSelectedTimeChanged(TimePickerBaseSelectionChangedEventArgs<TimeSpan?> e)
@@ -455,6 +479,11 @@ namespace MahApps.Metro.Controls
             {
                 _button.Click += OnButtonClicked;
             }
+            if (_textBox != null)
+            {
+                _textBox.TextChanged += OnTextChanged;
+                _textBox.LostFocus += InternalOnTextBoxLostFocus;
+            }
         }
 
         protected virtual void UnSubscribeEvents()
@@ -464,6 +493,21 @@ namespace MahApps.Metro.Controls
             if (_button != null)
             {
                 _button.Click -= OnButtonClicked;
+            }
+            if (_textBox != null)
+            {
+                _textBox.TextChanged -= OnTextChanged;
+                _textBox.LostFocus -= InternalOnTextBoxLostFocus;
+            }
+        }
+
+        protected virtual void WriteValueToTextBox()
+        {
+            if (_textBox != null)
+            {
+                _deactivateTextChangedEvent = true;
+                _textBox.Text = GetValueForTextBox();
+                _deactivateTextChangedEvent = false;
             }
         }
 
@@ -511,9 +555,27 @@ namespace MahApps.Metro.Controls
                 {
                     return hourList.Where(i => i > 0 && i <= 12).OrderBy(i => i, new AmPmComparer());
                 }
-                return hourList.Where(i => i > 0 && i <= 24);
+                return hourList.Where(i => i >= 0 && i < 24);
             }
             return Enumerable.Empty<int>();
+        }
+
+        private void InternalOnTextBoxLostFocus(object sender, RoutedEventArgs e)
+        {
+            if (_textInputChanged)
+            {
+                _textInputChanged = false;
+
+                OnTextBoxLostFocus(sender, e);
+            }
+        }
+
+        private void InternalOnRangeBaseValueChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!_deactivateRangeBaseEvent)
+            {
+                OnRangeBaseValueChanged(sender, e);
+            }
         }
 
         private static void OnCultureChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -567,9 +629,25 @@ namespace MahApps.Metro.Controls
         private static void OnSelectedTimeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var timePartPickerBase = (TimePickerBase)d;
+
+            if (timePartPickerBase._deactivateRangeBaseEvent)
+            {
+                return;
+            }
+
             timePartPickerBase.SetHourPartValues((e.NewValue as TimeSpan?).GetValueOrDefault(TimeSpan.Zero));
 
             timePartPickerBase.OnSelectedTimeChanged(new TimePickerBaseSelectionChangedEventArgs<TimeSpan?>(SelectedTimeChangedEvent, (TimeSpan?)e.OldValue, (TimeSpan?)e.NewValue));
+
+            timePartPickerBase.WriteValueToTextBox();
+        }
+
+        private void OnTextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (!_deactivateTextChangedEvent)
+            {
+                _textInputChanged = true;
+            }
         }
 
         private static void SetVisibility(UIElement partHours, UIElement partMinutes, UIElement partSeconds, TimePartVisibility visibility)
@@ -606,7 +684,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        private TimeSpan? GetTimeOfDayFromClockHands()
+        protected TimeSpan? GetSelectedTimeFromGUI()
         {
             {
                 if (IsValueSelected(_hourInput) &&
@@ -703,6 +781,11 @@ namespace MahApps.Metro.Controls
 
         private void SetHourPartValues(TimeSpan timeOfDay)
         {
+            if (this._deactivateRangeBaseEvent)
+            {
+                return;
+            }
+
             _deactivateRangeBaseEvent = true;
             if (_hourInput != null)
             {
@@ -747,7 +830,7 @@ namespace MahApps.Metro.Controls
         {
             foreach (var selector in selectors.Where(i => i != null))
             {
-                selector.SelectionChanged += OnRangeBaseValueChanged;
+                selector.SelectionChanged += InternalOnRangeBaseValueChanged;
             }
         }
 
@@ -755,7 +838,7 @@ namespace MahApps.Metro.Controls
         {
             foreach (var selector in selectors.Where(i => i != null))
             {
-                selector.SelectionChanged -= OnRangeBaseValueChanged;
+                selector.SelectionChanged -= InternalOnRangeBaseValueChanged;
             }
         }
     }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
@@ -374,16 +374,17 @@ namespace MahApps.Metro.Controls
             _secondHand = GetTemplateChild(ElementSecondHand) as FrameworkElement;
             _textBox = GetTemplateChild(ElementTextBox) as DatePickerTextBox;
 
-
             SetHandVisibility(HandVisibility);
             SetPickerVisibility(PickerVisibility);
+
+            SetHourPartValues(SelectedTime.GetValueOrDefault());
+            WriteValueToTextBox();
 
             SetDefaultTimeOfDayValues();
             SubscribeEvents();
             ApplyCulture();
             ApplyBindings();
 
-            WriteValueToTextBox();
         }
 
         protected virtual void ApplyBindings()

--- a/src/MahApps.Metro/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -148,7 +148,6 @@
                                                    x:Name="PART_TextBox"
                                                    Grid.Row="1"
                                                    IsReadOnly="{Binding Path=IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}"
-                                                   Text="{Binding Path=SelectedTime, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TimeSpanToStringConverter}}" 
                                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                                    Foreground="{TemplateBinding Foreground}"
@@ -362,7 +361,7 @@
                         <Trigger Property="IsDatePickerVisible" Value="True">
                             <Setter TargetName="PART_Calendar" Property="Visibility" Value="Visible" />
                             <Setter TargetName="StackPanel" Property="Orientation" Value="{Binding Path=Orientation, RelativeSource={RelativeSource TemplatedParent}}" />
-                            <Setter TargetName="PART_TextBox" Property="Text" Value="{Binding Path=SelectedDate, RelativeSource={RelativeSource TemplatedParent}}" />
+                            <!--<Setter TargetName="PART_TextBox" Property="Text" Value="{Binding Path=SelectedDate, RelativeSource={RelativeSource TemplatedParent}}" />-->
                         </Trigger>
                         <Trigger Property="IsDatePickerVisible"
                                  Value="False">
@@ -371,7 +370,6 @@
                                     Property="Content"
                                     Value="M12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22C6.47,22 2,17.5 2,12A10,10 0 0,1 12,2M12.5,7V12.25L17,14.92L16.25,16.15L11,13V7H12.5Z" />
                         </Trigger>
-
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding Path=(controls:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}" Value="True" />

--- a/src/Mahapps.Metro.Tests/Mahapps.Metro.Tests.Shared/Tests/DateTimePickerTests.cs
+++ b/src/Mahapps.Metro.Tests/Mahapps.Metro.Tests.Shared/Tests/DateTimePickerTests.cs
@@ -16,12 +16,42 @@
 
             var window = await WindowHelpers.CreateInvisibleWindowAsync<DateAndTimePickerWindow>().ConfigureAwait(false);
             window.Invoke(() =>
-                {
-                    Assert.NotNull(window.TheDateTimePicker.SelectedDate);
-                    Assert.NotNull(window.TheDateTimePicker.Culture);
-                    Assert.Equal("pt-BR", window.TheDateTimePicker.Culture.IetfLanguageTag);
-                    Assert.Equal("31/08/2016 14:00:01", window.TheDateTimePicker.FindChild<DatePickerTextBox>(string.Empty).Text);
-                });
+                              {
+                                  Assert.NotNull(window.TheDateTimePicker.SelectedDate);
+                                  Assert.NotNull(window.TheDateTimePicker.Culture);
+                                  Assert.Equal("pt-BR", window.TheDateTimePicker.Culture.IetfLanguageTag);
+                                  Assert.Equal("31/08/2016 14:00:01", window.TheDateTimePicker.FindChild<DatePickerTextBox>(string.Empty).Text);
+                              });
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task TimePickerCultureDeTest()
+        {
+            await TestHost.SwitchToAppThread();
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DateAndTimePickerWindow>().ConfigureAwait(false);
+            window.Invoke(() =>
+                              {
+                                  Assert.NotNull(window.TheTimePickerDe.SelectedTime);
+                                  Assert.NotNull(window.TheTimePickerDe.Culture);
+                                  Assert.Equal("de-DE", window.TheTimePickerDe.Culture.IetfLanguageTag);
+                                  Assert.Equal("14:00:01", window.TheTimePickerDe.FindChild<DatePickerTextBox>(string.Empty).Text);
+                              });
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task TimePickerCultureUsTest()
+        {
+            await TestHost.SwitchToAppThread();
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DateAndTimePickerWindow>().ConfigureAwait(false);
+            window.Invoke(() =>
+                              {
+                                  Assert.NotNull(window.TheTimePickerUs.SelectedTime);
+                                  Assert.NotNull(window.TheTimePickerUs.Culture);
+                                  Assert.Equal("en-US", window.TheTimePickerUs.Culture.IetfLanguageTag);
+                                  Assert.Equal("2:00:01 PM", window.TheTimePickerUs.FindChild<DatePickerTextBox>(string.Empty).Text);
+                              });
         }
     }
 }

--- a/src/Mahapps.Metro.Tests/Mahapps.Metro.Tests.Shared/Views/DateAndTimePickerWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Mahapps.Metro.Tests.Shared/Views/DateAndTimePickerWindow.xaml
@@ -9,5 +9,7 @@
                       d:DesignWidth="300">
     <StackPanel>
         <controls:DateTimePicker x:Name="TheDateTimePicker" Culture="pt-BR" SelectedDate="08/31/2016 14:00:01" />
+        <controls:TimePicker x:Name="TheTimePickerDe" Culture="de-de" SelectedTime="14:00:01" />
+        <controls:TimePicker x:Name="TheTimePickerUs" Culture="en-us" SelectedTime="14:00:01" />
     </StackPanel>
 </controls:MetroWindow>


### PR DESCRIPTION
- Binding should now work correctly in both directions
- [Fix] Issue where clearing text does not immediately set value to ""
- Add Unit-Test for DateTimePicker
- [Fix] Issue where Hour 0 is not shown when using 24h clock
- [Fix] Issue where Binding issues on DateTimePicker/TimePicker are shown on the output window
- [Fix] Change DateTimePicker.SelectedDate to BindsTwoWayByDefault. The reason is that we do not have to use Mode=TwoWay explicit, and DatePicker.SelectedDate has BindsTwoWayByDefault too.
- [x] Fix DateTimePickerSetCulture unit test <-- @xxMUROxx 