### PR TITLE
New ScrollViewerHelper class with IsHorizontalScrollWheelEnabled

### DIFF
--- a/docs/release-notes/1.6.0.md
+++ b/docs/release-notes/1.6.0.md
@@ -67,7 +67,7 @@
 	```
 - New `ScrollViewerHelper` class
 	+ New attached property `IsHorizontalScrollWheelEnabled`. If it's set to true and a horizontal ScrollBar is visible then the mouse wheel scrolls to left and right.
-	+ `VerticalScrollBarOnLeftSide` attached property moved from ScrollBarHelper to ScrollViewerHelper. ScrollBarHelper is now marked as obsolete.
+	+ Moved `VerticalScrollBarOnLeftSide` attached property from ScrollBarHelper to ScrollViewerHelper. ScrollBarHelper is now marked as obsolete.
 
 ## Breaking Change
 

--- a/docs/release-notes/1.6.0.md
+++ b/docs/release-notes/1.6.0.md
@@ -65,6 +65,9 @@
 	    <TextBox Text="Enabled" />
 	</Controls:MetroHeader>
 	```
+- New `ScrollViewerHelper` class
+	+ New attached property `IsHorizontalScrollWheelEnabled`. If it's set to true and a horizontal ScrollBar is visible then the mouse wheel scrolls to left and right.
+	+ `VerticalScrollBarOnLeftSide` attached property moved from ScrollBarHelper to ScrollViewerHelper. ScrollBarHelper is now marked as obsolete.
 
 ## Breaking Change
 

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/ScrollBarHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/ScrollBarHelper.cs
@@ -1,19 +1,33 @@
-﻿using System.Windows;
+﻿using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
 
 namespace MahApps.Metro.Controls
 {
-    using System.ComponentModel;
-    using System.Windows.Controls;
-
+    [Obsolete("This helper class will be deleted in the next release. Instead use the ScrollViewerHelper.")]
     public static class ScrollBarHelper
     {
         /// <summary>
         /// This property can be used to set vertical scrollbar left side from the tabpanel (look at MetroAnimatedSingleRowTabControl)
         /// </summary>
+        [Obsolete("This attached property will be deleted in the next release. Instead use ScrollViewerHelper.VerticalScrollBarOnLeftSide attached property.")]
         public static readonly DependencyProperty VerticalScrollBarOnLeftSideProperty =
-            DependencyProperty.RegisterAttached("VerticalScrollBarOnLeftSide", typeof(bool), typeof(ScrollBarHelper),
-                                                new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits));
+            DependencyProperty.RegisterAttached("VerticalScrollBarOnLeftSide",
+                                                typeof(bool),
+                                                typeof(ScrollBarHelper),
+                                                new FrameworkPropertyMetadata(false,
+                                                                              FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits,
+                                                                              (o, e) =>
+                                                                                  {
+                                                                                      var element = o as ScrollViewer;
+                                                                                      if (element != null && e.OldValue != e.NewValue && e.NewValue is bool)
+                                                                                      {
+                                                                                          ScrollViewerHelper.SetVerticalScrollBarOnLeftSide(element, (bool)e.NewValue);
+                                                                                      }
+                                                                                  }));
 
+        [Obsolete("This attached property will be deleted in the next release. Instead use ScrollViewerHelper.VerticalScrollBarOnLeftSide attached property.")]
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(ScrollViewer))]
         public static bool GetVerticalScrollBarOnLeftSide(ScrollViewer obj)
@@ -21,6 +35,7 @@ namespace MahApps.Metro.Controls
             return (bool)obj.GetValue(VerticalScrollBarOnLeftSideProperty);
         }
 
