### PR TITLE
TabControl Underlined TabPanel

### DIFF
--- a/docs/release-notes/1.5.0.md
+++ b/docs/release-notes/1.5.0.md
@@ -17,7 +17,28 @@
 - New `Badged` control. Thx to @ButchersBoy  
 ![image](https://cloud.githubusercontent.com/assets/658431/23340345/d7dc4c86-fc34-11e6-838b-1ebee9381c7d.png)
 - The `ControlsHelper.CornerRadius` can now used for `SplitButton` and `DropDownButton`.
-
+- New underline types for `TabControl` and `MetroTabControl` [#2902](https://github.com/MahApps/MahApps.Metro/pull/2902)
+    + Adds a new `Underlined` attached property to `TabControlHelper` which controls the type of the underline type. The old `IsUnderlined` property is now obsolete.  
+    ```
+    /// <summary>
+    /// Specifies the underline position of a TabControl.
+    /// </summary>
+    public enum UnderlinedType
+    {
+        None, // nothing
+        TabItems, // the old behavior with `IsUnderlined="True"`
+        SelectedTabItem, // selected TabItem underlined + underline hover effect for unselected items
+        TabPanel // underlined TabPanel and selected/hovered TabItem
+    }
+    ```
+    + Add also new `Brush` attached properties to enable easy changing the underline brushes.  
+    ```
+    TabControlHelper.UnderlineBrush
+    TabControlHelper.UnderlineSelectedBrush
+    TabControlHelper.UnderlineMouseOverBrush
+    TabControlHelper.UnderlineMouseOverSelectedBrush
+    ```
+    ![mahapps_newunderline4](https://cloud.githubusercontent.com/assets/658431/24204520/0e6f3cbc-0f19-11e7-8a2b-f40752918a96.gif)
 
 ## Closed Issues
 
@@ -33,3 +54,4 @@
 - [#2792](https://github.com/MahApps/MahApps.Metro/issues/2792) Win32Exception on closing window
 - [#2886](https://github.com/MahApps/MahApps.Metro/issues/2886) NumericUpDown: HasDecimals=False & using a bound StringFormat allows to enter a decimal point [@davericardo](https://github.com/davericardo)
 - [#2885](https://github.com/MahApps/MahApps.Metro/issues/2885) [Bug] Badged Control Causes Window Loading to Hang
+- [#2895](https://github.com/MahApps/MahApps.Metro/issues/2895) [RFC] [Enhancement] Proposed TabControlHelper.IsUnderlined Change

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
@@ -11,6 +11,13 @@
              d:DataContext="{d:DesignInstance MetroDemo:MainWindowViewModel}">
 
     <UserControl.Resources>
+        <ObjectDataProvider x:Key="TabStripPlacementEnumValues"
+                            MethodName="GetValues"
+                            ObjectType="{x:Type Dock}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="Dock" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
         <ObjectDataProvider x:Key="UnderlinedEnumValues"
                             MethodName="GetValues"
                             ObjectType="{x:Type Controls:UnderlinedType}">
@@ -24,17 +31,28 @@
         <StackPanel Margin="5, 10, 5, 0">
             <Expander Margin="0" IsExpanded="True" Header="_Default TabControl">
                 <StackPanel Margin="15, 5, 15, 5">
-                    <Label Content="Default TabControl normal style" Style="{DynamicResource DescriptionHeaderStyle}" />
+                    <Label Content="Default TabControl" Style="{DynamicResource DescriptionHeaderStyle}" />
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="TabControl Underlined type" Margin="5 5" VerticalAlignment="Center" />
-                        <ComboBox x:Name="UnderlinedCheckBox"
+                        <TextBlock Text="Underlined type" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="UnderlinedComboBox"
                                   HorizontalAlignment="Left"
                                   VerticalAlignment="Center"
                                   Margin="5 5"
+                                  Width="100"
                                   ItemsSource="{Binding Source={StaticResource UnderlinedEnumValues}}"
                                   SelectedIndex="0" />
+                        <TextBlock Text="TabStripPlacement" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="TabStripPlacementComboBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  Width="100"
+                                  ItemsSource="{Binding Source={StaticResource TabStripPlacementEnumValues}}"
+                                  SelectedItem="{x:Static Dock.Top}" />
                     </StackPanel>
-                    <TabControl Controls:TabControlHelper.Underlined="{Binding ElementName=UnderlinedCheckBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    <TabControl Height="200"
+                                Controls:TabControlHelper.Underlined="{Binding ElementName=UnderlinedComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                TabStripPlacement="{Binding ElementName=TabStripPlacementComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                         <TabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _1">
                             <TextBlock FontSize="30" Text="Content" />
                         </TabItem>
@@ -54,6 +72,7 @@
                             <TextBlock FontSize="30" Text="This is not content (it is)" />
                         </TabItem>
                     </TabControl>
+
                     <Label Margin="0, 5, 0, 0"
                            Content="Default TabControl with _AnimatedTabControl style"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
@@ -73,6 +92,7 @@
                             </Controls:MetroTabItem>
                         </TabControl>
                     </Grid>
+
                     <Label Margin="0, 5, 0, 0"
                            Content="Default TabControl with Animated_SingleRowTabControl style"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
@@ -95,47 +115,7 @@
                             </TabItem>
                         </TabControl>
                     </Grid>
-                    <Label Margin="0, 5, 0, 0"
-                           Content="Default TabControl _left style"
-                           Style="{DynamicResource DescriptionHeaderStyle}" />
-                    <Grid>
-                        <Grid.Resources>
-                            <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.AnimatedSingleRowTabControl.xaml" />
-                        </Grid.Resources>
-                        <TabControl Height="200"
-                                    Margin="0, 10, 0, 0"
-                                    Controls:TabControlHelper.IsUnderlined="True"
-                                    TabStripPlacement="Left">
-                            <TabItem Header="LeftItem 0">
-                                <TextBlock FontSize="24" Text="This is left content 0" />
-                            </TabItem>
-                            <TabItem Header="LeftItem 1 Header">
-                                <TextBlock FontSize="24" Text="This is left content 1" />
-                            </TabItem>
-                            <TabItem Header="LeftItem 2 Text">
-                                <TextBlock FontSize="24" Text="This is left content 2" />
-                            </TabItem>
-                            <TabItem Header="LeftItem 3">
-                                <TextBlock FontSize="24" Text="This is left content 3" />
-                            </TabItem>
-                            <TabItem Header="LeftItem 4">
-                                <TextBlock FontSize="24" Text="This is left content 4" />
-                            </TabItem>
-                        </TabControl>
-                    </Grid>
-                    <!--
-                                    Right & Bottom are both work, no need to show them all
-                                    <TabControl TabStripPlacement="Right" Style="{DynamicResource MetroTabControl}">
-                                        <TabItem Header="RightItem0" Content="This is Right content 0" />
-                                        <TabItem Header="RightItem1" Content="This is Right content 1" />
-                                        <TabItem Header="RightItem2" Content="This is Right content 2" />
-                                    </TabControl>
-                                    <TabControl TabStripPlacement="Bottom" Style="{DynamicResource MetroTabControl}">
-                                        <TabItem Header="BottomItem0" Content="This is Bottom content 0" />
-                                        <TabItem Header="BottomItem1" Content="This is Bottom content 1" />
-                                        <TabItem Header="BottomItem2" Content="This is Bottom content 2" />
-                                    </TabControl>
-                    -->
+
                 </StackPanel>
             </Expander>
 
@@ -213,6 +193,7 @@
                             <TextBlock FontSize="30" Text="Animate everything!" />
                         </TabItem>
                     </Controls:MetroAnimatedTabControl>
+
                     <Label Margin="0, 5, 0, 0"
                            Content="MetroAnimatedSingleRowTabControl"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
@@ -230,6 +211,7 @@
                             <TextBlock FontSize="30" Text="Content" />
                         </TabItem>
                     </Controls:MetroAnimatedSingleRowTabControl>
+
                     <Label Margin="0 5 0 0"
                            Content="MetroTabControl w/ Closable Items"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
@@ -276,29 +258,49 @@
                     </Controls:MetroTabControl>
 
                     <Label Margin="0, 5, 0, 0"
-                           Content="MetroTabControl _left style"
+                           Content="MetroTabControl style"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
-                    <Controls:MetroTabControl Height="220"
-                                              Margin="0, 10, 0, 0"
-                                              Controls:TabControlHelper.IsUnderlined="True"
-                                              TabStripPlacement="Left">
-                        <Controls:MetroTabItem Header="LeftItem 0">
-                            <TextBlock FontSize="24" Text="This is left content 0" />
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Underlined type" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="MetroTabControlUnderlinedComboBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  ItemsSource="{Binding Source={StaticResource UnderlinedEnumValues}}"
+                                  SelectedIndex="0" />
+                        <TextBlock Text="TabStripPlacement" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="MetroTabStripPlacementComboBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  Width="100"
+                                  ItemsSource="{Binding Source={StaticResource TabStripPlacementEnumValues}}"
+                                  SelectedItem="{x:Static Dock.Top}" />
+                    </StackPanel>
+                    <Controls:MetroTabControl Height="200"
+                                              Controls:TabControlHelper.Underlined="{Binding ElementName=MetroTabControlUnderlinedComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                              TabStripPlacement="{Binding ElementName=MetroTabStripPlacementComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _1">
+                            <TextBlock FontSize="30" Text="Content" />
                         </Controls:MetroTabItem>
-                        <Controls:MetroTabItem Header="LeftItem 1 Header">
-                            <TextBlock FontSize="24" Text="This is left content 1" />
+                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _2">
+                            <TextBlock FontSize="30" Text="More content" />
                         </Controls:MetroTabItem>
-                        <Controls:MetroTabItem Header="LeftItem 2 Text">
-                            <TextBlock FontSize="24" Text="This is left content 2" />
+                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _3">
+                            <TextBlock FontSize="30" Text="More more content" />
                         </Controls:MetroTabItem>
-                        <Controls:MetroTabItem Header="LeftItem 3" CloseButtonEnabled="True">
-                            <TextBlock FontSize="24" Text="This is left content 3" />
+                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _4">
+                            <TextBlock FontSize="30" Text="So much content!" />
                         </Controls:MetroTabItem>
-                        <Controls:MetroTabItem Header="LeftItem 4">
-                            <TextBlock FontSize="24" Text="This is left content 4" />
+                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _5" CloseButtonEnabled="True">
+                            <TextBlock FontSize="30" Text="Content!" />
+                        </Controls:MetroTabItem>
+                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _6">
+                            <TextBlock FontSize="30" Text="This is not content (it is)" />
                         </Controls:MetroTabItem>
                     </Controls:MetroTabControl>
                 </StackPanel>
+
             </Expander>
         </StackPanel>
 

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
@@ -10,12 +10,31 @@
              d:DesignWidth="800"
              d:DataContext="{d:DesignInstance MetroDemo:MainWindowViewModel}">
 
+    <UserControl.Resources>
+        <ObjectDataProvider x:Key="UnderlinedEnumValues"
+                            MethodName="GetValues"
+                            ObjectType="{x:Type Controls:UnderlinedType}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="Controls:UnderlinedType" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+    </UserControl.Resources>
+
     <ScrollViewer>
         <StackPanel Margin="5, 10, 5, 0">
-            <Expander Margin="0" Header="_Default TabControl">
+            <Expander Margin="0" IsExpanded="True" Header="_Default TabControl">
                 <StackPanel Margin="15, 5, 15, 5">
                     <Label Content="Default TabControl normal style" Style="{DynamicResource DescriptionHeaderStyle}" />
-                    <TabControl>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="TabControl Underlined type" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="UnderlinedCheckBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  ItemsSource="{Binding Source={StaticResource UnderlinedEnumValues}}"
+                                  SelectedIndex="0" />
+                    </StackPanel>
+                    <TabControl Controls:TabControlHelper.Underlined="{Binding ElementName=UnderlinedCheckBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                         <TabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _1">
                             <TextBlock FontSize="30" Text="Content" />
                         </TabItem>
@@ -32,27 +51,6 @@
                             <TextBlock FontSize="30" Text="Content!" />
                         </TabItem>
                         <TabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _6">
-                            <TextBlock FontSize="30" Text="This is not content (it is)" />
-                        </TabItem>
-                    </TabControl>
-                    <Label Content="Default _TabControl with underline" Style="{DynamicResource DescriptionHeaderStyle}" />
-                    <TabControl Controls:TabControlHelper.IsUnderlined="True">
-                        <TabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item 1">
-                            <TextBlock FontSize="30" Text="Content" />
-                        </TabItem>
-                        <TabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item 2">
-                            <TextBlock FontSize="30" Text="More content" />
-                        </TabItem>
-                        <TabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item 3">
-                            <TextBlock FontSize="30" Text="More more content" />
-                        </TabItem>
-                        <TabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item 4">
-                            <TextBlock FontSize="30" Text="So much content!" />
-                        </TabItem>
-                        <TabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item 5">
-                            <TextBlock FontSize="30" Text="Content!" />
-                        </TabItem>
-                        <TabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item 6">
                             <TextBlock FontSize="30" Text="This is not content (it is)" />
                         </TabItem>
                     </TabControl>
@@ -140,7 +138,8 @@
                     -->
                 </StackPanel>
             </Expander>
-            <Expander Margin="0, 10, 0, 0" Header="_Generic theme TabControls">
+
+            <Expander Margin="0, 10, 0, 0" IsExpanded="True" Header="_Generic theme TabControls">
                 <StackPanel Margin="15, 5, 15, 5">
                     <Label Content="MetroAnimatedTabControl" Style="{DynamicResource DescriptionHeaderStyle}" />
                     <Grid>
@@ -232,7 +231,7 @@
                         </TabItem>
                     </Controls:MetroAnimatedSingleRowTabControl>
                     <Label Margin="0 5 0 0"
-                           Content="TabControl w/ Closable Items"
+                           Content="MetroTabControl w/ Closable Items"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
                     <Controls:MetroTabControl TabItemClosingEvent="MetroTabControl_TabItemClosingEvent">
                         <Controls:MetroTabItem CloseButtonEnabled="True"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
@@ -283,13 +283,13 @@
                         <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _1">
                             <TextBlock FontSize="30" Text="Content" />
                         </Controls:MetroTabItem>
-                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _2">
+                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _2 more">
                             <TextBlock FontSize="30" Text="More content" />
                         </Controls:MetroTabItem>
-                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _3">
+                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _3 header here">
                             <TextBlock FontSize="30" Text="More more content" />
                         </Controls:MetroTabItem>
-                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _4">
+                        <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _4 ">
                             <TextBlock FontSize="30" Text="So much content!" />
                         </Controls:MetroTabItem>
                         <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _5" CloseButtonEnabled="True">

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TabControlHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TabControlHelper.cs
@@ -12,7 +12,8 @@ namespace MahApps.Metro.Controls
     public enum UnderlinedType
     {
         None,
-        TabItem,
+        TabItems,
+        SelectedTabItem,
         TabPanel
     }
 
@@ -32,7 +33,7 @@ namespace MahApps.Metro.Controls
                                                                              var element = o as UIElement;
                                                                              if (element != null && e.OldValue != e.NewValue && e.NewValue is bool)
                                                                              {
-                                                                                 TabControlHelper.SetUnderlined(element, (bool)e.NewValue ? UnderlinedType.TabItem : UnderlinedType.None);
+                                                                                 TabControlHelper.SetUnderlined(element, (bool)e.NewValue ? UnderlinedType.TabItems : UnderlinedType.None);
                                                                              }
                                                                          }));
 

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TabControlHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TabControlHelper.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Media;
 
 namespace MahApps.Metro.Controls
 {
@@ -70,6 +71,90 @@ namespace MahApps.Metro.Controls
         public static void SetUnderlined(UIElement element, UnderlinedType value)
         {
             element.SetValue(UnderlinedProperty, value);
+        }
+
+        /// <summary>
+        /// Defines the underline brush below the <see cref="TabItem"/> or <see cref="TabPanel"/>.
+        /// </summary>
+        public static readonly DependencyProperty UnderlineBrushProperty =
+            DependencyProperty.RegisterAttached("UnderlineBrush",
+                                                typeof(Brush),
+                                                typeof(TabControlHelper),
+                                                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.SubPropertiesDoNotAffectRender));
+
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static Brush GetUnderlineBrush(UIElement element)
+        {
+            return (Brush)element.GetValue(UnderlineBrushProperty);
+        }
+
+        public static void SetUnderlineBrush(UIElement element, Brush value)
+        {
+            element.SetValue(UnderlineBrushProperty, value);
+        }
+
+        /// <summary>
+        /// Defines the underline brush below the <see cref="TabItem"/> or <see cref="TabPanel"/> of an selected item.
+        /// </summary>
+        public static readonly DependencyProperty UnderlineSelectedBrushProperty =
+            DependencyProperty.RegisterAttached("UnderlineSelectedBrush",
+                                                typeof(Brush),
+                                                typeof(TabControlHelper),
+                                                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.SubPropertiesDoNotAffectRender));
+
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static Brush GetUnderlineSelectedBrush(UIElement element)
+        {
+            return (Brush)element.GetValue(UnderlineSelectedBrushProperty);
+        }
+
+        public static void SetUnderlineSelectedBrush(UIElement element, Brush value)
+        {
+            element.SetValue(UnderlineSelectedBrushProperty, value);
+        }
+
+        /// <summary>
+        /// Defines the underline brush below the <see cref="TabItem"/> or <see cref="TabPanel"/> if the mouse is over an item.
+        /// </summary>
+        public static readonly DependencyProperty UnderlineMouseOverBrushProperty =
+            DependencyProperty.RegisterAttached("UnderlineMouseOverBrush",
+                                                typeof(Brush),
+                                                typeof(TabControlHelper),
+                                                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.SubPropertiesDoNotAffectRender));
+
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static Brush GetUnderlineMouseOverBrush(UIElement element)
+        {
+            return (Brush)element.GetValue(UnderlineMouseOverBrushProperty);
+        }
+
+        public static void SetUnderlineMouseOverBrush(UIElement element, Brush value)
+        {
+            element.SetValue(UnderlineMouseOverBrushProperty, value);
+        }
+
+        /// <summary>
+        /// Defines the underline brush below the <see cref="TabItem"/> or <see cref="TabPanel"/> if the mouse is over a selected item.
+        /// </summary>
+        public static readonly DependencyProperty UnderlineMouseOverSelectedBrushProperty =
+            DependencyProperty.RegisterAttached("UnderlineMouseOverSelectedBrush",
+                                                typeof(Brush),
+                                                typeof(TabControlHelper),
+                                                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.SubPropertiesDoNotAffectRender));
+
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static Brush GetUnderlineMouseOverSelectedBrush(UIElement element)
+        {
+            return (Brush)element.GetValue(UnderlineMouseOverSelectedBrushProperty);
+        }
+
+        public static void SetUnderlineMouseOverSelectedBrush(UIElement element, Brush value)
+        {
+            element.SetValue(UnderlineMouseOverSelectedBrushProperty, value);
         }
 
         /// <summary>

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TabControlHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TabControlHelper.cs
@@ -1,36 +1,83 @@
-﻿using System.Windows;
+﻿using System;
+using System.ComponentModel;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 
 namespace MahApps.Metro.Controls
 {
-    using System.ComponentModel;
+    /// <summary>
+    /// Specifies the underline position of a TabControl.
+    /// </summary>
+    public enum UnderlinedType
+    {
+        None,
+        TabItem,
+        TabPanel
+    }
 
     public static class TabControlHelper
     {
         /// <summary>
-        /// Defines whether the underline below the <see cref="TabControl"/> is shown or not.
+        /// Defines whether the underline below the <see cref="TabItem"/> is shown or not.
         /// </summary>
+        [Obsolete(@"This property will be deleted in the next release. You should now use the Underlined attached property.")]
         public static readonly DependencyProperty IsUnderlinedProperty =
-            DependencyProperty.RegisterAttached("IsUnderlined", typeof(bool), typeof(TabControlHelper), new PropertyMetadata(false));
+            DependencyProperty.RegisterAttached("IsUnderlined",
+                                                typeof(bool),
+                                                typeof(TabControlHelper),
+                                                new PropertyMetadata(false,
+                                                                     (o, e) =>
+                                                                         {
+                                                                             var element = o as UIElement;
+                                                                             if (element != null && e.OldValue != e.NewValue && e.NewValue is bool)
+                                                                             {
+                                                                                 TabControlHelper.SetUnderlined(element, (bool)e.NewValue ? UnderlinedType.TabItem : UnderlinedType.None);
+                                                                             }
+                                                                         }));
 
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(TabControl))]
-        [AttachedPropertyBrowsableForType(typeof(TabItem))]
+        [Obsolete(@"This property will be deleted in the next release. You should now use the Underlined attached property.")]
         public static bool GetIsUnderlined(UIElement element)
         {
             return (bool)element.GetValue(IsUnderlinedProperty);
         }
 
+        [Obsolete(@"This property will be deleted in the next release. You should now use the Underlined attached property.")]
         public static void SetIsUnderlined(UIElement element, bool value)
         {
             element.SetValue(IsUnderlinedProperty, value);
         }
 
         /// <summary>
+        /// Defines whether the underline below the <see cref="TabItem"/> or <see cref="TabPanel"/> is shown or not.
+        /// </summary>
+        public static readonly DependencyProperty UnderlinedProperty =
+            DependencyProperty.RegisterAttached("Underlined",
+                                                typeof(UnderlinedType),
+                                                typeof(TabControlHelper),
+                                                new PropertyMetadata(UnderlinedType.None));
+
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static UnderlinedType GetUnderlined(UIElement element)
+        {
+            return (UnderlinedType)element.GetValue(UnderlinedProperty);
+        }
+
+        public static void SetUnderlined(UIElement element, UnderlinedType value)
+        {
+            element.SetValue(UnderlinedProperty, value);
+        }
+
+        /// <summary>
         /// This property can be used to set the Transition for animated TabControls
         /// </summary>
         public static readonly DependencyProperty TransitionProperty =
-            DependencyProperty.RegisterAttached("Transition", typeof(TransitionType), typeof(TabControlHelper),
+            DependencyProperty.RegisterAttached("Transition",
+                                                typeof(TransitionType),
+                                                typeof(TabControlHelper),
                                                 new FrameworkPropertyMetadata(TransitionType.Default, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits));
 
         [Category(AppName.MahApps)]

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Underline.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Underline.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace MahApps.Metro.Controls
+{
+    [TemplatePart(Name = UnderlineBorderPartName, Type = typeof(Border))]
+    public class Underline : ContentControl
+    {
+        public const string UnderlineBorderPartName = "PART_UnderlineBorder";
+        private Border _underlineBorder;
+
+        public static readonly DependencyProperty PlacementProperty =
+            DependencyProperty.Register(nameof(Placement),
+                                        typeof(Dock),
+                                        typeof(Underline),
+                                        new PropertyMetadata(default(Dock), (o, e) => { (o as Underline)?.ApplyBorderProperties(); }));
+
+        public Dock Placement
+        {
+            get { return (Dock)this.GetValue(PlacementProperty); }
+            set { this.SetValue(PlacementProperty, value); }
+        }
+
+        public static readonly DependencyProperty LineThicknessProperty =
+            DependencyProperty.Register(nameof(LineThickness),
+                                        typeof(double),
+                                        typeof(Underline),
+                                        new PropertyMetadata(1d, (o, e) => { (o as Underline)?.ApplyBorderProperties(); }));
+
+        public double LineThickness
+        {
+            get { return (double)this.GetValue(LineThicknessProperty); }
+            set { this.SetValue(LineThicknessProperty, value); }
+        }
+
+        static Underline()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(Underline), new FrameworkPropertyMetadata(typeof(Underline)));
+        }
+
+        public override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+
+            this._underlineBorder = this.GetTemplateChild(UnderlineBorderPartName) as Border;
+            this.ApplyBorderProperties();
+        }
+
+        private void ApplyBorderProperties()
+        {
+            if (this._underlineBorder == null)
+            {
+                return;
+            }
+
+            this._underlineBorder.BorderThickness = new Thickness();
+            switch (this.Placement)
+            {
+                case Dock.Left:
+                    this._underlineBorder.BorderThickness = new Thickness(this.LineThickness, 0d, 0d, 0d);
+                    break;
+                case Dock.Top:
+                    this._underlineBorder.BorderThickness = new Thickness(0d, this.LineThickness, 0d, 0d);
+                    break;
+                case Dock.Right:
+                    this._underlineBorder.BorderThickness = new Thickness(0d, 0d, this.LineThickness, 0d);
+                    break;
+                case Dock.Bottom:
+                    this._underlineBorder.BorderThickness = new Thickness(0d, 0d, 0d, this.LineThickness);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            this._underlineBorder.InvalidateVisual();
+        }
+    }
+}

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Underline.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Underline.cs
@@ -34,6 +34,18 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(LineThicknessProperty, value); }
         }
 
