### PR TITLE
🍔 menu scroll bar behavior like in the UWPCommunityToolkit

### DIFF
--- a/docs/release-notes/1.5.0.md
+++ b/docs/release-notes/1.5.0.md
@@ -10,6 +10,9 @@
     + `ItemCommand` and `OptionsItemCommand`
     + `Command` for `HamburgerMenuItem`
     + New property `PaneForeground` for HamburgerMenu and Splitview and new Foreground/Background brushes `MahApps.Metro.HamburgerMenu.PaneBackgroundBrush`, `MahApps.Metro.HamburgerMenu.PaneForegroundBrush`
+    + Update scroll behavior to match with the UWPCommunityToolkit (see UWP Toolkit Issue [#954](https://github.com/Microsoft/UWPCommunityToolkit/issues/954)).
+        * Add a new dependency property `VerticalScrollBarOnLeftSide` to show the vertical scrollbar on the left side
+        * Use a disappearing ScrollViewer
 - If `ShowInTaskbar = false`, when double click on the title bar of a minimized window, the window will be restored instead of maximized. [#2854](https://github.com/MahApps/MahApps.Metro/pull/2854) [@hausenism](https://github.com/hausenism)
 - Fix WindowCommands tab stop bug [#2858](https://github.com/MahApps/MahApps.Metro/pull/2858) [@neilt6](https://github.com/neilt6)
 - Don't overwrite cancellation for window close event [#2868](https://github.com/MahApps/MahApps.Metro/pull/2868) [@batzen](https://github.com/batzen)
@@ -72,3 +75,4 @@
 - [#2337](https://github.com/MahApps/MahApps.Metro/issues/2337) Flyout style from Accent to Light is not working
 - [#2883](https://github.com/MahApps/MahApps.Metro/issues/2883) Can Reproduce BindingExpression path error: ... property not found ... On DropDownButton
 - [#2683](https://github.com/MahApps/MahApps.Metro/issues/2683) [Question] Force TextBox uppercase in ShowLoginAsync
+- [#2857](https://github.com/MahApps/MahApps.Metro/issues/2857) HamburgerMenuItem Scrolling

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/HamburgerMenuSample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/HamburgerMenuSample.xaml
@@ -48,6 +48,7 @@
 
     <Grid>
         <controls:HamburgerMenu x:Name="HamburgerMenuControl"
+                                VerticalScrollBarOnLeftSide="False"
                                 SelectedIndex="1"
                                 Margin="20"
                                 HamburgerWidth="48"

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/HamburgerMenu.Properties.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/HamburgerMenu.Properties.cs
@@ -87,6 +87,11 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty ItemCommandParameterProperty = DependencyProperty.Register("ItemCommandParameter", typeof(object), typeof(HamburgerMenu), new PropertyMetadata(null));
 
         /// <summary>
+        /// Identifies the <see cref="VerticalScrollBarOnLeftSide"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty VerticalScrollBarOnLeftSideProperty = DependencyProperty.Register("VerticalScrollBarOnLeftSide", typeof(bool), typeof(HamburgerMenu), new PropertyMetadata(false));
+
+        /// <summary>
         /// Gets or sets the width of the pane when it's fully expanded.
         /// </summary>
         public double OpenPaneLength
@@ -235,6 +240,15 @@ namespace MahApps.Metro.Controls
         {
             get { return (object)GetValue(ItemCommandParameterProperty); }
             set { SetValue(ItemCommandParameterProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets wheather the ScrollBar of the HamburgerMenu is on the left side or on the right side.
+        /// </summary>
+        public bool VerticalScrollBarOnLeftSide
+        {
+            get { return (bool)GetValue(VerticalScrollBarOnLeftSideProperty); }
+            set { SetValue(VerticalScrollBarOnLeftSideProperty, value); }
         }
 
         /// <summary>

--- a/src/MahApps.Metro/MahApps.Metro/Themes/HamburgerMenu.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/HamburgerMenu.xaml
@@ -1,10 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:pOptions="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    mc:Ignorable="pOptions"
                     xmlns:controls="clr-namespace:MahApps.Metro.Controls">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Buttons.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.ListBox.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Scrollbars.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="HamburgerButtonStyle"
@@ -52,6 +56,19 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ListBox}">
+                    <Border Name="Border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
         <Setter Property="ItemContainerStyle">
             <Setter.Value>
                 <Style BasedOn="{StaticResource MetroListBoxItem}" TargetType="{x:Type ListBoxItem}">
@@ -70,7 +87,116 @@
                 </Style>
             </Setter.Value>
         </Setter>
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+    </Style>
+
+    <QuinticEase x:Key="ScrollBarEaseInOut"
+                 pOptions:Freeze="true"
+                 EasingMode="EaseInOut" />
+
+    <Style x:Key="HamburgerScrollViewerStyle"
+           BasedOn="{StaticResource MetroScrollViewer}"
+           TargetType="{x:Type ScrollViewer}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                    <Grid x:Name="Grid" Background="{TemplateBinding Background}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition x:Name="leftColumn" Width="*" />
+                            <ColumnDefinition x:Name="rightColumn" Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
+                                                Grid.Row="0"
+                                                Grid.Column="0"
+                                                Margin="{TemplateBinding Padding}"
+                                                CanContentScroll="{TemplateBinding CanContentScroll}"
+                                                CanHorizontallyScroll="False"
+                                                CanVerticallyScroll="False"
+                                                Content="{TemplateBinding Content}"
+                                                ContentTemplate="{TemplateBinding ContentTemplate}" />
+                        <ScrollBar x:Name="PART_VerticalScrollBar"
+                                   Grid.Row="0"
+                                   Grid.Column="0"
+                                   Grid.ColumnSpan="2"
+                                   HorizontalAlignment="Right"
+                                   AutomationProperties.AutomationId="VerticalScrollBar"
+                                   Cursor="Arrow"
+                                   Maximum="{TemplateBinding ScrollableHeight}"
+                                   Minimum="0"
+                                   Opacity="0"
+                                   ViewportSize="{TemplateBinding ViewportHeight}"
+                                   Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                                   Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                        <ScrollBar x:Name="PART_HorizontalScrollBar"
+                                   Grid.Row="0"
+                                   Grid.RowSpan="2"
+                                   Grid.Column="0"
+                                   VerticalAlignment="Bottom"
+                                   AutomationProperties.AutomationId="HorizontalScrollBar"
+                                   Cursor="Arrow"
+                                   Maximum="{TemplateBinding ScrollableWidth}"
+                                   Minimum="0"
+                                   Opacity="0"
+                                   Orientation="Horizontal"
+                                   ViewportSize="{TemplateBinding ViewportWidth}"
+                                   Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
+                                   Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="controls:ScrollBarHelper.VerticalScrollBarOnLeftSide" Value="True">
+                            <Setter TargetName="PART_HorizontalScrollBar" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_ScrollContentPresenter" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_VerticalScrollBar" Property="HorizontalAlignment" Value="Left" />
+                            <Setter TargetName="leftColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="rightColumn" Property="Width" Value="*" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="UIElement.IsMouseOver" Value="True" />
+                                <Condition Property="ComputedVerticalScrollBarVisibility" Value="Visible" />
+                            </MultiTrigger.Conditions>
+                            <TriggerBase.EnterActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="PART_VerticalScrollBar"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="1"
+                                                         Duration="0:0:0.2"
+                                                         EasingFunction="{StaticResource ScrollBarEaseInOut}" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_HorizontalScrollBar"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="1"
+                                                         Duration="0:0:0.2"
+                                                         EasingFunction="{StaticResource ScrollBarEaseInOut}" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </TriggerBase.EnterActions>
+                            <TriggerBase.ExitActions>
+                                <BeginStoryboard>
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="PART_VerticalScrollBar"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="0"
+                                                         BeginTime="0:0:2"
+                                                         Duration="0:0:1"
+                                                         EasingFunction="{StaticResource ScrollBarEaseInOut}" />
+                                        <DoubleAnimation Storyboard.TargetName="PART_HorizontalScrollBar"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         To="0"
+                                                         BeginTime="0:0:2"
+                                                         Duration="0:0:1"
+                                                         EasingFunction="{StaticResource ScrollBarEaseInOut}" />
+                                    </Storyboard>
+                                </BeginStoryboard>
+                            </TriggerBase.ExitActions>
+                        </MultiTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style TargetType="{x:Type controls:HamburgerMenu}">
@@ -108,45 +234,51 @@
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition />
-                                        <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
                                     <Grid Grid.Row="0" Height="{TemplateBinding HamburgerHeight}" />
-                                    <ListBox Name="ButtonsListView"
-                                             Grid.Row="1"
-                                             Foreground="{TemplateBinding PaneForeground}"
-                                             Width="{TemplateBinding OpenPaneLength}"
-                                             AutomationProperties.Name="Menu items"
-                                             ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                             ItemTemplate="{TemplateBinding ItemTemplate}"
-                                             ItemsSource="{TemplateBinding ItemsSource}"
-                                             SelectedIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedIndex, Mode=TwoWay}"
-                                             SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedItem, Mode=TwoWay}"
-                                             SelectionMode="Single"
-                                             Style="{StaticResource HamburgerListBoxStyle}"
-                                             TabIndex="1">
-                                    </ListBox>
-
-                                    <Grid Grid.Row="2" Visibility="{TemplateBinding OptionsVisibility}">
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition />
-                                        </Grid.RowDefinitions>
-
-                                        <ListBox Name="OptionsListView"
-                                                 Grid.Row="1"
-                                                 Foreground="{TemplateBinding PaneForeground}"
-                                                 Width="{TemplateBinding OpenPaneLength}"
-                                                 VerticalAlignment="Bottom"
-                                                 AutomationProperties.Name="Option items"
-                                                 ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
-                                                 ItemTemplate="{TemplateBinding OptionsItemTemplate}"
-                                                 ItemsSource="{TemplateBinding OptionsItemsSource}"
-                                                 SelectedIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedOptionsIndex, Mode=TwoWay}"
-                                                 SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedOptionsItem, Mode=TwoWay}"
-                                                 Style="{StaticResource HamburgerListBoxStyle}"
-                                                 TabIndex="2" />
-                                    </Grid>
-
+                                    <ScrollViewer x:Name="PaneScrollViewer"
+                                                  Grid.Row="1"
+                                                  Style="{StaticResource HamburgerScrollViewerStyle}"
+                                                  HorizontalAlignment="Stretch"
+                                                  VerticalAlignment="Stretch"
+                                                  controls:ScrollBarHelper.VerticalScrollBarOnLeftSide="{TemplateBinding VerticalScrollBarOnLeftSide}"
+                                                  HorizontalScrollBarVisibility="Disabled"
+                                                  VerticalScrollBarVisibility="Auto">
+                                        <Grid>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition />
+                                                <RowDefinition Height="Auto " />
+                                            </Grid.RowDefinitions>
+                                            <ListBox Name="ButtonsListView"
+                                                     Grid.Row="0"
+                                                     Foreground="{TemplateBinding PaneForeground}"
+                                                     Width="{TemplateBinding OpenPaneLength}"
+                                                     AutomationProperties.Name="Menu items"
+                                                     ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                                     ItemTemplate="{TemplateBinding ItemTemplate}"
+                                                     ItemsSource="{TemplateBinding ItemsSource}"
+                                                     SelectedIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedIndex, Mode=TwoWay}"
+                                                     SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedItem, Mode=TwoWay}"
+                                                     SelectionMode="Single"
+                                                     Style="{StaticResource HamburgerListBoxStyle}"
+                                                     TabIndex="1">
+                                            </ListBox>
+                                            <ListBox Name="OptionsListView"
+                                                     Grid.Row="2"
+                                                     Foreground="{TemplateBinding PaneForeground}"
+                                                     Width="{TemplateBinding OpenPaneLength}"
+                                                     VerticalAlignment="Bottom"
+                                                     AutomationProperties.Name="Option items"
+                                                     ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
+                                                     ItemTemplate="{TemplateBinding OptionsItemTemplate}"
+                                                     ItemsSource="{TemplateBinding OptionsItemsSource}"
+                                                     SelectedIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedOptionsIndex, Mode=TwoWay}"
+                                                     SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedOptionsItem, Mode=TwoWay}"
+                                                     Style="{StaticResource HamburgerListBoxStyle}"
+                                                     TabIndex="2" />
+                                        </Grid>
+                                    </ScrollViewer>
                                 </Grid>
                             </controls:SplitView.Pane>
                             <controls:TransitioningContentControl HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -181,6 +313,3 @@
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
     </Style>
 </ResourceDictionary>
-
-
-


### PR DESCRIPTION
## What changed?

- Update `HamburgerMenu` scroll behavior to match the UWP Toolkit (see UWP Toolkit Issue [#954](https://github.com/Microsoft/UWPCommunityToolkit/issues/954)).
- Add a new dependency property `VerticalScrollBarOnLeftSide` to show the vertical scrollbar on the left side
- Use a disappearing ScrollViewer
- thx to @amkuchta for the initial idea

![mahapps_hamburger_scrollbar](https://cloud.githubusercontent.com/assets/658431/24431149/912dc1fe-141a-11e7-9079-895301b3a6ba.gif)

Closes #2897 [RFC] [WIP] HamburgerMenu Scroll Behavior Correction
Closes #2857 HamburgerMenuItem Scrolling