### PR TITLE
Fix for Floating watermak field doesn't fit according to floating watermark FontSize

### DIFF
--- a/docs/release-notes/1.6.0.md
+++ b/docs/release-notes/1.6.0.md
@@ -107,3 +107,4 @@ More informations about the reason of this decision can be found here:
 - [#3070](https://github.com/MahApps/MahApps.Metro/issues/3070) VS GroupBox style
 - [#957](https://github.com/MahApps/MahApps.Metro/issues/957) Expander icon in VS theme
 - [#1731](https://github.com/MahApps/MahApps.Metro/issues/1731) VS Theme TabItem Question
+- [#3009](https://github.com/MahApps/MahApps.Metro/issues/3009) Floating Watermak field doesn't fit according FontSize

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Converters/MarkupConverter.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Converters/MarkupConverter.cs
@@ -15,6 +15,7 @@ namespace MahApps.Metro.Converters
         }
 
         protected abstract object Convert(object value, Type targetType, object parameter, CultureInfo culture);
+
         protected abstract object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture);
 
         object IValueConverter.Convert(object value, Type targetType, object parameter, CultureInfo culture)
@@ -39,6 +40,23 @@ namespace MahApps.Metro.Converters
             {
                 return DependencyProperty.UnsetValue;
             }
+        }
+    }
+
+    [MarkupExtensionReturnType(typeof(MarkupMultiConverter))]
+    public abstract class MarkupMultiConverter : MarkupExtension, IValueConverter, IMultiValueConverter
+    {
+        public abstract object Convert(object value, Type targetType, object parameter, CultureInfo culture);
+
+        public abstract object Convert(object[] values, Type targetType, object parameter, CultureInfo culture);
+
+        public abstract object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture);
+
+        public abstract object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture);
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
         }
     }
 }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Converters/MathConverter.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Converters/MathConverter.cs