+        public static readonly DependencyProperty LineExtentProperty =
+            DependencyProperty.Register(nameof(LineExtent),
+                                        typeof(double),
+                                        typeof(Underline),
+                                        new PropertyMetadata(Double.NaN, (o, e) => { (o as Underline)?.ApplyBorderProperties(); }));
+
+        public double LineExtent
+        {
+            get { return (double)this.GetValue(LineExtentProperty); }
+            set { this.SetValue(LineExtentProperty, value); }
+        }
+
         static Underline()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(Underline), new FrameworkPropertyMetadata(typeof(Underline)));
@@ -54,25 +66,31 @@ namespace MahApps.Metro.Controls
                 return;
             }
 
+            this._underlineBorder.Height = Double.NaN;
+            this._underlineBorder.Width = Double.NaN;
             this._underlineBorder.BorderThickness = new Thickness();
             switch (this.Placement)
             {
                 case Dock.Left:
+                    this._underlineBorder.Width = this.LineExtent;
                     this._underlineBorder.BorderThickness = new Thickness(this.LineThickness, 0d, 0d, 0d);
                     break;
                 case Dock.Top:
+                    this._underlineBorder.Height = this.LineExtent;
                     this._underlineBorder.BorderThickness = new Thickness(0d, this.LineThickness, 0d, 0d);
                     break;
                 case Dock.Right:
+                    this._underlineBorder.Width = this.LineExtent;
                     this._underlineBorder.BorderThickness = new Thickness(0d, 0d, this.LineThickness, 0d);
                     break;
                 case Dock.Bottom:
+                    this._underlineBorder.Height = this.LineExtent;
                     this._underlineBorder.BorderThickness = new Thickness(0d, 0d, 0d, this.LineThickness);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            this._underlineBorder.InvalidateVisual();
+            this.InvalidateVisual();
         }
     }
 }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
