### PR TITLE
Correct display of media buttons in HotKeyBox

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TextExamples.xaml
@@ -346,7 +346,6 @@
                         Margin="{StaticResource ColumnMargin}">
                 <Label Style="{DynamicResource DescriptionHeaderStyle}" Content="HotKeyBox" />
                 <Controls:HotKeyBox Margin="{StaticResource ControlMargin}"
-                                    Controls:ControlsHelper.ContentCharacterCasing="Upper"
                                     AreModifierKeysRequired="{Binding ElementName=ModifierKeysRequired, Path=IsChecked}"
                                     HotKey="{Binding HotKey, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}"
                                     Watermark="Enter hot key" />

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
@@ -255,9 +255,9 @@ namespace MahApps.Metro.Controls {
             }
             if ((_modifierKeys & ModifierKeys.Windows) == ModifierKeys.Windows)
             {
-                sb.Append("WINDOWS+");
+                sb.Append("Windows+");
             }
-            sb.Append(GetLocalizedKeyStringUnsafe(_key).ToUpper());
+            sb.Append(GetLocalizedKeyStringUnsafe(_key));
             return sb.ToString();
         }
 

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
@@ -257,11 +257,11 @@ namespace MahApps.Metro.Controls {
             {
                 sb.Append("Windows+");
             }
-            sb.Append(GetLocalizedKeyStringUnsafe(_key));
+            sb.Append(GetLocalizedKeyString(_key));
             return sb.ToString();
         }
 
-        private static string GetLocalizedKeyStringUnsafe(Key key)
+        private static string GetLocalizedKeyString(Key key)
         {
             if (key >= Key.BrowserBack && key <= Key.LaunchApplication2)
             {

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
@@ -201,7 +201,7 @@ namespace MahApps.Metro.Controls {
         private readonly Key _key;
         private readonly ModifierKeys _modifierKeys;
 
-        public HotKey(Key key, ModifierKeys modifierKeys)
+        public HotKey(Key key, ModifierKeys modifierKeys = ModifierKeys.None)
         {
             _key = key;
             _modifierKeys = modifierKeys;
@@ -257,8 +257,19 @@ namespace MahApps.Metro.Controls {
             {
                 sb.Append("WINDOWS+");
             }
-            sb.Append(GetLocalizedKeyStringUnsafe(KeyInterop.VirtualKeyFromKey(_key)).ToUpper());
+            sb.Append(GetLocalizedKeyStringUnsafe(_key).ToUpper());
             return sb.ToString();
+        }
+
+        private static string GetLocalizedKeyStringUnsafe(Key key)
+        {
+            if (key >= Key.BrowserBack && key <= Key.LaunchApplication2)
+            {
+                return key.ToString();
+            }
+
+            var vkey = KeyInterop.VirtualKeyFromKey(key);
+            return GetLocalizedKeyStringUnsafe(vkey) ?? key.ToString();
         }
 
         private static string GetLocalizedKeyStringUnsafe(int key)
@@ -281,8 +292,8 @@ namespace MahApps.Metro.Controls {
                 scanCode |= 0x1000000;
             }
 
-            UnsafeNativeMethods.GetKeyNameText((int)scanCode, sb, 256);
-            return sb.ToString();
+            var resultLength = UnsafeNativeMethods.GetKeyNameText((int)scanCode, sb, 256);
+            return resultLength > 0 ? sb.ToString() : null;
         }
 
     }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
@@ -263,6 +263,11 @@ namespace MahApps.Metro.Controls {
 
         private static string GetLocalizedKeyStringUnsafe(Key key)
         {
+            if (key >= Key.BrowserBack && key <= Key.LaunchApplication2)
+            {
+                return key.ToString();
+            }
+
             var vkey = KeyInterop.VirtualKeyFromKey(key);
             return GetLocalizedKeyStringUnsafe(vkey) ?? key.ToString();
         }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
@@ -263,11 +263,6 @@ namespace MahApps.Metro.Controls {
 
         private static string GetLocalizedKeyStringUnsafe(Key key)
         {
-            if (key >= Key.BrowserBack && key <= Key.LaunchApplication2)
-            {
-                return key.ToString();
-            }
-
             var vkey = KeyInterop.VirtualKeyFromKey(key);
             return GetLocalizedKeyStringUnsafe(vkey) ?? key.ToString();
         }

--- a/src/MahApps.Metro/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -10,6 +10,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource TextBoxFocusBorderBrush}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource TextBoxMouseOverBorderBrush}" />
+        <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Upper" />
         <Setter Property="FontFamily" Value="{DynamicResource ContentFontFamily}" />
         <Setter Property="FontSize" Value="{DynamicResource ContentFontSize}" />
         <Setter Property="MinHeight" Value="26" />


### PR DESCRIPTION
This PR fixes the wrong display of special media buttons in `HotKeyBox` as described in #2585.

Unfortunately, Windows does not localize media buttons, therefore I've implemented a fallback using `ToString()`.

Additionally, upper case isn't hard-coded anymore. The user has now the option to use `ControlsHelper.ContentCharacterCasing`. (Upper case is still the default)

I haven't edited any release notes in the PR as I don't know in which release will include this PR.