### PR TITLE
WIP Handle CloseButton together with ShowDialogsOverTitleBar

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/DialogManager.cs
@@ -21,12 +21,11 @@ namespace MahApps.Metro.Controls.Dialogs
         public static Task<LoginDialogData> ShowLoginAsync(this MetroWindow window, string title, string message, LoginDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
+            settings = settings ?? new LoginDialogSettings();
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
             {
                 return (Task<LoginDialogData>)window.Dispatcher.Invoke(new Func<Task<LoginDialogData>>(() =>
                 {
-                    settings = settings ?? new LoginDialogSettings();
-
                     //create the dialog control
                     LoginDialog dialog = new LoginDialog(window, settings)
                     {
@@ -87,12 +86,11 @@ namespace MahApps.Metro.Controls.Dialogs
         public static Task<string> ShowInputAsync(this MetroWindow window, string title, string message, MetroDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
+            settings = settings ?? window.MetroDialogOptions;
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
             {
                 return (Task<string>)window.Dispatcher.Invoke(new Func<Task<string>>(() =>
                 {
-                    settings = settings ?? window.MetroDialogOptions;
-
                     //create the dialog control
                     var dialog = new InputDialog(window, settings)
                     {
@@ -154,12 +152,11 @@ namespace MahApps.Metro.Controls.Dialogs
         public static Task<MessageDialogResult> ShowMessageAsync(this MetroWindow window, string title, string message, MessageDialogStyle style = MessageDialogStyle.Affirmative, MetroDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
+            settings = settings ?? window.MetroDialogOptions;
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
             {
                 return (Task<MessageDialogResult>)window.Dispatcher.Invoke(new Func<Task<MessageDialogResult>>(() =>
                 {
-                    settings = settings ?? window.MetroDialogOptions;
-
                     //create the dialog control
                     var dialog = new MessageDialog(window, settings)
                     {
@@ -221,13 +218,11 @@ namespace MahApps.Metro.Controls.Dialogs
         public static Task<ProgressDialogController> ShowProgressAsync(this MetroWindow window, string title, string message, bool isCancelable = false, MetroDialogSettings settings = null)
         {
             window.Dispatcher.VerifyAccess();
-
+            settings = settings ?? window.MetroDialogOptions;
             return HandleOverlayOnShow(settings, window).ContinueWith(z =>
             {
                 return ((Task<ProgressDialogController>)window.Dispatcher.Invoke(new Func<Task<ProgressDialogController>>(() =>
                 {
-                    settings = settings ?? window.MetroDialogOptions;
-
                     //create the dialog control
                     var dialog = new ProgressDialog(window, settings)
                     {
@@ -291,6 +286,8 @@ namespace MahApps.Metro.Controls.Dialogs
 
         private static Task HandleOverlayOnShow(MetroDialogSettings settings, MetroWindow window)
         {
+            window.SetValue(MetroWindow.IsCloseButtonEnabledWithDialogPropertyKey, window.ShowDialogsOverTitleBar || settings == null || settings.CanCloseDialogOwner);
+
             if (!window.metroActiveDialogContainer.Children.OfType<BaseMetroDialog>().Any())
             {
                 return (settings == null || settings.AnimateShow ? window.ShowOverlayAsync() : Task.Factory.StartNew(() => window.Dispatcher.Invoke(new Action(window.ShowOverlay))));
@@ -509,7 +506,13 @@ namespace MahApps.Metro.Controls.Dialogs
 
             if (window.metroActiveDialogContainer.Children.Count == 0)
             {
+                window.SetValue(MetroWindow.IsCloseButtonEnabledWithDialogPropertyKey, true);
                 window.RestoreFocus();
+            }
+            else
+            {
+                var settings = window.metroActiveDialogContainer.Children.OfType<BaseMetroDialog>().LastOrDefault()?.DialogSettings;
+                window.SetValue(MetroWindow.IsCloseButtonEnabledWithDialogPropertyKey, window.ShowDialogsOverTitleBar || settings == null || settings.CanCloseDialogOwner);
             }
 
             window.SetValue(MetroWindow.IsAnyDialogOpenPropertyKey, window.metroActiveDialogContainer.Children.Count > 0);

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/LoginDialog.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/LoginDialog.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Security;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -7,72 +6,6 @@ using System.Windows.Input;
 
 namespace MahApps.Metro.Controls.Dialogs
 {
-    public class LoginDialogSettings : MetroDialogSettings
-    {
-        private const string DefaultUsernameWatermark = "Username...";
-        private const string DefaultPasswordWatermark = "Password...";
-        private const string DefaultRememberCheckBoxText = "Remember";
-
-        public LoginDialogSettings()
-        {
-            this.UsernameWatermark = DefaultUsernameWatermark;
-            this.UsernameCharacterCasing = CharacterCasing.Normal;
-            this.PasswordWatermark = DefaultPasswordWatermark;
-            this.NegativeButtonVisibility = Visibility.Collapsed;
-            this.ShouldHideUsername = false;
-            this.AffirmativeButtonText = "Login";
-            this.EnablePasswordPreview = false;
-            this.RememberCheckBoxVisibility = Visibility.Collapsed;
-            this.RememberCheckBoxText = DefaultRememberCheckBoxText;
-        }
-
-        public string InitialUsername { get; set; }
-
-        public string InitialPassword { get; set; }
-
-        public string UsernameWatermark { get; set; }
-
-        public CharacterCasing UsernameCharacterCasing { get; set; }
-
-        public bool ShouldHideUsername { get; set; }
-
-        public string PasswordWatermark { get; set; }
-
-        public Visibility NegativeButtonVisibility { get; set; }
-
-        public bool EnablePasswordPreview { get; set; }
-
-        public Visibility RememberCheckBoxVisibility { get; set; }
-
-        public string RememberCheckBoxText { get; set; }
-    }
-
-    public class LoginDialogData
-    {
-        public string Username { get; internal set; }
-
-        public string Password
-        {
-            [SecurityCritical]
-            get
-            {
-                IntPtr ptr = System.Runtime.InteropServices.Marshal.SecureStringToBSTR(this.SecurePassword);
-                try
-                {
-                    return System.Runtime.InteropServices.Marshal.PtrToStringBSTR(ptr);
-                }
-                finally
-                {
-                    System.Runtime.InteropServices.Marshal.ZeroFreeBSTR(ptr);
-                }
-            }
-        }
-
-        public SecureString SecurePassword { get; internal set; }
-
-        public bool ShouldRemember { get; internal set; }
-    }
-
     public partial class LoginDialog : BaseMetroDialog
     {
         internal LoginDialog()

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/LoginDialogData.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/LoginDialogData.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Security;
+
+namespace MahApps.Metro.Controls.Dialogs
+{
+    public class LoginDialogData
+    {
+        public string Username { get; internal set; }
+
+        public string Password
+        {
+            [SecurityCritical]
+            get
+            {
+                IntPtr ptr = System.Runtime.InteropServices.Marshal.SecureStringToBSTR(this.SecurePassword);
+                try
+                {
+                    return System.Runtime.InteropServices.Marshal.PtrToStringBSTR(ptr);
+                }
+                finally
+                {
+                    System.Runtime.InteropServices.Marshal.ZeroFreeBSTR(ptr);
+                }
+            }
+        }
+
+        public SecureString SecurePassword { get; internal set; }
+
+        public bool ShouldRemember { get; internal set; }
+    }
+}

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/LoginDialogSettings.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/LoginDialogSettings.cs
@@ -1,0 +1,45 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace MahApps.Metro.Controls.Dialogs
+{
+    public class LoginDialogSettings : MetroDialogSettings
+    {
+        private const string DefaultUsernameWatermark = "Username...";
+        private const string DefaultPasswordWatermark = "Password...";
+        private const string DefaultRememberCheckBoxText = "Remember";
+
+        public LoginDialogSettings()
+        {
+            this.UsernameWatermark = DefaultUsernameWatermark;
+            this.UsernameCharacterCasing = CharacterCasing.Normal;
+            this.PasswordWatermark = DefaultPasswordWatermark;
+            this.NegativeButtonVisibility = Visibility.Collapsed;
+            this.ShouldHideUsername = false;
+            this.AffirmativeButtonText = "Login";
+            this.EnablePasswordPreview = false;
+            this.RememberCheckBoxVisibility = Visibility.Collapsed;
+            this.RememberCheckBoxText = DefaultRememberCheckBoxText;
+        }
+
+        public string InitialUsername { get; set; }
+
+        public string InitialPassword { get; set; }
+
+        public string UsernameWatermark { get; set; }
+
+        public CharacterCasing UsernameCharacterCasing { get; set; }
+
+        public bool ShouldHideUsername { get; set; }
+
+        public string PasswordWatermark { get; set; }
+
+        public Visibility NegativeButtonVisibility { get; set; }
+
+        public bool EnablePasswordPreview { get; set; }
+
+        public Visibility RememberCheckBoxVisibility { get; set; }
+
+        public string RememberCheckBoxText { get; set; }
+    }
+}

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/MetroDialogSettings.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Dialogs/MetroDialogSettings.cs
@@ -11,6 +11,8 @@ namespace MahApps.Metro.Controls.Dialogs
     {
         public MetroDialogSettings()
         {
+            this.CanCloseDialogOwner = false;
+
             this.AffirmativeButtonText = "OK";
             this.NegativeButtonText = "Cancel";
 
@@ -26,6 +28,11 @@ namespace MahApps.Metro.Controls.Dialogs
             this.DialogMessageFontSize = Double.NaN;
             this.DialogResultOnCancel = null;
         }
+
+        /// <summary>
+        /// Gets or sets wheater the owner of the dialog can be closed.
+        /// </summary>
+        public bool CanCloseDialogOwner { get; set; }
 
         /// <summary>
         /// Gets or sets the text used for the Affirmative button. For example: "OK" or "Yes".

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
@@ -75,6 +75,13 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty IsMaxRestoreButtonEnabledProperty = DependencyProperty.Register("IsMaxRestoreButtonEnabled", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
         public static readonly DependencyProperty IsCloseButtonEnabledProperty = DependencyProperty.Register("IsCloseButtonEnabled", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
 
+        public static readonly DependencyPropertyKey IsCloseButtonEnabledWithDialogPropertyKey = DependencyProperty.RegisterReadOnly(nameof(IsCloseButtonEnabledWithDialog), typeof(bool), typeof(MetroWindow), new PropertyMetadata(false));
+
+        /// <summary>
+        /// Identifies the <see cref="IsCloseButtonEnabledWithDialog"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty IsCloseButtonEnabledWithDialogProperty = IsCloseButtonEnabledWithDialogPropertyKey.DependencyProperty;
+
         public static readonly DependencyProperty ShowSystemMenuOnRightClickProperty = DependencyProperty.Register("ShowSystemMenuOnRightClick", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
 
         public static readonly DependencyProperty TitlebarHeightProperty = DependencyProperty.Register("TitlebarHeight", typeof(int), typeof(MetroWindow), new PropertyMetadata(30, TitlebarHeightPropertyChangedCallback));
@@ -568,6 +575,15 @@ namespace MahApps.Metro.Controls
         }
 
         /// <summary>
+        /// Gets or sets whether if the close button should be enabled or not if a dialog is shown.
+        /// </summary>
+        public bool IsCloseButtonEnabledWithDialog
+        {
+            get { return (bool)GetValue(IsCloseButtonEnabledWithDialogProperty); }
+            private set { SetValue(IsCloseButtonEnabledWithDialogProperty, value); }
+        }
+
+        /// <summary>
         /// Gets/sets if the the system menu should popup on right click.
         /// </summary>
         public bool ShowSystemMenuOnRightClick
@@ -920,7 +936,7 @@ namespace MahApps.Metro.Controls
             {
                 // #2409: don't close window if there is a dialog still open
                 var dialog = await this.GetCurrentDialogAsync<BaseMetroDialog>();
-                e.Cancel = dialog != null;
+                e.Cancel = dialog != null && (dialog.DialogSettings == null || !dialog.DialogSettings.CanCloseDialogOwner);
             }
 
             base.OnClosing(e);
@@ -933,7 +949,7 @@ namespace MahApps.Metro.Controls
             {
                 // #2409: don't close window if there is a dialog still open
                 var dialog = this.Invoke(() => this.metroActiveDialogContainer?.Children.OfType<BaseMetroDialog>().LastOrDefault());
-                e.Cancel = dialog != null;
+                e.Cancel = dialog != null && (dialog.DialogSettings == null || !dialog.DialogSettings.CanCloseDialogOwner);
             }
 
             base.OnClosing(e);

--- a/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
@@ -41,6 +41,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Dialogs\IDialogCoordinator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Dialogs\InputDialog.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Dialogs\LoginDialog.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\Dialogs\LoginDialogData.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\Dialogs\LoginDialogSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Dialogs\MessageDialog.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Dialogs\MessageDialogResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\Dialogs\MessageDialogStyle.cs" />


### PR DESCRIPTION
## What changed?

- Pass correct dialogs settings to HandleOverlayOnShow 
- New `CanCloseDialogOwner` property at `MetroDialogSettings` which can be used to handle how the owner of the dialog can be closed.
- New `IsCloseButtonEnabledWithDialog` property at `MetroWindow` which indicates if the close button should be enabled or not if a dialog is shown.

_Closed issues._

Closes #2882 