@@ -131,6 +131,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ToggleSwitchButton.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\TransitioningContentControl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\TreeHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\Underline.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\VisualStates.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\WinApiHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\WindowButtonCommands.cs" />

--- a/src/MahApps.Metro/MahApps.Metro/MahApps.Metro.NET40.csproj
+++ b/src/MahApps.Metro/MahApps.Metro/MahApps.Metro.NET40.csproj
@@ -536,6 +536,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Themes\Underline.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Themes\WindowButtonCommands.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/MahApps.Metro/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/src/MahApps.Metro/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -536,6 +536,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Themes\Underline.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Themes\WindowButtonCommands.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -5,7 +5,7 @@
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
     <Style x:Key="MetroTabControl" TargetType="{x:Type TabControl}">
-        <Setter Property="Background" Value="{x:Null}" />
+        <Setter Property="Background" Value="{DynamicResource WhiteBrush}" />
         <Setter Property="BorderBrush" Value="{x:Null}" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
@@ -20,12 +20,21 @@
                             <RowDefinition x:Name="RowDefinition0" Height="Auto" />
                             <RowDefinition x:Name="RowDefinition1" Height="*" />
                         </Grid.RowDefinitions>
-                        <TabPanel x:Name="HeaderPanel"
-                                  Grid.Row="0"
-                                  Grid.Column="0"
-                                  Panel.ZIndex="1"
-                                  IsItemsHost="true"
-                                  KeyboardNavigation.TabIndex="1" />
+                        <Grid x:Name="HeaderPanelGrid"
+                              Grid.Row="0"
+                              Grid.Column="0"
+                              Panel.ZIndex="1">
+                            <Controls:Underline x:Name="Underline"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                Background="{TemplateBinding Background}"
+                                                BorderBrush="{DynamicResource GrayNormalBrush}"
+                                                Placement="Bottom"
+                                                LineThickness="1"
+                                                Visibility="Collapsed" />
+                            <TabPanel x:Name="HeaderPanel"
+                                      IsItemsHost="true"
+                                      KeyboardNavigation.TabIndex="1" />
+                        </Grid>
                         <Border x:Name="ContentPanel"
                                 Grid.Row="1"
                                 Grid.Column="0"