@@ -1,0 +1,263 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Data;
+using System.Windows;
+using System.Windows.Markup;
+
+namespace MahApps.Metro.Converters
+{
+    /// <summary>
+    /// The math operations which can be used at the <see cref="MathConverter"/>
+    /// </summary>
+    public enum MathOperation
+    {
+        Add,
+        Subtract,
+        Multiply,
+        Divide
+    }
+
+    /// <summary>
+    /// MathConverter provides a value converter which can be used for math operations.
+    /// It can be used for normal binding or multi binding as well.
+    /// If it is used for normal binding the given parameter will be used as operands with the selected operation.
+    /// If it is used for multi binding then the first and second binding will be used as operands with the selected operation.
+    /// This class cannot be inherited.
+    /// </summary>
+    public sealed class MathConverter : IValueConverter, IMultiValueConverter
+    {
+        public MathOperation Operation { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return DoConvert(value, parameter, this.Operation);
+        }
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values == null || values.Length < 2)
+            {
+                return Binding.DoNothing;
+            }
+            return DoConvert(values[0], values[1], this.Operation);
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return Binding.DoNothing;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            return targetTypes.Select(t => Binding.DoNothing).ToArray();
+        }
+
+        private static object DoConvert(object firstValue, object secondValue, MathOperation operation)
+        {
+            if (firstValue == null
+                || secondValue == null
+                || firstValue == DependencyProperty.UnsetValue
+                || secondValue == DependencyProperty.UnsetValue
+                || firstValue == DBNull.Value
+                || secondValue == DBNull.Value)
+            {
+                return Binding.DoNothing;
+            }
+
+            try
+            {
+                var value1 = (firstValue as double?).GetValueOrDefault(System.Convert.ToDouble(firstValue, CultureInfo.InvariantCulture));
+                var value2 = (secondValue as double?).GetValueOrDefault(System.Convert.ToDouble(secondValue, CultureInfo.InvariantCulture));
+
+                switch (operation)
+                {
+                    case MathOperation.Add:
+                        return value1 + value2;
+                    case MathOperation.Divide:
+                        return value1 / value2;
+                    case MathOperation.Multiply:
+                        return value1 * value2;
+                    case MathOperation.Subtract:
+                        return value1 - value2;
+                    default:
+                        return Binding.DoNothing;
+                }
+            }
+            catch (Exception e)
+            {
+                Trace.TraceError($"Error while converting: value1={firstValue} value2={secondValue} operation={operation} exception: {e}");
+                return Binding.DoNothing;
+            }
+        }
+    }
+
+    /// <summary>
+    /// MathAddConverter provides a multi value converter as a MarkupExtension which can be used for math operations.
+    /// This class cannot be inherited.
+    /// </summary>
+    [MarkupExtensionReturnType(typeof(MarkupMultiConverter))]
+    public sealed class MathAddConverter : MarkupMultiConverter
+    {
+        private static MathAddConverter _instance;
+        private readonly MathConverter theMathConverter = new MathConverter() { Operation = MathOperation.Add };
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static MathAddConverter()
+        {
+        }
+
+        public override object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.Convert(values, targetType, parameter, culture);
+        }
+
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.Convert(value, targetType, parameter, culture);
+        }
+
+        public override object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.ConvertBack(value, targetTypes, parameter, culture);
+        }
+
+        public override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.ConvertBack(value, targetType, parameter, culture);
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance ?? (_instance = new MathAddConverter());
+        }
+    }
+
+    /// <summary>
+    /// MathSubtractConverter provides a multi value converter as a MarkupExtension which can be used for math operations.
+    /// This class cannot be inherited.
+    /// </summary>
+    [MarkupExtensionReturnType(typeof(MarkupMultiConverter))]
+    public sealed class MathSubtractConverter : MarkupMultiConverter
+    {
+        private static MathSubtractConverter _instance;
+        private readonly MathConverter theMathConverter = new MathConverter() { Operation = MathOperation.Subtract };
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static MathSubtractConverter()
+        {
+        }
+
+        public override object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.Convert(values, targetType, parameter, culture);
+        }
+
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.Convert(value, targetType, parameter, culture);
+        }
+
+        public override object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.ConvertBack(value, targetTypes, parameter, culture);
+        }
+
+        public override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.ConvertBack(value, targetType, parameter, culture);
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance ?? (_instance = new MathSubtractConverter());
+        }
+    }
+
+    /// <summary>
+    /// MathMultiplyConverter provides a multi value converter as a MarkupExtension which can be used for math operations.
+    /// This class cannot be inherited.
+    /// </summary>
+    [MarkupExtensionReturnType(typeof(MarkupMultiConverter))]
+    public sealed class MathMultiplyConverter : MarkupMultiConverter
+    {
+        private static MathMultiplyConverter _instance;
+        private readonly MathConverter theMathConverter = new MathConverter() { Operation = MathOperation.Multiply };
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static MathMultiplyConverter()
+        {
+        }
+
+        public override object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.Convert(values, targetType, parameter, culture);
+        }
+
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.Convert(value, targetType, parameter, culture);
+        }
+
+        public override object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.ConvertBack(value, targetTypes, parameter, culture);
+        }
+
+        public override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.ConvertBack(value, targetType, parameter, culture);
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance ?? (_instance = new MathMultiplyConverter());
+        }
+    }
+
+    /// <summary>
+    /// MathDivideConverter provides a multi value converter as a MarkupExtension which can be used for math operations.
+    /// This class cannot be inherited.
+    /// </summary>
+    [MarkupExtensionReturnType(typeof(MarkupMultiConverter))]
+    public sealed class MathDivideConverter : MarkupMultiConverter
+    {
+        private static MathDivideConverter _instance;
+        private readonly MathConverter theMathConverter = new MathConverter() { Operation = MathOperation.Divide };
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static MathDivideConverter()
+        {
+        }
+
+        public override object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.Convert(values, targetType, parameter, culture);
+        }
+
+        public override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.Convert(value, targetType, parameter, culture);
+        }
+
+        public override object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.ConvertBack(value, targetTypes, parameter, culture);
+        }
+
+        public override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return this.theMathConverter.ConvertBack(value, targetType, parameter, culture);
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance ?? (_instance = new MathDivideConverter());
+        }
+    }
+}

--- a/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
@@ -141,6 +141,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\WindowCommandsOverlayBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\WindowSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\BackgroundToForegroundConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Converters\MathConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ThicknessToDoubleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ClockDegreeConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\FontSizeOffsetConverter.cs" />

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -1,13 +1,11 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
-                    xmlns:converters="clr-namespace:MahApps.Metro.Converters">
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TextBox.xaml" />
     </ResourceDictionary.MergedDictionaries>
-
-    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
     <Thickness x:Key="ComboBoxBorderThemeThickness">1</Thickness>
     <Thickness x:Key="ComboBoxPopupBorderThemeThickness">1</Thickness>
