### PR TITLE
Don't overwrite cancellation for close

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
@@ -853,17 +853,27 @@ namespace MahApps.Metro.Controls
 #if NET4_5
         protected override async void OnClosing(CancelEventArgs e)
         {
-            // #2409: don't close window if there is a dialog still open
-            var dialog = await this.GetCurrentDialogAsync<BaseMetroDialog>();
-            e.Cancel = dialog != null;
+            // Don't overwrite cancellation for close
+            if (e.Cancel == false)
+            {
+                // #2409: don't close window if there is a dialog still open
+                var dialog = await this.GetCurrentDialogAsync<BaseMetroDialog>();
+                e.Cancel = dialog != null;
+            }
+
             base.OnClosing(e);
         }
 #else
         protected override void OnClosing(CancelEventArgs e)
         {
-            // #2409: don't close window if there is a dialog still open
-            var dialog = this.Invoke(() => this.metroActiveDialogContainer?.Children.OfType<BaseMetroDialog>().LastOrDefault());
-            e.Cancel = dialog != null;
+            // Don't overwrite cancellation for close
+            if (e.Cancel == false)
+            {
+                // #2409: don't close window if there is a dialog still open
+                var dialog = this.Invoke(() => this.metroActiveDialogContainer?.Children.OfType<BaseMetroDialog>().LastOrDefault());
+                e.Cancel = dialog != null;
+            }
+
             base.OnClosing(e);
         }
 #endif


### PR DESCRIPTION
## What changed?

If someone listening for `Closing` set `e.Cancel = true` we should not overwrite/overrule that request.