@@ -43,34 +52,40 @@
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:TabControlHelper.Underlined" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="Visibility" Value="Visible" />
+                        </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1" />
-                            <Setter TargetName="HeaderPanel" Property="Margin" Value="2 0 2 2" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="1" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Margin" Value="2 0 2 2" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Top" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Left">
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
                             <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
                             <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Margin" Value="2 2 0 2" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Margin" Value="2 2 0 2" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Right" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
                             <Setter TargetName="ColumnDefinition1" Property="Width" Value="Auto" />
                             <Setter TargetName="ContentPanel" Property="Grid.Column" Value="0" />
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Margin" Value="0 2 2 2" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Margin" Value="0 2 2 2" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Left" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -79,8 +94,8 @@
     </Style>
 
     <Style x:Key="MetroTabItem" TargetType="TabItem">
-        <Setter Property="Foreground" Value="{DynamicResource BlackBrush}" />
-        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="{DynamicResource GrayNormalBrush}" />
+        <Setter Property="Background" Value="{DynamicResource WhiteBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource AccentColorBrush}" />
         <Setter Property="BorderThickness" Value="0" />
         <!--  special property for header font size  -->
@@ -102,114 +117,89 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="PART_ContentLeftCol" Width="Auto" />
-                                <ColumnDefinition x:Name="PART_ContentRightCol" Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition x:Name="PART_ContentTopRow" Height="Auto" />
-                                <RowDefinition x:Name="PART_ContentBottomRow" Height="Auto" />
-                            </Grid.RowDefinitions>
+                        <Controls:Underline x:Name="Underline"
+                                            HorizontalAlignment="Stretch"
+                                            VerticalAlignment="Stretch"
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{DynamicResource GrayNormalBrush}"
+                                            Placement="Bottom"
+                                            Padding="0 0 0 1"
+                                            LineThickness="2">
                             <Controls:ContentControlEx x:Name="ContentSite"
-                                                       Grid.Column="0"
-                                                       Grid.Row="0"
-                                                       Padding="{TemplateBinding Padding}"
-                                                       Foreground="{TemplateBinding Foreground}"
-                                                       FontStyle="{TemplateBinding FontStyle}"
-                                                       FontFamily="{TemplateBinding FontFamily}"
-                                                       FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
-                                                       FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
-                                                       FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
-                                                       Content="{TemplateBinding Header}"
-                                                       ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
-                                                       ContentStringFormat="{TemplateBinding HeaderStringFormat}"
-                                                       ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                                       ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
-                                                       RecognizesAccessKey="True"
-                                                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                            <Rectangle x:Name="Underline"
-                                       Grid.Column="0"
-                                       Grid.Row="1"
-                                       Height="2"
-                                       Width="Auto"
-                                       Margin="0 1 0 0"
-                                       HorizontalAlignment="Stretch"
-                                       Visibility="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.IsUnderlined), Converter={StaticResource BooleanToVisibilityConverter}}" />
-                        </Grid>
+                                                        Padding="{TemplateBinding Padding}"
+                                                        Foreground="{TemplateBinding Foreground}"
+                                                        FontStyle="{TemplateBinding FontStyle}"
+                                                        FontFamily="{TemplateBinding FontFamily}"
+                                                        FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
+                                                        FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
+                                                        FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
+                                                        Content="{TemplateBinding Header}"
+                                                        ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
+                                                        ContentStringFormat="{TemplateBinding HeaderStringFormat}"
+                                                        ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                                        ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                                        RecognizesAccessKey="True"
+                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Controls:Underline>
                     </Border>
                     <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="None">
+                            <Setter TargetName="Underline" Property="LineThickness" Value="0" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="LineThickness" Value="1" />
+                        </DataTrigger>
+
                         <Trigger Property="TabStripPlacement" Value="Left">
