### PR TITLE
Allow TimePicker to parse times with an AM/PM.

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
@@ -466,10 +466,12 @@ namespace MahApps.Metro.Controls
 
         protected virtual void OnTextBoxLostFocus(object sender, RoutedEventArgs e)
         {
-            TimeSpan ts;
-            if (TimeSpan.TryParse(((DatePickerTextBox)sender).Text, SpecificCultureInfo, out ts))
+            var text = DateTime.MinValue.ToString(SpecificCultureInfo.DateTimeFormat.ShortDatePattern) + " " +
+                       ((DatePickerTextBox)sender).Text;
+            DateTime dt;
+            if (DateTime.TryParse(text, SpecificCultureInfo, DateTimeStyles.None, out dt))
             {
-                SelectedTime = ts;
+                SelectedTime = dt.TimeOfDay;
             }
             else
             {


### PR DESCRIPTION
## What Changed?
_Changed TimePickerBase.OnTextBoxLostFocus() to parse the DatePickerTextBox text as a DateTime rather than a TimeSpan so that time strings with an AM/PM will be parsed correctly_

_Closed issues. #3049_

I would have added a test, but there are currently no tests for editing the time via the textbox, and it seemed non-trivial to add.