### PR TITLE
Hamburger Header Templating

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/HamburgerMenuSample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/HamburgerMenuSample.xaml
@@ -56,6 +56,15 @@
                                 ItemTemplate="{StaticResource HamburgerMenuImageItem}"
                                 OptionsItemClick="HamburgerMenu_OnOptionsItemClick"
                                 OptionsItemTemplate="{StaticResource HamburgerMenuItem}">
+            <!-- Header -->
+            <controls:HamburgerMenu.HamburgerMenuHeaderTemplate>
+                <DataTemplate>
+                    <TextBlock Grid.Column="1"
+                             VerticalAlignment="Center"
+                             FontSize="16"
+                             Foreground="White"
+                </DataTemplate>
+            </controls:HamburgerMenu.HamburgerMenuHeaderTemplate>
             <!--  Items  -->
             <controls:HamburgerMenu.ItemsSource>
                 <controls:HamburgerMenuItemCollection>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/HamburgerMenuSample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/HamburgerMenuSample.xaml
@@ -61,8 +61,10 @@
                 <DataTemplate>
                     <TextBlock Grid.Column="1"
                              VerticalAlignment="Center"
+                             HorizontalAlignment="Left"
                              FontSize="16"
                              Foreground="White"
+                             Text="Pictures" />
                 </DataTemplate>
             </controls:HamburgerMenu.HamburgerMenuHeaderTemplate>
             <!--  Items  -->

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/HamburgerMenu.HamburgerButton.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/HamburgerMenu.HamburgerButton.cs
@@ -42,6 +42,19 @@ namespace MahApps.Metro.Controls
         }
 
         /// <summary>
+        /// Identifies the <see cref="HamburgerMenuHeaderTemplate"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty HamburgerMenuHeaderTemplateProperty = DependencyProperty.Register(nameof(HamburgerMenuHeaderTemplate), typeof(DataTemplate), typeof(HamburgerMenu), new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets a template for the hamburger icon.
+        /// </summary>
+        public DataTemplate HamburgerMenuHeaderTemplate
+        {
+            get { return (DataTemplate)GetValue(HamburgerMenuHeaderTemplateProperty); }
+            set { SetValue(HamburgerMenuHeaderTemplateProperty, value); }
+        }
+        /// <summary>
         /// Gets or sets main button's width.
         /// </summary>
         public double HamburgerWidth

--- a/src/MahApps.Metro/MahApps.Metro/Themes/HamburgerMenu.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/HamburgerMenu.xaml
@@ -235,7 +235,16 @@
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition />
                                     </Grid.RowDefinitions>
-                                    <Grid Grid.Row="0" Height="{TemplateBinding HamburgerHeight}" />
+                                    <Grid Grid.Row="0" Height="{TemplateBinding HamburgerHeight}" HorizontalAlignment="Stretch"  >
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition />
+                                        </Grid.ColumnDefinitions>
+                                        <Grid Width="{TemplateBinding HamburgerWidth}" HorizontalAlignment="Left" />
+                                        <ContentControl  Grid.Column="1"
+                                                ContentTemplate="{TemplateBinding HamburgerMenuHeaderTemplate}"
+                                                IsTabStop="False" />
+                                    </Grid>
                                     <ScrollViewer x:Name="PaneScrollViewer"
                                                   Grid.Row="1"
                                                   Style="{StaticResource HamburgerScrollViewerStyle}"


### PR DESCRIPTION
Added hamburfer header templating support.
Template accessible trough "HamburgerMenu.HamburgerMenuHeaderTemplate".

I experienced little problem, that GridColumn ignored HamburgerWidth (not sure why), it is reason for this code (workaround):
```
<Grid.ColumnDefinitions>
      <ColumnDefinition Width="Auto"/>
      <ColumnDefinition />
</Grid.ColumnDefinitions>
<Grid Width="{TemplateBinding HamburgerWidth}" HorizontalAlignment="Left" />
```
istead of ` <ColumnDefinition Width="{TemplateBinding HamburgerWidth}"/>`

I wanted to have possibility to add title to HamburgerMenu... Now it is possible for example this way:

```
<controls:HamburgerMenu.HamburgerMenuHeaderTemplate>
     <DataTemplate>
          <TextBlock Grid.Column="1"
                             VerticalAlignment="Center"
                             HorizontalAlignment="Center"
                             FontSize="16"
                             Foreground="White"
                             Text="Menu" />
      </DataTemplate>
</controls:HamburgerMenu.HamburgerMenuHeaderTemplate>
```
Result:
![image](https://cloud.githubusercontent.com/assets/17603598/24617585/9a53cb06-1894-11e7-907e-63d91f61177d.png)

If there is any problem with naming. Let me know. :)