-                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
-                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
-                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
-                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
-                            <Setter TargetName="ContentSite" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="ContentSite" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Height" Value="Auto" />
-                            <Setter TargetName="Underline" Property="Margin" Value="1 0 0 0" />
-                            <Setter TargetName="Underline" Property="Width" Value="2" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Right" />
+                            <Setter TargetName="Underline" Property="Padding" Value="0 0 1 0" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Top">
-                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
-                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
-                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
-                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
-                            <Setter TargetName="ContentSite" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="ContentSite" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Row" Value="1" />
-                            <Setter TargetName="Underline" Property="Height" Value="2" />
-                            <Setter TargetName="Underline" Property="Margin" Value="0 1 0 0" />
-                            <Setter TargetName="Underline" Property="Width" Value="Auto" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Bottom" />
+                            <Setter TargetName="Underline" Property="Padding" Value="0 0 0 1" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
-                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="Auto" />
-                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="*" />
-                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
-                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
-                            <Setter TargetName="ContentSite" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="ContentSite" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Height" Value="Auto" />
-                            <Setter TargetName="Underline" Property="Margin" Value="0 0 1 0" />
-                            <Setter TargetName="Underline" Property="Width" Value="2" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Left" />
+                            <Setter TargetName="Underline" Property="Padding" Value="1 0 0 0" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
-                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
-                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
-                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="Auto" />
-                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="*" />
-                            <Setter TargetName="ContentSite" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="ContentSite" Property="Grid.Row" Value="1" />
-                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Height" Value="2" />
-                            <Setter TargetName="Underline" Property="Margin" Value="0 0 0 1" />
-                            <Setter TargetName="Underline" Property="Width" Value="Auto" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Top" />
+                            <Setter TargetName="Underline" Property="Padding" Value="1 0 0 0" />
                         </Trigger>
+
                         <Trigger Property="IsSelected" Value="true">
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource AccentColorBrush}" />
-                            <Setter TargetName="Underline" Property="Fill" Value="{DynamicResource AccentColorBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource AccentColorBrush}" />
                         </Trigger>
-                        <Trigger Property="IsSelected" Value="false">
-                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource GrayNormalBrush}" />
-                            <Setter TargetName="Underline" Property="Fill" Value="{DynamicResource GrayNormalBrush}" />
-                        </Trigger>
-                        <Trigger SourceName="ContentSite" Property="IsMouseOver" Value="True">
+                        
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Underline" Property="LineThickness" Value="3" />
+                        </MultiDataTrigger>
+
+                        <Trigger SourceName="Border" Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource GrayHoverBrush}" />
-                            <Setter TargetName="Underline" Property="Fill" Value="{DynamicResource GrayHoverBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource GrayHoverBrush}" />
                         </Trigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="False" />
+                                <Condition Binding="{Binding ElementName=Border, Path=IsMouseOver}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Underline" Property="LineThickness" Value="2" />
+                        </MultiDataTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition SourceName="ContentSite" Property="IsMouseOver" Value="True" />
+                                <Condition SourceName="Border" Property="IsMouseOver" Value="True" />
                                 <Condition Property="IsSelected" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource HighlightBrush}" />
-                            <Setter TargetName="Underline" Property="Fill" Value="{DynamicResource HighlightBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource HighlightBrush}" />
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -26,7 +26,7 @@
                               Panel.ZIndex="1">
                             <Controls:Underline x:Name="Underline"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                Background="{TemplateBinding Background}"
+                                                Background="Transparent"
                                                 BorderBrush="{DynamicResource GrayNormalBrush}"
                                                 Placement="Bottom"
                                                 LineThickness="1"
@@ -95,7 +95,7 @@
 
     <Style x:Key="MetroTabItem" TargetType="TabItem">
         <Setter Property="Foreground" Value="{DynamicResource GrayNormalBrush}" />
-        <Setter Property="Background" Value="{DynamicResource WhiteBrush}" />
+        <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=Background, Mode=OneWay}" />
         <Setter Property="BorderBrush" Value="{DynamicResource AccentColorBrush}" />
         <Setter Property="BorderThickness" Value="0" />
         <!--  special property for header font size  -->

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -127,30 +127,23 @@
                                             Padding="0 0 0 1"
                                             LineThickness="2">
                             <Controls:ContentControlEx x:Name="ContentSite"
-                                                        Padding="{TemplateBinding Padding}"
-                                                        Foreground="{TemplateBinding Foreground}"
-                                                        FontStyle="{TemplateBinding FontStyle}"
-                                                        FontFamily="{TemplateBinding FontFamily}"
-                                                        FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
-                                                        FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
-                                                        FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
-                                                        Content="{TemplateBinding Header}"
-                                                        ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
-                                                        ContentStringFormat="{TemplateBinding HeaderStringFormat}"
-                                                        ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                                        ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
-                                                        RecognizesAccessKey="True"
-                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                                       Padding="{TemplateBinding Padding}"
+                                                       Foreground="{TemplateBinding Foreground}"
+                                                       FontStyle="{TemplateBinding FontStyle}"
+                                                       FontFamily="{TemplateBinding FontFamily}"
+                                                       FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
+                                                       FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
+                                                       FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
+                                                       Content="{TemplateBinding Header}"
+                                                       ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
+                                                       ContentStringFormat="{TemplateBinding HeaderStringFormat}"
+                                                       ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                                       ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                                       RecognizesAccessKey="True"
+                                                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Controls:Underline>
                     </Border>
                     <ControlTemplate.Triggers>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="None">
-                            <Setter TargetName="Underline" Property="LineThickness" Value="0" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel">
-                            <Setter TargetName="Underline" Property="LineThickness" Value="1" />
-                        </DataTrigger>
-
                         <Trigger Property="TabStripPlacement" Value="Left">
                             <Setter TargetName="Underline" Property="Placement" Value="Right" />
                             <Setter TargetName="Underline" Property="Padding" Value="0 0 1 0" />
@@ -168,6 +161,17 @@
                             <Setter TargetName="Underline" Property="Padding" Value="1 0 0 0" />
                         </Trigger>
 
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="None">
+                            <Setter TargetName="Underline" Property="LineThickness" Value="0" />
+                            <Setter TargetName="Underline" Property="Padding" Value="0" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="SelectedTabItem">
+                            <Setter TargetName="Underline" Property="LineThickness" Value="0" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="LineThickness" Value="1" />
+                        </DataTrigger>
+
                         <Trigger Property="IsSelected" Value="true">
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource AccentColorBrush}" />
                             <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource AccentColorBrush}" />
@@ -180,11 +184,19 @@
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="Underline" Property="LineThickness" Value="3" />
                         </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="SelectedTabItem" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Underline" Property="LineThickness" Value="2" />
+                        </MultiDataTrigger>
 
                         <Trigger SourceName="Border" Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource GrayHoverBrush}" />
                             <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource GrayHoverBrush}" />
                         </Trigger>
+
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel" />
@@ -193,6 +205,15 @@
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="Underline" Property="LineThickness" Value="2" />
                         </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="SelectedTabItem" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="False" />
+                                <Condition Binding="{Binding ElementName=Border, Path=IsMouseOver}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Underline" Property="LineThickness" Value="2" />
+                        </MultiDataTrigger>
+                        
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition SourceName="Border" Property="IsMouseOver" Value="True" />

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -117,16 +117,18 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <Controls:Underline x:Name="Underline"
-                                            HorizontalAlignment="Stretch"
-                                            VerticalAlignment="Stretch"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                            Background="{TemplateBinding Background}"
-                                            BorderBrush="{DynamicResource GrayNormalBrush}"
-                                            Placement="Bottom"
-                                            Padding="0 0 0 1"
-                                            LineThickness="2">
+                        <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition x:Name="PART_ContentLeftCol" Width="Auto" />
+                                <ColumnDefinition x:Name="PART_ContentRightCol" Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition x:Name="PART_ContentTopRow" Height="Auto" />
+                                <RowDefinition x:Name="PART_ContentBottomRow" Height="Auto" />
+                            </Grid.RowDefinitions>
                             <Controls:ContentControlEx x:Name="ContentSite"
+                                                       Grid.Column="0"
+                                                       Grid.Row="0"
                                                        Padding="{TemplateBinding Padding}"
                                                        Foreground="{TemplateBinding Foreground}"
                                                        FontStyle="{TemplateBinding FontStyle}"
