### PR TITLE
Close validation popup with SetCurrentValue

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/CustomValidationPopup.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/CustomValidationPopup.cs
@@ -40,7 +40,7 @@ namespace MahApps.Metro.Controls
         {
             if (CloseOnMouseLeftButtonDown)
             {
-                this.IsOpen = false;
+                this.SetCurrentValue(Popup.IsOpenProperty, false);
             }
         }
 


### PR DESCRIPTION
## What changed?

Close validation popup by setting the IsOpen property with SetCurrentValue (prevents breaking available bindings). 

_Closed issues._
#2866