@@ -82,6 +80,16 @@
                                             Grid.Row="0"
                                             Grid.Column="0"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
+                                <ContentControl.Height>
+                                    <MultiBinding Converter="{Converters:MathMultiplyConverter}">
+                                        <Binding ElementName="PART_FloatingMessage"
+                                                 Mode="OneWay"
+                                                 Path="ActualHeight" />
+                                        <Binding ElementName="PART_FloatingMessageContainer"
+                                                 Mode="OneWay"
+                                                 Path="Opacity" />
+                                    </MultiBinding>
+                                </ContentControl.Height>
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -89,7 +97,22 @@
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                            TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}">
+                                    <TextBlock.RenderTransform>
+                                        <TranslateTransform x:Name="FloatingMessageTransform">
+                                            <TranslateTransform.Y>
+                                                <MultiBinding Converter="{Converters:MathSubtractConverter}">
+                                                    <Binding ElementName="PART_FloatingMessage"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                    <Binding ElementName="PART_FloatingMessageContainer"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                </MultiBinding>
+                                            </TranslateTransform.Y>
+                                        </TranslateTransform>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
                             </ContentControl>
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"
@@ -379,6 +402,16 @@
                                             Grid.Row="0"
                                             Grid.Column="0"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
+                                <ContentControl.Height>
+                                    <MultiBinding Converter="{Converters:MathMultiplyConverter}">
+                                        <Binding ElementName="PART_FloatingMessage"
+                                                 Mode="OneWay"
+                                                 Path="ActualHeight" />
+                                        <Binding ElementName="PART_FloatingMessageContainer"
+                                                 Mode="OneWay"
+                                                 Path="Opacity" />
+                                    </MultiBinding>
+                                </ContentControl.Height>
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            Margin="2 2 0 0"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -387,7 +420,22 @@
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                            TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}">
+                                    <TextBlock.RenderTransform>
+                                        <TranslateTransform x:Name="FloatingMessageTransform">
+                                            <TranslateTransform.Y>
+                                                <MultiBinding Converter="{Converters:MathSubtractConverter}">
+                                                    <Binding ElementName="PART_FloatingMessage"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                    <Binding ElementName="PART_FloatingMessageContainer"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                </MultiBinding>
+                                            </TranslateTransform.Y>
+                                        </TranslateTransform>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
                             </ContentControl>
 
                             <Grid x:Name="ContentSite"
@@ -470,7 +518,7 @@
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsEditable}" Value="True" />
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=ContextMenu, Converter={x:Static converters:IsNullConverter.Instance}}" Value="False" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=ContextMenu, Converter={x:Static Converters:IsNullConverter.Instance}}" Value="False" />
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="PART_EditableTextBox" Property="ContextMenu" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=ContextMenu}" />
                         </MultiDataTrigger>
@@ -484,7 +532,7 @@
                         </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=SelectedItem, Mode=OneWay, Converter={x:Static converters:IsNullConverter.Instance}}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=SelectedItem, Mode=OneWay, Converter={x:Static Converters:IsNullConverter.Instance}}" Value="True" />
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsKeyboardFocusWithin}" Value="True" />
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsEditable}" Value="False" />
                             </MultiDataTrigger.Conditions>
@@ -497,7 +545,7 @@
                         </MultiDataTrigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=SelectedItem, Mode=OneWay, Converter={x:Static converters:IsNullConverter.Instance}}" Value="False" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=SelectedItem, Mode=OneWay, Converter={x:Static Converters:IsNullConverter.Instance}}" Value="False" />
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsEditable}" Value="False" />
                             </MultiDataTrigger.Conditions>
                             <MultiDataTrigger.EnterActions>
@@ -512,7 +560,7 @@
                                 <Condition Binding="{Binding Path=IsVisible, RelativeSource={RelativeSource Self}}" Value="True" />
                                 <Condition Binding="{Binding Path=(Controls:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}" Value="True" />
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsEditable}" Value="False" />
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=SelectedItem, Mode=OneWay, Converter={x:Static converters:IsNullConverter.Instance}}" Value="False" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=SelectedItem, Mode=OneWay, Converter={x:Static Converters:IsNullConverter.Instance}}" Value="False" />
                             </MultiDataTrigger.Conditions>
                             <MultiDataTrigger.EnterActions>
                                 <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -1,16 +1,13 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
