### PR TITLE
Added event delegates to the show dialog methods

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/DialogCoordinator.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/DialogCoordinator.cs
@@ -13,54 +13,72 @@ namespace MahApps.Metro.Controls.Dialogs
 
         public Task<string> ShowInputAsync(object context, string title, string message, MetroDialogSettings settings = null)
         {
+            this.BeforeShowInputAsync?.Invoke(this, EventArgs.Empty);
+
             var metroWindow = GetMetroWindow(context);
             return metroWindow.Invoke(() => metroWindow.ShowInputAsync(title, message, settings));
         }
 
         public string ShowModalInputExternal(object context, string title, string message, MetroDialogSettings metroDialogSettings = null)
         {
+            this.BeforeShowModalInputExternal?.Invoke(this, EventArgs.Empty);
+
             var metroWindow = GetMetroWindow(context);
             return metroWindow.ShowModalInputExternal(title, message, metroDialogSettings);
         }
 
         public Task<LoginDialogData> ShowLoginAsync(object context, string title, string message, LoginDialogSettings settings = null)
         {
+            this.BeforeShowLoginAsync?.Invoke(this, EventArgs.Empty);
+
             var metroWindow = GetMetroWindow(context);
             return metroWindow.Invoke(() => metroWindow.ShowLoginAsync(title, message, settings));
         }
 
         public LoginDialogData ShowModalLoginExternal(object context, string title, string message, LoginDialogSettings settings = null)
         {
+            this.BeforeShowModalLoginExternal?.Invoke(this, EventArgs.Empty);
+
             var metroWindow = GetMetroWindow(context);
             return metroWindow.ShowModalLoginExternal(title, message, settings);
         }
 
         public Task<MessageDialogResult> ShowMessageAsync(object context, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, MetroDialogSettings settings = null)
         {
+            this.BeforeShowMessageAsync?.Invoke(this, EventArgs.Empty);
+
             var metroWindow = GetMetroWindow(context);
             return metroWindow.Invoke(() => metroWindow.ShowMessageAsync(title, message, style, settings));
         }
 
         public MessageDialogResult ShowModalMessageExternal(object context, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, MetroDialogSettings settings = null)
         {
+            this.BeforeShowModalMessageExternal?.Invoke(this, EventArgs.Empty);
+
             var metroWindow = GetMetroWindow(context);
             return metroWindow.ShowModalMessageExternal(title, message, style, settings);
         }
 
         public Task<ProgressDialogController> ShowProgressAsync(object context, string title, string message, bool isCancelable = false, MetroDialogSettings settings = null)
         {
+            this.BeforeShowProgressAsync?.Invoke(this, EventArgs.Empty);
+
             var metroWindow = GetMetroWindow(context);
             return metroWindow.Invoke(() => metroWindow.ShowProgressAsync(title, message, isCancelable, settings));
         }
 
         public Task ShowMetroDialogAsync(object context, BaseMetroDialog dialog, MetroDialogSettings settings = null)
         {
+            this.BeforeShowMetroDialogAsync?.Invoke(this, EventArgs.Empty);
+
             var metroWindow = GetMetroWindow(context);
             return metroWindow.Invoke(() => metroWindow.ShowMetroDialogAsync(dialog, settings));
         }
 
         public Task HideMetroDialogAsync(object context, BaseMetroDialog dialog, MetroDialogSettings settings = null)
         {
+            this.BeforeHideMetroDialogAsync?.Invoke(this, EventArgs.Empty);
+
             var metroWindow = GetMetroWindow(context);
             return metroWindow.Invoke(() => metroWindow.HideMetroDialogAsync(dialog, settings));
         }
@@ -90,5 +108,23 @@ namespace MahApps.Metro.Controls.Dialogs
             }
             return metroWindow;
         }
+
+        public EventHandler BeforeShowInputAsync { get; set; }
+
+        public EventHandler BeforeShowModalInputExternal { get; set; }
+
+        public EventHandler BeforeShowLoginAsync { get; set; }
+
+        public EventHandler BeforeShowModalLoginExternal { get; set; }
+
+        public EventHandler BeforeShowMessageAsync { get; set; }
+
+        public EventHandler BeforeShowModalMessageExternal { get; set; }
+
+        public EventHandler BeforeShowProgressAsync { get; set; }
+
+        public EventHandler BeforeShowMetroDialogAsync { get; set; }
+
+        public EventHandler BeforeHideMetroDialogAsync { get; set; }
     }
 }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/IDialogCoordinator.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/IDialogCoordinator.cs
@@ -111,6 +111,51 @@ namespace MahApps.Metro.Controls.Dialogs
         /// Gets the current shown dialog.
         /// </summary>
         /// <param name="context">Typically this should be the view model, which you register in XAML using <see cref="DialogParticipation.SetRegister"/>.</param>
-        Task<TDialog> GetCurrentDialogAsync<TDialog>(object context) where TDialog : BaseMetroDialog;        
+        Task<TDialog> GetCurrentDialogAsync<TDialog>(object context) where TDialog : BaseMetroDialog;
+
+        /// <summary>
+        /// Occurs before showing the input dialog.
+        /// </summary>
+        EventHandler BeforeShowInputAsync { get; set; }
+
+        /// <summary>
+        /// Occurs before showing the modal input dialog. 
+        /// </summary>
+        EventHandler BeforeShowModalInputExternal { get; set; }
+
+        /// <summary>
+        /// Occurs before showing the login dialog.
+        /// </summary>
+        EventHandler BeforeShowLoginAsync { get; set; }
+
+        /// <summary>
+        /// Occurs before showing the modal login dialog.
+        /// </summary>
+        EventHandler BeforeShowModalLoginExternal { get; set; }
+
+        /// <summary>
+        /// Occurs before showing the message dialog.
+        /// </summary>
+        EventHandler BeforeShowMessageAsync { get; set; }
+
+        /// <summary>
+        /// Occurs before showing the modal message dialog.
+        /// </summary>
+        EventHandler BeforeShowModalMessageExternal { get; set; }
+
+        /// <summary>
+        /// Occurs before showing the progress dialog.
+        /// </summary>
+        EventHandler BeforeShowProgressAsync { get; set; }
+
+        /// <summary>
+        /// Occurs before showing the metro dialog.
+        /// </summary>
+        EventHandler BeforeShowMetroDialogAsync { get; set; }
+
+        /// <summary>
+        /// Occurs before hiding the metro dialog.
+        /// </summary>
+        EventHandler BeforeHideMetroDialogAsync { get; set; }
     }
 }


### PR DESCRIPTION
## What changed?

The new event delegates provides extra flexibility to the dialog coordinator class.
If you want, for example, always close all open dialogs before showing another dialog, you can create an method and add it to the delegate that is invoked before showing the dialog. The current solution for this is to replicate code or wrap the the methods in another method.
