### PR TITLE
(GH-3175) MetroWindow: use BorderThickness as Margin for inner window content

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/DateExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleViews/DateExamples.xaml
@@ -35,9 +35,9 @@
                             Controls:TextBoxHelper.WatermarkAlignment="Right" />
                 <DatePicker Width="200"
                             Margin="0 10 0 0"
+                            HorizontalAlignment="Center"
                             Controls:ControlsHelper.IsReadOnly="True"
-                            SelectedDate="{x:Static system:DateTime.Now}"
-                            HorizontalAlignment="Center" />
+                            SelectedDate="{x:Static system:DateTime.Now}" />
                 <DatePicker Width="200"
                             Margin="0 10 0 0"
                             HorizontalAlignment="Center"

--- a/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -135,8 +135,8 @@
 
                     <ControlTemplate.Triggers>
                         <Trigger Property="Controls:ControlsHelper.IsReadOnly" Value="True">
-                            <Setter TargetName="PART_TextBox" Property="IsReadOnly" Value="True" />
                             <Setter TargetName="PART_Button" Property="IsEnabled" Value="False" />
+                            <Setter TargetName="PART_TextBox" Property="IsReadOnly" Value="True" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.MouseOverBorderBrush)}" />

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroWindow.xaml
@@ -13,9 +13,11 @@
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
     <ControlTemplate x:Key="WindowTemplateKey" TargetType="{x:Type Controls:MetroWindow}">
-        <Grid LayoutTransform="{Binding LayoutTransform, RelativeSource={RelativeSource TemplatedParent}}" RenderTransform="{Binding RenderTransform, RelativeSource={RelativeSource TemplatedParent}}">
+        <Grid Background="{TemplateBinding Background}"
+              LayoutTransform="{Binding LayoutTransform, RelativeSource={RelativeSource TemplatedParent}}"
+              RenderTransform="{Binding RenderTransform, RelativeSource={RelativeSource TemplatedParent}}">
             <AdornerDecorator>
-                <Grid Background="{TemplateBinding Background}">
+                <Grid Margin="{TemplateBinding BorderThickness}">
                     <Grid.ColumnDefinitions>
                         <!--  icon  -->
                         <ColumnDefinition Width="Auto" />
@@ -266,9 +268,11 @@
     </ControlTemplate>
 
     <ControlTemplate x:Key="CenterWindowTemplateKey" TargetType="{x:Type Controls:MetroWindow}">
-        <Grid LayoutTransform="{Binding LayoutTransform, RelativeSource={RelativeSource TemplatedParent}}" RenderTransform="{Binding RenderTransform, RelativeSource={RelativeSource TemplatedParent}}">
+        <Grid Background="{TemplateBinding Background}"
+              LayoutTransform="{Binding LayoutTransform, RelativeSource={RelativeSource TemplatedParent}}"
+              RenderTransform="{Binding RenderTransform, RelativeSource={RelativeSource TemplatedParent}}">
             <AdornerDecorator>
-                <Grid Background="{TemplateBinding Background}">
+                <Grid Margin="{TemplateBinding BorderThickness}">
                     <Grid.ColumnDefinitions>
                         <!--  icon  -->
                         <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
## What changed?

Use `BorderThickness` as Margin for inner `MetroWindow` content.

_Closed issues._

Closes #3175 

![2018-01-24_22h51_47](https://user-images.githubusercontent.com/658431/35359840-f5b4e3a8-015b-11e8-817d-71fb4337f65f.png)
