### PR TITLE
(#3109) Fix NullReferenceException when using Flyout with theme

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Flyout.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Flyout.cs
@@ -387,7 +387,15 @@ namespace MahApps.Metro.Controls
                 resources["TextBrush"] = newBrush;
                 resources["LabelTextBrush"] = newBrush;
 
-                fromColor = (Color)resources["AccentBaseColor"];
+                if (resources.Contains("AccentBaseColor"))
+                {
+                    fromColor = (Color)resources["AccentBaseColor"];
+                }
+                else
+                {
+                    var accentColor = (Color)resources["AccentColor"];
+                    fromColor = Color.FromArgb(255, accentColor.R, accentColor.G, accentColor.B);
+                }
                 newBrush = new SolidColorBrush(fromColor);
                 newBrush.Freeze();
                 resources["HighlightColor"] = fromColor;


### PR DESCRIPTION
The `AccentBaseColor` color could not be found which was introduced with 1.3.0 (which was a breaking change, if users has their own accents).

Closes #3109 
Relates to #3109 