### PR TITLE
Analyse code with DotNetAnalyzers/WpfAnalyzers

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleWindows/ShowcaseFlyout.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.Shared/ExampleWindows/ShowcaseFlyout.xaml
@@ -1,8 +1,10 @@
 ﻿<controls:Flyout x:Class="MetroDemo.ExampleWindows.ShowcaseFlyout"
                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:actions="clr-namespace:MahApps.Metro.Actions;assembly=MahApps.Metro"
                  xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls"
                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                  xmlns:metroDemo="clr-namespace:MetroDemo"
                  xmlns:system="clr-namespace:System;assembly=mscorlib"
@@ -39,8 +41,6 @@
                         Height="34"
                         Margin="2 4 2 2"
                         VerticalAlignment="Bottom"
-                        Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type controls:Flyout}}, Path=InternalCloseCommand, Mode=OneWay}"
-                        CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type controls:Flyout}}, Path=CloseCommandParameter, Mode=OneWay}"
                         DockPanel.Dock="Left"
                         FontFamily="Segoe UI Symbol"
                         FontSize="16"
@@ -48,6 +48,11 @@
                         IsCancel="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:Flyout}}, Path=CloseButtonIsCancel}"
                         Style="{DynamicResource MahApps.Metro.Styles.MetroCircleButtonStyle}"
                         Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type controls:Flyout}}, Path=CloseButtonVisibility}">
+                    <i:Interaction.Triggers>
+                        <i:EventTrigger EventName="Click">
+                            <actions:CloseFlyoutAction Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type controls:Flyout}}, Path=CloseCommand, Mode=OneWay}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type controls:Flyout}}, Path=CloseCommandParameter, Mode=OneWay}" />
+                        </i:EventTrigger>
+                    </i:Interaction.Triggers>
                     <ContentControl Width="20"
                                     Height="20"
                                     Content="M19,34V42H43.75L33.75,52H44.25L58.25,38L44.25,24H33.75L43.75,34H19Z"

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Actions/CloseFlyoutAction.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Actions/CloseFlyoutAction.cs
@@ -1,0 +1,38 @@
+﻿using MahApps.Metro.Controls;
+
+namespace MahApps.Metro.Actions
+{
+    public class CloseFlyoutAction : CommandTriggerAction
+    {
+        private Flyout associatedFlyout;
+
+        private Flyout AssociatedFlyout => this.associatedFlyout ?? (this.associatedFlyout = this.AssociatedObject.TryFindParent<Flyout>());
+
+        protected override void Invoke(object parameter)
+        {
+            if (this.AssociatedObject == null || (this.AssociatedObject != null && !this.AssociatedObject.IsEnabled))
+            {
+                return;
+            }
+
+            var command = this.Command;
+            if (command != null)
+            {
+                var commandParameter = this.GetCommandParameter();
+                if (command.CanExecute(commandParameter))
+                {
+                    command.Execute(commandParameter);
+                }
+            }
+            else
+            {
+                this.AssociatedFlyout?.SetCurrentValue(Flyout.IsOpenProperty, false);
+            }
+        }
+
+        protected override object GetCommandParameter()
+        {
+            return this.CommandParameter ?? this.AssociatedFlyout;
+        }
+    }
+}

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Actions/CloseTabItemAction.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Actions/CloseTabItemAction.cs
@@ -3,61 +3,15 @@ using System.Collections;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
-using System.Windows.Interactivity;
 using MahApps.Metro.Controls;
 
 namespace MahApps.Metro.Actions
 {
-    public class CloseTabItemAction : TriggerAction<FrameworkElement>
+    public class CloseTabItemAction : CommandTriggerAction
     {
         private TabItem associatedTabItem;
 
         private TabItem AssociatedTabItem => this.associatedTabItem ?? (this.associatedTabItem = this.AssociatedObject.TryFindParent<TabItem>());
-
-        /// <summary>
-        /// Identifies the <see cref="Command" /> dependency property
-        /// </summary>
-        public static readonly DependencyProperty CommandProperty
-            = DependencyProperty.Register(nameof(Command),
-                                          typeof(ICommand),
-                                          typeof(CloseTabItemAction),
-                                          new PropertyMetadata(null, (s, e) => OnCommandChanged(s as CloseTabItemAction, e)));
-
-        /// <summary>
-        /// Gets or sets the command that this trigger is bound to.
-        /// </summary>
-        public ICommand Command
-        {
-            get { return (ICommand)this.GetValue(CommandProperty); }
-            set { this.SetValue(CommandProperty, value); }
-        }
-
-        /// <summary>
-        /// Identifies the <see cref="CommandParameter" /> dependency property
-        /// </summary>
-        public static readonly DependencyProperty CommandParameterProperty
-            = DependencyProperty.Register(nameof(CommandParameter),
-                                          typeof(object),
-                                          typeof(CloseTabItemAction),
-                                          new PropertyMetadata(null,
-                                                               (s, e) =>
-                                                                   {
-                                                                       var sender = s as CloseTabItemAction;
-                                                                       if (sender?.AssociatedObject != null)
-                                                                       {
-                                                                           sender.EnableDisableElement();
-                                                                       }
-                                                                   }));
-
-        /// <summary>
-        /// Gets or sets an object that will be passed to the <see cref="Command" /> attached to this trigger.
-        /// </summary>
-        public object CommandParameter
-        {
-            get { return this.GetValue(CommandParameterProperty); }
-            set { this.SetValue(CommandParameterProperty, value); }
-        }
 
         [Obsolete("This property will be deleted in the next release.")]
         public static readonly DependencyProperty TabControlProperty =
@@ -85,12 +39,6 @@ namespace MahApps.Metro.Actions
         {
             get { return (TabItem)this.GetValue(TabItemProperty); }
             set { this.SetValue(TabItemProperty, value); }
-        }
-
-        protected override void OnAttached()
-        {
-            base.OnAttached();
-            this.EnableDisableElement();
         }
 
         protected override void Invoke(object parameter)
@@ -160,46 +108,9 @@ namespace MahApps.Metro.Actions
             }
         }
 
-        private static void OnCommandChanged(CloseTabItemAction action, DependencyPropertyChangedEventArgs e)
-        {
-            if (action == null)
-            {
-                return;
-            }
-
-            if (e.OldValue != null)
-            {
-                ((ICommand)e.OldValue).CanExecuteChanged -= action.OnCommandCanExecuteChanged;
-            }
-
-            var command = (ICommand)e.NewValue;
-            if (command != null)
-            {
-                command.CanExecuteChanged += action.OnCommandCanExecuteChanged;
-            }
-
-            action.EnableDisableElement();
-        }
-
-        private object GetCommandParameter()
+        protected override object GetCommandParameter()
         {
             return this.CommandParameter ?? this.AssociatedTabItem;
-        }
-
-        private void EnableDisableElement()
-        {
-            if (this.AssociatedObject == null)
-            {
-                return;
-            }
-
-            var command = this.Command;
-            this.AssociatedObject.IsEnabled = command == null || command.CanExecute(this.GetCommandParameter());
-        }
-
-        private void OnCommandCanExecuteChanged(object sender, EventArgs e)
-        {
-            this.EnableDisableElement();
         }
     }
 }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Actions/CommandTriggerAction.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Actions/CommandTriggerAction.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Interactivity;
