### PR TITLE
GetAncestors method added to TreeHelper. Use TreeHelper  where it is needed.

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/ReloadBehavior.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/ReloadBehavior.cs
@@ -1,8 +1,5 @@
-using System.Collections.Generic;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using MahApps.Metro.Controls;
 
 namespace MahApps.Metro.Behaviours
@@ -54,12 +51,10 @@ namespace MahApps.Metro.Behaviours
             ((ContentControl)d).Loaded += ReloadLoaded;
         }
 
-        static void ReloadLoaded(object sender, RoutedEventArgs e)
+        private static void ReloadLoaded(object sender, RoutedEventArgs e)
         {
-            var metroContentControl = ((ContentControl)sender);
-            var tab = Ancestors(metroContentControl)
-                .OfType<TabControl>()
-                .FirstOrDefault();
+            var metroContentControl = (ContentControl)sender;
+            var tab = metroContentControl.TryFindParent<TabControl>();
 
             if (tab == null) return;
 
@@ -67,19 +62,8 @@ namespace MahApps.Metro.Behaviours
             tab.SelectionChanged -= ReloadSelectionChanged;
             tab.SelectionChanged += ReloadSelectionChanged;
         }
-
-        private static IEnumerable<DependencyObject> Ancestors(DependencyObject obj)
-        {
-            var parent = VisualTreeHelper.GetParent(obj);
-            while (parent != null)
-            {
-                yield return parent;
-                obj = parent;
-                parent = VisualTreeHelper.GetParent(obj);
-            }
-        }
-
-        static void ReloadSelectionChanged(object sender, SelectionChangedEventArgs e)
+        
+        private static void ReloadSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (e.OriginalSource != sender)
                 return;

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/TiltBehavior.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/TiltBehavior.cs
@@ -172,10 +172,7 @@ namespace MahApps.Metro.Behaviours
 
         private static Panel GetParentPanel(DependencyObject element)
         {
-            var parent = VisualTreeHelper.GetParent(element);
-            var panel = parent as Panel;
-
-            return panel ?? (parent == null ? null : GetParentPanel(parent));
+            return element.TryFindParent<Panel>();
         }
     }
 }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
@@ -886,13 +886,10 @@ namespace MahApps.Metro.Controls
 
         public static void ButtonClicked(object sender, RoutedEventArgs e)
         {
-            var button = ((Button)sender);
-            var parent = VisualTreeHelper.GetParent(button);
-            while (!(parent is TextBox || parent is PasswordBox || parent is ComboBox))
-            {
-                parent = VisualTreeHelper.GetParent(parent);
-            }
+            var button = (Button)sender;
 
+            var parent = button.GetAncestors().FirstOrDefault(a => a is TextBox || a is PasswordBox || a is ComboBox);
+            
             var command = GetButtonCommand(parent);
             var commandParameter = GetButtonCommandParameter(parent) ?? parent;
             if (command != null && command.CanExecute(commandParameter))

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TreeHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TreeHelper.cs
@@ -36,6 +36,21 @@ namespace MahApps.Metro.Controls
         }
 
         /// <summary>
+        /// Finds all Ancestors of a given item on the visual tree.
+        /// </summary>
+        /// <param name="child">A node in a visual tree</param>
+        /// <returns>All ancestors in visual tree of <paramref name="child"/> element</returns>
+        public static IEnumerable<DependencyObject> GetAncestors(this DependencyObject child)
+        {
+            var parent = VisualTreeHelper.GetParent(child);
+            while (parent != null)
+            {
+                yield return parent;
+                parent = VisualTreeHelper.GetParent(parent);
+            }
+        }
+
+        /// <summary>
         /// Finds a Child of a given item in the visual tree. 
         /// </summary>
         /// <param name="parent">A direct parent of the queried item.</param>

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Converters/TreeViewMarginConverter.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Converters/TreeViewMarginConverter.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using MahApps.Metro.Controls;
+using System;
 using System.Globalization;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Media;
 
 namespace MahApps.Metro.Converters
 {
@@ -30,22 +31,7 @@ namespace MahApps.Metro.Converters
     {
         public static int GetDepth(this TreeViewItem item)
         {
-            TreeViewItem parent;
-            while ((parent = GetParent(item)) != null)
-            {
-                return GetDepth(parent) + 1;
-            }
-            return 0;
-        }
-
-        private static TreeViewItem GetParent(TreeViewItem item)
-        {
-            var parent = item != null ? VisualTreeHelper.GetParent(item) : null;
-            while (parent != null && !(parent is TreeViewItem || parent is TreeView))
-            {
-                parent = VisualTreeHelper.GetParent(parent);
-            }
-            return parent as TreeViewItem;
+            return item.GetAncestors().TakeWhile(e => !(e is TreeView)).OfType<TreeViewItem>().Count();
         }
     }
 }


### PR DESCRIPTION
Added one method to TreeHepler.
In every place where visual tree Ancestors are needed TreeHelper is used.