@@ -141,34 +143,73 @@
                                                        ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
                                                        RecognizesAccessKey="True"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </Controls:Underline>
+                            <Controls:Underline x:Name="Underline"
+                                                Grid.Column="0"
+                                                Grid.Row="1"
+                                                HorizontalAlignment="Stretch"
+                                                VerticalAlignment="Stretch"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                Background="{TemplateBinding Background}"
+                                                BorderBrush="{DynamicResource GrayNormalBrush}"
+                                                Placement="Bottom"
+                                                LineExtent="3"
+                                                LineThickness="2" />
+                        </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="TabStripPlacement" Value="Left">
+                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
+                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
+                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
+                            <Setter TargetName="ContentSite" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="ContentSite" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
                             <Setter TargetName="Underline" Property="Placement" Value="Right" />
-                            <Setter TargetName="Underline" Property="Padding" Value="0 0 1 0" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Top">
+                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
+                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
+                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
+                            <Setter TargetName="ContentSite" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="ContentSite" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Row" Value="1" />
                             <Setter TargetName="Underline" Property="Placement" Value="Bottom" />
-                            <Setter TargetName="Underline" Property="Padding" Value="0 0 0 1" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
+                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="*" />
+                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
+                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
+                            <Setter TargetName="ContentSite" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="ContentSite" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
                             <Setter TargetName="Underline" Property="Placement" Value="Left" />
-                            <Setter TargetName="Underline" Property="Padding" Value="1 0 0 0" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
+                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
+                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="Auto" />
+                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="*" />
+                            <Setter TargetName="ContentSite" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="ContentSite" Property="Grid.Row" Value="1" />
+                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
                             <Setter TargetName="Underline" Property="Placement" Value="Top" />
-                            <Setter TargetName="Underline" Property="Padding" Value="1 0 0 0" />
                         </Trigger>
 
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="None">
-                            <Setter TargetName="Underline" Property="LineThickness" Value="0" />
-                            <Setter TargetName="Underline" Property="Padding" Value="0" />
+                            <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="SelectedTabItem">
                             <Setter TargetName="Underline" Property="LineThickness" Value="0" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="LineExtent" Value="4" />
                             <Setter TargetName="Underline" Property="LineThickness" Value="1" />
                         </DataTrigger>
 

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -5,6 +5,10 @@
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
     <Style x:Key="MetroTabControl" TargetType="{x:Type TabControl}">
+        <Setter Property="Controls:TabControlHelper.UnderlineBrush" Value="{DynamicResource GrayNormalBrush}" />
+        <Setter Property="Controls:TabControlHelper.UnderlineSelectedBrush" Value="{DynamicResource AccentColorBrush}" />
+        <Setter Property="Controls:TabControlHelper.UnderlineMouseOverBrush" Value="{DynamicResource GrayHoverBrush}" />
+        <Setter Property="Controls:TabControlHelper.UnderlineMouseOverSelectedBrush" Value="{DynamicResource HighlightBrush}" />
         <Setter Property="Background" Value="{DynamicResource WhiteBrush}" />
         <Setter Property="BorderBrush" Value="{x:Null}" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -27,7 +31,7 @@
                             <Controls:Underline x:Name="Underline"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                 Background="Transparent"
-                                                BorderBrush="{DynamicResource GrayNormalBrush}"
+                                                BorderBrush="{TemplateBinding Controls:TabControlHelper.UnderlineBrush}"
                                                 Placement="Bottom"
                                                 LineThickness="1"
                                                 Visibility="Collapsed" />
@@ -150,7 +154,7 @@
                                                 VerticalAlignment="Stretch"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                 Background="{TemplateBinding Background}"
-                                                BorderBrush="{DynamicResource GrayNormalBrush}"
+                                                BorderBrush="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.UnderlineBrush), Mode=OneWay}"
                                                 Placement="Bottom"
                                                 LineExtent="3"
                                                 LineThickness="2" />
@@ -215,7 +219,7 @@
 
                         <Trigger Property="IsSelected" Value="true">
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource AccentColorBrush}" />
-                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource AccentColorBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.UnderlineSelectedBrush), Mode=OneWay}" />
                         </Trigger>
                         
                         <MultiDataTrigger>
@@ -235,7 +239,7 @@
 
                         <Trigger SourceName="Border" Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource GrayHoverBrush}" />
-                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource GrayHoverBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.UnderlineMouseOverBrush), Mode=OneWay}" />
                         </Trigger>
 
                         <MultiDataTrigger>
@@ -261,7 +265,7 @@
                                 <Condition Property="IsSelected" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource HighlightBrush}" />
-                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource HighlightBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.UnderlineMouseOverSelectedBrush), Mode=OneWay}" />
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/MahApps.Metro/Themes/Generic.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/Generic.xaml
@@ -6,6 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
 
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/Underline.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/Badged.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/DateTimePicker.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/DropDownButton.xaml" />

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabControl.xaml
@@ -27,7 +27,7 @@
                             <Controls:Underline x:Name="Underline"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                 Background="Transparent"
-                                                BorderBrush="{DynamicResource GrayNormalBrush}"
+                                                BorderBrush="{TemplateBinding Controls:TabControlHelper.UnderlineBrush}"
                                                 Placement="Bottom"
                                                 LineThickness="1"
                                                 Visibility="Collapsed" />

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabControl.xaml
@@ -26,7 +26,7 @@
                               Panel.ZIndex="1">
                             <Controls:Underline x:Name="Underline"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                Background="{TemplateBinding Background}"
+                                                Background="Transparent"
                                                 BorderBrush="{DynamicResource GrayNormalBrush}"
                                                 Placement="Bottom"
                                                 LineThickness="1"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabControl.xaml
@@ -2,8 +2,11 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
-    <Style TargetType="{x:Type Controls:MetroTabControl}">
-        <Setter Property="Background" Value="{x:Null}" />
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TabControl.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <Style TargetType="{x:Type Controls:MetroTabControl}" BasedOn="{StaticResource MetroTabControl}">
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Controls:MetroTabControl}">
@@ -16,13 +19,22 @@
                             <RowDefinition x:Name="RowDefinition0" Height="Auto" />
                             <RowDefinition x:Name="RowDefinition1" Height="*" />
                         </Grid.RowDefinitions>
-                        <TabPanel x:Name="HeaderPanel"
-                                  Grid.Row="0"
-                                  Grid.Column="0"
-                                  Margin="{TemplateBinding TabStripMargin}"
-                                  Panel.ZIndex="1"
-                                  IsItemsHost="true"
-                                  KeyboardNavigation.TabIndex="1" />
+                        <Grid x:Name="HeaderPanelGrid"
+                              Grid.Row="0"
+                              Grid.Column="0"
+                              Margin="{TemplateBinding TabStripMargin}"
+                              Panel.ZIndex="1">
+                            <Controls:Underline x:Name="Underline"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                Background="{TemplateBinding Background}"
+                                                BorderBrush="{DynamicResource GrayNormalBrush}"
+                                                Placement="Bottom"
+                                                LineThickness="1"
+                                                Visibility="Collapsed" />
+                            <TabPanel x:Name="HeaderPanel"
+                                      IsItemsHost="true"
+                                      KeyboardNavigation.TabIndex="1" />
+                        </Grid>
                         <Border x:Name="ContentPanel"
                                 Grid.Row="1"
                                 Grid.Column="0"
@@ -39,31 +51,37 @@
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:TabControlHelper.Underlined" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="Visibility" Value="Visible" />
+                        </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="1" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Top" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Left">
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
                             <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
                             <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Right" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
                             <Setter TargetName="ColumnDefinition1" Property="Width" Value="Auto" />
                             <Setter TargetName="ContentPanel" Property="Grid.Column" Value="0" />
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Left" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabItem.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabItem.xaml
@@ -20,18 +20,16 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="PART_ContentLeftCol" Width="Auto" />
-                                <ColumnDefinition x:Name="PART_ContentRightCol" Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition x:Name="PART_ContentTopRow" Height="Auto" />
-                                <RowDefinition x:Name="PART_ContentBottomRow" Height="Auto" />
-                            </Grid.RowDefinitions>
+                        <Controls:Underline x:Name="Underline"
+                                            HorizontalAlignment="Stretch"
+                                            VerticalAlignment="Stretch"
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{DynamicResource GrayNormalBrush}"
+                                            Placement="Bottom"
+                                            Padding="0 0 0 1"
+                                            LineThickness="2">
                             <Grid x:Name="PART_ContentSite"