-                    xmlns:System="clr-namespace:System;assembly=mscorlib"
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters"
                     xmlns:behaviours="clr-namespace:MahApps.Metro.Behaviours"
                     xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
     </ResourceDictionary.MergedDictionaries>
-
-
-    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
     <Style x:Key="MetroDatePicker" TargetType="{x:Type DatePicker}">
         <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
@@ -79,10 +76,21 @@
                                     <behaviours:DatePickerTextBoxBehavior />
                                 </i:Interaction.Behaviors>
                             </DatePickerTextBox>
+
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
+                                <ContentControl.Height>
+                                    <MultiBinding Converter="{Converters:MathMultiplyConverter}">
+                                        <Binding ElementName="PART_FloatingMessage"
+                                                 Mode="OneWay"
+                                                 Path="ActualHeight" />
+                                        <Binding ElementName="PART_FloatingMessageContainer"
+                                                 Mode="OneWay"
+                                                 Path="Opacity" />
+                                    </MultiBinding>
+                                </ContentControl.Height>
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -90,7 +98,22 @@
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                            TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}">
+                                    <TextBlock.RenderTransform>
+                                        <TranslateTransform x:Name="FloatingMessageTransform">
+                                            <TranslateTransform.Y>
+                                                <MultiBinding Converter="{Converters:MathSubtractConverter}">
+                                                    <Binding ElementName="PART_FloatingMessage"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                    <Binding ElementName="PART_FloatingMessageContainer"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                </MultiBinding>
+                                            </TranslateTransform.Y>
+                                        </TranslateTransform>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
                             </ContentControl>
 
                             <Popup x:Name="PART_Popup"
@@ -135,6 +158,7 @@
                         </Trigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsVisible, RelativeSource={RelativeSource Self}}" Value="True" />
                                 <Condition Binding="{Binding Path=(Controls:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}" Value="True" />
                                 <Condition Binding="{Binding Path=(Controls:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" Value="True" />
                             </MultiDataTrigger.Conditions>

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -10,6 +10,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
     <Converters:StringToVisibilityConverter x:Key="StringToVisibilityConverter" />
     <Converters:StringToVisibilityConverter x:Key="StringToOppositeVisibilityConverter" OppositeStringValue="True" />
 
@@ -191,6 +192,16 @@
                                             Grid.Row="0"
                                             Grid.Column="0"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
+                                <ContentControl.Height>
+                                    <MultiBinding Converter="{Converters:MathMultiplyConverter}">
+                                        <Binding ElementName="PART_FloatingMessage"
+                                                 Mode="OneWay"
+                                                 Path="ActualHeight" />
+                                        <Binding ElementName="PART_FloatingMessageContainer"
+                                                 Mode="OneWay"
+                                                 Path="Opacity" />
+                                    </MultiBinding>
+                                </ContentControl.Height>
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -198,7 +209,22 @@
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                            TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}">
+                                    <TextBlock.RenderTransform>
+                                        <TranslateTransform x:Name="FloatingMessageTransform">
+                                            <TranslateTransform.Y>
+                                                <MultiBinding Converter="{Converters:MathSubtractConverter}">
+                                                    <Binding ElementName="PART_FloatingMessage"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                    <Binding ElementName="PART_FloatingMessageContainer"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                </MultiBinding>
+                                            </TranslateTransform.Y>
+                                        </TranslateTransform>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
                             </ContentControl>
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"
@@ -412,6 +438,16 @@
                                             Grid.Row="0"
                                             Grid.Column="0"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
+                                <ContentControl.Height>
+                                    <MultiBinding Converter="{Converters:MathMultiplyConverter}">
+                                        <Binding ElementName="PART_FloatingMessage"
+                                                 Mode="OneWay"
+                                                 Path="ActualHeight" />
+                                        <Binding ElementName="PART_FloatingMessageContainer"
+                                                 Mode="OneWay"
+                                                 Path="Opacity" />
+                                    </MultiBinding>
+                                </ContentControl.Height>
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -419,7 +455,22 @@
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                            TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}">
+                                    <TextBlock.RenderTransform>
+                                        <TranslateTransform x:Name="FloatingMessageTransform">
+                                            <TranslateTransform.Y>
+                                                <MultiBinding Converter="{Converters:MathSubtractConverter}">
+                                                    <Binding ElementName="PART_FloatingMessage"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                    <Binding ElementName="PART_FloatingMessageContainer"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                </MultiBinding>
+                                            </TranslateTransform.Y>
+                                        </TranslateTransform>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
                             </ContentControl>
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"
@@ -644,6 +695,16 @@
                                             Grid.Row="0"
                                             Grid.Column="0"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
