### PR TITLE
DateTimePicker SelectedDate issue

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
@@ -270,7 +270,7 @@
             if (dateTime != null)
             {
                 DisplayDate = dateTime != DateTime.MinValue ? dateTime : DateTime.Today;
-                if (SelectedDate != DisplayDate || (Popup != null && Popup.IsOpen))
+                if ((SelectedDate != DisplayDate && SelectedDate != DateTime.MinValue) || (Popup != null && Popup.IsOpen))
                 {
                     SelectedDate = DisplayDate;
                 }


### PR DESCRIPTION
## What changed?

[Fix] Issue where *SelectedDate* is set to the *DisplayDate* if the SelectedDate is DateTime.MinValue

This issue appears when binding to a property of `DateTime` and the date is DateTime.MinValue
