### PR TITLE
New IsAnyDialogVisible dependency property for MetroWindow

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/DialogManager.cs
@@ -484,6 +484,8 @@ namespace MahApps.Metro.Controls.Dialogs
             }
 
             window.metroActiveDialogContainer.Children.Add(dialog); //add the dialog to the container}
+
+            window.SetValue(MetroWindow.IsAnyDialogVisiblePropertyKey, true);
         }
 
         private static void RemoveDialog(this MetroWindow window, BaseMetroDialog dialog)
@@ -509,6 +511,8 @@ namespace MahApps.Metro.Controls.Dialogs
             {
                 window.RestoreFocus();
             }
+
+            window.SetValue(MetroWindow.IsAnyDialogVisiblePropertyKey, window.metroActiveDialogContainer.Children.Count > 0);
         }
 
         public static BaseMetroDialog ShowDialogExternally(this BaseMetroDialog dialog)

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
@@ -12,18 +12,15 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Shapes;
 using System.Windows.Controls.Primitives;
+using ControlzEx.Behaviors;
+using ControlzEx.Native;
 using ControlzEx.Standard;
 using JetBrains.Annotations;
+using MahApps.Metro.Behaviours;
 using MahApps.Metro.Controls.Dialogs;
 
 namespace MahApps.Metro.Controls
 {
-    using System.Windows.Data;
-    using System.Windows.Interactivity;
-    using ControlzEx.Behaviors;
-    using MahApps.Metro.Behaviours;
-    using ControlzEx.Native;
-
     /// <summary>
     /// An extended, metrofied Window class.
     /// </summary>
@@ -62,6 +59,13 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty ShowTitleBarProperty = DependencyProperty.Register("ShowTitleBar", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true, OnShowTitleBarPropertyChangedCallback, OnShowTitleBarCoerceValueCallback));
 
         public static readonly DependencyProperty ShowDialogsOverTitleBarProperty = DependencyProperty.Register("ShowDialogsOverTitleBar", typeof(bool), typeof(MetroWindow), new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender));
+
+        public static readonly DependencyPropertyKey IsAnyDialogVisiblePropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsAnyDialogVisible), typeof(bool), typeof(MetroWindow), new PropertyMetadata(false));
+
+        /// <summary>
+        /// Identifies the <see cref="IsAnyDialogVisible"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty IsAnyDialogVisibleProperty = IsAnyDialogVisiblePropertyKey.DependencyProperty;
 
         public static readonly DependencyProperty ShowMinButtonProperty = DependencyProperty.Register("ShowMinButton", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
         public static readonly DependencyProperty ShowMaxRestoreButtonProperty = DependencyProperty.Register("ShowMaxRestoreButton", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
@@ -402,6 +406,15 @@ namespace MahApps.Metro.Controls
         {
             get { return (bool)GetValue(ShowDialogsOverTitleBarProperty); }
             set { SetValue(ShowDialogsOverTitleBarProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets whether one or more dialogs are shown.
+        /// </summary>
+        public bool IsAnyDialogVisible
+        {
+            get { return (bool)GetValue(IsAnyDialogVisibleProperty); }
+            private set { SetValue(IsAnyDialogVisibleProperty, value); }
         }
 
         /// <summary>


### PR DESCRIPTION
## What changed?

Add a new (readonly) `IsAnyDialogVisible` dependency property. This property will be updated if a dialog is shown or not.

_Closed issues._

Closes #2806 