+                                <ContentControl.Height>
+                                    <MultiBinding Converter="{Converters:MathMultiplyConverter}">
+                                        <Binding ElementName="PART_FloatingMessage"
+                                                 Mode="OneWay"
+                                                 Path="ActualHeight" />
+                                        <Binding ElementName="PART_FloatingMessageContainer"
+                                                 Mode="OneWay"
+                                                 Path="Opacity" />
+                                    </MultiBinding>
+                                </ContentControl.Height>
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -651,7 +712,22 @@
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                            TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}">
+                                    <TextBlock.RenderTransform>
+                                        <TranslateTransform x:Name="FloatingMessageTransform">
+                                            <TranslateTransform.Y>
+                                                <MultiBinding Converter="{Converters:MathSubtractConverter}">
+                                                    <Binding ElementName="PART_FloatingMessage"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                    <Binding ElementName="PART_FloatingMessageContainer"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                </MultiBinding>
+                                            </TranslateTransform.Y>
+                                        </TranslateTransform>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
                             </ContentControl>
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBlock.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBlock.xaml
@@ -16,11 +16,6 @@
            TargetType="{x:Type TextBlock}">
         <Setter Property="FontSize" Value="{DynamicResource FloatingWatermarkFontSize}" />
         <Setter Property="Opacity" Value="0.6" />
-        <Setter Property="RenderTransform">
-            <Setter.Value>
-                <TranslateTransform />
-            </Setter.Value>
-        </Setter>
         <Style.Triggers>
             <Trigger Property="Text" Value="">
                 <Setter Property="Visibility" Value="Collapsed" />

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
@@ -109,6 +110,16 @@
                                             Grid.Row="0"
                                             Grid.Column="0"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
+                                <ContentControl.Height>
+                                    <MultiBinding Converter="{Converters:MathMultiplyConverter}">
+                                        <Binding ElementName="PART_FloatingMessage"
+                                                 Mode="OneWay"
+                                                 Path="ActualHeight" />
+                                        <Binding ElementName="PART_FloatingMessageContainer"
+                                                 Mode="OneWay"
+                                                 Path="Opacity" />
+                                    </MultiBinding>
+                                </ContentControl.Height>
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -116,7 +127,22 @@
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                            TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}">
+                                    <TextBlock.RenderTransform>
+                                        <TranslateTransform x:Name="FloatingMessageTransform">
+                                            <TranslateTransform.Y>
+                                                <MultiBinding Converter="{Converters:MathSubtractConverter}">
+                                                    <Binding ElementName="PART_FloatingMessage"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                    <Binding ElementName="PART_FloatingMessageContainer"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                </MultiBinding>
+                                            </TranslateTransform.Y>
+                                        </TranslateTransform>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
                             </ContentControl>
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"
@@ -329,6 +355,16 @@
                                             Grid.Row="0"
                                             Grid.Column="0"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
+                                <ContentControl.Height>
+                                    <MultiBinding Converter="{Converters:MathMultiplyConverter}">
+                                        <Binding ElementName="PART_FloatingMessage"
+                                                 Mode="OneWay"
+                                                 Path="ActualHeight" />
+                                        <Binding ElementName="PART_FloatingMessageContainer"
+                                                 Mode="OneWay"
+                                                 Path="Opacity" />
+                                    </MultiBinding>
+                                </ContentControl.Height>
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -336,7 +372,22 @@
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
                                            Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                            TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}">
+                                    <TextBlock.RenderTransform>
+                                        <TranslateTransform x:Name="FloatingMessageTransform">
+                                            <TranslateTransform.Y>
+                                                <MultiBinding Converter="{Converters:MathSubtractConverter}">
+                                                    <Binding ElementName="PART_FloatingMessage"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                    <Binding ElementName="PART_FloatingMessageContainer"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                </MultiBinding>
+                                            </TranslateTransform.Y>
+                                        </TranslateTransform>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
                             </ContentControl>
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
-                    xmlns:converters="clr-namespace:MahApps.Metro.Converters">
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Sizes.xaml" />
@@ -44,8 +44,7 @@
         <Setter Property="IsHitTestVisible" Value="False" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Margin" Value="5 0" />
