### PR TITLE
Add missing VS StandardExpander style

### DIFF
--- a/docs/release-notes/1.6.0.md
+++ b/docs/release-notes/1.6.0.md
@@ -42,6 +42,7 @@
 	+ New `TextBoxHelper.WatermarkWrapping` attached property (only for `TextBox`) to set how the watermark should wrap text. Default is binded to `TextWrapping` property. thx to [@amkuchta](https://github.com/amkuchta)
 - `VS Theme` changes / enhancements
 	+ Add `StandardGroupBox` style
+	+ Add `StandardExpander` style
 
 ## Breaking Change
 
@@ -100,3 +101,4 @@ More informations about the reason of this decision can be found here:
 - [#2884](https://github.com/MahApps/MahApps.Metro/issues/2884) [Feature Request] Watermark Trimming
 - [#2889](https://github.com/MahApps/MahApps.Metro/issues/2889) [Feature Request] Watermark Wrapping
 - [#3070](https://github.com/MahApps/MahApps.Metro/issues/3070) VS GroupBox style
+- [#957](https://github.com/MahApps/MahApps.Metro/issues/957) Expander icon in VS theme

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleWindows/VSDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleWindows/VSDemo.xaml
@@ -64,75 +64,89 @@
             </Grid.ColumnDefinitions>
             <TabControl Margin="0 10 0 0" TabStripPlacement="Top">
                 <TabItem Header="Start">
-                    <GroupBox Margin="50" Header="Into Space">
-                        <Grid Margin="10">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="50" />
-                                <RowDefinition Height="25" />
-                                <RowDefinition Height="25" />
-                                <RowDefinition Height="15" />
-                                <RowDefinition Height="25" />
-                                <RowDefinition Height="25" />
-                            </Grid.RowDefinitions>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition />
-                                <ColumnDefinition />
-                                <ColumnDefinition />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Row="0"
-                                       Grid.ColumnSpan="3"
-                                       FontSize="30"
-                                       Foreground="{StaticResource Foreground}">
-                                Space Commander - Starship Enterprise
-                            </TextBlock>
-                            <TextBlock Grid.Row="1"
-                                       FontSize="16"
-                                       Foreground="{StaticResource Foreground}">
-                                You are logged in as:
-                            </TextBlock>
-                            <TextBlock Grid.Row="1"
-                                       Grid.Column="1"
-                                       FontSize="16"
-                                       Foreground="{StaticResource Foreground}"
-                                       Text="{x:Static System:Environment.UserName}" />
-                            <TextBlock Grid.Row="2"
-                                       FontSize="16"
-                                       Foreground="{StaticResource Foreground}">
-                                Ship state
-                            </TextBlock>
-                            <TextBlock Grid.Row="2"
-                                       Grid.Column="1"
-                                       FontSize="16"
-                                       Foreground="{StaticResource BackgroundSelected}">
-                                IO
-                            </TextBlock>
-                            <Separator Grid.Row="3"
-                                       Grid.ColumnSpan="2"
-                                       Margin="5" />
-                            <TextBlock Grid.Row="4"
-                                       FontSize="16"
-                                       Foreground="{StaticResource Foreground}">
-                                Ship commander
-                            </TextBlock>
-                            <TextBlock Grid.Row="4"
-                                       Grid.Column="1"
-                                       FontSize="16"
-                                       Foreground="{StaticResource Foreground}">
-                                Captain James T. Kirk
-                            </TextBlock>
-                            <TextBlock Grid.Row="5"
-                                       FontSize="16"
-                                       Foreground="{StaticResource Foreground}">
-                                Ship name
-                            </TextBlock>
-                            <TextBlock Grid.Row="5"
-                                       Grid.Column="1"
-                                       FontSize="16"
-                                       Foreground="{StaticResource Foreground}">
-                                Enterprise (NCC-1701)
-                            </TextBlock>
-                        </Grid>
-                    </GroupBox>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <GroupBox Grid.Row="0"
+                                  Margin="20"
+                                  Header="Into Space">
+                            <Grid Margin="10">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="50" />
+                                    <RowDefinition Height="25" />
+                                    <RowDefinition Height="25" />
+                                    <RowDefinition Height="15" />
+                                    <RowDefinition Height="25" />
+                                    <RowDefinition Height="25" />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                    <ColumnDefinition />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Row="0"
+                                           Grid.ColumnSpan="3"
+                                           FontSize="30"
+                                           Foreground="{StaticResource Foreground}">
+                                    Space Commander - Starship Enterprise
+                                </TextBlock>
+                                <TextBlock Grid.Row="1"
+                                           FontSize="16"
+                                           Foreground="{StaticResource Foreground}">
+                                    You are logged in as:
+                                </TextBlock>
+                                <TextBlock Grid.Row="1"
+                                           Grid.Column="1"
+                                           FontSize="16"
+                                           Foreground="{StaticResource Foreground}"
+                                           Text="{x:Static System:Environment.UserName}" />
+                                <TextBlock Grid.Row="2"
+                                           FontSize="16"
+                                           Foreground="{StaticResource Foreground}">
+                                    Ship state
+                                </TextBlock>
+                                <TextBlock Grid.Row="2"
+                                           Grid.Column="1"
+                                           FontSize="16"
+                                           Foreground="{StaticResource BackgroundSelected}">
+                                    IO
+                                </TextBlock>
+                                <Separator Grid.Row="3"
+                                           Grid.ColumnSpan="2"
+                                           Margin="5" />
+                                <TextBlock Grid.Row="4"
+                                           FontSize="16"
+                                           Foreground="{StaticResource Foreground}">
+                                    Ship commander
+                                </TextBlock>
+                                <TextBlock Grid.Row="4"
+                                           Grid.Column="1"
+                                           FontSize="16"
+                                           Foreground="{StaticResource Foreground}">
+                                    Captain James T. Kirk
+                                </TextBlock>
+                                <TextBlock Grid.Row="5"
+                                           FontSize="16"
+                                           Foreground="{StaticResource Foreground}">
+                                    Ship name
+                                </TextBlock>
+                                <TextBlock Grid.Row="5"
+                                           Grid.Column="1"
+                                           FontSize="16"
+                                           Foreground="{StaticResource Foreground}">
+                                    Enterprise (NCC-1701)
+                                </TextBlock>
+                            </Grid>
+                        </GroupBox>
+                        <Expander Grid.Row="1"
+                                  Margin="20"
+                                  ExpandDirection="Down"
+                                  Header="Hidden Stuff">
+                            <!--  some content here  -->
+                        </Expander>
+                    </Grid>
                 </TabItem>
                 <TabItem Header="Manage Rockets">
                     <DockPanel>

--- a/src/MahApps.Metro/MahApps.Metro/MahApps.Metro.NET40.csproj
+++ b/src/MahApps.Metro/MahApps.Metro/MahApps.Metro.NET40.csproj
@@ -361,6 +361,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Styles\VS\Expander.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Styles\VS\GroupBox.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/MahApps.Metro/MahApps.Metro/MahApps.Metro.NET45.csproj
+++ b/src/MahApps.Metro/MahApps.Metro/MahApps.Metro.NET45.csproj
@@ -361,6 +361,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Styles\VS\Expander.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Styles\VS\GroupBox.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/MahApps.Metro/MahApps.Metro/Styles/VS/Expander.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/VS/Expander.xaml
@@ -1,0 +1,435 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <Converters:ThicknessBindingConverter x:Key="ThicknessBindingConverter" />
+
+    <Thickness x:Key="ExpanderHeaderThemePadding">2</Thickness>
+    <sys:Double x:Key="ExpanderHeaderThemeFontSize">16</sys:Double>
+    <sys:Double x:Key="ExpanderToggleButtonThemeSize">18</sys:Double>
+
+    <Style x:Key="ExpanderBaseHeaderStyle" TargetType="{x:Type ToggleButton}">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="Padding" Value="{DynamicResource ExpanderHeaderThemePadding}" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+    </Style>
+
+    <Style x:Key="ExpanderRightHeaderStyle"
+           BasedOn="{StaticResource ExpanderBaseHeaderStyle}"
+           TargetType="{x:Type ToggleButton}">
+        <Setter Property="BorderThickness" Value="0 0 2 0" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid Margin="{TemplateBinding Padding}"
+                              Background="Transparent"
+                              SnapsToDevicePixels="False">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid x:Name="ArrowGrid"
+                                  Width="{DynamicResource ExpanderToggleButtonThemeSize}"
+                                  Height="{DynamicResource ExpanderToggleButtonThemeSize}"
+                                  Margin="1"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Background="Transparent">
+                                <Grid.LayoutTransform>
+                                    <TransformGroup>
+                                        <TransformGroup.Children>
+                                            <TransformCollection>
+                                                <RotateTransform Angle="-90" />
+                                            </TransformCollection>
+                                        </TransformGroup.Children>
+                                    </TransformGroup>
+                                </Grid.LayoutTransform>
+                                <Path x:Name="Arrow"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Data="M 1,1.5 L 4.5,5 L 8,1.5"
+                                      IsHitTestVisible="False"
+                                      SnapsToDevicePixels="False"
+                                      Stroke="{DynamicResource BorderBrushNormal}"
+                                      StrokeThickness="2" />
+                            </Grid>
+                            <Controls:ContentControlEx Grid.Row="1"
+                                                       Margin="0 4 0 0"
+                                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                       Content="{TemplateBinding Content}"
+                                                       ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
+                                                       ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                       ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                       ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                       RecognizesAccessKey="True"
+                                                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="Arrow" Property="Data" Value="M 1,4.5  L 4.5,1  L 8,4.5" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource Foreground}" />
+                            <Setter TargetName="ArrowGrid" Property="Background" Value="{DynamicResource BackgroundHighlighted}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="ArrowGrid" Property="Background" Value="{DynamicResource BackgroundSelected}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    </Style>
+
+    <Style x:Key="ExpanderUpHeaderStyle"
+           BasedOn="{StaticResource ExpanderBaseHeaderStyle}"
+           TargetType="{x:Type ToggleButton}">
+        <Setter Property="BorderThickness" Value="0 2 0 0" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <Grid Margin="{TemplateBinding Padding}"
+                              Background="Transparent"
+                              SnapsToDevicePixels="False">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Controls:ContentControlEx Grid.Column="0"
+                                                       Margin="0 0 4 0"
+                                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                       Content="{TemplateBinding Content}"
+                                                       ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
+                                                       ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                       ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                       ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                       RecognizesAccessKey="True"
+                                                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <Grid x:Name="ArrowGrid"
+                                  Grid.Column="1"
+                                  Width="{DynamicResource ExpanderToggleButtonThemeSize}"
+                                  Height="{DynamicResource ExpanderToggleButtonThemeSize}"
+                                  Margin="1"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Background="Transparent">
+                                <Grid.LayoutTransform>
+                                    <TransformGroup>
+                                        <TransformGroup.Children>
+                                            <TransformCollection>
+                                                <RotateTransform Angle="180" />
+                                            </TransformCollection>
+                                        </TransformGroup.Children>
+                                    </TransformGroup>
+                                </Grid.LayoutTransform>
+                                <Path x:Name="Arrow"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Data="M 1,1.5 L 4.5,5 L 8,1.5"
+                                      SnapsToDevicePixels="False"
+                                      Stroke="{DynamicResource BorderBrushNormal}"
+                                      StrokeThickness="2" />
+                            </Grid>
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="Arrow" Property="Data" Value="M 1,4.5  L 4.5,1  L 8,4.5" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource Foreground}" />
+                            <Setter TargetName="ArrowGrid" Property="Background" Value="{DynamicResource BackgroundHighlighted}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="ArrowGrid" Property="Background" Value="{DynamicResource BackgroundSelected}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+
+    <Style x:Key="ExpanderLeftHeaderStyle"
+           BasedOn="{StaticResource ExpanderRightHeaderStyle}"
+           TargetType="{x:Type ToggleButton}">
+        <Setter Property="BorderThickness" Value="2 0 0 0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <Grid Margin="{TemplateBinding Padding}"
+                              Background="Transparent"
+                              SnapsToDevicePixels="False">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid x:Name="ArrowGrid"
+                                  Width="{DynamicResource ExpanderToggleButtonThemeSize}"
+                                  Height="{DynamicResource ExpanderToggleButtonThemeSize}"
+                                  Margin="1"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Background="Transparent">
+                                <Grid.LayoutTransform>
+                                    <TransformGroup>
+                                        <TransformGroup.Children>
+                                            <TransformCollection>
+                                                <RotateTransform Angle="90" />
+                                            </TransformCollection>
+                                        </TransformGroup.Children>
+                                    </TransformGroup>
+                                </Grid.LayoutTransform>
+                                <Path x:Name="Arrow"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Data="M 1,1.5 L 4.5,5 L 8,1.5"
+                                      SnapsToDevicePixels="False"
+                                      Stroke="{DynamicResource BorderBrushNormal}"
+                                      StrokeThickness="2" />
+                            </Grid>
+                            <Controls:ContentControlEx Grid.Row="1"
+                                                       Margin="0 4 0 0"
+                                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                       Content="{TemplateBinding Content}"
+                                                       ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
+                                                       ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                       ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                       ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                       RecognizesAccessKey="True"
+                                                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="Arrow" Property="Data" Value="M 1,4.5  L 4.5,1  L 8,4.5" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource Foreground}" />
+                            <Setter TargetName="ArrowGrid" Property="Background" Value="{DynamicResource BackgroundHighlighted}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="ArrowGrid" Property="Background" Value="{DynamicResource BackgroundSelected}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="ExpanderDownHeaderStyle"
+           BasedOn="{StaticResource ExpanderUpHeaderStyle}"
+           TargetType="{x:Type ToggleButton}">
+        <Setter Property="BorderThickness" Value="0 0 0 2" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Border Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                        <Grid Margin="{TemplateBinding Padding}"
+                              Background="Transparent"
+                              SnapsToDevicePixels="False">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Controls:ContentControlEx Grid.Column="0"
+                                                       Margin="0 0 4 0"
+                                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                       Content="{TemplateBinding Content}"
+                                                       ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
+                                                       ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                       ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                       ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                       RecognizesAccessKey="True"
+                                                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <Grid x:Name="ArrowGrid"
+                                  Grid.Column="1"
+                                  Width="{DynamicResource ExpanderToggleButtonThemeSize}"
+                                  Height="{DynamicResource ExpanderToggleButtonThemeSize}"
+                                  Margin="1"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Background="Transparent">
+                                <Path x:Name="Arrow"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Data="M 1,1.5 L 4.5,5 L 8,1.5"
+                                      SnapsToDevicePixels="False"
+                                      Stroke="{DynamicResource BorderBrushNormal}"
+                                      StrokeThickness="2" />
+                            </Grid>
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter TargetName="Arrow" Property="Data" Value="M 1,4.5  L 4.5,1  L 8,4.5" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource Foreground}" />
+                            <Setter TargetName="ArrowGrid" Property="Background" Value="{DynamicResource BackgroundHighlighted}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="ArrowGrid" Property="Background" Value="{DynamicResource BackgroundSelected}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Storyboard x:Key="MetroExpanderExpandStoryboard">
+        <DoubleAnimation Storyboard.TargetName="ExpandSite"
+                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                         To="1"
+                         Duration="0:0:0.25" />
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ExpandSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+            <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+        </ObjectAnimationUsingKeyFrames>
+    </Storyboard>
+
+    <Storyboard x:Key="MetroExpanderCollapseStoryboard">
+        <DoubleAnimation Storyboard.TargetName="ExpandSite"
+                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                         To="0"
+                         Duration="0:0:0.25" />
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ExpandSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+            <DiscreteObjectKeyFrame KeyTime="0:0:0.25" Value="{x:Static Visibility.Collapsed}" />
+        </ObjectAnimationUsingKeyFrames>
+    </Storyboard>
+
+    <Style x:Key="StandardExpander" TargetType="{x:Type Expander}">
+        <Setter Property="Background" Value="{x:Null}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushNormal}" />
+        <Setter Property="BorderThickness" Value="2" />
+        <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Normal" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource ExpanderHeaderThemeFontSize}" />
+        <Setter Property="Controls:ExpanderHelper.HeaderDownStyle" Value="{StaticResource ExpanderDownHeaderStyle}" />
+        <Setter Property="Controls:ExpanderHelper.HeaderLeftStyle" Value="{StaticResource ExpanderLeftHeaderStyle}" />
+        <Setter Property="Controls:ExpanderHelper.HeaderRightStyle" Value="{StaticResource ExpanderRightHeaderStyle}" />
+        <Setter Property="Controls:ExpanderHelper.HeaderUpStyle" Value="{StaticResource ExpanderUpHeaderStyle}" />
+        <Setter Property="Controls:GroupBoxHelper.HeaderForeground" Value="{DynamicResource Foreground}" />
+        <Setter Property="Foreground" Value="{DynamicResource Foreground}" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Expander}">
+                    <Grid>
+                        <Rectangle x:Name="DisabledVisualElement"
+                                   Fill="{DynamicResource ControlsDisabledBrush}"
+                                   IsHitTestVisible="False"
+                                   Opacity="0" />
+                        <DockPanel x:Name="ExpanderRoot">
+                            <ToggleButton x:Name="ToggleSite"
+                                          Controls:ControlsHelper.ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
+                                          BorderBrush="{TemplateBinding BorderBrush}"
+                                          Content="{TemplateBinding Header}"
+                                          ContentStringFormat="{TemplateBinding HeaderStringFormat}"
+                                          ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                          DockPanel.Dock="Top"
+                                          FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
+                                          FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
+                                          FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
+                                          Foreground="{TemplateBinding Controls:GroupBoxHelper.HeaderForeground}"
+                                          IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          Style="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderDownStyle)}" />
+                            <Border x:Name="ExpandSite"
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    Background="Transparent"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Top}}"
+                                    DockPanel.Dock="Bottom"
+                                    Focusable="False"
+                                    Opacity="0"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                    UseLayoutRounding="True"
+                                    Visibility="Collapsed">
+                                <ContentPresenter Margin="{TemplateBinding Padding}"
+                                                  Content="{TemplateBinding Content}"
+                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                  Cursor="{TemplateBinding Cursor}"
+                                                  UseLayoutRounding="False" />
+                            </Border>
+                        </DockPanel>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="MouseOver" />
+                                <VisualState x:Name="Disabled">
+                                    <Storyboard>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="DisabledVisualElement" Storyboard.TargetProperty="Opacity">
+                                            <SplineDoubleKeyFrame KeyTime="0" Value="0.7" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                        <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ExpanderRoot" Storyboard.TargetProperty="(UIElement.Opacity)">
+                                            <EasingDoubleKeyFrame KeyTime="0" Value="0.3" />
+                                        </DoubleAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsExpanded" Value="True">
+                            <Setter TargetName="ExpandSite" Property="Visibility" Value="Visible" />
+                            <Trigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource MetroExpanderExpandStoryboard}" />
+                            </Trigger.EnterActions>
+                            <Trigger.ExitActions>
+                                <BeginStoryboard Storyboard="{StaticResource MetroExpanderCollapseStoryboard}" />
+                            </Trigger.ExitActions>
+                        </Trigger>
+                        <Trigger Property="ExpandDirection" Value="Right">
+                            <Setter TargetName="ExpandSite" Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}" />
+                            <Setter TargetName="ExpandSite" Property="DockPanel.Dock" Value="Right" />
+                            <Setter TargetName="ToggleSite" Property="DockPanel.Dock" Value="Left" />
+                            <Setter TargetName="ToggleSite" Property="Style" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderRightStyle)}" />
+                        </Trigger>
+                        <Trigger Property="ExpandDirection" Value="Up">
+                            <Setter TargetName="ExpandSite" Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Bottom}}" />
+                            <Setter TargetName="ExpandSite" Property="DockPanel.Dock" Value="Top" />
+                            <Setter TargetName="ToggleSite" Property="DockPanel.Dock" Value="Bottom" />
+                            <Setter TargetName="ToggleSite" Property="Style" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderUpStyle)}" />
+                        </Trigger>
+                        <Trigger Property="ExpandDirection" Value="Left">
+                            <Setter TargetName="ExpandSite" Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
+                            <Setter TargetName="ExpandSite" Property="DockPanel.Dock" Value="Left" />
+                            <Setter TargetName="ToggleSite" Property="DockPanel.Dock" Value="Right" />
+                            <Setter TargetName="ToggleSite" Property="Style" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ExpanderHelper.HeaderLeftStyle)}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/src/MahApps.Metro/MahApps.Metro/Styles/VS/GroupBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/VS/GroupBox.xaml
@@ -7,11 +7,12 @@
     <System:Double x:Key="GroupBoxHeaderThemeFontSize">16</System:Double>
 
     <Style x:Key="StandardGroupBox" TargetType="{x:Type GroupBox}">
