### PR TITLE
Watermark fixes and improvements

### DIFF
--- a/docs/release-notes/1.6.0.md
+++ b/docs/release-notes/1.6.0.md
@@ -34,6 +34,10 @@
 - `Badged` control has now a different look when disabled. thx [@xxMUROxx](https://github.com/xxMUROxx)
   + Adds new brush to light and dark themes `MahApps.Metro.Brushes.Badged.DisabledBackgroundBrush`
 - Don't catch `TextChangedEvent` in `NumericUpDown` [#3066](https://github.com/MahApps/MahApps.Metro/pull/3066) [@Silv3rcircl3](https://github.com/Silv3rcircl3)
+- `Watermark` fixes and improvements
+	+ Fix right aligned floating watermark.
+	+ Use `TextBoxHelper.Watermark` for `HotKeyBox` instead own DependencyProperty (marked as obsolete).
+	+ Allow `TextBoxHelper.AutoWatermark` for `HotKey` DependencyProperty of `HotKeyBox`.
 
 ## Breaking Change
 

--- a/docs/release-notes/1.6.0.md
+++ b/docs/release-notes/1.6.0.md
@@ -38,6 +38,7 @@
 	+ Fix right aligned floating watermark.
 	+ Use `TextBoxHelper.Watermark` for `HotKeyBox` instead own DependencyProperty (marked as obsolete).
 	+ Allow `TextBoxHelper.AutoWatermark` for `HotKey` DependencyProperty of `HotKeyBox`.
+	+ New `TextBoxHelper.WatermarkTrimming` attached property to set the text trimming behavior to employ when watermark overflows the content area. thx to [@amkuchta](https://github.com/amkuchta)
 
 ## Breaking Change
 

--- a/docs/release-notes/1.6.0.md
+++ b/docs/release-notes/1.6.0.md
@@ -93,3 +93,7 @@ More informations about the reason of this decision can be found here:
 - [#3017](https://github.com/MahApps/MahApps.Metro/issues/3017) SplitButton with custom ItemTemplate - Source change does not always update layout
 - [#2977](https://github.com/MahApps/MahApps.Metro/issues/2977) Badge must have a different look when disabled
 - [#2937](https://github.com/MahApps/MahApps.Metro/issues/2937) Fuzzy button outline [#3064](https://github.com/MahApps/MahApps.Metro/pull/3064) [@n00bje](https://github.com/n00bje)
+- [#3067](https://github.com/MahApps/MahApps.Metro/issues/3067) Right aligned floating Watermark goes behind clear button
+- [#3068](https://github.com/MahApps/MahApps.Metro/issues/3068) AutoWatermark attached property has no effect on HotKeyBox
+- [#2884](https://github.com/MahApps/MahApps.Metro/issues/2884) [Feature Request] Watermark Trimming
+- [#2889](https://github.com/MahApps/MahApps.Metro/issues/2889) [Feature Request] Watermark Wrapping

--- a/docs/release-notes/1.6.0.md
+++ b/docs/release-notes/1.6.0.md
@@ -38,7 +38,8 @@
 	+ Fix right aligned floating watermark.
 	+ Use `TextBoxHelper.Watermark` for `HotKeyBox` instead own DependencyProperty (marked as obsolete).
 	+ Allow `TextBoxHelper.AutoWatermark` for `HotKey` DependencyProperty of `HotKeyBox`.
-	+ New `TextBoxHelper.WatermarkTrimming` attached property to set the text trimming behavior to employ when watermark overflows the content area. thx to [@amkuchta](https://github.com/amkuchta)
+	+ New `TextBoxHelper.WatermarkTrimming` attached property to set the text trimming behavior to employ when (floating) watermark overflows the content area. thx to [@amkuchta](https://github.com/amkuchta)
+	+ New `TextBoxHelper.WatermarkWrapping` attached property (only for `TextBox`) to set how the watermark should wrap text. Default is binded to `TextWrapping` property. thx to [@amkuchta](https://github.com/amkuchta)
 
 ## Breaking Change
 

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
@@ -85,6 +85,7 @@ namespace MahApps.Metro.Controls
                                                                                                         { typeof(TextBox), TextBox.TextProperty },
                                                                                                         { typeof(ComboBox), Selector.SelectedItemProperty },
                                                                                                         { typeof(NumericUpDown), NumericUpDown.ValueProperty },
+                                                                                                        { typeof(HotKeyBox), HotKeyBox.HotKeyProperty },
                                                                                                         { typeof(DatePicker), DatePicker.SelectedDateProperty },
                                                                                                         { typeof(TimePicker), TimePickerBase.SelectedTimeProperty },
                                                                                                         { typeof(DateTimePicker), DateTimePicker.SelectedDateProperty }
@@ -112,6 +113,7 @@ namespace MahApps.Metro.Controls
         [AttachedPropertyBrowsableForType(typeof(DatePicker))]
         [AttachedPropertyBrowsableForType(typeof(TimePickerBase))]
         [AttachedPropertyBrowsableForType(typeof(NumericUpDown))]
+        [AttachedPropertyBrowsableForType(typeof(HotKeyBox))]
         public static bool GetAutoWatermark(DependencyObject element)
         {
             return (bool)element.GetValue(AutoWatermarkProperty);
@@ -428,6 +430,7 @@ namespace MahApps.Metro.Controls
         [AttachedPropertyBrowsableForType(typeof(DatePicker))]
         [AttachedPropertyBrowsableForType(typeof(TimePickerBase))]
         [AttachedPropertyBrowsableForType(typeof(NumericUpDown))]
+        [AttachedPropertyBrowsableForType(typeof(HotKeyBox))]
         public static string GetWatermark(DependencyObject obj)
         {
             return (string)obj.GetValue(WatermarkProperty);
@@ -451,6 +454,7 @@ namespace MahApps.Metro.Controls
         [AttachedPropertyBrowsableForType(typeof(DatePicker))]
         [AttachedPropertyBrowsableForType(typeof(TimePickerBase))]
         [AttachedPropertyBrowsableForType(typeof(NumericUpDown))]
+        [AttachedPropertyBrowsableForType(typeof(HotKeyBox))]
         public static TextAlignment GetWatermarkAlignment(DependencyObject obj)
         {
             return (TextAlignment)obj.GetValue(WatermarkAlignmentProperty);
@@ -466,6 +470,7 @@ namespace MahApps.Metro.Controls
         [AttachedPropertyBrowsableForType(typeof(DatePicker))]
         [AttachedPropertyBrowsableForType(typeof(TimePickerBase))]
         [AttachedPropertyBrowsableForType(typeof(NumericUpDown))]
+        [AttachedPropertyBrowsableForType(typeof(HotKeyBox))]
         public static void SetWatermarkAlignment(DependencyObject obj, TextAlignment value)
         {
             obj.SetValue(WatermarkAlignmentProperty, value);
@@ -476,6 +481,7 @@ namespace MahApps.Metro.Controls
         [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
         [AttachedPropertyBrowsableForType(typeof(ComboBox))]
         [AttachedPropertyBrowsableForType(typeof(NumericUpDown))]
+        [AttachedPropertyBrowsableForType(typeof(HotKeyBox))]
         public static bool GetUseFloatingWatermark(DependencyObject obj)
         {
             return (bool)obj.GetValue(UseFloatingWatermarkProperty);

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
@@ -43,6 +43,7 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty IsMonitoringProperty = DependencyProperty.RegisterAttached("IsMonitoring", typeof(bool), typeof(TextBoxHelper), new UIPropertyMetadata(false, OnIsMonitoringChanged));
         public static readonly DependencyProperty WatermarkProperty = DependencyProperty.RegisterAttached("Watermark", typeof(string), typeof(TextBoxHelper), new UIPropertyMetadata(string.Empty));
         public static readonly DependencyProperty WatermarkAlignmentProperty = DependencyProperty.RegisterAttached("WatermarkAlignment", typeof(TextAlignment), typeof(TextBoxHelper), new FrameworkPropertyMetadata(TextAlignment.Left, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
+        public static readonly DependencyProperty WatermarkTrimmingProperty = DependencyProperty.RegisterAttached("WatermarkTrimming", typeof(TextTrimming), typeof(TextBoxHelper), new FrameworkPropertyMetadata(TextTrimming.None, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty UseFloatingWatermarkProperty = DependencyProperty.RegisterAttached("UseFloatingWatermark", typeof(bool), typeof(TextBoxHelper), new FrameworkPropertyMetadata(false, ButtonCommandOrClearTextChanged));
         public static readonly DependencyProperty TextLengthProperty = DependencyProperty.RegisterAttached("TextLength", typeof(int), typeof(TextBoxHelper), new UIPropertyMetadata(0));
         public static readonly DependencyProperty ClearTextButtonProperty = DependencyProperty.RegisterAttached("ClearTextButton", typeof(bool), typeof(TextBoxHelper), new FrameworkPropertyMetadata(false, ButtonCommandOrClearTextChanged));
@@ -474,6 +475,41 @@ namespace MahApps.Metro.Controls
         public static void SetWatermarkAlignment(DependencyObject obj, TextAlignment value)
         {
             obj.SetValue(WatermarkAlignmentProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the text trimming behavior to employ when watermark overflows the content area.
+        /// </summary>
+        /// <returns>
+        /// One of the <see cref="T:System.Windows.TextTrimming" /> values that specifies the text trimming behavior to employ. The default is <see cref="F:System.Windows.TextTrimming.None" />.
+        /// </returns>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TextBoxBase))]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
+        [AttachedPropertyBrowsableForType(typeof(DatePicker))]
+        [AttachedPropertyBrowsableForType(typeof(TimePickerBase))]
+        [AttachedPropertyBrowsableForType(typeof(NumericUpDown))]
+        [AttachedPropertyBrowsableForType(typeof(HotKeyBox))]
+        public static TextTrimming GetWatermarkTrimming(DependencyObject obj)
+        {
+            return (TextTrimming)obj.GetValue(WatermarkTrimmingProperty);
+        }
+
+        /// <summary>
+        /// Sets the text trimming behavior to employ when watermark overflows the content area.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TextBoxBase))]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
+        [AttachedPropertyBrowsableForType(typeof(DatePicker))]
+        [AttachedPropertyBrowsableForType(typeof(TimePickerBase))]
+        [AttachedPropertyBrowsableForType(typeof(NumericUpDown))]
+        [AttachedPropertyBrowsableForType(typeof(HotKeyBox))]
+        public static void SetWatermarkTrimming(DependencyObject obj, TextTrimming value)
+        {
+            obj.SetValue(WatermarkTrimmingProperty, value);
         }
 
         [Category(AppName.MahApps)]

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
@@ -44,6 +44,7 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty WatermarkProperty = DependencyProperty.RegisterAttached("Watermark", typeof(string), typeof(TextBoxHelper), new UIPropertyMetadata(string.Empty));
         public static readonly DependencyProperty WatermarkAlignmentProperty = DependencyProperty.RegisterAttached("WatermarkAlignment", typeof(TextAlignment), typeof(TextBoxHelper), new FrameworkPropertyMetadata(TextAlignment.Left, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
         public static readonly DependencyProperty WatermarkTrimmingProperty = DependencyProperty.RegisterAttached("WatermarkTrimming", typeof(TextTrimming), typeof(TextBoxHelper), new FrameworkPropertyMetadata(TextTrimming.None, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender));
+        public static readonly DependencyProperty WatermarkWrappingProperty = DependencyProperty.RegisterAttached("WatermarkWrapping", typeof(TextWrapping), typeof(TextBoxHelper), new FrameworkPropertyMetadata(TextWrapping.NoWrap, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty UseFloatingWatermarkProperty = DependencyProperty.RegisterAttached("UseFloatingWatermark", typeof(bool), typeof(TextBoxHelper), new FrameworkPropertyMetadata(false, ButtonCommandOrClearTextChanged));
         public static readonly DependencyProperty TextLengthProperty = DependencyProperty.RegisterAttached("TextLength", typeof(int), typeof(TextBoxHelper), new UIPropertyMetadata(0));
         public static readonly DependencyProperty ClearTextButtonProperty = DependencyProperty.RegisterAttached("ClearTextButton", typeof(bool), typeof(TextBoxHelper), new FrameworkPropertyMetadata(false, ButtonCommandOrClearTextChanged));
@@ -510,6 +511,28 @@ namespace MahApps.Metro.Controls
         public static void SetWatermarkTrimming(DependencyObject obj, TextTrimming value)
         {
             obj.SetValue(WatermarkTrimmingProperty, value);
+        }
+
+        /// <summary>
+        /// Gets how the watermark should wrap text.
+        /// </summary>
+        /// <returns>One of the <see cref="T:System.Windows.TextWrapping" /> values. The default is <see cref="F:System.Windows.TextWrapping.NoWrap" />.
+        /// </returns>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TextBoxBase))]
+        public static TextWrapping GetWatermarkWrapping(DependencyObject obj)
+        {
+            return (TextWrapping)obj.GetValue(WatermarkWrappingProperty);
+        }
+
+        /// <summary>
+        /// Sets how the watermark should wrap text.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TextBoxBase))]
+        public static void SetWatermarkWrapping(DependencyObject obj, TextWrapping value)
+        {
+            obj.SetValue(WatermarkWrappingProperty, value);
         }
 
         [Category(AppName.MahApps)]

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
@@ -38,9 +38,11 @@ namespace MahApps.Metro.Controls {
             set { SetValue(AreModifierKeysRequiredProperty, value); }
         }
 
+        [Obsolete("This property will be deleted in the next release. Instead use TextBoxHelper.Watermark attached property.")]
         public static readonly DependencyProperty WatermarkProperty = DependencyProperty.Register(
             "Watermark", typeof(string), typeof(HotKeyBox), new PropertyMetadata(default(string)));
 
+        [Obsolete("This property will be deleted in the next release. Instead use TextBoxHelper.Watermark attached property.")]
         public string Watermark
         {
             get { return (string) GetValue(WatermarkProperty); }

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -76,6 +76,7 @@
                                        Style="{DynamicResource MahApps.Metro.Styles.MetroWatermarkTextBlock}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                       TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
@@ -87,7 +88,8 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}" />
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
                             </ContentControl>
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"
@@ -346,6 +348,7 @@
                                      Controls:TextBoxHelper.UseFloatingWatermark="{TemplateBinding Controls:TextBoxHelper.UseFloatingWatermark}"
                                      Controls:TextBoxHelper.Watermark="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                      Controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                     Controls:TextBoxHelper.WatermarkTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                      Background="{x:Null}"
                                      BorderThickness="0"
                                      CharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ComboBoxHelper.CharacterCasing), Mode=OneWay}"
@@ -370,6 +373,7 @@
                                        Style="{DynamicResource MahApps.Metro.Styles.MetroWatermarkTextBlock}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                       TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
@@ -382,7 +386,8 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}" />
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
                             </ContentControl>
 
                             <Grid x:Name="ContentSite"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -80,7 +80,6 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -69,6 +69,7 @@
                                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                                Controls:TextBoxHelper.Watermark="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.Watermark), Mode=OneWay}"
                                                Controls:TextBoxHelper.WatermarkAlignment="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.WatermarkAlignment), Mode=OneWay}"
+                                               Controls:TextBoxHelper.WatermarkTrimming="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.WatermarkTrimming), Mode=OneWay}"
                                                CaretBrush="{DynamicResource BlackBrush}"
                                                Focusable="{TemplateBinding Focusable}"
                                                FontSize="{TemplateBinding FontSize}"
@@ -88,7 +89,8 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}" />
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
                             </ContentControl>
 
                             <Popup x:Name="PART_Popup"
@@ -217,6 +219,7 @@
                                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                         Controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                        Controls:TextBoxHelper.WatermarkTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                         Focusable="False"
                                         Foreground="{TemplateBinding Foreground}"
                                         IsHitTestVisible="False"
@@ -227,7 +230,8 @@
                                     <TextBlock HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                Text="{TemplateBinding Content}"
-                                               TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}" />
+                                               TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                               TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
                                 </ControlTemplate>
                             </ContentControl.Template>
                         </ContentControl>
@@ -238,7 +242,8 @@
                                    Foreground="{TemplateBinding Foreground}"
                                    Style="{DynamicResource MahApps.Metro.Styles.MetroWatermarkTextBlock}"
                                    Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
-                                   TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}" />
+                                   TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                   TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <MultiTrigger>

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -81,7 +81,6 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -185,6 +185,7 @@
                                        Style="{DynamicResource MahApps.Metro.Styles.MetroWatermarkTextBlock}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                       TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
@@ -196,7 +197,8 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}" />
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
                             </ContentControl>
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"
@@ -395,6 +397,7 @@
                                        Style="{DynamicResource MahApps.Metro.Styles.MetroWatermarkTextBlock}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                       TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
@@ -406,7 +409,8 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}" />
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
                             </ContentControl>
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"
@@ -616,6 +620,7 @@
                                        Style="{DynamicResource MahApps.Metro.Styles.MetroWatermarkTextBlock}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                       TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
@@ -627,7 +632,8 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}" />
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
                             </ContentControl>
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -189,7 +189,6 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -400,7 +399,6 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -622,7 +620,6 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -101,6 +101,7 @@
                                        Style="{DynamicResource MahApps.Metro.Styles.MetroWatermarkTextBlock}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                       TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
@@ -112,7 +113,8 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}" />
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
                             </ContentControl>
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"
@@ -318,6 +320,7 @@
                                        Style="{DynamicResource MahApps.Metro.Styles.MetroWatermarkTextBlock}"
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                       TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
@@ -329,7 +332,8 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}" />
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
                             </ContentControl>
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -21,6 +21,7 @@
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="Controls:TextBoxHelper.IsSpellCheckContextMenuEnabled" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
+        <Setter Property="Controls:TextBoxHelper.WatermarkWrapping" Value="{Binding RelativeSource={RelativeSource Self}, Path=TextWrapping, Mode=OneWay}" />
         <Setter Property="FontFamily" Value="{DynamicResource ContentFontFamily}" />
         <Setter Property="FontSize" Value="{DynamicResource ContentFontSize}" />
         <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
@@ -102,6 +103,7 @@
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
+                                       TextWrapping="{TemplateBinding Controls:TextBoxHelper.WatermarkWrapping}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
@@ -321,6 +323,7 @@
                                        Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
+                                       TextWrapping="{TemplateBinding Controls:TextBoxHelper.WatermarkWrapping}"
                                        Visibility="Collapsed" />
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -105,7 +105,6 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -323,7 +322,6 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -145,6 +145,7 @@
                                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                                controls:TextBoxHelper.Watermark="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:TextBoxHelper.Watermark), Mode=OneWay}"
                                                controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding controls:TextBoxHelper.WatermarkAlignment}"
+                                               controls:TextBoxHelper.WatermarkTrimming="{TemplateBinding controls:TextBoxHelper.WatermarkTrimming}"
                                                CaretBrush="{DynamicResource BlackBrush}"
                                                Focusable="{TemplateBinding Focusable}"
                                                FontFamily="{TemplateBinding FontFamily}"
@@ -166,7 +167,8 @@
                                            Foreground="{TemplateBinding Foreground}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding controls:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding controls:TextBoxHelper.WatermarkAlignment}" />
+                                           TextAlignment="{TemplateBinding controls:TextBoxHelper.WatermarkAlignment}"
+                                           TextTrimming="{TemplateBinding controls:TextBoxHelper.WatermarkTrimming}" />
                             </ContentControl>
                             <Button x:Name="PART_Button"
                                     Grid.Row="0"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -159,7 +159,6 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Grid.ColumnSpan="2"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -40,6 +40,7 @@
                              Controls:TextBoxHelper.UseFloatingWatermark="{TemplateBinding Controls:TextBoxHelper.UseFloatingWatermark}"
                              Controls:TextBoxHelper.Watermark="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                              Controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                             Controls:TextBoxHelper.WatermarkTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                              Background="{TemplateBinding Background}"
                              BorderBrush="{TemplateBinding BorderBrush}"
                              BorderThickness="{TemplateBinding BorderThickness}"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -11,6 +11,7 @@
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource TextBoxFocusBorderBrush}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource TextBoxMouseOverBorderBrush}" />
         <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource ClearTextButtonFontSize}" />
+        <Setter Property="Controls:TextBoxHelper.Watermark" Value="{Binding RelativeSource={RelativeSource Self}, Path=Watermark, Mode=OneWay}" />
         <Setter Property="FontFamily" Value="{DynamicResource ContentFontFamily}" />
         <Setter Property="FontSize" Value="{DynamicResource ContentFontSize}" />
         <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
@@ -37,7 +38,7 @@
                              Controls:TextBoxHelper.IsWaitingForData="{TemplateBinding Controls:TextBoxHelper.IsWaitingForData}"
                              Controls:TextBoxHelper.SelectAllOnFocus="{TemplateBinding Controls:TextBoxHelper.SelectAllOnFocus}"
                              Controls:TextBoxHelper.UseFloatingWatermark="{TemplateBinding Controls:TextBoxHelper.UseFloatingWatermark}"
-                             Controls:TextBoxHelper.Watermark="{TemplateBinding Watermark}"
+                             Controls:TextBoxHelper.Watermark="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                              Controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                              Background="{TemplateBinding Background}"
                              BorderBrush="{TemplateBinding BorderBrush}"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -61,6 +61,7 @@
                                      Controls:TextBoxHelper.UseFloatingWatermark="{TemplateBinding Controls:TextBoxHelper.UseFloatingWatermark}"
                                      Controls:TextBoxHelper.Watermark="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                      Controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                     Controls:TextBoxHelper.WatermarkTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                      Background="{x:Null}"
                                      BorderThickness="0"
                                      FocusVisualStyle="{x:Null}"

--- a/src/Mahapps.Metro.Tests/Mahapps.Metro.Tests.Shared/Tests/AutoWatermarkTest.cs
+++ b/src/Mahapps.Metro.Tests/Mahapps.Metro.Tests.Shared/Tests/AutoWatermarkTest.cs
@@ -25,6 +25,7 @@ namespace Mahapps.Metro.Tests
                                   Assert.Equal(autoWatermark, window.TestComboBox.GetValue(TextBoxHelper.WatermarkProperty));
                                   Assert.Equal(autoWatermark, window.TestNumericUpDown.GetValue(TextBoxHelper.WatermarkProperty));
                                   Assert.Equal(autoWatermark, window.TestDatePicker.GetValue(TextBoxHelper.WatermarkProperty));
+                                  Assert.Equal(autoWatermark, window.TestHotKeyBox.GetValue(TextBoxHelper.WatermarkProperty));
                               });
         }
     }

--- a/src/Mahapps.Metro.Tests/Mahapps.Metro.Tests.Shared/Views/AutoWatermarkTestWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Mahapps.Metro.Tests.Shared/Views/AutoWatermarkTestWindow.xaml
@@ -28,5 +28,8 @@
         <DatePicker x:Name="TestDatePicker"
                     controls:TextBoxHelper.AutoWatermark="True"
                     SelectedDate="{Binding DatePickerDate}" />
+        <controls:HotKeyBox x:Name="TestHotKeyBox"
+                            controls:TextBoxHelper.AutoWatermark="True"
+                            HotKey="{Binding HotKey}" />
     </StackPanel>
 </controls:MetroWindow>

--- a/src/Mahapps.Metro.Tests/Mahapps.Metro.Tests.Shared/Views/AutoWatermarkTestWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Mahapps.Metro.Tests.Shared/Views/AutoWatermarkTestWindow.xaml.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.ObjectModel;
     using System.ComponentModel.DataAnnotations;
+    using MahApps.Metro.Controls;
 
     public partial class AutoWatermarkTestWindow
     {
@@ -25,6 +26,9 @@
 
         [Display(Prompt = "AutoWatermark")]
         public DateTime? DatePickerDate { get; set; }
+
+        [Display(Prompt = "AutoWatermark")]
+        public HotKey HotKey { get; set; }
 
         public AutoWatermarkTestSubModel SubModel { get; set; }= new AutoWatermarkTestSubModel();
 


### PR DESCRIPTION
`Watermark` fixes and improvements
- Fix right aligned floating watermark.
- Use `TextBoxHelper.Watermark` for `HotKeyBox` instead own DependencyProperty (marked as obsolete).
- Allow `TextBoxHelper.AutoWatermark` for `HotKey` DependencyProperty of `HotKeyBox`.
- New `TextBoxHelper.WatermarkTrimming` attached property to set the text trimming behavior to employ when (floating) watermark overflows the content area. thx to [@amkuchta](https://github.com/amkuchta)
- New `TextBoxHelper.WatermarkWrapping` attached property (only for `TextBox`) to set how the watermark should wrap text. Default is binded to `TextWrapping` property. thx to [@amkuchta](https://github.com/amkuchta)

Closes #3067
Closes #3068
Closes #2884
Closes #2889