-        <Setter Property="MaxHeight" Value="0" />
-        <Setter Property="Visibility" Value="Visible" />
+        <Setter Property="Visibility" Value="Collapsed" />
     </Style>
 
     <Style x:Key="PathIconContentControlStyle" TargetType="{x:Type ContentControl}">
@@ -59,7 +58,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ContentControl}">
                     <Viewbox Margin="{TemplateBinding Padding}" UseLayoutRounding="True">
-                        <Path Data="{Binding Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={converters:NullToUnsetValueConverter}}"
+                        <Path Data="{Binding Content, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={Converters:NullToUnsetValueConverter}}"
                               Fill="{TemplateBinding Foreground}"
                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                               Stretch="Uniform"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Shared.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Shared.xaml
@@ -2,9 +2,11 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
 
+    <!--  obsolete  -->
     <ExponentialEase x:Key="ExpoEaseIn"
                      EasingMode="EaseIn"
                      Exponent="2" />
+    <!--  obsolete  -->
     <ExponentialEase x:Key="ExpoEaseOut"
                      EasingMode="EaseOut"
                      Exponent="2" />
@@ -31,38 +33,27 @@
                          Duration="00:00:02" />
     </Storyboard>
 
-    <Storyboard x:Key="HideFloatingMessageStoryboard">
+    <Storyboard x:Key="HideFloatingMessageStoryboard" po:Freeze="True">
         <DoubleAnimation EasingFunction="{StaticResource ExpoEaseInOut}"
                          Storyboard.TargetName="PART_FloatingMessageContainer"
-                         Storyboard.TargetProperty="MaxHeight"
-                         From="15"
-                         To="0"
-                         Duration="0:0:.2" />
-        <DoubleAnimation Storyboard.TargetName="PART_FloatingMessageContainer"
                          Storyboard.TargetProperty="Opacity"
+                         From="1"
                          To="0"
                          Duration="0:0:.2" />
-        <DoubleAnimation EasingFunction="{StaticResource ExpoEaseIn}"
-                         Storyboard.TargetName="PART_FloatingMessage"
-                         Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
-                         To="20"
-                         Duration="0:0:.2" />
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_FloatingMessageContainer" Storyboard.TargetProperty="(UIElement.Visibility)">
+            <DiscreteObjectKeyFrame KeyTime="0:0:.2" Value="{x:Static Visibility.Collapsed}" />
+        </ObjectAnimationUsingKeyFrames>
     </Storyboard>
 
-    <Storyboard x:Key="ShowFloatingMessageStoryboard">
+    <Storyboard x:Key="ShowFloatingMessageStoryboard" po:Freeze="True">
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_FloatingMessageContainer" Storyboard.TargetProperty="(UIElement.Visibility)">
+            <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
+        </ObjectAnimationUsingKeyFrames>
         <DoubleAnimation EasingFunction="{StaticResource ExpoEaseInOut}"
                          Storyboard.TargetName="PART_FloatingMessageContainer"
-                         Storyboard.TargetProperty="MaxHeight"
-                         From="0"
-                         To="15"
-                         Duration="0:0:.2" />
-        <DoubleAnimation Storyboard.TargetName="PART_FloatingMessageContainer"
                          Storyboard.TargetProperty="Opacity"
-                         Duration="0:0:.2" />
-        <DoubleAnimation EasingFunction="{StaticResource ExpoEaseOut}"
-                         Storyboard.TargetName="PART_FloatingMessage"
-                         Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
-                         To="0"
+                         From="0"
+                         To="1"
                          Duration="0:0:.2" />
     </Storyboard>
 

--- a/src/MahApps.Metro/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -1,8 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:behaviours="clr-namespace:MahApps.Metro.Behaviours"
-                    xmlns:controls="clr-namespace:MahApps.Metro.Controls"
-                    xmlns:converters="clr-namespace:MahApps.Metro.Converters"
+                    xmlns:Behaviours="clr-namespace:MahApps.Metro.Behaviours"
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:Converters="clr-namespace:MahApps.Metro.Converters"
                     xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
 
@@ -10,9 +10,9 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <converters:ClockDegreeConverter x:Key="ClockDegreeConverter" TotalParts="60" />
-    <converters:ClockDegreeConverter x:Key="HourDegreeConverter" TotalParts="12" />
-    <converters:TimeSpanToStringConverter x:Key="TimeSpanToStringConverter" />
+    <Converters:ClockDegreeConverter x:Key="ClockDegreeConverter" TotalParts="60" />
+    <Converters:ClockDegreeConverter x:Key="HourDegreeConverter" TotalParts="12" />
+    <Converters:TimeSpanToStringConverter x:Key="TimeSpanToStringConverter" />
 
     <DataTemplate x:Key="FiveMinuteIndicator">
         <StackPanel Height="57"
