### PR TITLE
Fix loaded content at HamburgerMenu

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/HamburgerMenu.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/HamburgerMenu.cs
@@ -76,6 +76,11 @@ namespace MahApps.Metro.Controls
 
         private void HamburgerMenu_Loaded(object sender, RoutedEventArgs e)
         {
+            if (GetValue(ContentProperty) != null)
+            {
+                return;
+            }
+
             var selectedItem = _buttonsListView?.SelectedItem ?? _optionsListView?.SelectedItem;
             if (selectedItem != null)
             {

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.xaml
@@ -38,6 +38,7 @@
         <!--  Theme styles with keys  -->
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/WindowButtonCommands.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/Dialogs/BaseMetroDialog.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/HamburgerMenu.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="FloatingMessageContainerStyle" TargetType="{x:Type ContentControl}">


### PR DESCRIPTION
## What changed?

- Set a selected Item only if there is no content set
- Add `HamburgerMenu` resources to Control styles to allow style manipulation and fix binding expression infos

_Closed issues._

Closes #3089 
Closes #3104 
Closes #3106 
