### PR TITLE
Fix not focusing custom controls via FocusManager

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HotKeyBox.cs
@@ -70,23 +70,27 @@ namespace MahApps.Metro.Controls {
 
         private static void OnGotFocus(object sender, RoutedEventArgs e)
         {
-            HotKeyBox hotKeyBox = (HotKeyBox)sender;
-
             // If we're an editable HotKeyBox, forward focus to the TextBox or previous element
             if (!e.Handled)
             {
-                if (hotKeyBox.Focusable && hotKeyBox._textBox != null)
+                HotKeyBox hotKeyBox = (HotKeyBox)sender;
+                if (hotKeyBox.Focusable && e.OriginalSource == hotKeyBox)
                 {
-                    if (e.OriginalSource == hotKeyBox)
+                    // MoveFocus takes a TraversalRequest as its argument.
+                    var request = new TraversalRequest((Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift ? FocusNavigationDirection.Previous : FocusNavigationDirection.Next);
+                    // Gets the element with keyboard focus.
+                    var elementWithFocus = Keyboard.FocusedElement as UIElement;
+                    // Change keyboard focus.
+                    if (elementWithFocus != null)
                     {
-                        // MoveFocus takes a TraversalRequest as its argument.
-                        var request = new TraversalRequest((Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift ? FocusNavigationDirection.Previous : FocusNavigationDirection.Next);
-                        // Gets the element with keyboard focus.
-                        var elementWithFocus = Keyboard.FocusedElement as UIElement;
-                        // Change keyboard focus.
-                        elementWithFocus?.MoveFocus(request);
-                        e.Handled = true;
+                        elementWithFocus.MoveFocus(request);
                     }
+                    else
+                    {
+                        hotKeyBox.Focus();
+                    }
+
+                    e.Handled = true;
                 }
             }
         }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/NumericUpDown.cs
@@ -508,23 +508,27 @@ namespace MahApps.Metro.Controls
         private static void OnGotFocus(object sender, RoutedEventArgs e)
         {
             // When NumericUpDown gets logical focus, select the text inside us.
-            NumericUpDown numericUpDown = (NumericUpDown)sender;
-
             // If we're an editable NumericUpDown, forward focus to the TextBox element
             if (!e.Handled)
             {
-                if ((numericUpDown.InterceptManualEnter || numericUpDown.IsReadOnly) && numericUpDown.Focusable && numericUpDown._valueTextBox != null)
+                NumericUpDown numericUpDown = (NumericUpDown)sender;
+                if ((numericUpDown.InterceptManualEnter || numericUpDown.IsReadOnly) && numericUpDown.Focusable && e.OriginalSource == numericUpDown)
                 {
-                    if (e.OriginalSource == numericUpDown)
+                    // MoveFocus takes a TraversalRequest as its argument.
+                    var request = new TraversalRequest((Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift ? FocusNavigationDirection.Previous : FocusNavigationDirection.Next);
+                    // Gets the element with keyboard focus.
+                    var elementWithFocus = Keyboard.FocusedElement as UIElement;
+                    // Change keyboard focus.
+                    if (elementWithFocus != null)
                     {
-                        // MoveFocus takes a TraversalRequest as its argument.
-                        var request = new TraversalRequest((Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift ? FocusNavigationDirection.Previous : FocusNavigationDirection.Next);
-                        // Gets the element with keyboard focus.
-                        var elementWithFocus = Keyboard.FocusedElement as UIElement;
-                        // Change keyboard focus.
-                        elementWithFocus?.MoveFocus(request);
-                        e.Handled = true;
+                        elementWithFocus.MoveFocus(request);
                     }
+                    else
+                    {
+                        numericUpDown.Focus();
+                    }
+
+                    e.Handled = true;
                 }
             }
         }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/TimePickerBase.cs
@@ -658,7 +658,7 @@ namespace MahApps.Metro.Controls
         private static void OnGotFocus(object sender, RoutedEventArgs e)
         {
             TimePickerBase picker = (TimePickerBase)sender;
-            if (!e.Handled && picker.Focusable && (picker._textBox != null))
+            if (!e.Handled && picker.Focusable)
             {
                 if (Equals(e.OriginalSource, picker))
                 {
@@ -667,10 +667,18 @@ namespace MahApps.Metro.Controls
                     // Gets the element with keyboard focus.
                     var elementWithFocus = Keyboard.FocusedElement as UIElement;
                     // Change keyboard focus.
-                    elementWithFocus?.MoveFocus(request);
+                    if (elementWithFocus != null)
+                    {
+                        elementWithFocus.MoveFocus(request);
+                    }
+                    else
+                    {
+                        picker.Focus();
+                    }
+
                     e.Handled = true;
                 }
-                else if (Equals(e.OriginalSource, picker._textBox))
+                else if (picker._textBox != null && Equals(e.OriginalSource, picker._textBox))
                 {
                     picker._textBox.SelectAll();
                     e.Handled = true;


### PR DESCRIPTION
Problem: NumericUpDown, HotKeyBox and TimerPickerBase doesn't focus for the first time when the FocusManager will be used.

## What changed?

Fix not focusing at the OnGotFocus event.

_Closed issues._

Closes #3042 