@@ -108,10 +108,14 @@
         <system:Int32>59</system:Int32>
     </x:Array>
 
-    <Style x:Key="TimePartPickerBase" TargetType="{x:Type controls:TimePickerBase}">
+    <Style x:Key="TimePartPickerBase" TargetType="{x:Type Controls:TimePickerBase}">
         <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource TextBoxFocusBorderBrush}" />
+        <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource TextBoxMouseOverBorderBrush}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
+        <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FontFamily" Value="{DynamicResource ContentFontFamily}" />
         <Setter Property="FontSize" Value="{DynamicResource ContentFontSize}" />
         <Setter Property="Foreground" Value="{DynamicResource TextBrush}" />
@@ -122,7 +126,7 @@
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="{x:Type controls:TimePickerBase}">
+                <ControlTemplate TargetType="{x:Type Controls:TimePickerBase}">
                     <Grid>
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
@@ -143,9 +147,9 @@
                                                Grid.Column="0"
                                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                               controls:TextBoxHelper.Watermark="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:TextBoxHelper.Watermark), Mode=OneWay}"
-                                               controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding controls:TextBoxHelper.WatermarkAlignment}"
-                                               controls:TextBoxHelper.WatermarkTrimming="{TemplateBinding controls:TextBoxHelper.WatermarkTrimming}"
+                                               Controls:TextBoxHelper.Watermark="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.Watermark), Mode=OneWay}"
+                                               Controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                               Controls:TextBoxHelper.WatermarkTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                                CaretBrush="{DynamicResource BlackBrush}"
                                                Focusable="{TemplateBinding Focusable}"
                                                FontFamily="{TemplateBinding FontFamily}"
@@ -154,21 +158,46 @@
                                                IsReadOnly="{Binding Path=IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}"
                                                SelectionBrush="{DynamicResource HighlightBrush}">
                                 <i:Interaction.Behaviors>
-                                    <behaviours:DatePickerTextBoxBehavior />
+                                    <Behaviours:DatePickerTextBoxBehavior />
                                 </i:Interaction.Behaviors>
                             </DatePickerTextBox>
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
                                             Style="{DynamicResource FloatingMessageContainerStyle}">
+                                <ContentControl.Height>
+                                    <MultiBinding Converter="{Converters:MathMultiplyConverter}">
+                                        <Binding ElementName="PART_FloatingMessage"
+                                                 Mode="OneWay"
+                                                 Path="ActualHeight" />
+                                        <Binding ElementName="PART_FloatingMessageContainer"
+                                                 Mode="OneWay"
+                                                 Path="Opacity" />
+                                    </MultiBinding>
+                                </ContentControl.Height>
                                 <TextBlock x:Name="PART_FloatingMessage"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Foreground="{TemplateBinding Foreground}"
                                            Style="{DynamicResource MetroAutoCollapsingTextBlock}"
-                                           Text="{TemplateBinding controls:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding controls:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding controls:TextBoxHelper.WatermarkTrimming}" />
+                                           Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
+                                           TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
+                                           TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}">
+                                    <TextBlock.RenderTransform>
+                                        <TranslateTransform x:Name="FloatingMessageTransform">
+                                            <TranslateTransform.Y>
+                                                <MultiBinding Converter="{Converters:MathSubtractConverter}">
+                                                    <Binding ElementName="PART_FloatingMessage"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                    <Binding ElementName="PART_FloatingMessageContainer"
+                                                             Mode="OneWay"
+                                                             Path="ActualHeight" />
+                                                </MultiBinding>
+                                            </TranslateTransform.Y>
+                                        </TranslateTransform>
+                                    </TextBlock.RenderTransform>
+                                </TextBlock>
                             </ContentControl>
                             <Button x:Name="PART_Button"
                                     Grid.Row="0"
@@ -178,8 +207,8 @@
                                     Style="{DynamicResource ChromelessButtonStyle}">
                                 <!--  PackIconModern - Calendar14  -->
                                 <ContentControl x:Name="PART_ButtonIcon"
