### PR TITLE
Prevent the MetroDataGridCheckBox from being toggled by a TAB + SPACE…

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -17,6 +17,7 @@
         <Style.Triggers>
             <DataTrigger Binding="{Binding Path=IsReadOnly, RelativeSource={RelativeSource AncestorType=DataGridCell}}" Value="True">
                 <Setter Property="IsHitTestVisible" Value="False" />
+                <Setter Property="Focusable" Value="False" />
             </DataTrigger>
         </Style.Triggers>
     </Style>


### PR DESCRIPTION
… when the cell is supposed to be read only.

## What changed?

Set Focusable to False in the MetroDataGridCheckBox's style definition in Controls.DataGrid.xaml inside of the IsReadOnly DataTrigger.

For issue #2788.