-                                  Grid.Column="0"
-                                  Grid.Row="0"
                                   Margin="{TemplateBinding Padding}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
@@ -85,72 +83,37 @@
                                     </Button.OpacityMask>
                                 </Button>
                             </Grid>
-                            <Rectangle x:Name="Underline"
-                                       Grid.Column="0"
-                                       Grid.Row="1"
-                                       Height="2"
-                                       Width="Auto"
-                                       Margin="0 1 0 0"
-                                       HorizontalAlignment="Stretch"
-                                       Visibility="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.IsUnderlined), Converter={StaticResource BooleanToVisibilityConverter}}" />
-                        </Grid>
+                        </Controls:Underline>
                     </Border>
                     <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="None">
+                            <Setter TargetName="Underline" Property="LineThickness" Value="0" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="LineThickness" Value="1" />
+                        </DataTrigger>
+
                         <Trigger Property="TabStripPlacement" Value="Left">
-                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
-                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
-                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
-                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
-                            <Setter TargetName="PART_ContentSite" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_ContentSite" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Height" Value="Auto" />
-                            <Setter TargetName="Underline" Property="Margin" Value="1 0 0 0" />
-                            <Setter TargetName="Underline" Property="Width" Value="2" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Right" />
+                            <Setter TargetName="Underline" Property="Padding" Value="0 0 1 0" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Top">
-                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
-                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
-                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
-                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
-                            <Setter TargetName="PART_ContentSite" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_ContentSite" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Row" Value="1" />
-                            <Setter TargetName="Underline" Property="Height" Value="2" />
-                            <Setter TargetName="Underline" Property="Margin" Value="0 1 0 0" />
-                            <Setter TargetName="Underline" Property="Width" Value="Auto" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Bottom" />
+                            <Setter TargetName="Underline" Property="Padding" Value="0 0 0 1" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
-                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="Auto" />
-                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="*" />
-                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
-                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
-                            <Setter TargetName="PART_ContentSite" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="PART_ContentSite" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Height" Value="Auto" />
-                            <Setter TargetName="Underline" Property="Margin" Value="0 0 1 0" />
-                            <Setter TargetName="Underline" Property="Width" Value="2" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Left" />
+                            <Setter TargetName="Underline" Property="Padding" Value="1 0 0 0" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
-                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
-                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
-                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="Auto" />
-                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="*" />
-                            <Setter TargetName="PART_ContentSite" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_ContentSite" Property="Grid.Row" Value="1" />
-                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="Underline" Property="Height" Value="2" />
-                            <Setter TargetName="Underline" Property="Margin" Value="0 0 0 1" />
-                            <Setter TargetName="Underline" Property="Width" Value="Auto" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Top" />
+                            <Setter TargetName="Underline" Property="Padding" Value="1 0 0 0" />
                         </Trigger>
+
                         <Trigger Property="CloseButtonEnabled" Value="True">
                             <Setter TargetName="PART_CloseButton" Property="Visibility" Value="Hidden" />
                         </Trigger>
+
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="IsSelected" Value="True" />
@@ -168,29 +131,46 @@
 
                         <Trigger Property="IsSelected" Value="true">
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource AccentColorBrush}" />
-                            <Setter TargetName="Underline" Property="Fill" Value="{DynamicResource AccentColorBrush}" />
-                        </Trigger>
-                        <Trigger Property="IsSelected" Value="false">
-                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource GrayNormalBrush}" />
-                            <Setter TargetName="Underline" Property="Fill" Value="{DynamicResource GrayNormalBrush}" />
-                        </Trigger>
-                        <Trigger SourceName="ContentSite" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource GrayHoverBrush}" />
-                            <Setter TargetName="PART_CloseButton" Property="Background" Value="{DynamicResource GrayHoverBrush}" />
-                            <Setter TargetName="Underline" Property="Fill" Value="{DynamicResource GrayHoverBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource AccentColorBrush}" />
                         </Trigger>
 
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Underline" Property="LineThickness" Value="3" />
+                        </MultiDataTrigger>
+
+                        <Trigger SourceName="Border" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource GrayHoverBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource GrayHoverBrush}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition SourceName="Border" Property="IsMouseOver" Value="True" />
+                                <Condition SourceName="PART_CloseButton" Property="IsEnabled" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_CloseButton" Property="Background" Value="{DynamicResource GrayHoverBrush}" />
+                        </MultiTrigger>
                         <Trigger SourceName="PART_CloseButton" Property="IsMouseOver" Value="True">
                             <Setter TargetName="PART_CloseButton" Property="Background" Value="{DynamicResource AccentColorBrush}" />
                         </Trigger>
-
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="False" />
+                                <Condition Binding="{Binding ElementName=Border, Path=IsMouseOver}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Underline" Property="LineThickness" Value="2" />
+                        </MultiDataTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition SourceName="ContentSite" Property="IsMouseOver" Value="True" />
                                 <Condition Property="IsSelected" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource HighlightBrush}" />
-                            <Setter TargetName="Underline" Property="Fill" Value="{DynamicResource HighlightBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource HighlightBrush}" />
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabItem.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabItem.xaml
@@ -10,7 +10,6 @@
     <Converters:MetroTabItemCloseButtonWidthConverter x:Key="MetroTabItemCloseButtonWidthConverter" />
 
     <Style BasedOn="{StaticResource MetroTabItem}" TargetType="{x:Type Controls:MetroTabItem}">
-        <Setter Property="Padding" Value="2 1 2 1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Controls:MetroTabItem}">
@@ -20,24 +19,24 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <Controls:Underline x:Name="Underline"
-                                            HorizontalAlignment="Stretch"
-                                            VerticalAlignment="Stretch"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                            Background="{TemplateBinding Background}"
-                                            BorderBrush="{DynamicResource GrayNormalBrush}"
-                                            Placement="Bottom"
-                                            Padding="0 0 0 1"
-                                            LineThickness="2">
+                        <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition x:Name="PART_ContentLeftCol" Width="Auto" />
+                                <ColumnDefinition x:Name="PART_ContentRightCol" Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition x:Name="PART_ContentTopRow" Height="Auto" />
+                                <RowDefinition x:Name="PART_ContentBottomRow" Height="Auto" />
+                            </Grid.RowDefinitions>
                             <Grid x:Name="PART_ContentSite"
-                                  Margin="{TemplateBinding Padding}">
+                                  Grid.Column="0"
+                                  Grid.Row="0">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
                                 <Controls:ContentControlEx x:Name="ContentSite"
                                                            Grid.Column="0"
-                                                           Margin="0 2 2 0"
                                                            Padding="{TemplateBinding Padding}"
                                                            Foreground="{TemplateBinding Foreground}"
                                                            FontStyle="{TemplateBinding FontStyle}"
@@ -83,7 +82,18 @@
                                     </Button.OpacityMask>
                                 </Button>
                             </Grid>
-                        </Controls:Underline>
+                            <Controls:Underline x:Name="Underline"
+                                                Grid.Column="0"
+                                                Grid.Row="1"
+                                                HorizontalAlignment="Stretch"
+                                                VerticalAlignment="Stretch"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                Background="{TemplateBinding Background}"
+                                                BorderBrush="{DynamicResource GrayNormalBrush}"
+                                                Placement="Bottom"
+                                                LineExtent="3"
+                                                LineThickness="2" />
+                        </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="CloseButtonEnabled" Value="True">
@@ -91,30 +101,58 @@
                         </Trigger>
 
                         <Trigger Property="TabStripPlacement" Value="Left">
+                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
+                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
+                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
+                            <Setter TargetName="PART_ContentSite" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_ContentSite" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
                             <Setter TargetName="Underline" Property="Placement" Value="Right" />
-                            <Setter TargetName="Underline" Property="Padding" Value="0 0 1 0" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Top">
+                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
+                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
+                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
+                            <Setter TargetName="PART_ContentSite" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_ContentSite" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Row" Value="1" />
                             <Setter TargetName="Underline" Property="Placement" Value="Bottom" />
-                            <Setter TargetName="Underline" Property="Padding" Value="0 0 0 1" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
+                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="*" />
+                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="*" />
+                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="Auto" />
+                            <Setter TargetName="PART_ContentSite" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_ContentSite" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
                             <Setter TargetName="Underline" Property="Placement" Value="Left" />
