### PR TITLE
WIP NumericUpDown: Add a new property to handle the allowed numeric input

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericInput.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericInput.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace MahApps.Metro.Controls
+{
+    /// <summary>
+    /// Enum NumericInput which indicates what input is allowed for NumericUpdDown.
+    /// </summary>
+    [Flags]
+    public enum NumericInput
+    {
+        /// <summary>
+        /// Only numbers are allowed
+        /// </summary>
+        Numbers = 1 << 1, // Only Numbers
+        /// <summary>
+        /// Decimal numbers are allowed
+        /// </summary>
+        Decimal = 2 << 1, // Numbers with decimal point
+        /// <summary>
+        /// Scientific is allowed for (decimal) numbers
+        /// </summary>
+        Scientific = 3 << 1, // Numbers and Decimal with scientific
+        /// <summary>
+        /// All is allowed
+        /// </summary>
+        All = Decimal | Scientific
+    }
+}

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericInput.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericInput.cs
@@ -13,16 +13,12 @@ namespace MahApps.Metro.Controls
         /// </summary>
         Numbers = 1 << 1, // Only Numbers
         /// <summary>
-        /// Decimal numbers are allowed
+        /// Numbers with decimal point and allowed scientific input
         /// </summary>
-        Decimal = 2 << 1, // Numbers with decimal point
-        /// <summary>
-        /// Scientific is allowed for (decimal) numbers
-        /// </summary>
-        Scientific = 3 << 1, // Numbers and Decimal with scientific
+        Decimal = 2 << 1,
         /// <summary>
         /// All is allowed
         /// </summary>
-        All = Decimal | Scientific
+        All = Numbers | Decimal
     }
 }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericUpDown.cs
@@ -743,13 +743,14 @@ namespace MahApps.Metro.Controls
                         else if (textBox.SelectionStart > 0)
                         {
                             string elementBeforeCaret = textBox.Text.ElementAt(textBox.SelectionStart - 1).ToString(equivalentCulture);
-                            if (elementBeforeCaret.Equals(ScientificNotationChar, StrComp))
+                            if (elementBeforeCaret.Equals(ScientificNotationChar, StrComp) && NumericInputMode.HasFlag(NumericInput.Decimal))
                             {
                                 e.Handled = false;
                             }
                         }
                     }
                     else if (text.Equals(ScientificNotationChar, StrComp) &&
+                             NumericInputMode.HasFlag(NumericInput.Decimal) &&
                              textBox.SelectionStart > 0 &&
                              !textBox.Text.Any(i => i.ToString(equivalentCulture).Equals(ScientificNotationChar, StrComp)))
                     {

--- a/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
@@ -114,6 +114,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\MetroWindow.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\MetroWindowHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\MultiFrameImage.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\NumericInput.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\NumericUpDown.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\NumericUpDownChangedRoutedEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\NumericUpDownChangedRoutedEventHandler.cs" />


### PR DESCRIPTION
## What changed?

- Add new `NumericInputMode` property with the new flag enumeration NumericInput (default is NumericInput.All)
- Mark `HasDecimals` as obsolete
- Block scientific input if only numbers allowed

_Closed issues._

Closes #2422 
Closes #2423 
Closes #2496 
