### PR TITLE
DependencyProperty DisplayFormat for DateTimePicker and TimePicker

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
@@ -32,7 +32,7 @@
             typeof(DateTimePicker));
 
         public static readonly DependencyProperty SelectedDateProperty = DatePicker.SelectedDateProperty.AddOwner(typeof(DateTimePicker), new FrameworkPropertyMetadata(default(DateTime?), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedDateChanged));
-      
+
         private const string ElementCalendar = "PART_Calendar";
         private Calendar _calendar;
         private bool _deactivateWriteValueToTextBox;
@@ -171,7 +171,7 @@
         protected override string GetValueForTextBox()
         {
             var formatInfo = SpecificCultureInfo.DateTimeFormat;
-            var dateTimeFormat = string.Intern($"{formatInfo.ShortDatePattern} {formatInfo.LongTimePattern}");
+            var dateTimeFormat = string.Intern(DisplayFormat ?? $"{formatInfo.ShortDatePattern} {formatInfo.LongTimePattern}");
 
             var selectedDateTimeFromGui = this.GetSelectedDateTimeFromGUI();
             var valueForTextBox = selectedDateTimeFromGui?.ToString(dateTimeFormat, this.SpecificCultureInfo);

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
@@ -89,6 +89,11 @@ namespace MahApps.Metro.Controls
             typeof(TimePickerBase),
             new FrameworkPropertyMetadata(default(TimeSpan?), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedTimeChanged, CoerceSelectedTime));
 
+        public static readonly DependencyProperty DisplayFormatProperty = DependencyProperty.Register(
+            "DisplayFormat",
+            typeof(string),
+            typeof(TimePickerBase));
+
         private const string ElementAmPmSwitcher = "PART_AmPmSwitcher";
         private const string ElementButton = "PART_Button";
         private const string ElementHourHand = "PART_HourHand";
@@ -360,6 +365,18 @@ namespace MahApps.Metro.Controls
         }
 
         /// <summary>
+        ///     Gets or sets the currently used display format for the date time.
+        /// </summary>
+        /// <returns>
+        ///     The currently used display format for the date time.
+        /// </returns>
+        public string DisplayFormat
+        {
+            get { return (string)GetValue(DisplayFormatProperty); }
+            set { SetValue(DisplayFormatProperty, value); }
+        }
+
+        /// <summary>
         ///     When overridden in a derived class, is invoked whenever application code or internal processes call
         ///     <see cref="M:System.Windows.FrameworkElement.ApplyTemplate" />.
         /// </summary>
@@ -438,7 +455,7 @@ namespace MahApps.Metro.Controls
 
         protected virtual string GetValueForTextBox()
         {
-            var valueForTextBox = (DateTime.MinValue + SelectedTime)?.ToString(string.Intern(SpecificCultureInfo.DateTimeFormat.LongTimePattern), SpecificCultureInfo);
+            var valueForTextBox = (DateTime.MinValue + SelectedTime)?.ToString(string.Intern(DisplayFormat ?? SpecificCultureInfo.DateTimeFormat.LongTimePattern), SpecificCultureInfo);
             return valueForTextBox;
         }
 


### PR DESCRIPTION
Customizable format of the displayed Date / DateTime.
The default value is still the format of the SpecificCultureInfo.