### PR TITLE
(#3105) Allow to change the RevealButton Icon in the PasswordBox

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/PasswordBoxHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/PasswordBoxHelper.cs
@@ -12,11 +12,6 @@ namespace MahApps.Metro.Controls
                                                   typeof(object),
                                                   typeof(PasswordBoxHelper),
                                                   new PropertyMetadata("!", ShowCapslockWarningChanged));
-        public static readonly DependencyProperty CapsLockWarningToolTipProperty
-            = DependencyProperty.RegisterAttached("CapsLockWarningToolTip",
-                                                  typeof(object),
-                                                  typeof(PasswordBoxHelper),
-                                                  new PropertyMetadata("Caps lock is on"));
 
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
@@ -25,21 +20,11 @@ namespace MahApps.Metro.Controls
             return element.GetValue(CapsLockIconProperty);
         }
 
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
         public static void SetCapsLockIcon(PasswordBox element, object value)
         {
             element.SetValue(CapsLockIconProperty, value);
-        }
-
-        [Category(AppName.MahApps)]
-        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
-        public static object GetCapsLockWarningToolTip(PasswordBox element)
-        {
-            return element.GetValue(CapsLockWarningToolTipProperty);
-        }
-
-        public static void SetCapsLockWarningToolTip(PasswordBox element, object value)
-        {
-            element.SetValue(CapsLockWarningToolTipProperty, value);
         }
 
         private static void ShowCapslockWarningChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -84,6 +69,78 @@ namespace MahApps.Metro.Controls
         private static FrameworkElement FindCapsLockIndicator(Control pb)
         {
             return pb?.Template?.FindName("PART_CapsLockIndicator", pb) as FrameworkElement;
+        }
+
+        public static readonly DependencyProperty CapsLockWarningToolTipProperty
+            = DependencyProperty.RegisterAttached("CapsLockWarningToolTip",
+                                                  typeof(object),
+                                                  typeof(PasswordBoxHelper),
+                                                  new PropertyMetadata("Caps lock is on"));
+
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
+        public static object GetCapsLockWarningToolTip(PasswordBox element)
+        {
+            return element.GetValue(CapsLockWarningToolTipProperty);
+        }
+
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
+        public static void SetCapsLockWarningToolTip(PasswordBox element, object value)
+        {
+            element.SetValue(CapsLockWarningToolTipProperty, value);
+        }
+
+        public static readonly DependencyProperty RevealButtonContentProperty
+            = DependencyProperty.RegisterAttached("RevealButtonContent",
+                                                  typeof(object),
+                                                  typeof(PasswordBoxHelper),
+                                                  new FrameworkPropertyMetadata(null));
+
+        /// <summary>
+        /// Gets the content of the RevealButton.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
+        public static object GetRevealButtonContent(DependencyObject d)
+        {
+            return (object)d.GetValue(RevealButtonContentProperty);
+        }
+
+        /// <summary>
+        /// Sets the content of the RevealButton.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
+        public static void SetRevealButtonContent(DependencyObject obj, object value)
+        {
+            obj.SetValue(RevealButtonContentProperty, value);
+        }
+
+        public static readonly DependencyProperty RevealButtonContentTemplateProperty
+            = DependencyProperty.RegisterAttached("RevealButtonContentTemplate",
+                                                  typeof(DataTemplate),
+                                                  typeof(PasswordBoxHelper),
+                                                  new FrameworkPropertyMetadata((DataTemplate)null));
+
+        /// <summary> 
+        /// Gets the data template used to display the content of the RevealButton.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
+        public static DataTemplate GetRevealButtonContentTemplate(DependencyObject d)
+        {
+            return (DataTemplate)d.GetValue(RevealButtonContentTemplateProperty);
+        }
+
+        /// <summary> 
+        /// Sets the data template used to display the content of the RevealButton.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
+        public static void SetRevealButtonContentTemplate(DependencyObject obj, DataTemplate value)
+        {
+            obj.SetValue(RevealButtonContentTemplateProperty, value);
         }
     }
 }

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -12,6 +12,7 @@
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
     <Converters:StringToVisibilityConverter x:Key="StringToVisibilityConverter" />
+    <!--  obsolete  -->
     <Converters:StringToVisibilityConverter x:Key="StringToOppositeVisibilityConverter" OppositeStringValue="True" />
 
     <!--  obsolete  -->
@@ -40,33 +41,40 @@
     <Style x:Key="RevealButtonStyle"
            BasedOn="{StaticResource ChromelessButtonStyle}"
            TargetType="{x:Type ButtonBase}">
-        <Setter Property="Margin" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
                     <Grid Background="{TemplateBinding Background}">
-                        <!--  Material - Eye  -->
-                        <ContentControl x:Name="PART_PackIcon"
-                                        Width="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
-                                        Height="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
-                                        Padding="2"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        Content="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"
-                                        Style="{DynamicResource PathIconContentControlStyle}" />
+                        <ContentPresenter x:Name="PART_ContentPresenter"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          RecognizesAccessKey="True"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_PackIcon" Property="Opacity" Value="1" />
+                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="1" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
-                            <Setter TargetName="PART_PackIcon" Property="Opacity" Value=".5" />
+                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value=".5" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>
+
+    <!--  Material - Eye  -->
+    <ContentControl x:Key="DefaultRevealButtonIcon"
+                    Width="Auto"
+                    Height="Auto"
+                    Padding="2"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    x:Shared="False"
+                    Content="M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5Z"
+                    Style="{DynamicResource PathIconContentControlStyle}" />
 
     <Grid x:Key="DefaultCapsLockIcon"
           Width="16"
@@ -618,6 +626,7 @@
     <Style x:Key="MetroButtonRevealedPasswordBox"
            BasedOn="{StaticResource MetroPasswordBox}"
            TargetType="{x:Type PasswordBox}">
+        <Setter Property="Controls:PasswordBoxHelper.RevealButtonContent" Value="{DynamicResource DefaultRevealButtonIcon}" />
         <Setter Property="Controls:TextBoxHelper.ButtonTemplate" Value="{DynamicResource ChromelessButtonTemplate}" />
         <Setter Property="Template">
             <Setter.Value>
@@ -768,11 +777,12 @@
                                     Grid.RowSpan="2"
                                     Grid.Column="2"
                                     Width="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
-                                    Margin="0"
+                                    Content="{TemplateBinding Controls:PasswordBoxHelper.RevealButtonContent}"
+                                    ContentTemplate="{TemplateBinding Controls:PasswordBoxHelper.RevealButtonContentTemplate}"
                                     Focusable="False"
                                     Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
-                                    Style="{StaticResource RevealButtonStyle}"
+                                    Style="{DynamicResource RevealButtonStyle}"
                                     Visibility="{Binding ElementName=RevealedPassword, Path=Text, Converter={StaticResource StringToVisibilityConverter}}" />
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"
@@ -912,10 +922,3 @@
     </Style>
 
 </ResourceDictionary>
-
-
-
-
-
-
-


### PR DESCRIPTION
- Add 2 new attached properties `RevealButtonContent` and `RevealButtonContentTemplate` to `PasswordBoxHelper`
- Set the `DefaultRevealButtonIcon` to `RevealButtonContent` property

Closes #3105 
Relates to #3105 