### PR TITLE
Using OrdinalIgnoreCase instead of InvariantCultureIgnoreCase in ThemeManager

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/ThemeManager/ThemeManager.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/ThemeManager/ThemeManager.cs
@@ -597,7 +597,7 @@ namespace MahApps.Metro
         private static bool AreResourceDictionarySourcesEqual(Uri first, Uri second)
         {
             return Uri.Compare(first, second,
-                 UriComponents.Host | UriComponents.Path, UriFormat.SafeUnescaped, StringComparison.InvariantCultureIgnoreCase) == 0;
+                 UriComponents.Host | UriComponents.Path, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase) == 0;
         }
     }
 


### PR DESCRIPTION
I forgot to replace one occurences of InvariantCultureIgnoreCase in my previous PR.