-                                                Width="{TemplateBinding controls:TextBoxHelper.ButtonWidth}"
-                                                Height="{TemplateBinding controls:TextBoxHelper.ButtonWidth}"
+                                                Width="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
+                                                Height="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
                                                 Padding="2"
                                                 Content="M34,52H31V38.5C29.66,39.9 28.16,40.78 26.34,41.45V37.76C27.3,37.45 28.34,36.86 29.46,36C30.59,35.15 31.36,34.15 31.78,33H34V52M45,52V48H37V45L45,33H48V45H50V48H48V52H45M45,45V38.26L40.26,45H45M18,57V23H23V20A2,2 0 0,1 25,18H29C30.11,18 31,18.9 31,20V23H45V20A2,2 0 0,1 47,18H51C52.11,18 53,18.9 53,20V23H58V57H18M21,54H55V31H21V54M48.5,20A1.5,1.5 0 0,0 47,21.5V24.5A1.5,1.5 0 0,0 48.5,26H49.5C50.34,26 51,25.33 51,24.5V21.5A1.5,1.5 0 0,0 49.5,20H48.5M26.5,20A1.5,1.5 0 0,0 25,21.5V24.5A1.5,1.5 0 0,0 26.5,26H27.5A1.5,1.5 0 0,0 29,24.5V21.5A1.5,1.5 0 0,0 27.5,20H26.5Z"
                                                 Style="{DynamicResource PathIconContentControlStyle}" />
@@ -338,15 +367,15 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:ControlsHelper.MouseOverBorderBrush)}" />
+                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.MouseOverBorderBrush)}" />
                         </Trigger>
                         <Trigger SourceName="PART_TextBox" Property="IsFocused" Value="True">
-                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:ControlsHelper.FocusBorderBrush)}" />
+                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderBrush)}" />
                             <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
                             <Setter TargetName="PART_FloatingMessage" Property="Opacity" Value="1" />
                         </Trigger>
                         <Trigger Property="IsKeyboardFocusWithin" Value="True">
-                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(controls:ControlsHelper.FocusBorderBrush)}" />
+                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderBrush)}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
@@ -378,8 +407,8 @@
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding Path=IsVisible, RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(controls:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(controls:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" Value="True" />
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}" Value="True" />
+                                <Condition Binding="{Binding Path=(Controls:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" Value="True" />
                             </MultiDataTrigger.Conditions>
                             <MultiDataTrigger.EnterActions>
                                 <BeginStoryboard Storyboard="{StaticResource ShowFloatingMessageStoryboard}" />
@@ -394,18 +423,14 @@
             </Setter.Value>
         </Setter>
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
-        <Setter Property="controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource TextBoxFocusBorderBrush}" />
-        <Setter Property="controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource TextBoxMouseOverBorderBrush}" />
-        <Setter Property="controls:TextBoxHelper.ButtonWidth" Value="22" />
-        <Setter Property="controls:TextBoxHelper.IsMonitoring" Value="True" />
     </Style>
 
-    <Style BasedOn="{StaticResource TimePartPickerBase}" TargetType="{x:Type controls:DateTimePicker}">
+    <Style BasedOn="{StaticResource TimePartPickerBase}" TargetType="{x:Type Controls:DateTimePicker}">
+        <Setter Property="Controls:TextBoxHelper.Watermark" Value="Select a date" />
         <Setter Property="IsTodayHighlighted" Value="True" />
-        <Setter Property="controls:TextBoxHelper.Watermark" Value="Select a date" />
     </Style>
 
-    <Style BasedOn="{StaticResource TimePartPickerBase}" TargetType="{x:Type controls:TimePicker}">
-        <Setter Property="controls:TextBoxHelper.Watermark" Value="Select a time" />
+    <Style BasedOn="{StaticResource TimePartPickerBase}" TargetType="{x:Type Controls:TimePicker}">
+        <Setter Property="Controls:TextBoxHelper.Watermark" Value="Select a time" />
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
The height of the floating watermark container adapts now according to the font size of the floating watermark.

Before

![2017-10-11_14h10_27](https://user-images.githubusercontent.com/658431/31439849-044b5b2a-ae8e-11e7-9505-763a318537bc.png)

After

![2017-10-11_14h07_05](https://user-images.githubusercontent.com/658431/31439761-9cf16078-ae8d-11e7-8347-fbbf3e9f4ef5.png)

Closes #3009 