### PR TITLE
Use the original Win 10 close button style

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/MainWindow.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/MainWindow.xaml
@@ -93,7 +93,7 @@
     </Window.Resources>
 
     <Controls:MetroWindow.WindowButtonCommands>
-        <Controls:WindowButtonCommands Template="{DynamicResource MahApps.Metro.Templates.WindowButtonCommands.Win10}" />
+        <Controls:WindowButtonCommands Style="{DynamicResource MahApps.Metro.Styles.WindowButtonCommands.Win10}" />
     </Controls:MetroWindow.WindowButtonCommands>
 
     <Controls:MetroWindow.LeftWindowCommands>
@@ -284,4 +284,3 @@
 
     </Grid>
 </Controls:MetroWindow>
-

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -419,6 +419,18 @@
         <Setter Property="MaxHeight" Value="34" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="Width" Value="34" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource SemiTransparentWhiteBrush}" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="{DynamicResource AccentColorBrush}" />
+                <Setter Property="Foreground" Value="White" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource IdealForegroundDisabledBrush}" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <!--  dark button style for min, max and close window buttons  -->
@@ -437,6 +449,28 @@
                 <Setter Property="Foreground" Value="{DynamicResource DarkIdealForegroundDisabledBrush}" />
             </Trigger>
         </Style.Triggers>
+    </Style>
+
+    <Style x:Key="MahApps.Metro.Styles.WindowButton.Close.Light.Win10"
+           BasedOn="{StaticResource LightMetroWindowButtonStyle}"
+           TargetType="{x:Type Button}">
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="#E81123" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="#F1707A" />
+                <Setter Property="Foreground" Value="Black" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource DarkIdealForegroundDisabledBrush}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="MahApps.Metro.Styles.WindowButton.Close.Dark.Win10"
+           BasedOn="{StaticResource LightMetroWindowButtonStyle}"
+           TargetType="{x:Type Button}">
     </Style>
 
     <!--  style for default button  -->

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -463,14 +463,26 @@
                 <Setter Property="Foreground" Value="Black" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">
-                <Setter Property="Foreground" Value="{DynamicResource DarkIdealForegroundDisabledBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource IdealForegroundDisabledBrush}" />
             </Trigger>
         </Style.Triggers>
     </Style>
 
     <Style x:Key="MahApps.Metro.Styles.WindowButton.Close.Dark.Win10"
-           BasedOn="{StaticResource LightMetroWindowButtonStyle}"
+           BasedOn="{StaticResource DarkMetroWindowButtonStyle}"
            TargetType="{x:Type Button}">
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="#E81123" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="#F1707A" />
+                <Setter Property="Foreground" Value="Black" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource DarkIdealForegroundDisabledBrush}" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <!--  style for default button  -->

--- a/src/MahApps.Metro/MahApps.Metro/Themes/WindowButtonCommands.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/WindowButtonCommands.xaml
@@ -211,6 +211,8 @@
     <Style x:Key="MahApps.Metro.Styles.WindowButtonCommands.Win10"
            BasedOn="{StaticResource MahApps.Metro.Styles.WindowButtonCommands}"
            TargetType="{x:Type Controls:WindowButtonCommands}">
+        <Setter Property="DarkCloseButtonStyle" Value="{DynamicResource MahApps.Metro.Styles.WindowButton.Close.Dark.Win10}" />
+        <Setter Property="LightCloseButtonStyle" Value="{DynamicResource MahApps.Metro.Styles.WindowButton.Close.Light.Win10}" />
         <Setter Property="Template" Value="{StaticResource MahApps.Metro.Templates.WindowButtonCommands.Win10}" />
     </Style>
 


### PR DESCRIPTION
## What changed?

The Win 10 close button style is a little bit different to the MahApps one, so this PR adds the correct style for the close button (light and dark) (https://github.com/MahApps/MahApps.Metro/pull/2378#issuecomment-350606002).

## New styles added
- `MahApps.Metro.Styles.WindowButton.Close.Light.Win10`
- `MahApps.Metro.Styles.WindowButton.Close.Dark.Win10`

![2017-12-30_17h03_11](https://user-images.githubusercontent.com/658431/34455670-56baa624-ed84-11e7-92b2-e7c195f42df4.png)
![2017-12-30_17h04_19](https://user-images.githubusercontent.com/658431/34455671-5811a2d4-ed84-11e7-8119-d3480edd1f2b.png)
![2017-12-30_17h04_25](https://user-images.githubusercontent.com/658431/34455672-595e9084-ed84-11e7-8695-cfd712304bc1.png)



