### PR TITLE
New WatermarkAlignment attached property

### DIFF
--- a/docs/release-notes/1.5.0.md
+++ b/docs/release-notes/1.5.0.md
@@ -64,6 +64,7 @@
 - Fix `SelectionChanged` event of `SplitButton` which fires now only once.
 - Change `Flyout` from `ContentControl` to `HeaderedContentControl` which has the correct properties for headers.
 - Add `TransitionCompleted` event to `MetroContentControl` and `WindowTransitionCompleted` event to `MetroWindow` which will be fired after the loaded Storyboard is completed.
+- Add new `WatermarkAlignment` attached property to `TextBoxHelper` which indicates the horizontal alignment of the watermark (incl. floating watermark).
 
 ## Closed Issues
 
@@ -90,3 +91,4 @@
 - [#2917](https://github.com/MahApps/MahApps.Metro/pull/2917) Hamburger Header Templating
 - [#2332](https://github.com/MahApps/MahApps.Metro/issues/2332) Calendar ignores IsTodayHighlighted property
 - [#2434](https://github.com/MahApps/MahApps.Metro/issues/2434) DataGridNumericUpDownColumn foreground color
+- [#2627](https://github.com/MahApps/MahApps.Metro/issues/2627) Inconsistent FloatingWatermark Alignment

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
@@ -41,6 +41,7 @@ namespace MahApps.Metro.Controls
     {
         public static readonly DependencyProperty IsMonitoringProperty = DependencyProperty.RegisterAttached("IsMonitoring", typeof(bool), typeof(TextBoxHelper), new UIPropertyMetadata(false, OnIsMonitoringChanged));
         public static readonly DependencyProperty WatermarkProperty = DependencyProperty.RegisterAttached("Watermark", typeof(string), typeof(TextBoxHelper), new UIPropertyMetadata(string.Empty));
+        public static readonly DependencyProperty WatermarkAlignmentProperty = DependencyProperty.RegisterAttached("WatermarkAlignment", typeof(TextAlignment), typeof(TextBoxHelper), new FrameworkPropertyMetadata(TextAlignment.Left, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
         public static readonly DependencyProperty UseFloatingWatermarkProperty = DependencyProperty.RegisterAttached("UseFloatingWatermark", typeof(bool), typeof(TextBoxHelper), new FrameworkPropertyMetadata(false, ButtonCommandOrClearTextChanged));
         public static readonly DependencyProperty TextLengthProperty = DependencyProperty.RegisterAttached("TextLength", typeof(int), typeof(TextBoxHelper), new UIPropertyMetadata(0));
         public static readonly DependencyProperty ClearTextButtonProperty = DependencyProperty.RegisterAttached("ClearTextButton", typeof(bool), typeof(TextBoxHelper), new FrameworkPropertyMetadata(false, ButtonCommandOrClearTextChanged));
@@ -408,6 +409,39 @@ namespace MahApps.Metro.Controls
         public static void SetWatermark(DependencyObject obj, string value)
         {
             obj.SetValue(WatermarkProperty, value);
+        }
+
+        /// <summary>
+        /// Gets a value that indicates the horizontal alignment of the watermark.
+        /// </summary>
+        /// <returns>
+        /// One of the <see cref="System.Windows.TextAlignment" /> values that specifies the desired alignment. The default is <see cref="System.Windows.TextAlignment.Left" />.
+        /// </returns>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TextBoxBase))]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
+        [AttachedPropertyBrowsableForType(typeof(DatePicker))]
+        [AttachedPropertyBrowsableForType(typeof(TimePickerBase))]
+        [AttachedPropertyBrowsableForType(typeof(NumericUpDown))]
+        public static TextAlignment GetWatermarkAlignment(DependencyObject obj)
+        {
+            return (TextAlignment)obj.GetValue(WatermarkAlignmentProperty);
+        }
+
+        /// <summary>
+        /// Sets a value that indicates the horizontal alignment of the watermark.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TextBoxBase))]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
+        [AttachedPropertyBrowsableForType(typeof(DatePicker))]
+        [AttachedPropertyBrowsableForType(typeof(TimePickerBase))]
+        [AttachedPropertyBrowsableForType(typeof(NumericUpDown))]
+        public static void SetWatermarkAlignment(DependencyObject obj, TextAlignment value)
+        {
+            obj.SetValue(WatermarkAlignmentProperty, value);
         }
 
         [Category(AppName.MahApps)]

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -76,6 +76,7 @@
                                        Foreground="{TemplateBinding Foreground}"
                                        Opacity="0.6"
                                        IsHitTestVisible="False"
+                                       TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
@@ -88,6 +89,7 @@
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Foreground="{TemplateBinding Foreground}"
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
                             <Button x:Name="PART_ClearText"
@@ -359,6 +361,7 @@
                                      Controls:TextBoxHelper.ButtonFontFamily="{TemplateBinding Controls:TextBoxHelper.ButtonFontFamily}"
                                      Controls:TextBoxHelper.ButtonFontSize="{TemplateBinding Controls:TextBoxHelper.ButtonFontSize}"
                                      Controls:TextBoxHelper.UseFloatingWatermark="{TemplateBinding Controls:TextBoxHelper.UseFloatingWatermark}"
+                                     Controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                      Controls:TextBoxHelper.Watermark="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                      CharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ComboBoxHelper.CharacterCasing), Mode=OneWay}"
                                      Focusable="True"
@@ -378,6 +381,7 @@
                                        FontFamily="{TemplateBinding FontFamily}"
                                        FontSize="{TemplateBinding FontSize}"
                                        IsHitTestVisible="False"
+                                       TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
@@ -390,6 +394,7 @@
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Foreground="{TemplateBinding Foreground}"
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
                             <Grid x:Name="ContentSite"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -68,10 +68,11 @@
                             <DatePickerTextBox x:Name="PART_TextBox"
                                                Grid.Row="1"
                                                Grid.Column="0"
-                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                                Foreground="{TemplateBinding Foreground}"
                                                FontSize="{TemplateBinding FontSize}"
+                                               Controls:TextBoxHelper.WatermarkAlignment="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.WatermarkAlignment), Mode=OneWay}"
                                                Controls:TextBoxHelper.Watermark="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.Watermark), Mode=OneWay}"
                                                CaretBrush="{DynamicResource BlackBrush}"
                                                SelectionBrush="{DynamicResource HighlightBrush}"
@@ -91,6 +92,7 @@
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Foreground="{TemplateBinding Foreground}"
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
 
@@ -233,6 +235,7 @@
                                    Foreground="{TemplateBinding Foreground}"
                                    Opacity="0.6"
                                    IsHitTestVisible="False"
+                                   TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                    Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                     </Grid>
                     <ControlTemplate.Triggers>

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -190,6 +190,7 @@
                                        Foreground="{TemplateBinding Foreground}"
                                        Opacity="0.6"
                                        IsHitTestVisible="False"
+                                       TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
@@ -202,6 +203,7 @@
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Foreground="{TemplateBinding Foreground}"
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
@@ -405,6 +407,7 @@
                                        Foreground="{TemplateBinding Foreground}"
                                        Opacity="0.6"
                                        IsHitTestVisible="False"
+                                       TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
@@ -417,6 +420,7 @@
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Foreground="{TemplateBinding Foreground}"
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
@@ -632,6 +636,7 @@
                                        Foreground="{TemplateBinding Foreground}"
                                        Opacity="0.6"
                                        IsHitTestVisible="False"
+                                       TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
@@ -644,6 +649,7 @@
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Foreground="{TemplateBinding Foreground}"
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
                             <ContentPresenter x:Name="PART_CapsLockIndicator"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -105,6 +105,7 @@
                                        Foreground="{TemplateBinding Foreground}"
                                        Opacity="0.6"
                                        IsHitTestVisible="False"
+                                       TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
@@ -117,6 +118,7 @@
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Foreground="{TemplateBinding Foreground}"
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
                             <Button x:Name="PART_ClearText"
@@ -327,6 +329,7 @@
                                        Foreground="{TemplateBinding Foreground}"
                                        Opacity="0.6"
                                        IsHitTestVisible="False"
+                                       TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
@@ -339,6 +342,7 @@
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Foreground="{TemplateBinding Foreground}"
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}" />
                             </ContentControl>
                             <Button x:Name="PART_ClearText"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -152,6 +152,7 @@
                                                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                                    Foreground="{TemplateBinding Foreground}"
                                                    FontSize="{TemplateBinding FontSize}"
+                                                   controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding controls:TextBoxHelper.WatermarkAlignment}"
                                                    controls:TextBoxHelper.Watermark="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:TextBoxHelper.Watermark), Mode=OneWay}"
                                                    CaretBrush="{DynamicResource BlackBrush}"
                                                    SelectionBrush="{DynamicResource HighlightBrush}"
@@ -171,6 +172,7 @@
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Foreground="{TemplateBinding Foreground}"
+                                           TextAlignment="{TemplateBinding controls:TextBoxHelper.WatermarkAlignment}"
                                            Text="{TemplateBinding controls:TextBoxHelper.Watermark}" />
                                 </ContentControl>
                                 <Button x:Name="PART_Button"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -45,6 +45,7 @@
                              Controls:TextBoxHelper.IsWaitingForData="{TemplateBinding Controls:TextBoxHelper.IsWaitingForData}"
                              Controls:TextBoxHelper.SelectAllOnFocus="{TemplateBinding Controls:TextBoxHelper.SelectAllOnFocus}"
                              Controls:TextBoxHelper.UseFloatingWatermark="{TemplateBinding Controls:TextBoxHelper.UseFloatingWatermark}"
+                             Controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                              Controls:TextBoxHelper.Watermark="{TemplateBinding Watermark}"
                              Controls:ControlsHelper.FocusBorderBrush="{TemplateBinding Controls:ControlsHelper.FocusBorderBrush}"
                              Controls:ControlsHelper.MouseOverBorderBrush="{TemplateBinding Controls:ControlsHelper.MouseOverBorderBrush}"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -67,6 +67,7 @@
                                      Controls:TextBoxHelper.ButtonsAlignment="{TemplateBinding ButtonsAlignment}"
                                      Controls:TextBoxHelper.ClearTextButton="{TemplateBinding Controls:TextBoxHelper.ClearTextButton}"
                                      Controls:TextBoxHelper.SelectAllOnFocus="{TemplateBinding Controls:TextBoxHelper.SelectAllOnFocus}"
+                                     Controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                      Controls:TextBoxHelper.Watermark="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                      Controls:TextBoxHelper.UseFloatingWatermark="{TemplateBinding Controls:TextBoxHelper.UseFloatingWatermark}"
                                      Controls:TextBoxHelper.HasText="{TemplateBinding Controls:TextBoxHelper.HasText}"


### PR DESCRIPTION
## What changed?

Add new `WatermarkAlignment` attached property to `TextBoxHelper` which indicates the horizontal alignment of the watermark (incl. floating watermark).

Closes #2627 Inconsistent FloatingWatermark Alignment

![mahapps_watermark](https://cloud.githubusercontent.com/assets/658431/24903931/3979901a-1eaf-11e7-85be-9384239ae48f.gif)

