### PR TITLE
Fix a typo that stops users from setting the CloseButtonMargin proper…

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroTabItem.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroTabItem.cs
@@ -112,7 +112,7 @@ namespace MahApps.Metro.Controls
         public Thickness CloseButtonMargin
         {
             get { return (Thickness)GetValue(CloseButtonMarginProperty); }
-            set { SetValue(CloseButtonEnabledProperty, value); }
+            set { SetValue(CloseButtonMarginProperty, value); }
         }
     }
 }


### PR DESCRIPTION
…ty of MetroTabItem.


The fix is really simple and straightforward.

        public Thickness CloseButtonMargin
        {
             get { return (Thickness)GetValue(CloseButtonMarginProperty); }
    -        set { SetValue(CloseButtonEnabledProperty, value); }
    +        set { SetValue(CloseButtonMarginProperty, value); }
        }
