### PR TITLE
Fix DataGridRowHeader HorizontalAlignment

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -195,15 +195,19 @@
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 SnapsToDevicePixels="True">
-                            <StackPanel Orientation="Horizontal">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition></ColumnDefinition>
+                                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                                </Grid.ColumnDefinitions>
                                 <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                   RecognizesAccessKey="True"
                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                                <Control SnapsToDevicePixels="false"
+                                <Control Grid.Column="1" SnapsToDevicePixels="false"
                                          Template="{Binding ValidationErrorTemplate, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}"
                                          Visibility="{Binding (Validation.HasError), Converter={StaticResource bool2VisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}}" />
-                            </StackPanel>
+                            </Grid>
                         </Border>
                         <Thumb x:Name="PART_TopHeaderGripper"
                                VerticalAlignment="Top"


### PR DESCRIPTION
## What changed?
Some time ago i have made pull request #1819 that adds alignments to DataGridRowHeader, but in 6df54bab96e82be811edd414826636ca9084ba94 this feature was broken.

Before:
![before](https://cloud.githubusercontent.com/assets/526086/21416240/b81c195a-c82a-11e6-8dc8-5963a71f7cd4.png)
After:
![after](https://cloud.githubusercontent.com/assets/526086/21416243/bda03c9e-c82a-11e6-8279-78ff7b21c30d.png)


