### PR TITLE
Use new underlined types for animated TabControls

### DIFF
--- a/docs/release-notes/1.5.0.md
+++ b/docs/release-notes/1.5.0.md
@@ -39,6 +39,7 @@
     TabControlHelper.UnderlineMouseOverSelectedBrush
     ```
     ![mahapps_newunderline4](https://cloud.githubusercontent.com/assets/658431/24204520/0e6f3cbc-0f19-11e7-8a2b-f40752918a96.gif)
+- New underline types also for `AnimatedTabControl` and `AnimatedSingleRowTabControl` styles and for `MetroAnimatedTabControl` and `MetroAnimatedSingleRowTabControl` [#2905](https://github.com/MahApps/MahApps.Metro/pull/2905)
 
 ## Closed Issues
 

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
@@ -101,9 +101,9 @@
                         <TabControl Height="150"
                                     Controls:TabControlHelper.Underlined="{Binding ElementName=AnimatedTabControlUnderlinedComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                     TabStripPlacement="{Binding ElementName=AnimatedTabControlTabStripPlacementComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                            <Controls:MetroTabItem Header="this tabcontrol">
+                            <TabItem Header="this tabcontrol">
                                 <TextBlock FontSize="30" Text="Cool transition" />
-                            </Controls:MetroTabItem>
+                            </TabItem>
                             <Controls:MetroTabItem Header="animates its content">
                                 <TextBlock FontSize="30" Text="More cool transition" />
                             </Controls:MetroTabItem>
@@ -142,6 +142,55 @@
             <Expander Margin="0, 10, 0, 0" IsExpanded="True" Header="_Generic theme TabControls">
                 <StackPanel Margin="15, 5, 15, 5">
                     <Label Content="MetroAnimatedTabControl" Style="{DynamicResource DescriptionHeaderStyle}" />
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Underlined type" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="MetroAnimatedTabControlUnderlinedComboBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  Width="100"
+                                  ItemsSource="{Binding Source={StaticResource UnderlinedEnumValues}}"
+                                  SelectedIndex="0" />
+                        <TextBlock Text="TabStripPlacement" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="MetroAnimatedTabControlTabStripPlacementComboBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  Width="100"
+                                  ItemsSource="{Binding Source={StaticResource TabStripPlacementEnumValues}}"
+                                  SelectedItem="{x:Static Dock.Top}" />
+                    </StackPanel>
+                    <Controls:MetroAnimatedTabControl Height="150"
+                                                      Controls:TabControlHelper.Underlined="{Binding ElementName=MetroAnimatedTabControlUnderlinedComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                      TabStripPlacement="{Binding ElementName=MetroAnimatedTabControlTabStripPlacementComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                            <TabItem Header="this tabcontrol">
+                                <TextBlock FontSize="30" Text="Cool transition" />
+                            </TabItem>
+                            <Controls:MetroTabItem Header="animates its content">
+                                <TextBlock FontSize="30" Text="More cool transition" />
+                            </Controls:MetroTabItem>
+                            <Controls:MetroTabItem Header="with a transition">
+                                <TextBlock FontSize="30" Text="Animate everything!" />
+                            </Controls:MetroTabItem>
+                    </Controls:MetroAnimatedTabControl>
+
+                    <Label Margin="0, 5, 0, 0"
+                           Content="MetroAnimatedSingleRowTabControl"
+                           Style="{DynamicResource DescriptionHeaderStyle}" />
+                    <Controls:MetroAnimatedSingleRowTabControl>
+                        <TabItem Header="this tabcontrols tabs">
+                            <TextBlock FontSize="30" Text="Content" />
+                        </TabItem>
+                        <TabItem Header="appear only on a single line">
+                            <TextBlock FontSize="30" Text="Content" />
+                        </TabItem>
+                        <TabItem Header="if they are overflowing">
+                            <TextBlock FontSize="30" Text="Content" />
+                        </TabItem>
+                        <TabItem Header="instead of wrapping them">
+                            <TextBlock FontSize="30" Text="Content" />
+                        </TabItem>
+                    </Controls:MetroAnimatedSingleRowTabControl>
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition />
@@ -202,35 +251,6 @@
                             </TabItem>
                         </Controls:MetroAnimatedSingleRowTabControl>
                     </Grid>
-                    <Controls:MetroAnimatedTabControl>
-                        <TabItem Header="this tabcontrol">
-                            <TextBlock FontSize="30" Text="Cool transition" />
-                        </TabItem>
-                        <TabItem Header="animates its content">
-                            <TextBlock FontSize="30" Text="More cool transition" />
-                        </TabItem>
-                        <TabItem Header="with a transition">
-                            <TextBlock FontSize="30" Text="Animate everything!" />
-                        </TabItem>
-                    </Controls:MetroAnimatedTabControl>
-
-                    <Label Margin="0, 5, 0, 0"
-                           Content="MetroAnimatedSingleRowTabControl"
-                           Style="{DynamicResource DescriptionHeaderStyle}" />
-                    <Controls:MetroAnimatedSingleRowTabControl>
-                        <TabItem Header="this tabcontrols tabs">
-                            <TextBlock FontSize="30" Text="Content" />
-                        </TabItem>
-                        <TabItem Header="appear only on a single line">
-                            <TextBlock FontSize="30" Text="Content" />
-                        </TabItem>
-                        <TabItem Header="if they are overflowing">
-                            <TextBlock FontSize="30" Text="Content" />
-                        </TabItem>
-                        <TabItem Header="instead of wrapping them">
-                            <TextBlock FontSize="30" Text="Content" />
-                        </TabItem>
-                    </Controls:MetroAnimatedSingleRowTabControl>
 
                     <Label Margin="0 5 0 0"
                            Content="MetroTabControl w/ Closable Items"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
@@ -76,11 +76,31 @@
                     <Label Margin="0, 5, 0, 0"
                            Content="Default TabControl with _AnimatedTabControl style"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Underlined type" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="AnimatedTabControlUnderlinedComboBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  Width="100"
+                                  ItemsSource="{Binding Source={StaticResource UnderlinedEnumValues}}"
+                                  SelectedIndex="0" />
+                        <TextBlock Text="TabStripPlacement" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="AnimatedTabControlTabStripPlacementComboBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  Width="100"
+                                  ItemsSource="{Binding Source={StaticResource TabStripPlacementEnumValues}}"
+                                  SelectedItem="{x:Static Dock.Top}" />
+                    </StackPanel>
                     <Grid>
                         <Grid.Resources>
                             <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.AnimatedTabControl.xaml" />
                         </Grid.Resources>
-                        <TabControl>
+                        <TabControl Height="150"
+                                    Controls:TabControlHelper.Underlined="{Binding ElementName=AnimatedTabControlUnderlinedComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                    TabStripPlacement="{Binding ElementName=AnimatedTabControlTabStripPlacementComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                             <Controls:MetroTabItem Header="this tabcontrol">
                                 <TextBlock FontSize="30" Text="Cool transition" />
                             </Controls:MetroTabItem>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
@@ -116,22 +116,42 @@
                     <Label Margin="0, 5, 0, 0"
                            Content="Default TabControl with Animated_SingleRowTabControl style"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Underlined type" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="AnimatedSingleRowTabControlUnderlinedComboBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  Width="100"
+                                  ItemsSource="{Binding Source={StaticResource UnderlinedEnumValues}}"
+                                  SelectedIndex="0" />
+                        <TextBlock Text="TabStripPlacement" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="AnimatedSingleRowTabControlTabStripPlacementComboBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  Width="100"
+                                  ItemsSource="{Binding Source={StaticResource TabStripPlacementEnumValues}}"
+                                  SelectedItem="{x:Static Dock.Top}" />
+                    </StackPanel>
                     <Grid>
                         <Grid.Resources>
                             <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.AnimatedSingleRowTabControl.xaml" />
                         </Grid.Resources>
-                        <TabControl>
-                            <TabItem Header="this tabcontrols tabs">
-                                <TextBlock FontSize="30" Text="Content" />
+                        <TabControl Height="150"
+                                    Controls:TabControlHelper.Underlined="{Binding ElementName=AnimatedSingleRowTabControlUnderlinedComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                    TabStripPlacement="{Binding ElementName=AnimatedSingleRowTabControlTabStripPlacementComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                            <TabItem Header="these tabs">
+                                <TextBlock FontSize="30" Text="first content" />
                             </TabItem>
-                            <TabItem Header="appear only on a single line">
-                                <TextBlock FontSize="30" Text="Content" />
-                            </TabItem>
-                            <TabItem Header="if they are overflowing">
-                                <TextBlock FontSize="30" Text="Content" />
-                            </TabItem>
+                            <Controls:MetroTabItem Header="appear only on a single line">
+                                <TextBlock FontSize="30" Text="second one" />
+                            </Controls:MetroTabItem>
+                            <Controls:MetroTabItem Header="if they are overflowing">
+                                <TextBlock FontSize="30" Text="3" />
+                            </Controls:MetroTabItem>
                             <TabItem Header="instead of wrapping them">
-                                <TextBlock FontSize="30" Text="Content" />
+                                <TextBlock FontSize="30" Text="last of them" />
                             </TabItem>
                         </TabControl>
                     </Grid>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/TabControlExamples.xaml
@@ -197,18 +197,38 @@
                     <Label Margin="0, 5, 0, 0"
                            Content="MetroAnimatedSingleRowTabControl"
                            Style="{DynamicResource DescriptionHeaderStyle}" />
-                    <Controls:MetroAnimatedSingleRowTabControl>
-                        <TabItem Header="this tabcontrols tabs">
-                            <TextBlock FontSize="30" Text="Content" />
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="Underlined type" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="MetroAnimatedSingleRowTabControlUnderlinedComboBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  Width="100"
+                                  ItemsSource="{Binding Source={StaticResource UnderlinedEnumValues}}"
+                                  SelectedIndex="0" />
+                        <TextBlock Text="TabStripPlacement" Margin="5 5" VerticalAlignment="Center" />
+                        <ComboBox x:Name="MetroAnimatedSingleRowTabControlTabStripPlacementComboBox"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Margin="5 5"
+                                  Width="100"
+                                  ItemsSource="{Binding Source={StaticResource TabStripPlacementEnumValues}}"
+                                  SelectedItem="{x:Static Dock.Top}" />
+                    </StackPanel>
+                    <Controls:MetroAnimatedSingleRowTabControl Height="150"
+                                                               Controls:TabControlHelper.Underlined="{Binding ElementName=MetroAnimatedSingleRowTabControlUnderlinedComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                               TabStripPlacement="{Binding ElementName=MetroAnimatedSingleRowTabControlTabStripPlacementComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <TabItem Header="these tabs">
+                            <TextBlock FontSize="30" Text="first content" />
                         </TabItem>
-                        <TabItem Header="appear only on a single line">
-                            <TextBlock FontSize="30" Text="Content" />
-                        </TabItem>
-                        <TabItem Header="if they are overflowing">
-                            <TextBlock FontSize="30" Text="Content" />
-                        </TabItem>
+                        <Controls:MetroTabItem Header="appear only on a single line">
+                            <TextBlock FontSize="30" Text="second one" />
+                        </Controls:MetroTabItem>
+                        <Controls:MetroTabItem Header="if they are overflowing">
+                            <TextBlock FontSize="30" Text="3" />
+                        </Controls:MetroTabItem>
                         <TabItem Header="instead of wrapping them">
-                            <TextBlock FontSize="30" Text="Content" />
+                            <TextBlock FontSize="30" Text="last of them" />
                         </TabItem>
                     </Controls:MetroAnimatedSingleRowTabControl>
                     <Grid>

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.AnimatedSingleRowTabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.AnimatedSingleRowTabControl.xaml
@@ -3,6 +3,10 @@
                     xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TabControl.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
     <ControlTemplate x:Key="HorizontalScrollBarTemplate" TargetType="{x:Type ScrollBar}">
         <Grid>
             <Grid.ColumnDefinitions>
@@ -191,11 +195,8 @@
         </Grid>
     </ControlTemplate>
 
-    <Style TargetType="{x:Type TabControl}">
-        <Setter Property="Background" Value="{x:Null}" />
-        <Setter Property="BorderBrush" Value="{x:Null}" />
+    <Style TargetType="{x:Type TabControl}" BasedOn="{StaticResource MetroTabControl}">
         <Setter Property="Controls:TabControlHelper.Transition" Value="Left" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">
@@ -214,10 +215,19 @@
                                       HorizontalScrollBarVisibility="Auto"
                                       Template="{StaticResource ScrollViewerTemplate}"
                                       VerticalScrollBarVisibility="Disabled">
-                            <TabPanel x:Name="HeaderPanel"
-                                      Panel.ZIndex="1"
-                                      IsItemsHost="True"
-                                      KeyboardNavigation.TabIndex="1" />
+                            <Grid x:Name="HeaderPanelGrid"
+                                  Panel.ZIndex="1">
+                                <Controls:Underline x:Name="Underline"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                    Background="Transparent"
+                                                    BorderBrush="{TemplateBinding Controls:TabControlHelper.UnderlineBrush}"
+                                                    Placement="Bottom"
+                                                    LineThickness="1"
+                                                    Visibility="Collapsed" />
+                                <TabPanel x:Name="HeaderPanel"
+                                          IsItemsHost="true"
+                                          KeyboardNavigation.TabIndex="1" />
+                            </Grid>
                         </ScrollViewer>
                         <Controls:TransitioningContentControl x:Name="ContentPanel"
                                                               UseLayoutRounding="True"
@@ -234,15 +244,18 @@
                         </Controls:TransitioningContentControl>
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:TabControlHelper.Underlined" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="Visibility" Value="Visible" />
+                        </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
                             <Setter TargetName="HeaderPanelScroll" Property="Grid.Row" Value="1" />
                             <Setter TargetName="HeaderPanelScroll" Property="Margin" Value="2 0 2 2" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Top" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Left">
-                            <Setter Property="Controls:TabControlHelper.Transition" Value="Right" />
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
                             <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
                             <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
@@ -255,6 +268,7 @@
                             <Setter TargetName="HeaderPanelScroll" Property="VerticalScrollBarVisibility" Value="Auto" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Right" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
@@ -269,6 +283,7 @@
                             <Setter TargetName="HeaderPanelScroll" Property="VerticalScrollBarVisibility" Value="Auto" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Left" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.AnimatedTabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.AnimatedTabControl.xaml
@@ -3,18 +3,16 @@
                     xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
-    <Style TargetType="{x:Type TabControl}">
-        <Setter Property="Background" Value="{x:Null}" />
-        <Setter Property="BorderBrush" Value="{x:Null}" />
-        <Setter Property="ClipToBounds" Value="True" />
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TabControl.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <Style TargetType="{x:Type TabControl}" BasedOn="{StaticResource MetroTabControl}">
         <Setter Property="Controls:TabControlHelper.Transition" Value="Left" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TabControl}">
-                    <Grid ClipToBounds="{TemplateBinding ClipToBounds}"
-                          KeyboardNavigation.TabNavigation="Local"
-                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                    <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition x:Name="ColumnDefinition0" />
                             <ColumnDefinition x:Name="ColumnDefinition1" Width="0" />
@@ -23,21 +21,32 @@
                             <RowDefinition x:Name="RowDefinition0" Height="Auto" />
                             <RowDefinition x:Name="RowDefinition1" Height="*" />
                         </Grid.RowDefinitions>
-                        <TabPanel x:Name="HeaderPanel"
-                                  Grid.Row="0"
-                                  Grid.Column="0"
-                                  Panel.ZIndex="1"
-                                  IsItemsHost="True"
-                                  KeyboardNavigation.TabIndex="1" />
+                        <Grid x:Name="HeaderPanelGrid"
+                              Grid.Row="0"
+                              Grid.Column="0"
+                              Panel.ZIndex="1">
+                            <Controls:Underline x:Name="Underline"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                Background="Transparent"
+                                                BorderBrush="{TemplateBinding Controls:TabControlHelper.UnderlineBrush}"
+                                                Placement="Bottom"
+                                                LineThickness="1"
+                                                Visibility="Collapsed" />
+                            <TabPanel x:Name="HeaderPanel"
+                                      IsItemsHost="true"
+                                      KeyboardNavigation.TabIndex="1" />
+                        </Grid>
                         <Border x:Name="ContentPanel"
                                 Grid.Row="1"
                                 Grid.Column="0"
+                                ClipToBounds="{TemplateBinding ClipToBounds}"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 KeyboardNavigation.DirectionalNavigation="Contained"
                                 KeyboardNavigation.TabIndex="2"
-                                KeyboardNavigation.TabNavigation="Local">
+                                KeyboardNavigation.TabNavigation="Local"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                             <Controls:TransitioningContentControl UseLayoutRounding="True"
                                                                   Behaviours:ReloadBehavior.OnSelectedTabChanged="True"
                                                                   RestartTransitionOnContentChange="True"
@@ -51,35 +60,40 @@
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:TabControlHelper.Underlined" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="Visibility" Value="Visible" />
+                        </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1" />
-                            <Setter TargetName="HeaderPanel" Property="Margin" Value="2 0 2 2" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="1" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Margin" Value="2 0 2 2" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Top" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Left">
-                            <Setter Property="Controls:TabControlHelper.Transition" Value="Right" />
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
                             <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
                             <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Margin" Value="2 2 0 2" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Margin" Value="2 2 0 2" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Right" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
                             <Setter TargetName="ColumnDefinition1" Property="Width" Value="Auto" />
                             <Setter TargetName="ContentPanel" Property="Grid.Column" Value="0" />
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Margin" Value="0 2 2 2" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Margin" Value="0 2 2 2" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Left" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -121,7 +121,7 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                        <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" UseLayoutRounding="True">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="PART_ContentLeftCol" Width="Auto" />
                                 <ColumnDefinition x:Name="PART_ContentRightCol" Width="Auto" />
@@ -146,6 +146,7 @@
                                                        ContentTemplate="{TemplateBinding HeaderTemplate}"
                                                        ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
                                                        RecognizesAccessKey="True"
+                                                       UseLayoutRounding="False"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             <Controls:Underline x:Name="Underline"
                                                 Grid.Column="0"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroAnimatedSingleRowTabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroAnimatedSingleRowTabControl.xaml
@@ -4,15 +4,13 @@
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
     <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TabControl.xaml" />
         <!--  MetroScrollViewer  -->
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Scrollbars.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style TargetType="{x:Type Controls:MetroAnimatedSingleRowTabControl}">
-        <Setter Property="Background" Value="{x:Null}" />
-        <Setter Property="BorderBrush" Value="{x:Null}" />
+    <Style TargetType="{x:Type Controls:MetroAnimatedSingleRowTabControl}" BasedOn="{StaticResource MetroTabControl}">
         <Setter Property="Controls:TabControlHelper.Transition" Value="Left" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Controls:MetroAnimatedSingleRowTabControl}">
@@ -32,10 +30,19 @@
                                       Style="{DynamicResource MetroScrollViewer}"
                                       HorizontalScrollBarVisibility="Auto"
                                       VerticalScrollBarVisibility="Disabled">
-                            <TabPanel x:Name="HeaderPanel"
-                                      Panel.ZIndex="1"
-                                      IsItemsHost="True"
-                                      KeyboardNavigation.TabIndex="1" />
+                            <Grid x:Name="HeaderPanelGrid"
+                                  Panel.ZIndex="1">
+                                <Controls:Underline x:Name="Underline"
+                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                    Background="Transparent"
+                                                    BorderBrush="{TemplateBinding Controls:TabControlHelper.UnderlineBrush}"
+                                                    Placement="Bottom"
+                                                    LineThickness="1"
+                                                    Visibility="Collapsed" />
+                                <TabPanel x:Name="HeaderPanel"
+                                          IsItemsHost="true"
+                                          KeyboardNavigation.TabIndex="1" />
+                            </Grid>
                         </ScrollViewer>
                         <Controls:TransitioningContentControl x:Name="ContentPanel"
                                                               UseLayoutRounding="True"
@@ -52,14 +59,17 @@
                         </Controls:TransitioningContentControl>
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:TabControlHelper.Underlined" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="Visibility" Value="Visible" />
+                        </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
                             <Setter TargetName="HeaderPanelScroll" Property="Grid.Row" Value="1" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Top" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Left">
-                            <Setter Property="Controls:TabControlHelper.Transition" Value="Right" />
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
                             <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
                             <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
@@ -70,6 +80,7 @@
                             <Setter TargetName="HeaderPanelScroll" Property="VerticalScrollBarVisibility" Value="Auto" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Right" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
@@ -83,6 +94,7 @@
                             <Setter TargetName="HeaderPanelScroll" Property="VerticalScrollBarVisibility" Value="Auto" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Left" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroAnimatedTabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroAnimatedTabControl.xaml
@@ -3,18 +3,16 @@
                     xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
-    <Style TargetType="{x:Type Controls:MetroAnimatedTabControl}">
-        <Setter Property="Background" Value="{x:Null}" />
-        <Setter Property="BorderBrush" Value="{x:Null}" />
-        <Setter Property="ClipToBounds" Value="True" />
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TabControl.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <Style TargetType="{x:Type Controls:MetroAnimatedTabControl}" BasedOn="{StaticResource MetroTabControl}">
         <Setter Property="Controls:TabControlHelper.Transition" Value="Left" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Controls:MetroAnimatedTabControl}">
-                    <Grid ClipToBounds="{TemplateBinding ClipToBounds}"
-                          KeyboardNavigation.TabNavigation="Local"
-                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                    <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition x:Name="ColumnDefinition0" />
                             <ColumnDefinition x:Name="ColumnDefinition1" Width="0" />
@@ -23,22 +21,33 @@
                             <RowDefinition x:Name="RowDefinition0" Height="Auto" />
                             <RowDefinition x:Name="RowDefinition1" Height="*" />
                         </Grid.RowDefinitions>
-                        <TabPanel x:Name="HeaderPanel"
-                                  Grid.Row="0"
-                                  Grid.Column="0"
-                                  Margin="{TemplateBinding TabStripMargin}"
-                                  Panel.ZIndex="1"
-                                  IsItemsHost="True"
-                                  KeyboardNavigation.TabIndex="1" />
+                        <Grid x:Name="HeaderPanelGrid"
+                              Grid.Row="0"
+                              Grid.Column="0"
+                              Margin="{TemplateBinding TabStripMargin}"
+                              Panel.ZIndex="1">
+                            <Controls:Underline x:Name="Underline"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                Background="Transparent"
+                                                BorderBrush="{TemplateBinding Controls:TabControlHelper.UnderlineBrush}"
+                                                Placement="Bottom"
+                                                LineThickness="1"
+                                                Visibility="Collapsed" />
+                            <TabPanel x:Name="HeaderPanel"
+                                      IsItemsHost="true"
+                                      KeyboardNavigation.TabIndex="1" />
+                        </Grid>
                         <Border x:Name="ContentPanel"
                                 Grid.Row="1"
                                 Grid.Column="0"
+                                ClipToBounds="{TemplateBinding ClipToBounds}"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 KeyboardNavigation.DirectionalNavigation="Contained"
                                 KeyboardNavigation.TabIndex="2"
-                                KeyboardNavigation.TabNavigation="Local">
+                                KeyboardNavigation.TabNavigation="Local"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                             <Controls:TransitioningContentControl UseLayoutRounding="True"
                                                                   Behaviours:ReloadBehavior.OnSelectedTabChanged="True"
                                                                   RestartTransitionOnContentChange="True"
@@ -52,32 +61,37 @@
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:TabControlHelper.Underlined" Value="TabPanel">
+                            <Setter TargetName="Underline" Property="Visibility" Value="Visible" />
+                        </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Bottom">
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="1" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="1" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Top" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Left">
-                            <Setter Property="Controls:TabControlHelper.Transition" Value="Right" />
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
                             <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
                             <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Right" />
                         </Trigger>
                         <Trigger Property="TabStripPlacement" Value="Right">
                             <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
                             <Setter TargetName="ColumnDefinition1" Property="Width" Value="Auto" />
                             <Setter TargetName="ContentPanel" Property="Grid.Column" Value="0" />
                             <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="HeaderPanel" Property="Grid.Row" Value="0" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
                             <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
                             <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                            <Setter TargetName="Underline" Property="Placement" Value="Left" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabItem.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroTabItem.xaml
@@ -19,7 +19,7 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                        <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" UseLayoutRounding="True">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="PART_ContentLeftCol" Width="Auto" />
                                 <ColumnDefinition x:Name="PART_ContentRightCol" Width="Auto" />
@@ -30,7 +30,8 @@
                             </Grid.RowDefinitions>
                             <Grid x:Name="PART_ContentSite"
                                   Grid.Column="0"
-                                  Grid.Row="0">
+                                  Grid.Row="0"
+                                  UseLayoutRounding="False">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
## What changed?

This PR adds the new underlined types to the animated TabConotrols.

- [x] Underlined Controls.AnimatedTabControl.xaml
- [x] Underlined MetroAnimatedTabControl
- [x] Underlined Controls.AnimatedSingleRowTabControl.xaml
- [x] Underlined MetroAnimatedSingleRowTabControl

![mahapps_newunderline5](https://cloud.githubusercontent.com/assets/658431/24224971/64d4944a-0f5e-11e7-81b8-55d1ed8c1003.gif)