+
+namespace MahApps.Metro.Actions
+{
+    /// <summary>
+    /// This CommandTriggerAction can be used to bind any event on any FrameworkElement to an <see cref="ICommand" />.
+    /// This trigger can only be attached to a FrameworkElement or a class deriving from FrameworkElement.
+    /// 
+    /// This class is inspired from Laurent Bugnion and his EventToCommand.
+    /// <web>http://www.mvvmlight.net</web>
+    /// <license> See license.txt in this solution or http://www.galasoft.ch/license_MIT.txt </license>
+    /// </summary>
+    public class CommandTriggerAction : TriggerAction<FrameworkElement>
+    {
+        /// <summary>
+        /// Identifies the <see cref="Command" /> dependency property
+        /// </summary>
+        public static readonly DependencyProperty CommandProperty
+            = DependencyProperty.Register(nameof(Command),
+                                          typeof(ICommand),
+                                          typeof(CommandTriggerAction),
+                                          new PropertyMetadata(null, (s, e) => OnCommandChanged(s as CommandTriggerAction, e)));
+
+        /// <summary>
+        /// Gets or sets the command that this trigger is bound to.
+        /// </summary>
+        public ICommand Command
+        {
+            get { return (ICommand)this.GetValue(CommandProperty); }
+            set { this.SetValue(CommandProperty, value); }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="CommandParameter" /> dependency property
+        /// </summary>
+        public static readonly DependencyProperty CommandParameterProperty
+            = DependencyProperty.Register(nameof(CommandParameter),
+                                          typeof(object),
+                                          typeof(CommandTriggerAction),
+                                          new PropertyMetadata(null,
+                                                               (s, e) =>
+                                                                   {
+                                                                       var sender = s as CommandTriggerAction;
+                                                                       if (sender?.AssociatedObject != null)
+                                                                       {
+                                                                           sender.EnableDisableElement();
+                                                                       }
+                                                                   }));
+
+        /// <summary>
+        /// Gets or sets an object that will be passed to the <see cref="Command" /> attached to this trigger.
+        /// </summary>
+        public object CommandParameter
+        {
+            get { return this.GetValue(CommandParameterProperty); }
+            set { this.SetValue(CommandParameterProperty, value); }
+        }
+
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+            this.EnableDisableElement();
+        }
+
+        protected override void Invoke(object parameter)
+        {
+            if (this.AssociatedObject == null || (this.AssociatedObject != null && !this.AssociatedObject.IsEnabled))
+            {
+                return;
+            }
+
+            var command = this.Command;
+            if (command != null)
+            {
+                var commandParameter = this.GetCommandParameter();
+                if (command.CanExecute(commandParameter))
+                {
+                    command.Execute(commandParameter);
+                }
+            }
+        }
+
+        private static void OnCommandChanged(CommandTriggerAction action, DependencyPropertyChangedEventArgs e)
+        {
+            if (action == null)
+            {
+                return;
+            }
+
+            if (e.OldValue != null)
+            {
+                ((ICommand)e.OldValue).CanExecuteChanged -= action.OnCommandCanExecuteChanged;
+            }
+
+            var command = (ICommand)e.NewValue;
+            if (command != null)
+            {
+                command.CanExecuteChanged += action.OnCommandCanExecuteChanged;
+            }
+
+            action.EnableDisableElement();
+        }
+
+        protected virtual object GetCommandParameter()
+        {
+            return this.CommandParameter ?? this.AssociatedObject;
+        }
+
+        private void EnableDisableElement()
+        {
+            if (this.AssociatedObject == null)
+            {
+                return;
+            }
+
+            var command = this.Command;
+            this.AssociatedObject.SetCurrentValue(UIElement.IsEnabledProperty, command == null || command.CanExecute(this.GetCommandParameter()));
+        }
+
+        private void OnCommandCanExecuteChanged(object sender, EventArgs e)
+        {
+            this.EnableDisableElement();
+        }
+    }
+}

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/ReloadBehavior.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/ReloadBehavior.cs
@@ -1,15 +1,17 @@
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using MahApps.Metro.Controls;
 
 namespace MahApps.Metro.Behaviours
 {
-    using System.ComponentModel;
-
     public static class ReloadBehavior
     {
-        public static DependencyProperty OnDataContextChangedProperty =
-            DependencyProperty.RegisterAttached("OnDataContextChanged", typeof(bool), typeof(ReloadBehavior), new PropertyMetadata(OnDataContextChanged));
+        public static readonly DependencyProperty OnDataContextChangedProperty
+            = DependencyProperty.RegisterAttached("OnDataContextChanged",
+                                                  typeof(bool),
+                                                  typeof(ReloadBehavior),
+                                                  new PropertyMetadata(OnDataContextChanged));
 
         [Category(AppName.MahApps)]
         public static bool GetOnDataContextChanged(MetroContentControl element)
@@ -17,6 +19,7 @@ namespace MahApps.Metro.Behaviours
             return (bool)element.GetValue(OnDataContextChangedProperty);
         }
 
+        [Category(AppName.MahApps)]
         public static void SetOnDataContextChanged(MetroContentControl element, bool value)
         {
             element.SetValue(OnDataContextChangedProperty, value);
@@ -24,30 +27,36 @@ namespace MahApps.Metro.Behaviours
 
         private static void OnDataContextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
+            ((MetroContentControl)d).DataContextChanged -= ReloadDataContextChanged;
             ((MetroContentControl)d).DataContextChanged += ReloadDataContextChanged;
         }
 
-        static void ReloadDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        private static void ReloadDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             ((MetroContentControl)sender).Reload();
         }
 
-        public static DependencyProperty OnSelectedTabChangedProperty =
-            DependencyProperty.RegisterAttached("OnSelectedTabChanged", typeof(bool), typeof(ReloadBehavior), new PropertyMetadata(OnSelectedTabChanged));
+        public static readonly DependencyProperty OnSelectedTabChangedProperty
+            = DependencyProperty.RegisterAttached("OnSelectedTabChanged",
+                                                  typeof(bool),
+                                                  typeof(ReloadBehavior),
+                                                  new PropertyMetadata(OnSelectedTabChanged));
 
         [Category(AppName.MahApps)]
         public static bool GetOnSelectedTabChanged(ContentControl element)
         {
-            return (bool)element.GetValue(OnDataContextChangedProperty);
+            return (bool)element.GetValue(OnSelectedTabChangedProperty);
         }
 
+        [Category(AppName.MahApps)]
         public static void SetOnSelectedTabChanged(ContentControl element, bool value)
         {
-            element.SetValue(OnDataContextChangedProperty, value);
+            element.SetValue(OnSelectedTabChangedProperty, value);
         }
 
         private static void OnSelectedTabChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
+            ((ContentControl)d).Loaded -= ReloadLoaded;
             ((ContentControl)d).Loaded += ReloadLoaded;
         }
 
@@ -56,35 +65,39 @@ namespace MahApps.Metro.Behaviours
             var metroContentControl = (ContentControl)sender;
             var tab = metroContentControl.TryFindParent<TabControl>();
 
-            if (tab == null) return;
+            if (tab == null)
+            {
+                return;
+            }
 
             SetMetroContentControl(tab, metroContentControl);
             tab.SelectionChanged -= ReloadSelectionChanged;
             tab.SelectionChanged += ReloadSelectionChanged;
         }
-        
+
         private static void ReloadSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (e.OriginalSource != sender)
+            {
                 return;
+            }
 
             var contentControl = GetMetroContentControl((TabControl)sender);
+
             var metroContentControl = contentControl as MetroContentControl;
-            if (metroContentControl != null)
-            {
-                metroContentControl.Reload();
-            }
-            
+            metroContentControl?.Reload();
+
             var transitioningContentControl = contentControl as TransitioningContentControl;
-            if (transitioningContentControl != null)
-            {
-                transitioningContentControl.ReloadTransition();
-            }
+            transitioningContentControl?.ReloadTransition();
         }
 
-        public static readonly DependencyProperty MetroContentControlProperty =
-            DependencyProperty.RegisterAttached("MetroContentControl", typeof(ContentControl), typeof(ReloadBehavior), new PropertyMetadata(default(ContentControl)));
+        public static readonly DependencyProperty MetroContentControlProperty
+            = DependencyProperty.RegisterAttached("MetroContentControl",
+                                                  typeof(ContentControl),
+                                                  typeof(ReloadBehavior),
+                                                  new PropertyMetadata(default(ContentControl)));
 
+        [Category(AppName.MahApps)]
         public static void SetMetroContentControl(UIElement element, ContentControl value)
         {
             element.SetValue(MetroContentControlProperty, value);

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/StylizedBehaviors.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/StylizedBehaviors.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Interactivity;
 
@@ -78,7 +79,7 @@ namespace MahApps.Metro.Behaviours
 
         private static void Dispatcher_ShutdownStarted(object sender, System.EventArgs e)
         {
-            var s = "";
+            Debug.WriteLine("Dispatcher.ShutdownStarted");
         }
 
         private static void FrameworkElementUnloaded(object sender, RoutedEventArgs e)

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/StylizedBehaviors.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/StylizedBehaviors.cs
@@ -138,7 +138,7 @@ namespace MahApps.Metro.Behaviours
         }
 
         private static readonly DependencyProperty OriginalBehaviorProperty