-                            <Setter TargetName="Underline" Property="Padding" Value="1 0 0 0" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
+                            <Setter TargetName="PART_ContentLeftCol" Property="Width" Value="*" />
+                            <Setter TargetName="PART_ContentRightCol" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_ContentTopRow" Property="Height" Value="Auto" />
+                            <Setter TargetName="PART_ContentBottomRow" Property="Height" Value="*" />
+                            <Setter TargetName="PART_ContentSite" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_ContentSite" Property="Grid.Row" Value="1" />
+                            <Setter TargetName="Underline" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="Underline" Property="Grid.Row" Value="0" />
                             <Setter TargetName="Underline" Property="Placement" Value="Top" />
-                            <Setter TargetName="Underline" Property="Padding" Value="1 0 0 0" />
                         </Trigger>
 
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="None">
-                            <Setter TargetName="Underline" Property="LineThickness" Value="0" />
-                            <Setter TargetName="Underline" Property="Padding" Value="0" />
+                            <Setter TargetName="Underline" Property="Visibility" Value="Collapsed" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="SelectedTabItem">
                             <Setter TargetName="Underline" Property="LineThickness" Value="0" />
                         </DataTrigger>
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="LineExtent" Value="4" />
                             <Setter TargetName="Underline" Property="LineThickness" Value="1" />
                         </DataTrigger>
 

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabItem.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabItem.xaml
@@ -89,7 +89,7 @@
                                                 VerticalAlignment="Stretch"
                                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                 Background="{TemplateBinding Background}"
-                                                BorderBrush="{DynamicResource GrayNormalBrush}"
+                                                BorderBrush="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.UnderlineBrush), Mode=OneWay}"
                                                 Placement="Bottom"
                                                 LineExtent="3"
                                                 LineThickness="2" />
@@ -173,7 +173,7 @@
 
                         <Trigger Property="IsSelected" Value="true">
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource AccentColorBrush}" />
-                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource AccentColorBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.UnderlineSelectedBrush), Mode=OneWay}" />
                         </Trigger>
 
                         <MultiDataTrigger>
@@ -193,7 +193,7 @@
 
                         <Trigger SourceName="Border" Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource GrayHoverBrush}" />
-                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource GrayHoverBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.UnderlineMouseOverBrush), Mode=OneWay}" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -229,7 +229,7 @@
                                 <Condition Property="IsSelected" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource HighlightBrush}" />
-                            <Setter TargetName="Underline" Property="BorderBrush" Value="{DynamicResource HighlightBrush}" />
+                            <Setter TargetName="Underline" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.UnderlineMouseOverSelectedBrush), Mode=OneWay}" />
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabItem.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabItem.xaml
@@ -86,12 +86,9 @@
                         </Controls:Underline>
                     </Border>
                     <ControlTemplate.Triggers>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="None">
-                            <Setter TargetName="Underline" Property="LineThickness" Value="0" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel">
-                            <Setter TargetName="Underline" Property="LineThickness" Value="1" />
-                        </DataTrigger>
+                        <Trigger Property="CloseButtonEnabled" Value="True">
+                            <Setter TargetName="PART_CloseButton" Property="Visibility" Value="Hidden" />
+                        </Trigger>
 
                         <Trigger Property="TabStripPlacement" Value="Left">
                             <Setter TargetName="Underline" Property="Placement" Value="Right" />
@@ -110,9 +107,16 @@
                             <Setter TargetName="Underline" Property="Padding" Value="1 0 0 0" />
                         </Trigger>
 
-                        <Trigger Property="CloseButtonEnabled" Value="True">
-                            <Setter TargetName="PART_CloseButton" Property="Visibility" Value="Hidden" />
-                        </Trigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="None">
+                            <Setter TargetName="Underline" Property="LineThickness" Value="0" />
+                            <Setter TargetName="Underline" Property="Padding" Value="0" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="SelectedTabItem">
+                            <Setter TargetName="Underline" Property="LineThickness" Value="0" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="LineThickness" Value="1" />
+                        </DataTrigger>
 
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -141,6 +145,13 @@
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="Underline" Property="LineThickness" Value="3" />
                         </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="SelectedTabItem" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Underline" Property="LineThickness" Value="2" />
+                        </MultiDataTrigger>
 
                         <Trigger SourceName="Border" Property="IsMouseOver" Value="True">
                             <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource GrayHoverBrush}" />
@@ -156,6 +167,7 @@
                         <Trigger SourceName="PART_CloseButton" Property="IsMouseOver" Value="True">
                             <Setter TargetName="PART_CloseButton" Property="Background" Value="{DynamicResource AccentColorBrush}" />
                         </Trigger>
+
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="TabPanel" />
@@ -164,6 +176,15 @@
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="Underline" Property="LineThickness" Value="2" />
                         </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(Controls:TabControlHelper.Underlined)}" Value="SelectedTabItem" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="False" />
+                                <Condition Binding="{Binding ElementName=Border, Path=IsMouseOver}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Underline" Property="LineThickness" Value="2" />
+                        </MultiDataTrigger>
+
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition SourceName="ContentSite" Property="IsMouseOver" Value="True" />

--- a/src/MahApps.Metro/MahApps.Metro/Themes/Underline.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/Underline.xaml
@@ -10,6 +10,7 @@
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Focusable" Value="False" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="UseLayoutRounding" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:Underline}">
@@ -18,7 +19,7 @@
                             VerticalAlignment="{TemplateBinding VerticalAlignment}"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-                            UseLayoutRounding="True"
+                            UseLayoutRounding="{TemplateBinding UseLayoutRounding}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                         <controls:ClipBorder Background="{TemplateBinding Background}"
                                              BorderThickness="0"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/Underline.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/Underline.xaml
@@ -1,0 +1,34 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:MahApps.Metro.Controls">
+
+    <Style TargetType="{x:Type controls:Underline}">
+        <Setter Property="BorderBrush" Value="{DynamicResource GrayNormalBrush}" />
+        <Setter Property="Placement" Value="Bottom" />
+        <Setter Property="LineThickness" Value="1" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type controls:Underline}">
+                    <Border x:Name="PART_UnderlineBorder"
+                            HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <controls:ClipBorder Background="{TemplateBinding Background}"
+                                             BorderThickness="0"
+                                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <ContentPresenter Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </controls:ClipBorder>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+    </Style>
+
+</ResourceDictionary>

--- a/src/MahApps.Metro/MahApps.Metro/Themes/Underline.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/Underline.xaml
@@ -18,11 +18,14 @@
                             VerticalAlignment="{TemplateBinding VerticalAlignment}"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
+                            UseLayoutRounding="True"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                         <controls:ClipBorder Background="{TemplateBinding Background}"
                                              BorderThickness="0"
                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                            <ContentPresenter Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <ContentPresenter Margin="{TemplateBinding Padding}"
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                              UseLayoutRounding="False" />
                         </controls:ClipBorder>
                     </Border>
                 </ControlTemplate>


### PR DESCRIPTION
## What changed?

This PR adds a new attached property to add a new underlined type for the `TabControl` and `MetroTabControl`.

- Add new `Underlined` attached property to `TabControlHelper`. This property controls the type of the underline type which can be TabItem or TabPanel (with TabItem).
```
    /// <summary>
    /// Specifies the underline position of a TabControl.
    /// </summary>
    public enum UnderlinedType
    {
        None,
        TabItems,
        SelectedTabItem,
        TabPanel
    }
```
- Make `IsUnderlined` obsolete
- [x] Refactor Underline control, cause it doesn't work as expected (Bottom and Right doesn't works nicely)
- Add new `Brush` attached properties to enable easy changing the underline brushes
```
Controls:TabControlHelper.UnderlineBrush
Controls:TabControlHelper.UnderlineSelectedBrush
Controls:TabControlHelper.UnderlineMouseOverBrush
Controls:TabControlHelper.UnderlineMouseOverSelectedBrush
```

![mahapps_newunderline4](https://cloud.githubusercontent.com/assets/658431/24204520/0e6f3cbc-0f19-11e7-8a2b-f40752918a96.gif)

Closes #2895 [RFC] [Enhancement] Proposed TabControlHelper.IsUnderlined Change