### PR TITLE
DatePicker IsReadOnly

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/DateExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/DateExamples.xaml
@@ -35,6 +35,11 @@
                             Controls:TextBoxHelper.WatermarkAlignment="Right" />
                 <DatePicker Width="200"
                             Margin="0 10 0 0"
+                            Controls:ControlsHelper.IsReadOnly="True"
+                            SelectedDate="{x:Static system:DateTime.Now}"
+                            HorizontalAlignment="Center" />
+                <DatePicker Width="200"
+                            Margin="0 10 0 0"
                             HorizontalAlignment="Center"
                             Controls:TextBoxHelper.Watermark="" />
                 <DatePicker Width="200"

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/ControlsHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/ControlsHelper.cs
@@ -41,10 +41,10 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty ContentCharacterCasingProperty =
             DependencyProperty.RegisterAttached(
                 "ContentCharacterCasing",
-                typeof (CharacterCasing),
-                typeof (ControlsHelper),
+                typeof(CharacterCasing),
+                typeof(ControlsHelper),
                 new FrameworkPropertyMetadata(CharacterCasing.Normal, FrameworkPropertyMetadataOptions.AffectsMeasure),
-                new ValidateValueCallback(value => CharacterCasing.Normal <= (CharacterCasing) value && (CharacterCasing) value <= CharacterCasing.Upper));
+                new ValidateValueCallback(value => CharacterCasing.Normal <= (CharacterCasing)value && (CharacterCasing)value <= CharacterCasing.Upper));
 
         /// <summary>
         /// Gets the character casing of the control
@@ -67,7 +67,7 @@ namespace MahApps.Metro.Controls
         }
 
         public static readonly DependencyProperty HeaderFontSizeProperty =
-            DependencyProperty.RegisterAttached("HeaderFontSize", typeof(double), typeof(ControlsHelper), new FrameworkPropertyMetadata(SystemFonts.MessageFontSize){ Inherits = true});
+            DependencyProperty.RegisterAttached("HeaderFontSize", typeof(double), typeof(ControlsHelper), new FrameworkPropertyMetadata(SystemFonts.MessageFontSize) { Inherits = true });
 
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
@@ -233,6 +233,31 @@ namespace MahApps.Metro.Controls
         public static void SetCornerRadius(UIElement element, CornerRadius value)
         {
             element.SetValue(CornerRadiusProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the child contents of the control are not editable.
+        /// </summary>
+        public static readonly DependencyProperty IsReadOnlyProperty
+            = DependencyProperty.RegisterAttached("IsReadOnly",
+                                                  typeof(bool),
+                                                  typeof(ControlsHelper),
+                                                  new FrameworkPropertyMetadata(false));
+
+        /// <summary>
+        /// Gets a value indicating whether the child contents of the control are not editable.
+        /// </summary>
+        public static bool GetIsReadOnly(UIElement element)
+        {
+            return (bool)element.GetValue(IsReadOnlyProperty);
+        }
+
+        /// <summary>
+        /// Sets a value indicating whether the child contents of the control are not editable.
+        /// </summary>
+        public static void SetIsReadOnly(UIElement element, bool value)
+        {
+            element.SetValue(IsReadOnlyProperty, value);
         }
     }
 }

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -134,6 +134,10 @@
                     </Grid>
 
                     <ControlTemplate.Triggers>
+                        <Trigger Property="Controls:ControlsHelper.IsReadOnly" Value="True">
+                            <Setter TargetName="PART_TextBox" Property="IsReadOnly" Value="True" />
+                            <Setter TargetName="PART_Button" Property="IsEnabled" Value="False" />
+                        </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.MouseOverBorderBrush)}" />
                         </Trigger>


### PR DESCRIPTION
## What changed?

Add new dependency property `ControlsHelper.IsReadOnly`.

This property sets the IsReadOnly property on the inner TextBox and the IsEnabled on the inner popup button.
