### PR TITLE
Update TextBoxHelper.cs

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
@@ -836,9 +836,11 @@ namespace MahApps.Metro.Controls
 
             if (GetClearTextButton(parent))
             {
+                BindingExpression expression = null;
                 if (parent is TextBox)
                 {
                     ((TextBox)parent).Clear();
+                    expression = ((TextBox)parent).GetBindingExpression(TextBox.TextProperty);
                 }
                 else if (parent is PasswordBox)
                 {
@@ -851,7 +853,9 @@ namespace MahApps.Metro.Controls
                         ((ComboBox)parent).Text = string.Empty;
                     }
                     ((ComboBox)parent).SelectedItem = null;
+                    expression = ((ComboBox)parent).GetBindingExpression(ComboBox.SelectedItemProperty);
                 }
+                expression?.UpdateSource();
             }
         }
 

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
@@ -836,11 +836,10 @@ namespace MahApps.Metro.Controls
 
             if (GetClearTextButton(parent))
             {
-                BindingExpression expression = null;
                 if (parent is TextBox)
                 {
                     ((TextBox)parent).Clear();
-                    expression = ((TextBox)parent).GetBindingExpression(TextBox.TextProperty);
+                    ((TextBox)parent).GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
                 }
                 else if (parent is PasswordBox)
                 {
@@ -851,11 +850,11 @@ namespace MahApps.Metro.Controls
                     if (((ComboBox)parent).IsEditable)
                     {
                         ((ComboBox)parent).Text = string.Empty;
+                        ((ComboBox)parent).GetBindingExpression(ComboBox.TextProperty)?.UpdateSource();
                     }
                     ((ComboBox)parent).SelectedItem = null;
-                    expression = ((ComboBox)parent).GetBindingExpression(ComboBox.SelectedItemProperty);
+                    ((ComboBox)parent).GetBindingExpression(ComboBox.SelectedItemProperty)?.UpdateSource();
                 }
-                expression?.UpdateSource();
             }
         }
 


### PR DESCRIPTION
Executes UpdateSource() on target on ClearTextButton clicked.

## What changed?

Clicking the "X" button will now update the datasource immediately.

Referring to https://github.com/MahApps/MahApps.Metro/issues/3045