+        [Obsolete("This attached property will be deleted in the next release. Instead use ScrollViewerHelper.VerticalScrollBarOnLeftSide attached property.")]
         public static void SetVerticalScrollBarOnLeftSide(ScrollViewer obj, bool value)
         {
             obj.SetValue(VerticalScrollBarOnLeftSideProperty, value);

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/ScrollViewerHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/ScrollViewerHelper.cs
@@ -1,0 +1,98 @@
+﻿using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace MahApps.Metro.Controls
+{
+    public static class ScrollViewerHelper
+    {
+        /// <summary>
+        /// Identifies the VerticalScrollBarOnLeftSide attached property.
+        /// This property can be used to set vertical scrollbar left side from the tabpanel (look at MetroAnimatedSingleRowTabControl)
+        /// </summary>
+        public static readonly DependencyProperty VerticalScrollBarOnLeftSideProperty =
+            DependencyProperty.RegisterAttached("VerticalScrollBarOnLeftSide",
+                                                typeof(bool),
+                                                typeof(ScrollViewerHelper),
+                                                new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits));
+
+        /// <summary>
+        /// Gets whether the vertical ScrollBar is on the left side or not.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(ScrollViewer))]
+        public static bool GetVerticalScrollBarOnLeftSide(UIElement element)
+        {
+            return (bool)element.GetValue(VerticalScrollBarOnLeftSideProperty);
+        }
+
+        /// <summary>
+        /// Sets whether the vertical ScrollBar should be on the left side or not.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(ScrollViewer))]
+        public static void SetVerticalScrollBarOnLeftSide(UIElement element, bool value)
+        {
+            element.SetValue(VerticalScrollBarOnLeftSideProperty, value);
+        }
+
+        /// <summary>
+        /// Identifies the IsHorizontalScrollWheelEnabled attached property.
+        /// </summary>
+        public static readonly DependencyProperty IsHorizontalScrollWheelEnabledProperty =
+            DependencyProperty.RegisterAttached("IsHorizontalScrollWheelEnabled",
+                                                typeof(bool),
+                                                typeof(ScrollViewerHelper),
+                                                new PropertyMetadata(false, OnIsHorizontalScrollWheelEnabledPropertyChangedCallback));
+
+        private static void OnIsHorizontalScrollWheelEnabledPropertyChangedCallback(DependencyObject o, DependencyPropertyChangedEventArgs e)
+        {
+            var scrollViewer = o as ScrollViewer;
+            if (scrollViewer != null && e.NewValue != e.OldValue && e.NewValue is bool)
+            {
+                scrollViewer.PreviewMouseWheel -= ScrollViewerOnPreviewMouseWheel;
+                if ((bool)e.NewValue)
+                {
+                    scrollViewer.PreviewMouseWheel += ScrollViewerOnPreviewMouseWheel;
+                }
+            }
+        }
+
+        private static void ScrollViewerOnPreviewMouseWheel(object sender, System.Windows.Input.MouseWheelEventArgs e)
+        {
+            var scrollViewer = sender as ScrollViewer;
+            if (scrollViewer != null && scrollViewer.HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled)
+            {
+                if (e.Delta > 0)
+                {
+                    scrollViewer.LineLeft();
+                }
+                else
+                {
+                    scrollViewer.LineRight();
+                }
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets whether the ScrollViewer is scrolling horizontal by using the mouse wheel.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static bool GetIsHorizontalScrollWheelEnabled(UIElement element)
+        {
+            return (bool)element.GetValue(IsHorizontalScrollWheelEnabledProperty);
+        }
+
+        /// <summary>
+        /// Sets whether the ScrollViewer should be scroll horizontal by using the mouse wheel.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetIsHorizontalScrollWheelEnabled(UIElement element, bool value)
+        {
+            element.SetValue(IsHorizontalScrollWheelEnabledProperty, value);
+        }
+    }
+}

--- a/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
@@ -78,6 +78,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Helper\MouseWheelState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Helper\PasswordBoxHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Helper\ScrollBarHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\Helper\ScrollViewerHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Helper\SliderHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Helper\TabControlHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Helper\TextBoxHelper.cs" />

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.AnimatedSingleRowTabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.AnimatedSingleRowTabControl.xaml
@@ -196,6 +196,7 @@
             <ScrollViewer x:Name="HeaderPanelScroll"
                           Grid.Row="0"
                           Panel.ZIndex="1"
+                          Controls:ScrollViewerHelper.IsHorizontalScrollWheelEnabled="{TemplateBinding Controls:ScrollViewerHelper.IsHorizontalScrollWheelEnabled}"
                           HorizontalScrollBarVisibility="Auto"
                           Template="{StaticResource ScrollViewerTemplate}"
                           VerticalScrollBarVisibility="Disabled">
@@ -311,6 +312,7 @@
 
     <Style BasedOn="{StaticResource MetroTabControl}" TargetType="{x:Type TabControl}">
         <Setter Property="Controls:TabControlHelper.Transition" Value="Left" />
+        <Setter Property="Controls:ScrollViewerHelper.IsHorizontalScrollWheelEnabled" Value="True" />
         <Setter Property="Template" Value="{StaticResource HorizontalAnimatedSingleRowTabControl}" />
         <Style.Triggers>
             <Trigger Property="TabStripPlacement" Value="Top">

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.Scrollbars.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.Scrollbars.xaml
@@ -230,7 +230,7 @@
     </Style>
 
     <Style x:Key="MetroScrollViewer" TargetType="{x:Type ScrollViewer}">
-        <Setter Property="Controls:ScrollBarHelper.VerticalScrollBarOnLeftSide" Value="False" />
+        <Setter Property="Controls:ScrollViewerHelper.VerticalScrollBarOnLeftSide" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ScrollViewer}">
@@ -275,7 +275,7 @@
                                    Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="Controls:ScrollBarHelper.VerticalScrollBarOnLeftSide" Value="True">
+                        <Trigger Property="Controls:ScrollViewerHelper.VerticalScrollBarOnLeftSide" Value="True">
                             <Setter TargetName="PART_HorizontalScrollBar" Property="Grid.Column" Value="1" />
                             <Setter TargetName="PART_ScrollContentPresenter" Property="Grid.Column" Value="1" />
                             <Setter TargetName="PART_VerticalScrollBar" Property="Grid.Column" Value="0" />

--- a/src/MahApps.Metro/MahApps.Metro/Themes/HamburgerMenu.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/HamburgerMenu.xaml
@@ -149,7 +149,7 @@
                                    Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="controls:ScrollBarHelper.VerticalScrollBarOnLeftSide" Value="True">
+                        <Trigger Property="controls:ScrollViewerHelper.VerticalScrollBarOnLeftSide" Value="True">
                             <Setter TargetName="PART_HorizontalScrollBar" Property="Grid.Column" Value="1" />
                             <Setter TargetName="PART_ScrollContentPresenter" Property="Grid.Column" Value="1" />
                             <Setter TargetName="PART_VerticalScrollBar" Property="HorizontalAlignment" Value="Left" />
@@ -254,7 +254,7 @@
                                                   Grid.Row="1"
                                                   HorizontalAlignment="Stretch"
                                                   VerticalAlignment="Stretch"
-                                                  controls:ScrollBarHelper.VerticalScrollBarOnLeftSide="{TemplateBinding VerticalScrollBarOnLeftSide}"
+                                                  controls:ScrollViewerHelper.VerticalScrollBarOnLeftSide="{TemplateBinding VerticalScrollBarOnLeftSide}"
                                                   HorizontalScrollBarVisibility="Disabled"
                                                   Style="{StaticResource HamburgerScrollViewerStyle}"
                                                   VerticalScrollBarVisibility="Auto">

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroAnimatedSingleRowTabControl.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroAnimatedSingleRowTabControl.xaml
@@ -17,6 +17,7 @@
             </Grid.RowDefinitions>
             <ScrollViewer x:Name="HeaderPanelScroll"
                           Grid.Row="0"
+                          Controls:ScrollViewerHelper.IsHorizontalScrollWheelEnabled="{TemplateBinding Controls:ScrollViewerHelper.IsHorizontalScrollWheelEnabled}"
                           Margin="{TemplateBinding TabStripMargin}"
                           Panel.ZIndex="1"
                           HorizontalScrollBarVisibility="Auto"
@@ -131,6 +132,7 @@
 
     <Style BasedOn="{StaticResource MetroTabControl}" TargetType="{x:Type Controls:MetroAnimatedSingleRowTabControl}">
         <Setter Property="Controls:TabControlHelper.Transition" Value="Left" />
+        <Setter Property="Controls:ScrollViewerHelper.IsHorizontalScrollWheelEnabled" Value="True" />
         <Setter Property="Template" Value="{StaticResource HorizontalMetroAnimatedSingleRowTabControl}" />
         <Style.Triggers>
             <Trigger Property="TabStripPlacement" Value="Top">


### PR DESCRIPTION
## What changed?

- new attached property IsHorizontalScrollWheelEnabled. If it's set to true and a horizontal ScrollBar is visible then the mouse wheel scrolls to left and right.
- move VerticalScrollBarOnLeftSide attached property to ScrollViewerHelper

![mahapps_horizontal_scroll](https://user-images.githubusercontent.com/658431/31721980-1dff4ca6-b41b-11e7-8cba-ab8d5c0569d1.gif)

Closes #3084 