-            = DependencyProperty.RegisterAttached("OriginalBehaviorInternal",
+            = DependencyProperty.RegisterAttached("OriginalBehavior",
                                                   typeof(Behavior),
                                                   typeof(StylizedBehaviors),
                                                   new UIPropertyMetadata(null));

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/TiltBehavior.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Behaviours/TiltBehavior.cs
@@ -141,10 +141,8 @@ namespace MahApps.Metro.Behaviours
                         if (current.X > 0 && current.X < (attachedElement).ActualWidth && current.Y > 0 &&
                             current.Y < (attachedElement).ActualHeight)
                         {
-                            RotatorParent.RotationY = -1 * TiltFactor +
-                                                      current.X * 2 * TiltFactor / (attachedElement).ActualWidth;
-                            RotatorParent.RotationX = -1 * TiltFactor +
-                                                      current.Y * 2 * TiltFactor / (attachedElement).ActualHeight;
+                            RotatorParent.RotationY = -1 * TiltFactor + current.X * 2 * TiltFactor / (attachedElement).ActualWidth;
+                            RotatorParent.RotationX = -1 * TiltFactor + current.Y * 2 * TiltFactor / (attachedElement).ActualHeight;
                         }
                         isPressed = true;
                     }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/DropDownButton.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/DropDownButton.cs
@@ -257,7 +257,7 @@ namespace MahApps.Metro.Controls
 
         private void ButtonClick(object sender, RoutedEventArgs e)
         {
-            this.IsExpanded = true;
+            this.SetCurrentValue(IsExpandedProperty, true);
             e.RoutedEvent = ClickEvent;
             this.RaiseEvent(e);
         }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/FlipView.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/FlipView.cs
@@ -152,7 +152,7 @@ namespace MahApps.Metro.Controls
         {
             if (element != item)
             {
-                element.SetCurrentValue(DataContextProperty, item); //dont want to set the datacontext to itself. taken from MetroTabControl.cs
+                element.SetValue(DataContextProperty, item); //dont want to set the datacontext to itself.
             }
 
             base.PrepareContainerForItemOverride(element, item);

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/FlipView.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/FlipView.cs
@@ -496,7 +496,7 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty DownTransitionProperty = DependencyProperty.Register("DownTransition", typeof(TransitionType), typeof(FlipView), new PropertyMetadata(TransitionType.Down));
         public static readonly DependencyProperty LeftTransitionProperty = DependencyProperty.Register("LeftTransition", typeof(TransitionType), typeof(FlipView), new PropertyMetadata(TransitionType.LeftReplace));
         public static readonly DependencyProperty RightTransitionProperty = DependencyProperty.Register("RightTransition", typeof(TransitionType), typeof(FlipView), new PropertyMetadata(TransitionType.RightReplace));
-        [Obsolete(@"This property will be deleted in the next release. You should use now MouseHoverBorderEnabled instead.")]
+        [Obsolete("This property will be deleted in the next release. You should use now MouseHoverBorderEnabled instead.")]
         public static readonly DependencyProperty MouseOverGlowEnabledProperty = DependencyProperty.Register("MouseOverGlowEnabled", typeof(bool), typeof(FlipView), new PropertyMetadata(true, (o, e) => ((FlipView)o).MouseHoverBorderEnabled = (bool)e.NewValue));
         public static readonly DependencyProperty MouseHoverBorderEnabledProperty = DependencyProperty.Register("MouseHoverBorderEnabled", typeof(bool), typeof(FlipView), new PropertyMetadata(true));
         public static readonly DependencyProperty MouseHoverBorderBrushProperty = DependencyProperty.Register("MouseHoverBorderBrush", typeof(Brush), typeof(FlipView), new PropertyMetadata(Brushes.LightGray));
@@ -531,6 +531,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(RightTransitionProperty, value); }
         }
 
