### PR TITLE
Fix Dialogs Resource handling

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/DialogManager.cs
@@ -550,16 +550,6 @@ namespace MahApps.Metro.Controls.Dialogs
         private static Window SetupExternalDialogWindow(BaseMetroDialog dialog)
         {
             var win = CreateExternalWindow();
-
-            try
-            {
-                win.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml") });
-                win.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml") });
-                win.Resources.MergedDictionaries.Add(new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml") });
-                win.SetResourceReference(MetroWindow.GlowBrushProperty, "AccentColorBrush");
-            }
-            catch (Exception) { }
-
             win.Width = SystemParameters.PrimaryScreenWidth;
             win.MinHeight = SystemParameters.PrimaryScreenHeight / 4.0;
             win.SizeToContent = SizeToContent.Height;
@@ -567,6 +557,8 @@ namespace MahApps.Metro.Controls.Dialogs
             dialog.ParentDialogWindow = win; //THIS IS ONLY, I REPEAT, ONLY SET FOR EXTERNAL DIALOGS!
 
             win.Content = dialog;
+
+            dialog.HandleThemeChange();
 
             EventHandler closedHandler = null;
             closedHandler = (sender, args) =>

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.xaml
@@ -37,6 +37,7 @@
 
         <!--  Theme styles with keys  -->
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/WindowButtonCommands.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/Dialogs/BaseMetroDialog.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="FloatingMessageContainerStyle" TargetType="{x:Type ContentControl}">

--- a/src/MahApps.Metro/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -7,10 +7,6 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Buttons.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style BasedOn="{StaticResource SquareButtonStyle}" TargetType="{x:Type Button}">
-        <Setter Property="controls:ControlsHelper.ContentCharacterCasing" Value="Normal" />
-    </Style>
-
     <Style x:Key="AccentedDialogSquareButton"
            BasedOn="{StaticResource AccentedSquareButtonStyle}"
            TargetType="{x:Type ButtonBase}">
@@ -86,7 +82,12 @@
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
-    <Style TargetType="{x:Type Dialogs:BaseMetroDialog}">
+    <Style x:Key="MahApps.Metro.Styles.MetroDialog" TargetType="{x:Type Dialogs:BaseMetroDialog}">
+        <Style.Resources>
+            <Style BasedOn="{StaticResource SquareButtonStyle}" TargetType="{x:Type Button}">
+                <Setter Property="controls:ControlsHelper.ContentCharacterCasing" Value="Normal" />
+            </Style>
+        </Style.Resources>
         <Setter Property="Background" Value="{DynamicResource WhiteColorBrush}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Foreground" Value="{DynamicResource BlackBrush}" />

--- a/src/MahApps.Metro/MahApps.Metro/Themes/Generic.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/Generic.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:Dialogs="clr-namespace:MahApps.Metro.Controls.Dialogs">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
@@ -51,5 +52,7 @@
     <Style BasedOn="{StaticResource MahApps.Metro.Styles.HamburgerMenu}" TargetType="{x:Type Controls:HamburgerMenu}" />
 
     <Style BasedOn="{StaticResource MahApps.Metro.Styles.MetroHeader}" TargetType="{x:Type Controls:MetroHeader}" />
+
+    <Style BasedOn="{StaticResource MahApps.Metro.Styles.MetroDialog}" TargetType="{x:Type Dialogs:BaseMetroDialog}" />
 
 </ResourceDictionary>


### PR DESCRIPTION
## What changed?

- Create new style for Dialogs `MahApps.Metro.Styles.MetroDialog` and set this as default
- Add `BaseMetroDialog` resources to Control styles to allow easier dialog style manipulation
- Do not load all MahApps styles in code behind again (this is not necessary anymore, since it's now at Style level too)
- Fix inverted Dialogs theme (the background wasn't correct)

**Before**

![2018-01-09_23h57_45](https://user-images.githubusercontent.com/658431/34747536-f56d340a-f598-11e7-9c2a-29751cc66c46.png)

**Now**

![2018-01-09_23h56_31](https://user-images.githubusercontent.com/658431/34747544-fce322e4-f598-11e7-9f48-af930000ccd8.png)

Closes #2813 