-        <Setter Property="BorderBrush" Value="{DynamicResource BackgroundNormal}" />
+        <Setter Property="Background" Value="{x:Null}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrushNormal}" />
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Normal" />
         <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource GroupBoxHeaderThemeFontSize}" />
-        <Setter Property="Controls:GroupBoxHelper.HeaderForeground" Value="{x:Null}" />
+        <Setter Property="Controls:GroupBoxHelper.HeaderForeground" Value="{DynamicResource Foreground}" />
         <Setter Property="Foreground" Value="{DynamicResource Foreground}" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
@@ -33,6 +34,7 @@
                                                    FontSize="{TemplateBinding Controls:ControlsHelper.HeaderFontSize}"
                                                    FontStretch="{TemplateBinding Controls:ControlsHelper.HeaderFontStretch}"
                                                    FontWeight="{TemplateBinding Controls:ControlsHelper.HeaderFontWeight}"
+                                                   Foreground="{TemplateBinding Controls:GroupBoxHelper.HeaderForeground}"
                                                    RecognizesAccessKey="True"
                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         <Border Grid.Row="1"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/VS/Styles.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/VS/Styles.xaml
@@ -10,6 +10,7 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/VS/TabControl.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/VS/TextBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/VS/GroupBox.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/VS/Expander.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style BasedOn="{StaticResource StandardButton}" TargetType="Button" />
@@ -21,5 +22,6 @@
     <Style BasedOn="{StaticResource StandardTabControl}" TargetType="TabControl" />
     <Style BasedOn="{StaticResource StandardTextBox}" TargetType="TextBox" />
     <Style BasedOn="{StaticResource StandardGroupBox}" TargetType="GroupBox" />
+    <Style BasedOn="{StaticResource StandardExpander}" TargetType="Expander" />
 
 </ResourceDictionary>


### PR DESCRIPTION
This PR adds the missing Expander style for the VS theme.

![2017-10-07_23h35_30](https://user-images.githubusercontent.com/658431/31311966-4aa01bf2-abb8-11e7-8ff6-f750fcb56a2b.png)

![2017-10-07_23h35_41](https://user-images.githubusercontent.com/658431/31311967-4dacfb58-abb8-11e7-926c-710d020ee572.png)

Closes #957