+        [Obsolete("This property will be deleted in the next release. You should use now MouseHoverBorderEnabled instead.")]
         public bool MouseOverGlowEnabled
         {
             get { return (bool)this.GetValue(MouseOverGlowEnabledProperty); }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/FlipView.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/FlipView.cs
@@ -497,7 +497,7 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty LeftTransitionProperty = DependencyProperty.Register("LeftTransition", typeof(TransitionType), typeof(FlipView), new PropertyMetadata(TransitionType.LeftReplace));
         public static readonly DependencyProperty RightTransitionProperty = DependencyProperty.Register("RightTransition", typeof(TransitionType), typeof(FlipView), new PropertyMetadata(TransitionType.RightReplace));
         [Obsolete("This property will be deleted in the next release. You should use now MouseHoverBorderEnabled instead.")]
-        public static readonly DependencyProperty MouseOverGlowEnabledProperty = DependencyProperty.Register("MouseOverGlowEnabled", typeof(bool), typeof(FlipView), new PropertyMetadata(true, (o, e) => ((FlipView)o).MouseHoverBorderEnabled = (bool)e.NewValue));
+        public static readonly DependencyProperty MouseOverGlowEnabledProperty = DependencyProperty.Register("MouseOverGlowEnabled", typeof(bool), typeof(FlipView), new PropertyMetadata(true, (o, e) => ((FlipView)o).SetCurrentValue(MouseHoverBorderEnabledProperty, (bool)e.NewValue)));
         public static readonly DependencyProperty MouseHoverBorderEnabledProperty = DependencyProperty.Register("MouseHoverBorderEnabled", typeof(bool), typeof(FlipView), new PropertyMetadata(true));
         public static readonly DependencyProperty MouseHoverBorderBrushProperty = DependencyProperty.Register("MouseHoverBorderBrush", typeof(Brush), typeof(FlipView), new PropertyMetadata(Brushes.LightGray));
         public static readonly DependencyProperty MouseHoverBorderThicknessProperty = DependencyProperty.Register("MouseHoverBorderThickness", typeof(Thickness), typeof(FlipView), new PropertyMetadata(new Thickness(4)));

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Flyout.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Flyout.cs
@@ -56,6 +56,8 @@ namespace MahApps.Metro.Controls
 
         public static readonly DependencyProperty CloseCommandProperty = DependencyProperty.RegisterAttached("CloseCommand", typeof(ICommand), typeof(Flyout), new UIPropertyMetadata(null));
         public static readonly DependencyProperty CloseCommandParameterProperty = DependencyProperty.Register("CloseCommandParameter", typeof(object), typeof(Flyout), new PropertyMetadata(null));
+
+        [Obsolete("This property will be deleted in the next release. Please use the new CloseFlyoutAction trigger.")]
         internal static readonly DependencyProperty InternalCloseCommandProperty = DependencyProperty.Register("InternalCloseCommand", typeof(ICommand), typeof(Flyout));
 
         public static readonly DependencyProperty ThemeProperty = DependencyProperty.Register("Theme", typeof(FlyoutTheme), typeof(Flyout), new FrameworkPropertyMetadata(FlyoutTheme.Dark, ThemeChanged));
@@ -127,6 +129,7 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Gets/sets a command which will be executed if the close button was clicked.
         /// </summary>
+        [Obsolete("This property will be deleted in the next release. Please use the new CloseFlyoutAction trigger.")]
         internal ICommand InternalCloseCommand
         {
             get { return (ICommand)this.GetValue(InternalCloseCommandProperty); }
@@ -248,7 +251,9 @@ namespace MahApps.Metro.Controls
 
         public Flyout()
         {
+#pragma warning disable 618
             this.InternalCloseCommand = new CloseCommand(this.InternalCloseCommandCanExecute, this.InternalCloseCommandExecuteAction);
+#pragma warning restore 618
             this.Loaded += (sender, args) => this.UpdateFlyoutTheme();
             this.InitializeAutoCloseTimer();
         }
@@ -264,7 +269,7 @@ namespace MahApps.Metro.Controls
             // close the Flyout only if there is no command
             if (closeCommand == null)
             {
-                this.IsOpen = false;
+                this.SetCurrentValue(IsOpenProperty, false);
             }
             else
             {

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/MenuItems/HamburgerMenuGlyphItem.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/MenuItems/HamburgerMenuGlyphItem.cs
@@ -10,7 +10,7 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Identifies the <see cref="Glyph"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty GlyphProperty = DependencyProperty.Register(nameof(Glyph), typeof(string), typeof(HamburgerMenuItem), new PropertyMetadata(null));
+        public static readonly DependencyProperty GlyphProperty = DependencyProperty.Register(nameof(Glyph), typeof(string), typeof(HamburgerMenuGlyphItem), new PropertyMetadata(null));
 
         /// <summary>
         /// Gets or sets a value that specifies the glyph to use from Segoe MDL2 Assets font.

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/MenuItems/HamburgerMenuIconItem.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/MenuItems/HamburgerMenuIconItem.cs
@@ -10,7 +10,7 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Identifies the <see cref="Icon"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty IconProperty = DependencyProperty.Register(nameof(Icon), typeof(object), typeof(HamburgerMenuItem), new PropertyMetadata(null));
+        public static readonly DependencyProperty IconProperty = DependencyProperty.Register(nameof(Icon), typeof(object), typeof(HamburgerMenuIconItem), new PropertyMetadata(null));
 
         /// <summary>
         /// Gets or sets a value that specifies an user specific object which can be used as icon.

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/MenuItems/HamburgerMenuImageItem.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/HamburgerMenu/MenuItems/HamburgerMenuImageItem.cs
@@ -11,7 +11,7 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Identifies the <see cref="Thumbnail"/> dependency property.
         /// </summary>
-        public static readonly DependencyProperty ThumbnailProperty = DependencyProperty.Register(nameof(Thumbnail), typeof(ImageSource), typeof(HamburgerMenuItem), new PropertyMetadata(null));
+        public static readonly DependencyProperty ThumbnailProperty = DependencyProperty.Register(nameof(Thumbnail), typeof(ImageSource), typeof(HamburgerMenuImageItem), new PropertyMetadata(null));
 
         /// <summary>
         /// Gets or sets a value that specifies a bitmap to display with an Image control.

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/ComboBoxHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/ComboBoxHelper.cs
@@ -1,45 +1,55 @@
-﻿using System.Windows;
+﻿using System.ComponentModel;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace MahApps.Metro.Controls
 {
-    using System.ComponentModel;
-
     /// <summary>
-    /// A helper class that provides various attached properties for the ComboBox control.
-    /// <see cref="ComboBox"/>
+    /// A helper class that provides various attached properties for the <see cref="ComboBox"/> control.
     /// </summary>
     public class ComboBoxHelper
     {
-        public static readonly DependencyProperty EnableVirtualizationWithGroupingProperty = DependencyProperty.RegisterAttached("EnableVirtualizationWithGrouping", typeof(bool), typeof(ComboBoxHelper), new FrameworkPropertyMetadata(false, EnableVirtualizationWithGroupingPropertyChangedCallback));
+        public static readonly DependencyProperty EnableVirtualizationWithGroupingProperty
+            = DependencyProperty.RegisterAttached("EnableVirtualizationWithGrouping",
+                                                  typeof(bool),
+                                                  typeof(ComboBoxHelper),
+                                                  new FrameworkPropertyMetadata(false, OnEnableVirtualizationWithGroupingChanged));
 
-        private static void EnableVirtualizationWithGroupingPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        private static void OnEnableVirtualizationWithGroupingChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
             var comboBox = dependencyObject as ComboBox;
             if (comboBox != null && e.NewValue != e.OldValue)
             {
 #if NET4_5
-                comboBox.SetValue(VirtualizingStackPanel.IsVirtualizingProperty, e.NewValue);
-                comboBox.SetValue(VirtualizingPanel.IsVirtualizingWhenGroupingProperty, e.NewValue);
-                comboBox.SetValue(ScrollViewer.CanContentScrollProperty, e.NewValue);
+                comboBox.SetCurrentValue(VirtualizingStackPanel.IsVirtualizingProperty, e.NewValue);
+                comboBox.SetCurrentValue(VirtualizingPanel.IsVirtualizingWhenGroupingProperty, e.NewValue);
+                comboBox.SetCurrentValue(ScrollViewer.CanContentScrollProperty, e.NewValue);
 #endif
             }
         }
 
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
         public static void SetEnableVirtualizationWithGrouping(DependencyObject obj, bool value)
         {
             obj.SetValue(EnableVirtualizationWithGroupingProperty, value);
         }
 
         [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
         public static bool GetEnableVirtualizationWithGrouping(DependencyObject obj)
         {
             return (bool)obj.GetValue(EnableVirtualizationWithGroupingProperty);
         }
 
-        public static readonly DependencyProperty MaxLengthProperty = DependencyProperty.RegisterAttached("MaxLength", typeof(int), typeof(ComboBoxHelper), new FrameworkPropertyMetadata(0), new ValidateValueCallback(MaxLengthValidateValue));
+        public static readonly DependencyProperty MaxLengthProperty
+            = DependencyProperty.RegisterAttached("MaxLength",
+                                                  typeof(int),
+                                                  typeof(ComboBoxHelper),
+                                                  new FrameworkPropertyMetadata(0),
+                                                  ValidateMaxLength);
 
-        private static bool MaxLengthValidateValue(object value)
+        private static bool ValidateMaxLength(object value)
         {
             return ((int)value) >= 0;
         }
@@ -57,14 +67,21 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Sets the Maximum number of characters the TextBox can accept.
         /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
         public static void SetMaxLength(UIElement obj, int value)
         {
             obj.SetValue(MaxLengthProperty, value);
         }
 
-        public static readonly DependencyProperty CharacterCasingProperty = DependencyProperty.RegisterAttached("CharacterCasing", typeof(CharacterCasing), typeof(ComboBoxHelper), new FrameworkPropertyMetadata(CharacterCasing.Normal), new ValidateValueCallback(CharacterCasingValidateValue));
+        public static readonly DependencyProperty CharacterCasingProperty
+            = DependencyProperty.RegisterAttached("CharacterCasing",
+                                                  typeof(CharacterCasing),
+                                                  typeof(ComboBoxHelper),
+                                                  new FrameworkPropertyMetadata(CharacterCasing.Normal),
+                                                  ValidateCharacterCasing);
 
-        private static bool CharacterCasingValidateValue(object value)
+        private static bool ValidateCharacterCasing(object value)
         {
             return (CharacterCasing.Normal <= (CharacterCasing)value && (CharacterCasing)value <= CharacterCasing.Upper);
         }
@@ -82,6 +99,8 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Sets the Character casing of the TextBox.
         /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
         public static void SetCharacterCasing(UIElement obj, CharacterCasing value)
         {
             obj.SetValue(CharacterCasingProperty, value);

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/DataGridCellHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/DataGridCellHelper.cs
@@ -29,23 +29,29 @@ namespace MahApps.Metro.Controls
                     cell.Loaded += DataGridCellLoaded;
                     cell.Unloaded += DataGridCellUnloaded;
                 }
+#pragma warning disable 618
                 SetDataGrid(cell, dataGrid);
+#pragma warning restore 618
             }
         }
 
         static void DataGridCellLoaded(object sender, RoutedEventArgs e)
         {
             var cell = (DataGridCell)sender;
+#pragma warning disable 618
             if (GetDataGrid(cell) == null)
             {
                 var dataGrid = cell.TryFindParent<DataGrid>();
                 SetDataGrid(cell, dataGrid);
             }
+#pragma warning restore 618
         }
 
         static void DataGridCellUnloaded(object sender, RoutedEventArgs e)
         {
+#pragma warning disable 618
             SetDataGrid((DataGridCell)sender, null);
+#pragma warning restore 618
         }
 
         /// <summary>

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/Helper/TextBoxHelper.cs
@@ -184,7 +184,7 @@ namespace MahApps.Metro.Controls
 #endif
                 if (attribute != null)
                 {
-                    obj.SetValue(WatermarkProperty, attribute.GetPrompt());
+                    obj.SetCurrentValue(WatermarkProperty, attribute.GetPrompt());
                 }
             }
         }
@@ -267,7 +267,7 @@ namespace MahApps.Metro.Controls
 
             if (e.OldValue != e.NewValue)
             {
-                tb.SetValue(SpellCheck.IsEnabledProperty, (bool)e.NewValue);
+                tb.SetCurrentValue(SpellCheck.IsEnabledProperty, (bool)e.NewValue);
                 if ((bool)e.NewValue)
                 {
                     tb.ContextMenuOpening += TextBoxBaseContextMenuOpening;

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroProgressBar.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroProgressBar.cs
@@ -216,12 +216,12 @@ namespace MahApps.Metro.Controls
 
         private void SetEllipseDiameter(double width)
         {
-            this.EllipseDiameter = width <= 180 ? 4 : (width <= 280 ? 5 : 6);
+            this.SetCurrentValue(EllipseDiameterProperty, width <= 180 ? 4d : (width <= 280 ? 5d : 6d));
         }
 
         private void SetEllipseOffset(double width)
         {
-            this.EllipseOffset = width <= 180 ? 4 : (width <= 280 ? 7 : 9);
+            this.SetCurrentValue(EllipseOffsetProperty, width <= 180 ? 4d : (width <= 280 ? 7d : 9d));
         }
 
         private double CalcContainerAnimStart(double width)

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroTabControl.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroTabControl.cs
@@ -55,7 +55,9 @@ namespace MahApps.Metro.Controls
         protected override void PrepareContainerForItemOverride(DependencyObject element, object item)
         {
             if (element != item)
-                element.SetCurrentValue(DataContextProperty, item); //dont want to set the datacontext to itself.
+            {
+                element.SetValue(DataContextProperty, item); //dont want to set the datacontext to itself.
+            }
 
             base.PrepareContainerForItemOverride(element, item);
         }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
@@ -1025,10 +1025,12 @@ namespace MahApps.Metro.Controls
 
         private void MetroWindow_Loaded(object sender, RoutedEventArgs e)
         {
+#pragma warning disable 618
             if (EnableDWMDropShadow)
             {
                 this.UseDropShadow();
             }
+#pragma warning restore 618
 
             if (this.WindowTransitionsEnabled)
             {

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
@@ -86,7 +86,7 @@ namespace MahApps.Metro.Controls
 
         public static readonly DependencyProperty TitlebarHeightProperty = DependencyProperty.Register("TitlebarHeight", typeof(int), typeof(MetroWindow), new PropertyMetadata(30, TitlebarHeightPropertyChangedCallback));
         [Obsolete(@"This property will be deleted in the next release. You should use the new TitleCharacterCasing dependency property.")]
-        public static readonly DependencyProperty TitleCapsProperty = DependencyProperty.Register("TitleCaps", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true, (o, e) => ((MetroWindow)o).TitleCharacterCasing = (bool)e.NewValue ? CharacterCasing.Upper : CharacterCasing.Normal));
+        public static readonly DependencyProperty TitleCapsProperty = DependencyProperty.Register("TitleCaps", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true, (o, e) => ((MetroWindow)o).SetCurrentValue(TitleCharacterCasingProperty, (bool)e.NewValue ? CharacterCasing.Upper : CharacterCasing.Normal)));
         public static readonly DependencyProperty TitleCharacterCasingProperty = DependencyProperty.Register("TitleCharacterCasing", typeof(CharacterCasing), typeof(MetroWindow), new FrameworkPropertyMetadata(CharacterCasing.Upper, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure), value => CharacterCasing.Normal <= (CharacterCasing)value && (CharacterCasing)value <= CharacterCasing.Upper);
         public static readonly DependencyProperty TitleAlignmentProperty = DependencyProperty.Register("TitleAlignment", typeof(HorizontalAlignment), typeof(MetroWindow), new PropertyMetadata(HorizontalAlignment.Stretch, OnTitleAlignmentChanged));
 

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
@@ -88,7 +88,7 @@ namespace MahApps.Metro.Controls
         [Obsolete(@"This property will be deleted in the next release. You should use the new TitleCharacterCasing dependency property.")]
         public static readonly DependencyProperty TitleCapsProperty = DependencyProperty.Register("TitleCaps", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true, (o, e) => ((MetroWindow)o).TitleCharacterCasing = (bool)e.NewValue ? CharacterCasing.Upper : CharacterCasing.Normal));
         public static readonly DependencyProperty TitleCharacterCasingProperty = DependencyProperty.Register("TitleCharacterCasing", typeof(CharacterCasing), typeof(MetroWindow), new FrameworkPropertyMetadata(CharacterCasing.Upper, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure), value => CharacterCasing.Normal <= (CharacterCasing)value && (CharacterCasing)value <= CharacterCasing.Upper);
-        public static readonly DependencyProperty TitleAlignmentProperty = DependencyProperty.Register("TitleAlignment", typeof(HorizontalAlignment), typeof(MetroWindow), new PropertyMetadata(HorizontalAlignment.Stretch, PropertyChangedCallback));
+        public static readonly DependencyProperty TitleAlignmentProperty = DependencyProperty.Register("TitleAlignment", typeof(HorizontalAlignment), typeof(MetroWindow), new PropertyMetadata(HorizontalAlignment.Stretch, OnTitleAlignmentChanged));
 
         public static readonly DependencyProperty SaveWindowPositionProperty = DependencyProperty.Register("SaveWindowPosition", typeof(bool), typeof(MetroWindow), new PropertyMetadata(false));
         public static readonly DependencyProperty WindowPlacementSettingsProperty = DependencyProperty.Register("WindowPlacementSettings", typeof(IWindowPlacementSettings), typeof(MetroWindow), new PropertyMetadata(null));
@@ -678,7 +678,7 @@ namespace MahApps.Metro.Controls
             set { SetValue(TitleAlignmentProperty, value); }
         }
 
-        private static void PropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        private static void OnTitleAlignmentChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
             var window = dependencyObject as MetroWindow;
             if (window != null)

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/MetroWindow.cs
@@ -96,16 +96,16 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty IgnoreTaskbarOnMaximizeProperty = DependencyProperty.Register("IgnoreTaskbarOnMaximize", typeof(bool), typeof(MetroWindow), new PropertyMetadata(false));
         public static readonly DependencyProperty FlyoutsProperty = DependencyProperty.Register("Flyouts", typeof(FlyoutsControl), typeof(MetroWindow), new PropertyMetadata(null, UpdateLogicalChilds));
         public static readonly DependencyProperty WindowTransitionsEnabledProperty = DependencyProperty.Register("WindowTransitionsEnabled", typeof(bool), typeof(MetroWindow), new PropertyMetadata(true));
-        public static readonly DependencyProperty MetroDialogOptionsProperty = DependencyProperty.Register("MetroDialogOptions", typeof(MetroDialogSettings), typeof(MetroWindow), new PropertyMetadata(new MetroDialogSettings()));
+        public static readonly DependencyProperty MetroDialogOptionsProperty = DependencyProperty.Register("MetroDialogOptions", typeof(MetroDialogSettings), typeof(MetroWindow), new PropertyMetadata(default(MetroDialogSettings)));
 
         public static readonly DependencyProperty WindowTitleBrushProperty = DependencyProperty.Register("WindowTitleBrush", typeof(Brush), typeof(MetroWindow), new PropertyMetadata(Brushes.Transparent));
         public static readonly DependencyProperty NonActiveWindowTitleBrushProperty = DependencyProperty.Register("NonActiveWindowTitleBrush", typeof(Brush), typeof(MetroWindow), new PropertyMetadata(Brushes.Gray));
         public static readonly DependencyProperty NonActiveBorderBrushProperty = DependencyProperty.Register("NonActiveBorderBrush", typeof(Brush), typeof(MetroWindow), new PropertyMetadata(Brushes.Gray));
 
         public static readonly DependencyProperty GlowBrushProperty = DependencyProperty.Register("GlowBrush", typeof(Brush), typeof(MetroWindow), new PropertyMetadata(null));
-        public static readonly DependencyProperty NonActiveGlowBrushProperty = DependencyProperty.Register("NonActiveGlowBrush", typeof(Brush), typeof(MetroWindow), new PropertyMetadata(new SolidColorBrush(Color.FromRgb(153, 153, 153)))); // #999999
+        public static readonly DependencyProperty NonActiveGlowBrushProperty = DependencyProperty.Register("NonActiveGlowBrush", typeof(Brush), typeof(MetroWindow), new PropertyMetadata(null));
 
-        public static readonly DependencyProperty OverlayBrushProperty = DependencyProperty.Register("OverlayBrush", typeof(Brush), typeof(MetroWindow), new PropertyMetadata(new SolidColorBrush(Color.FromScRgb(255, 0, 0, 0)))); // BlackColorBrush
+        public static readonly DependencyProperty OverlayBrushProperty = DependencyProperty.Register("OverlayBrush", typeof(Brush), typeof(MetroWindow), new PropertyMetadata(null));
         public static readonly DependencyProperty OverlayOpacityProperty = DependencyProperty.Register("OverlayOpacity", typeof(double), typeof(MetroWindow), new PropertyMetadata(0.7d));
 
         /// <summary>
@@ -957,11 +957,18 @@ namespace MahApps.Metro.Controls
             restoreFocus = null;
         }
 
