### PR TITLE
Fix wrong caret index for revealed PasswordBox

### DIFF
--- a/docs/release-notes/1.6.0.md
+++ b/docs/release-notes/1.6.0.md
@@ -128,3 +128,4 @@ More informations about the reason of this decision can be found here:
 - [#3009](https://github.com/MahApps/MahApps.Metro/issues/3009) Floating Watermak field doesn't fit according FontSize
 - [#1825](https://github.com/MahApps/MahApps.Metro/pull/1825) [WIP] Header, headers, headers
 - [#3078](https://github.com/MahApps/MahApps.Metro/issues/3078) Not All "Grey" Values Are Set in BaseLight/BaseDark
+- [#2966](https://github.com/MahApps/MahApps.Metro/issues/2966) [Only visual] PasswordBox bug

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/PasswordBoxBindingBehavior.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/PasswordBoxBindingBehavior.cs
@@ -103,15 +103,12 @@ namespace MahApps.Metro.Behaviours
             {
                 selection.Changed += this.PasswordBoxSelectionChanged;
             }
-            this.Dispatcher.BeginInvoke(DispatcherPriority.Loaded,
-                                        new Action(() =>
-                                            {
-                                                SetPassword(this.AssociatedObject, this.AssociatedObject.Password);
-                                            }));
         }
 
         private void PasswordBoxLoaded(object sender, RoutedEventArgs e)
         {
+            SetPassword(this.AssociatedObject, this.AssociatedObject.Password);
+
             var textBox = this.AssociatedObject.FindChild<TextBox>("RevealedPassword");
             if (textBox != null)
             {

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/LoginDialog.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/LoginDialog.cs
@@ -229,6 +229,8 @@ namespace MahApps.Metro.Controls.Dialogs
                 if (win8MetroPasswordStyle != null)
                 {
                     this.PART_TextBox2.Style = win8MetroPasswordStyle;
+                    // apply template again to fire the loaded event which is necessary for revealed password
+                    this.PART_TextBox2.ApplyTemplate();
                 }
             }
 

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -598,6 +598,22 @@
         </Setter>
     </Style>
 
+    <Style x:Key="RevealedTextBoxStyle" TargetType="{x:Type TextBox}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type TextBox}">
+                    <Grid Background="{TemplateBinding Background}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <ScrollViewer x:Name="PART_ContentHost"
+                                      Margin="{TemplateBinding Padding}"
+                                      Background="{x:Null}"
+                                      BorderThickness="0"
+                                      IsTabStop="False" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!--  Button Revealed PasswordBox Style  -->
     <Style x:Key="MetroButtonRevealedPasswordBox"
            BasedOn="{StaticResource MetroPasswordBox}"
@@ -666,18 +682,25 @@
                                           Background="{x:Null}"
                                           BorderThickness="0"
                                           IsTabStop="False" />
-                            <TextBlock x:Name="RevealedPassword"
-                                       Grid.Row="1"
-                                       Grid.Column="0"
-                                       Margin="4 2 4 2"
-                                       Padding="{TemplateBinding Padding}"
-                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                       FontSize="{TemplateBinding FontSize}"
-                                       Foreground="{TemplateBinding Foreground}"
-                                       IsHitTestVisible="False"
-                                       Text="{TemplateBinding Behaviors:PasswordBoxBindingBehavior.Password}"
-                                       Visibility="Collapsed" />
+                            <TextBox x:Name="RevealedPassword"
+                                     Grid.Row="1"
+                                     Grid.Column="0"
+                                     Margin="2"
+                                     Padding="{TemplateBinding Padding}"
+                                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                     Background="{TemplateBinding Background}"
+                                     BorderThickness="0"
+                                     CaretBrush="{TemplateBinding CaretBrush}"
+                                     FocusManager.FocusedElement="{Binding RelativeSource={RelativeSource Self}}"
+                                     FontFamily="{TemplateBinding FontFamily}"
+                                     FontSize="{TemplateBinding FontSize}"
+                                     Foreground="{TemplateBinding Foreground}"
+                                     SelectionBrush="{TemplateBinding SelectionBrush}"
+                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                     Style="{DynamicResource RevealedTextBoxStyle}"
+                                     Text="{TemplateBinding Behaviors:PasswordBoxBindingBehavior.Password}"
+                                     Visibility="Hidden" />
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
                                        Grid.Column="0"
@@ -826,6 +849,7 @@
                         <Trigger SourceName="PART_RevealButton" Property="IsPressed" Value="True">
                             <Setter Property="PasswordChar" Value=" " />
                             <Setter TargetName="PART_ContentHost" Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
+                            <Setter TargetName="PART_ContentHost" Property="Visibility" Value="Hidden" />
                             <Setter TargetName="PART_RevealButton" Property="Background" Value="{DynamicResource BlackBrush}" />
                             <Setter TargetName="PART_RevealButton" Property="Foreground" Value="{DynamicResource WhiteBrush}" />
                             <Setter TargetName="RevealedPassword" Property="Visibility" Value="Visible" />


### PR DESCRIPTION
- Get the caret index from PasswordBox with reflection and set it to the hidden TextBox which shows the Password.

![mahapps_revealed_pw](https://user-images.githubusercontent.com/658431/31584319-84145912-b1ac-11e7-8a73-db4f17933e3a.gif)

Closes #2966 