### PR TITLE
window's default behavior : double click on title bar will restore Minimized window

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
@@ -1296,13 +1296,13 @@ namespace MahApps.Metro.Controls
                 var isMouseOnTitlebar = mousePos.Y <= window.TitlebarHeight && window.TitlebarHeight > 0;
                 if (canResize && isMouseOnTitlebar)
                 {
-                    if (window.WindowState == WindowState.Maximized)
+                    if (window.WindowState == WindowState.Normal)
                     {
-                        Microsoft.Windows.Shell.SystemCommands.RestoreWindow(window);
+                        Microsoft.Windows.Shell.SystemCommands.MaximizeWindow(window);
                     }
                     else
                     {
-                        Microsoft.Windows.Shell.SystemCommands.MaximizeWindow(window);
+                        Microsoft.Windows.Shell.SystemCommands.RestoreWindow(window);
                     }
                     mouseButtonEventArgs.Handled = true;
                 }


### PR DESCRIPTION
If ShowInTaskbar = false, when double click on the title bar of a Minimized window, the window will be Restored instead of Maximized.