+        static MetroWindow()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(MetroWindow), new FrameworkPropertyMetadata(typeof(MetroWindow)));
+        }
+
         /// <summary>
         /// Initializes a new instance of the MahApps.Metro.Controls.MetroWindow class.
         /// </summary>
         public MetroWindow()
         {
+            this.MetroDialogOptions = new MetroDialogSettings();
+
             DataContextChanged += MetroWindow_DataContextChanged;
             Loaded += this.MetroWindow_Loaded;
 
@@ -1202,11 +1209,6 @@ namespace MahApps.Metro.Controls
                 }
                 return children.GetEnumerator();
             }
-        }
-
-        static MetroWindow()
-        {
-            DefaultStyleKeyProperty.OverrideMetadata(typeof(MetroWindow), new FrameworkPropertyMetadata(typeof(MetroWindow)));
         }
 
         public override void OnApplyTemplate()

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/ProgressRing.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/ProgressRing.cs
@@ -106,12 +106,9 @@ namespace MahApps.Metro.Controls
             var action = new Action(() =>
             {
 
-                ring.SetEllipseDiameter(
-                    (double) dependencyPropertyChangedEventArgs.NewValue);
-                ring.SetEllipseOffset(
-                    (double) dependencyPropertyChangedEventArgs.NewValue);
-                ring.SetMaxSideLength(
-                    (double) dependencyPropertyChangedEventArgs.NewValue);
+                ring.SetEllipseDiameter((double) dependencyPropertyChangedEventArgs.NewValue);
+                ring.SetEllipseOffset((double) dependencyPropertyChangedEventArgs.NewValue);
+                ring.SetMaxSideLength((double) dependencyPropertyChangedEventArgs.NewValue);
             });
 
             if (ring._deferredActions != null)
