### PR TITLE
Enable LayoutTransform and RenderTransform on MetroWindow

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroWindow.xaml
@@ -12,7 +12,8 @@
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
     <ControlTemplate x:Key="WindowTemplateKey" TargetType="{x:Type Controls:MetroWindow}">
-        <Grid>
+        <Grid LayoutTransform="{Binding LayoutTransform, RelativeSource={RelativeSource TemplatedParent}}"  
+              RenderTransform="{Binding RenderTransform, RelativeSource={RelativeSource TemplatedParent}}"> 
             <AdornerDecorator>
                 <Grid Background="{TemplateBinding Background}">
                     <Grid.ColumnDefinitions>


### PR DESCRIPTION
This PR enables LayoutTransform and RenderTransform on MetroWindow by forwarding LayoutTransform and RenderTransform to the first template child.