### PR TITLE
Setting HasDecimals to true only if StringFormat contains a decimals …

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericUpDown.cs
@@ -893,7 +893,11 @@ namespace MahApps.Metro.Controls
             {
                 nud.InternalSetText(nud.Value);
             }
-            nud.HasDecimals = !RegexStringFormatHexadecimal.IsMatch((string)e.NewValue);
+
+            if (!nud.HasDecimals && RegexStringFormatHexadecimal.IsMatch((string)e.NewValue))
+            {
+                nud.HasDecimals = true;
+            }
         }
 
         private static void OnValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
This pull request should fix

#2886: NumericUpDown: HasDecimals=False & using a bound StringFormat allows to enter a decimal point