@@ -122,17 +119,17 @@ namespace MahApps.Metro.Controls
 
         private void SetMaxSideLength(double width)
         {
-            MaxSideLength = width <= 20 ? 20 : width;
+            SetCurrentValue(MaxSideLengthProperty, width <= 20 ? 20 : width);
         }
 
         private void SetEllipseDiameter(double width)
         {
-            EllipseDiameter =(width / 8)*EllipseDiameterScale;
+            SetCurrentValue(EllipseDiameterProperty, (width / 8)*EllipseDiameterScale);
         }
 
         private void SetEllipseOffset(double width)
         {
-            EllipseOffset = new Thickness(0, width / 2, 0, 0);
+            SetCurrentValue(EllipseOffsetProperty, new Thickness(0, width / 2, 0, 0));
         }
 
         private static void IsLargeChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
@@ -162,7 +159,7 @@ namespace MahApps.Metro.Controls
 
         private void OnSizeChanged(object sender, SizeChangedEventArgs sizeChangedEventArgs)
         {
-            BindableWidth = ActualWidth;
+            SetCurrentValue(BindableWidthProperty, ActualWidth);
         }
 
         private static void IsActiveChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
@@ -203,6 +200,7 @@ namespace MahApps.Metro.Controls
         }
     }
 
+    [Obsolete("This class will be deleted in the next release.")]
     internal class WidthToMaxSideLengthConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/RangeSlider.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/RangeSlider.cs
@@ -1938,16 +1938,6 @@ namespace MahApps.Metro.Controls
             _autoToolTip.HorizontalOffset = offset;
         }
 
-        private static bool IsValidDoubleValue(object value)
-        {
-            return value is double && IsValidDouble((double)value);
-        }
-
-        private static bool IsValidDouble(double d)
-        {
-            return !double.IsNaN(d) && !double.IsInfinity(d);
-        }
-
         //CHeck if two doubles approximately equals
         private bool ApproximatelyEquals(double value1, double value2)
         {
@@ -2024,6 +2014,16 @@ namespace MahApps.Metro.Controls
 
         #region Validation methods
 
+        private static bool IsValidDoubleValue(object value)
+        {
+            return value is double && IsValidDouble((double)value);
+        }
+
+        private static bool IsValidDouble(double d)
+        {
+            return !double.IsNaN(d) && !double.IsInfinity(d);
+        }
+
         private static bool IsValidPrecision(object value)
         {
             return ((Int32)value >= 0);
@@ -2031,13 +2031,7 @@ namespace MahApps.Metro.Controls
 
         private static bool IsValidMinRange(object value)
         {
-            double d = (double)value;
-            if (!Double.IsNaN(d))
-            {
-                return d >= 0d || !double.IsInfinity(d);
-            }
-
-            return false;
+            return value is double && IsValidDouble((double)value) && (double)value >= 0d;
         }
 
         #endregion

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/SplitView/SplitView.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/SplitView/SplitView.cs
@@ -354,13 +354,13 @@
             }
             else
             {
-                this.IsPaneOpen = false;
+                this.SetCurrentValue(IsPaneOpenProperty, false);
             }
         }        
 
         private void OnLightDismiss(object sender, MouseButtonEventArgs e)
         {
-            this.IsPaneOpen = false;
+            this.SetCurrentValue(IsPaneOpenProperty, false);
         }
     }
 }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/TimePicker/DateTimePicker.cs
@@ -192,7 +192,7 @@
         {
             base.ApplyCulture();
 
-            FirstDayOfWeek = SpecificCultureInfo.DateTimeFormat.FirstDayOfWeek;
+            SetCurrentValue(FirstDayOfWeekProperty, SpecificCultureInfo.DateTimeFormat.FirstDayOfWeek);
         }
 
         protected override string GetValueForTextBox()

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/ToggleSwitchButton.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/ToggleSwitchButton.cs
@@ -35,7 +35,7 @@ namespace MahApps.Metro.Controls
         private readonly PropertyChangeNotifier isCheckedPropertyChangeNotifier;
 
         [Obsolete(@"This property will be deleted in the next release. You should use OnSwitchBrush and OffSwitchBrush to change the switch's brushes.")]
-        public static readonly DependencyProperty SwitchForegroundProperty = DependencyProperty.Register("SwitchForeground", typeof(Brush), typeof(ToggleSwitchButton), new PropertyMetadata(null, (o, e) => ((ToggleSwitchButton)o).OnSwitchBrush = e.NewValue as Brush));
+        public static readonly DependencyProperty SwitchForegroundProperty = DependencyProperty.Register("SwitchForeground", typeof(Brush), typeof(ToggleSwitchButton), new PropertyMetadata(null, (o, e) => ((ToggleSwitchButton)o).SetCurrentValue(OnSwitchBrushProperty, e.NewValue as Brush)));
         public static readonly DependencyProperty OnSwitchBrushProperty = DependencyProperty.Register("OnSwitchBrush", typeof(Brush), typeof(ToggleSwitchButton), null);
         public static readonly DependencyProperty OffSwitchBrushProperty = DependencyProperty.Register("OffSwitchBrush", typeof(Brush), typeof(ToggleSwitchButton), null);
 

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/WinApiHelper.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/WinApiHelper.cs
@@ -25,6 +25,7 @@ namespace MahApps.Metro.Controls
         /// Try to get the relative mouse position to the given handle in client coordinates.
         /// </summary>
         /// <param name="hWnd">The handle for this method.</param>
