### PR TITLE
(#3101) Fix disabled Foreground for MahApps.Metro.Styles.MetroCircleButtonStyle

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/ButtonsExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/ButtonsExample.xaml
@@ -141,10 +141,25 @@
             <StackPanel Margin="{StaticResource ControlMargin}"
                         HorizontalAlignment="Center"
                         Orientation="Horizontal">
+                <StackPanel.Resources>
+                    <Style x:Key="AccentCircleButtonStyle"
+                           BasedOn="{StaticResource MahApps.Metro.Styles.MetroCircleButtonStyle}"
+                           TargetType="{x:Type ButtonBase}">
+                        <Setter Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="BorderBrush" Value="{DynamicResource AccentColorBrush}" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter Property="Foreground" Value="{DynamicResource GrayBrush7}" />
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </StackPanel.Resources>
                 <Button Width="48"
                         Height="48"
                         Margin="4"
-                        Style="{DynamicResource MahApps.Metro.Styles.MetroCircleButtonStyle}">
+                        Style="{StaticResource AccentCircleButtonStyle}">
                     <iconPacks:PackIconModern Width="20"
                                               Height="20"
                                               Kind="City" />
@@ -153,10 +168,24 @@
                         Height="48"
                         Margin="4"
                         IsEnabled="False"
-                        Style="{DynamicResource MahApps.Metro.Styles.MetroCircleButtonStyle}">
+                        Style="{StaticResource AccentCircleButtonStyle}">
                     <iconPacks:PackIconModern Width="20"
                                               Height="20"
-                                              Kind="City" />
+                                              Kind="CitySeattle" />
+                </Button>
+                <Button Width="48"
+                        Height="48"
+                        Margin="4"
+                        Foreground="{DynamicResource AccentColorBrush}"
+                        IsEnabled="False"
+                        Style="{StaticResource MahApps.Metro.Styles.MetroCircleButtonStyle}">
+                    <Button.ContentTemplate>
+                        <DataTemplate>
+                            <iconPacks:PackIconModern Width="20"
+                                                      Height="20"
+                                                      Kind="CitySeattle" />
+                        </DataTemplate>
+                    </Button.ContentTemplate>
                 </Button>
             </StackPanel>
         </StackPanel>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/ButtonsExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/ButtonsExample.xaml
@@ -28,7 +28,7 @@
             <RowDefinition />
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Column="0" UseLayoutRounding="True">
+        <StackPanel Grid.Column="0">
             <Label Content="Default button" Style="{DynamicResource DescriptionHeaderStyle}" />
             <Controls:Badged Width="100"
                              Margin="{StaticResource ControlMargin}"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -773,7 +773,7 @@
                             <Setter TargetName="ellipse" Property="Opacity" Value="0.7" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Foreground" Value="{DynamicResource GrayBrush7}" />
+                            <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource GrayBrush7}" />
                             <Setter TargetName="ellipse" Property="Opacity" Value="0.3" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -845,7 +845,7 @@
                             <Setter TargetName="ellipse" Property="Opacity" Value="0.7" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Foreground" Value="{DynamicResource GrayBrush7}" />
+                            <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource GrayBrush7}" />
                             <Setter TargetName="ellipse" Property="Opacity" Value="0.3" />
                         </Trigger>
                     </ControlTemplate.Triggers>

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -144,7 +144,7 @@
         </Style.Triggers>
     </Style>
 
-    <Style x:Key="MahApps.Metro.Styles.MetroCircleFocusVisual">
+    <Style x:Key="MahApps.Metro.Styles.CircleButtonFocusVisualStyle">
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Control}">
@@ -152,11 +152,15 @@
                              SnapsToDevicePixels="True"
                              Stroke="{DynamicResource BlackBrush}"
                              StrokeDashArray="2 2"
-                             StrokeThickness="1" />
+                             StrokeThickness="1"
+                             UseLayoutRounding="True" />
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!--  obsolete  -->
+    <Style x:Key="MahApps.Metro.Styles.MetroCircleFocusVisual" BasedOn="{StaticResource MahApps.Metro.Styles.CircleButtonFocusVisualStyle}" />
 
     <!--  obsolete  -->
     <Style x:Key="MetroCircleButtonFocusVisual">
@@ -178,7 +182,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="{DynamicResource GrayBrush3}" />
         <Setter Property="BorderThickness" Value="2" />
-        <Setter Property="FocusVisualStyle" Value="{StaticResource MahApps.Metro.Styles.MetroCircleFocusVisual}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource MahApps.Metro.Styles.CircleButtonFocusVisualStyle}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="Padding" Value="1" />
         <Setter Property="Template">
@@ -232,7 +236,7 @@
                             <Setter TargetName="ellipse" Property="Opacity" Value="0.7" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Foreground" Value="{DynamicResource GrayBrush7}" />
+                            <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource GrayBrush7}" />
                             <Setter TargetName="ellipse" Property="Opacity" Value="0.3" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -302,7 +306,7 @@
                             <Setter TargetName="ellipse" Property="Opacity" Value="0.7" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Foreground" Value="{DynamicResource GrayBrush7}" />
+                            <Setter TargetName="PART_ContentPresenter" Property="TextElement.Foreground" Value="{DynamicResource GrayBrush7}" />
                             <Setter TargetName="ellipse" Property="Opacity" Value="0.3" />
                         </Trigger>
                     </ControlTemplate.Triggers>
@@ -712,7 +716,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="{DynamicResource GrayBrush3}" />
         <Setter Property="BorderThickness" Value="2" />
-        <Setter Property="FocusVisualStyle" Value="{StaticResource MahApps.Metro.Styles.MetroCircleFocusVisual}" />
+        <Setter Property="FocusVisualStyle" Value="{StaticResource MahApps.Metro.Styles.CircleButtonFocusVisualStyle}" />
         <Setter Property="Foreground" Value="{DynamicResource BlackBrush}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="Padding" Value="1" />


### PR DESCRIPTION
Fix disabled foreground for MahApps.Metro.Styles.MetroCircleButtonStyle / obsolete MetroCircleButtonStyle and MetroCircleToggleButtonStyle .

Closes #3101 
Relates to #3101 
Relates to #3098 
