### PR TITLE
StringToVisibilityConverter should handle null like an empty string

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Converters/StringToVisibilityConverter.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Converters/StringToVisibilityConverter.cs
@@ -56,13 +56,13 @@ namespace MahApps.Metro.Converters
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is string && targetType == typeof (Visibility))
+            if ((value == null || value is string) && targetType == typeof (Visibility))
             {
                 if (OppositeStringValue)
                 {
-                    return (((string) value).ToLower().Equals(String.Empty)) ? Visibility.Visible : FalseEquivalent;
+                    return string.IsNullOrEmpty((string)value) ? Visibility.Visible : FalseEquivalent;
                 }
-                return (((string) value).ToLower().Equals(String.Empty)) ? FalseEquivalent : Visibility.Visible;
+                return string.IsNullOrEmpty((string)value) ? FalseEquivalent : Visibility.Visible;
             }
             return value;
         }


### PR DESCRIPTION
## What changed?

Currently `StringToVisibilityConverter` does not handle `null` gracefully. If the value is `null`, the output is `null` too. IMHO `null` should be handled like an empty string, i.e. if the value is `null`, the output should be `FalseEquivalent` (or `Visibility.Visible`, if `OppositeStringValue` is `true`)