+        /// <param name="point">The relative mouse position to the given handle.</param>
         public static bool TryGetRelativeMousePosition(IntPtr hWnd, out System.Windows.Point point)
         {
             POINT pt = new POINT();

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/WindowButtonCommands.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/WindowButtonCommands.cs
@@ -187,19 +187,19 @@ namespace MahApps.Metro.Controls
                                         new Action(() => {
                                                        if (string.IsNullOrWhiteSpace(this.Minimize))
                                                        {
-                                                           this.Minimize = GetCaption(900);
+                                                           this.SetCurrentValue(MinimizeProperty, GetCaption(900));
                                                        }
                                                        if (string.IsNullOrWhiteSpace(this.Maximize))
                                                        {
-                                                           this.Maximize = GetCaption(901);
+                                                           this.SetCurrentValue(MaximizeProperty, GetCaption(901));
                                                        }
                                                        if (string.IsNullOrWhiteSpace(this.Close))
                                                        {
-                                                           this.Close = GetCaption(905);
+                                                           this.SetCurrentValue(CloseProperty, GetCaption(905));
                                                        }
                                                        if (string.IsNullOrWhiteSpace(this.Restore))
                                                        {
-                                                           this.Restore = GetCaption(903);
+                                                           this.SetCurrentValue(RestoreProperty, GetCaption(903));
                                                        }
                                                    }));
         }

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/WindowButtonCommands.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/WindowButtonCommands.cs
@@ -224,10 +224,12 @@ namespace MahApps.Metro.Controls
             if (close != null)
             {
                 // TODO: Delete this if statement once WindowCloseButtonStyle property is deleted from MetroWindow!
+#pragma warning disable 618
                 if (ParentWindow?.WindowCloseButtonStyle != null)
                 {
                     close.Style = ParentWindow.WindowCloseButtonStyle;
                 }
+#pragma warning restore 618
                 else
                 {
                     close.Style = (Theme == Theme.Light) ? LightCloseButtonStyle : DarkCloseButtonStyle;
@@ -236,10 +238,12 @@ namespace MahApps.Metro.Controls
             if (max != null)
             {
                 // TODO: Delete this if statement once WindowMaxButtonStyle property is deleted from MetroWindow!
+#pragma warning disable 618
                 if (ParentWindow?.WindowMaxButtonStyle != null)
                 {
                     max.Style = ParentWindow.WindowMaxButtonStyle;
                 }
+#pragma warning restore 618
                 else
                 {
                     max.Style = (Theme == Theme.Light) ? LightMaxButtonStyle : DarkMaxButtonStyle;
@@ -248,10 +252,12 @@ namespace MahApps.Metro.Controls
             if (min != null)
             {
                 // TODO: Delete this if statement once WindowMinButtonStyle property is deleted from MetroWindow!
+#pragma warning disable 618
                 if (ParentWindow?.WindowMinButtonStyle != null)
                 {
                     min.Style = ParentWindow.WindowMinButtonStyle;
                 }
+#pragma warning restore 618
                 else
                 {
                     min.Style = (Theme == Theme.Light) ? LightMinButtonStyle : DarkMinButtonStyle;

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Controls/WindowSettings.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Controls/WindowSettings.cs
@@ -98,6 +98,11 @@ namespace MahApps.Metro.Controls
 
         public static void SetSave(DependencyObject dependencyObject, IWindowPlacementSettings windowPlacementSettings)
         {
+            SetWindowPlacementSettings(dependencyObject, windowPlacementSettings);
+        }
+
+        public static void SetWindowPlacementSettings(DependencyObject dependencyObject, IWindowPlacementSettings windowPlacementSettings)
+        {
             dependencyObject.SetValue(WindowPlacementSettingsProperty, windowPlacementSettings);
         }
 

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Converters/MathConverter.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Converters/MathConverter.cs
@@ -97,7 +97,7 @@ namespace MahApps.Metro.Converters
     /// MathAddConverter provides a multi value converter as a MarkupExtension which can be used for math operations.
     /// This class cannot be inherited.
     /// </summary>
-    [MarkupExtensionReturnType(typeof(MarkupMultiConverter))]
+    [MarkupExtensionReturnType(typeof(MathAddConverter))]
     public sealed class MathAddConverter : MarkupMultiConverter
     {
         private static MathAddConverter _instance;
@@ -139,7 +139,7 @@ namespace MahApps.Metro.Converters
     /// MathSubtractConverter provides a multi value converter as a MarkupExtension which can be used for math operations.
     /// This class cannot be inherited.
     /// </summary>
-    [MarkupExtensionReturnType(typeof(MarkupMultiConverter))]
+    [MarkupExtensionReturnType(typeof(MathSubtractConverter))]
     public sealed class MathSubtractConverter : MarkupMultiConverter
     {
         private static MathSubtractConverter _instance;
@@ -181,7 +181,7 @@ namespace MahApps.Metro.Converters
     /// MathMultiplyConverter provides a multi value converter as a MarkupExtension which can be used for math operations.
     /// This class cannot be inherited.
     /// </summary>
-    [MarkupExtensionReturnType(typeof(MarkupMultiConverter))]
+    [MarkupExtensionReturnType(typeof(MathMultiplyConverter))]
     public sealed class MathMultiplyConverter : MarkupMultiConverter
     {
         private static MathMultiplyConverter _instance;
@@ -223,7 +223,7 @@ namespace MahApps.Metro.Converters
     /// MathDivideConverter provides a multi value converter as a MarkupExtension which can be used for math operations.
     /// This class cannot be inherited.
     /// </summary>
-    [MarkupExtensionReturnType(typeof(MarkupMultiConverter))]
+    [MarkupExtensionReturnType(typeof(MathDivideConverter))]
     public sealed class MathDivideConverter : MarkupMultiConverter
     {
         private static MathDivideConverter _instance;

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Converters/RectangleHeightToRadiusConverter.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Converters/RectangleHeightToRadiusConverter.cs
@@ -6,7 +6,7 @@ using System.Windows.Markup;
 
 namespace MahApps.Metro.Converters
 {
-    [ValueConversion(typeof(double), typeof(double))]
+    [ValueConversion(typeof(double?), typeof(double))]
     [MarkupExtensionReturnType(typeof(RectangleHeightToRadiusConverter))]
     public class RectangleHeightToRadiusConverter : MarkupConverter
     {

--- a/src/MahApps.Metro/MahApps.Metro.Shared/Converters/ToUpperConverter.cs
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/Converters/ToUpperConverter.cs
@@ -5,7 +5,7 @@ using System.Windows.Markup;
 
 namespace MahApps.Metro.Converters
 {
-    [MarkupExtensionReturnType(typeof(IValueConverter))]
+    [MarkupExtensionReturnType(typeof(ToUpperConverter))]
     public class ToUpperConverter : MarkupConverter
     {
         private static ToUpperConverter _instance;
@@ -33,7 +33,7 @@ namespace MahApps.Metro.Converters
         }
     }
 
-    [MarkupExtensionReturnType(typeof(IValueConverter))]
+    [MarkupExtensionReturnType(typeof(ToLowerConverter))]
     public class ToLowerConverter : MarkupConverter
     {
         private static ToLowerConverter _instance;

--- a/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Actions\CloseTabItemAction.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Actions\CommandTriggerAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Actions\SetFlyoutOpenAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Behaviours\BindableResourceBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Behaviours\BorderlessWindowBehavior.cs" />

--- a/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
+++ b/src/MahApps.Metro/MahApps.Metro.Shared/MahApps.Metro.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>MahApps.Metro</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Actions\CloseFlyoutAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Actions\CloseTabItemAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Actions\CommandTriggerAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Actions\SetFlyoutOpenAction.cs" />

--- a/src/MahApps.Metro/MahApps.Metro/Properties/AssemblyInfo.cs
+++ b/src/MahApps.Metro/MahApps.Metro/Properties/AssemblyInfo.cs
@@ -19,3 +19,6 @@ using System.Windows.Markup;
 [assembly: AssemblyFileVersion("1.6.0.0")]
 [assembly: AssemblyInformationalVersion("1.6.0.0")]
 [assembly: AssemblyProduct("MahApps.Metro 1.6.0")]
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0006:Name of CoerceValueCallback should match registered name.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0007:Name of ValidateValueCallback should match registered name.")]

--- a/src/MahApps.Metro/MahApps.Metro/Properties/AssemblyInfo.cs
+++ b/src/MahApps.Metro/MahApps.Metro/Properties/AssemblyInfo.cs
@@ -20,6 +20,7 @@ using System.Windows.Markup;
 [assembly: AssemblyInformationalVersion("1.6.0.0")]
 [assembly: AssemblyProduct("MahApps.Metro 1.6.0")]
 
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0005:Name of PropertyChangedCallback should match registered name.")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0006:Name of CoerceValueCallback should match registered name.")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0007:Name of ValidateValueCallback should match registered name.")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0036:Avoid side effects in CLR accessors.")]

--- a/src/MahApps.Metro/MahApps.Metro/Properties/AssemblyInfo.cs
+++ b/src/MahApps.Metro/MahApps.Metro/Properties/AssemblyInfo.cs
@@ -24,3 +24,4 @@ using System.Windows.Markup;
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0006:Name of CoerceValueCallback should match registered name.")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0007:Name of ValidateValueCallback should match registered name.")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0036:Avoid side effects in CLR accessors.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0041:Set mutable dependency properties using SetCurrentValue.")]

--- a/src/MahApps.Metro/MahApps.Metro/Properties/AssemblyInfo.cs
+++ b/src/MahApps.Metro/MahApps.Metro/Properties/AssemblyInfo.cs
@@ -6,9 +6,15 @@ using System.Windows.Markup;
 [assembly: ComVisible(false)]
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
+[assembly: XmlnsPrefix("http://metro.mahapps.com/winfx/xaml/controls", "mah")]
+[assembly: XmlnsPrefix("http://metro.mahapps.com/winfx/xaml/shared", "mah")]
+
 [assembly: XmlnsDefinition("http://metro.mahapps.com/winfx/xaml/shared", "MahApps.Metro.Behaviours")]
+[assembly: XmlnsDefinition("http://metro.mahapps.com/winfx/xaml/shared", "MahApps.Metro.Actions")]
 [assembly: XmlnsDefinition("http://metro.mahapps.com/winfx/xaml/shared", "MahApps.Metro.Converters")]
+[assembly: XmlnsDefinition("http://metro.mahapps.com/winfx/xaml/controls", "MahApps.Metro")]
 [assembly: XmlnsDefinition("http://metro.mahapps.com/winfx/xaml/controls", "MahApps.Metro.Controls")]
+[assembly: XmlnsDefinition("http://metro.mahapps.com/winfx/xaml/controls", "MahApps.Metro.Controls.Dialogs")]
 
 [assembly: AssemblyTitle("MahApps.Metro")]
 [assembly: AssemblyCopyright("Copyright © MahApps.Metro 2011-2017")]

--- a/src/MahApps.Metro/MahApps.Metro/Properties/AssemblyInfo.cs
+++ b/src/MahApps.Metro/MahApps.Metro/Properties/AssemblyInfo.cs
@@ -22,3 +22,4 @@ using System.Windows.Markup;
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0006:Name of CoerceValueCallback should match registered name.")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0007:Name of ValidateValueCallback should match registered name.")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("WpfAnalyzers.DependencyProperty", "WPF0036:Avoid side effects in CLR accessors.")]

--- a/src/MahApps.Metro/MahApps.Metro/Themes/Flyout.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/Flyout.xaml
@@ -1,6 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:actions="clr-namespace:MahApps.Metro.Actions"
+                    xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
@@ -17,13 +19,16 @@
                     Height="34"
                     Margin="2 4 2 2"
                     VerticalAlignment="Bottom"
-                    Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=InternalCloseCommand, Mode=OneWay}"
-                    CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=CloseCommandParameter, Mode=OneWay}"
                     DockPanel.Dock="Left"
                     Foreground="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=Foreground}"
                     IsCancel="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:Flyout}}, Path=CloseButtonIsCancel}"
                     Style="{DynamicResource MahApps.Metro.Styles.MetroCircleButtonStyle}"
                     Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:Flyout}}, Path=CloseButtonVisibility}">
+                <i:Interaction.Triggers>
+                    <i:EventTrigger EventName="Click">
+                        <actions:CloseFlyoutAction Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=CloseCommand, Mode=OneWay}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:Flyout}}, Path=CloseCommandParameter, Mode=OneWay}" />
+                    </i:EventTrigger>
+                </i:Interaction.Triggers>
                 <ContentControl Width="20"
                                 Height="20"
                                 Content="M19,34V42H43.75L33.75,52H44.25L58.25,38L44.25,24H33.75L43.75,34H19Z"

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroWindow.xaml
@@ -571,8 +571,8 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Foreground" Value="{DynamicResource BlackBrush}" />
         <Setter Property="NonActiveBorderBrush" Value="{DynamicResource NonActiveBorderColorBrush}" />
