### PR TITLE
[Fix] Issue when the time is cleared if a date is selected

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
@@ -5,6 +5,7 @@
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Controls.Primitives;
+    using System.Windows.Input;
 
     /// <summary>
     ///     Represents a control that allows the user to select a date and a time.
@@ -175,6 +176,15 @@
             var selectedDateTimeFromGui = this.GetSelectedDateTimeFromGUI();
             var valueForTextBox = selectedDateTimeFromGui?.ToString(dateTimeFormat, this.SpecificCultureInfo);
             return valueForTextBox;
+        }
+
+        protected override void OnPreviewMouseUp(MouseButtonEventArgs e)
+        {
+            base.OnPreviewMouseUp(e);
+            if (Mouse.Captured is CalendarItem)
+            {
+                Mouse.Capture(null);
+            }
         }
 
         protected override void OnRangeBaseValueChanged(object sender, SelectionChangedEventArgs e)

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
@@ -156,7 +156,7 @@
                 _calendar.SetBinding(Calendar.FirstDayOfWeekProperty, GetBinding(FirstDayOfWeekProperty));
                 _calendar.SetBinding(Calendar.IsTodayHighlightedProperty, GetBinding(IsTodayHighlightedProperty));
                 _calendar.SetBinding(FlowDirectionProperty, GetBinding(FlowDirectionProperty));
-                _calendar.SetBinding(Calendar.SelectedDateProperty, GetBinding(SelectedDateProperty));
+                _calendar.SelectedDatesChanged += OnCalendarSelectedDateChanged;
             }
         }
 
@@ -207,6 +207,19 @@
             if (!_deactivateWriteValueToTextBox)
             {
                 base.WriteValueToTextBox();
+            }
+        }
+
+        private void OnCalendarSelectedDateChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (e.AddedItems.Count > 0)
+            {
+                var dt = (DateTime)e.AddedItems[0];
+
+                var timeOfDay = SelectedDate.GetValueOrDefault().TimeOfDay;
+
+                dt += timeOfDay;
+                SelectedDate = dt;
             }
         }
 

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
@@ -168,7 +168,7 @@ namespace MahApps.Metro.Controls
         private Selector _hourInput;
         private UIElement _minuteHand;
         private Selector _minuteInput;
-        protected Popup _popup;
+        private Popup _popup;
         private UIElement _secondHand;
         private Selector _secondInput;
         protected DatePickerTextBox _textBox;

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
@@ -168,7 +168,7 @@ namespace MahApps.Metro.Controls
         private Selector _hourInput;
         private UIElement _minuteHand;
         private Selector _minuteInput;
-        private Popup _popup;
+        protected Popup _popup;
         private UIElement _secondHand;
         private Selector _secondInput;
         protected DatePickerTextBox _textBox;


### PR DESCRIPTION
## What changed?



Before | After
------------ | -------------
**Time is set to 00:00:00** | **Time is now kept**
![datetimepicker-time-before](https://cloud.githubusercontent.com/assets/4341039/22588626/f1afb5f2-ea06-11e6-8d45-caaa87db0c97.gif) | ![datetimepicker-time-after](https://cloud.githubusercontent.com/assets/4341039/22588627/f1cf372e-ea06-11e6-94d1-c87aff9da3eb.gif)
**If a date is selected then selecting the time closes the control** | **The control does now stays open**
![datetimepicker](https://cloud.githubusercontent.com/assets/4341039/22588677/2ab6bf1c-ea07-11e6-9350-ddc8a1843cc9.gif) | ![datetimepicker-fixfocus](https://cloud.githubusercontent.com/assets/4341039/22597385/afdb4d70-ea2f-11e6-9de5-c7b303866926.gif)