### PR TITLE
Fix WindowCommands tab stop bug

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro/Themes/WindowCommands.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/WindowCommands.xaml
@@ -115,6 +115,7 @@
         <Setter Property="ItemContainerStyle">
             <Setter.Value>
                 <Style TargetType="{x:Type Controls:WindowCommandsItem}">
+                    <Setter Property="IsTabStop" Value="False"/>
                     <Setter Property="Template">
                         <Setter.Value>
                             <ControlTemplate TargetType="{x:Type Controls:WindowCommandsItem}">


### PR DESCRIPTION
## What changed?

Prevents `WindowCommandsItem` from erroneously responding to the tab key.