-        <Setter Property="NonActiveWindowTitleBrush" Value="{DynamicResource NonActiveWindowTitleColorBrush}" />
         <Setter Property="NonActiveGlowBrush" Value="{DynamicResource BlackColorBrush}" />
+        <Setter Property="NonActiveWindowTitleBrush" Value="{DynamicResource NonActiveWindowTitleColorBrush}" />
         <Setter Property="OverlayBrush" Value="{DynamicResource BlackColorBrush}" />
         <Setter Property="OverlayFadeIn" Value="{StaticResource OverlayFastSemiFadeIn}" />
         <Setter Property="OverlayFadeOut" Value="{StaticResource OverlayFastSemiFadeOut}" />

--- a/src/MahApps.Metro/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/MahApps.Metro/Themes/MetroWindow.xaml
@@ -572,6 +572,7 @@
         <Setter Property="Foreground" Value="{DynamicResource BlackBrush}" />
         <Setter Property="NonActiveBorderBrush" Value="{DynamicResource NonActiveBorderColorBrush}" />
         <Setter Property="NonActiveWindowTitleBrush" Value="{DynamicResource NonActiveWindowTitleColorBrush}" />
+        <Setter Property="NonActiveGlowBrush" Value="{DynamicResource BlackColorBrush}" />
         <Setter Property="OverlayBrush" Value="{DynamicResource BlackColorBrush}" />
         <Setter Property="OverlayFadeIn" Value="{StaticResource OverlayFastSemiFadeIn}" />
         <Setter Property="OverlayFadeOut" Value="{StaticResource OverlayFastSemiFadeOut}" />


### PR DESCRIPTION
## What changed?

Analyse code with DotNetAnalyzers/WpfAnalyzers

- WPF0072: ValueConversion must use correct types.
- WPF0001: Backing field for a DependencyProperty should match registered name.
- WPF0004: CLR method for a DependencyProperty must match registered name.
- warning disable 618, CS0219, CS1573
- WPF0081: MarkupExtensionReturnType must use correct return type.
- WPF0011: Containing type should be used as registered owner.
- WPF0006: Name of CoerceValueCallback should match registered name.
- WPF0007: Name of ValidateValueCallback should match registered name.
- WPF0043: Don't set DataContext using SetCurrentValue.
- WPF0016: Default value is shared reference type.
- Suppress WPF0036: Avoid side effects in CLR accessors.
- WPF0005: Name of PropertyChangedCallback should match registered name.
- Add new `CommandTriggerAction`
- Add new `CloseFlyoutAction` and mark the internal command as obsolete
- WPF0041: Set mutable dependency properties using SetCurrentValue.
- WPF0050: XmlnsPrefix must map to the same url as XmlnsDefinition.
- use `mah` as XmlnsPrefix
