### PR TITLE
Don't catch TextChangedEvent in NumericUpDown

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericUpDown.cs
@@ -1154,7 +1154,6 @@ namespace MahApps.Metro.Controls
                 if (ValidateText(((TextBox)sender).Text, out convertedValue))
                 {
                     SetCurrentValue(ValueProperty, convertedValue);
-                    e.Handled = true;
                 }
             }
         }


### PR DESCRIPTION
## What changed?

The `NumericUpDown` control catches the `TextBoxChangedEvent` and therefore other styles that depend on the event doesn't work correctly, i.e. the `SmartHint` feature from Material Design.
Example: 

![2017-10-06_13-42-12](https://user-images.githubusercontent.com/6583600/31276467-40d3d1c6-aa9c-11e7-9273-5a529aba45e3.gif)

This PR removes the line which catches the event. 

![2017-10-06_13-45-06](https://user-images.githubusercontent.com/6583600/31276528-9539018c-aa9c-11e7-8731-359282244a3a.gif)



