### PR TITLE
(GH-3227) Fix for ThemeManager: dynamic accents only work once

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -16,7 +16,6 @@
   <ItemGroup>
     <None Remove="**\*.png;**\*.jpg;**\*.ico"/>
     <Resource Include="**\*.png;**\*.jpg;**\*.ico"/>
-    <Compile DependentUpon="%(Filename)" SubType="Code" Update="**\*.g$(_SdkLanguageExtension)"/>
   </ItemGroup>
   <!-- workaround for https://github.com/NuGet/Home/issues/5894 -->
   <Import Condition=" '$(MSBuildProjectExtension)' == '.tmp_proj'" Project="obj\*.targets"/>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/MahApps.Metro.Caliburn.Demo.csproj
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/MahApps.Metro.Caliburn.Demo.csproj
@@ -8,24 +8,27 @@
     </PropertyGroup>
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <StartupObject/>
+        <StartupObject />
         <NoWarn>SA1652</NoWarn>
         <ApplicationIcon>mahapps.metro.logo2.ico</ApplicationIcon>
         <ApplicationManifest>app.manifest</ApplicationManifest>
     </PropertyGroup>
     <ItemGroup>
-        <ProjectReference Include="..\..\MahApps.Metro\MahApps.Metro.csproj"/>
+        <ProjectReference Include="..\..\MahApps.Metro\MahApps.Metro.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <Reference Include="System.ComponentModel.Composition"/>
+        <Reference Include="System.ComponentModel.Composition" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="app.manifest"/>
-        <None Include="paket.references"/>
-        <None Remove="App.config"/>
+        <None Include="app.manifest" />
+        <None Include="paket.references" />
+        <None Remove="App.config" />
         <AppConfigWithTargetPath Include="App.$(TargetFramework).config">
             <TargetPath>$(AssemblyName).config</TargetPath>
         </AppConfigWithTargetPath>
     </ItemGroup>
-    <Import Project="..\..\.paket\Paket.Restore.targets"/>
+    <ItemGroup>
+        <Compile DependentUpon="%(Filename)" SubType="Code" Update="$(MSBuildProjectDirectory)\obj\**\*.g$(_SdkLanguageExtension)" />
+    </ItemGroup>
+    <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.csproj
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.csproj
@@ -9,29 +9,32 @@
     </PropertyGroup>
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <StartupObject/>
+        <StartupObject />
         <NoWarn>SA1652</NoWarn>
         <ApplicationIcon>mahapps.metro.logo2.ico</ApplicationIcon>
         <ApplicationManifest>app.manifest</ApplicationManifest>
     </PropertyGroup>
     <ItemGroup>
-        <ProjectReference Include="..\..\MahApps.Metro\MahApps.Metro.csproj"/>
+        <ProjectReference Include="..\..\MahApps.Metro\MahApps.Metro.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <Reference Include="System.ComponentModel.DataAnnotations"/>
-        <Reference Include="System.Configuration"/>
-        <Reference Include="System.Data.DataSetExtensions"/>
-        <Reference Include="System.Data"/>
-        <Reference Include="System.Windows.Forms"/>
-        <Reference Include="WindowsFormsIntegration"/>
+        <Reference Include="System.ComponentModel.DataAnnotations" />
+        <Reference Include="System.Configuration" />
+        <Reference Include="System.Data.DataSetExtensions" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Windows.Forms" />
+        <Reference Include="WindowsFormsIntegration" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="app.manifest"/>
-        <None Include="paket.references"/>
-        <None Remove="App.config"/>
+        <None Include="app.manifest" />
+        <None Include="paket.references" />
+        <None Remove="App.config" />
         <AppConfigWithTargetPath Include="App.$(TargetFramework).config">
             <TargetPath>$(AssemblyName).config</TargetPath>
         </AppConfigWithTargetPath>
     </ItemGroup>
-    <Import Project="..\..\.paket\Paket.Restore.targets"/>
+    <ItemGroup>
+        <Compile DependentUpon="%(Filename)" SubType="Code" Update="$(MSBuildProjectDirectory)\obj\**\*.g$(_SdkLanguageExtension)" />
+    </ItemGroup>
+    <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/MahApps.Metro.sln
+++ b/src/MahApps.Metro.sln
@@ -16,6 +16,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MahApps.Metro.Caliburn.Demo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MahApps.Metro.Tests", "Mahapps.Metro.Tests\MahApps.Metro.Tests.csproj", "{40048BCF-D1C7-46CC-B781-05718BE25BFC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EC5373FC-2098-4D7B-8990-B15E9C631AE8}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.build.props = Directory.build.props
+		Directory.build.targets = Directory.build.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/MahApps.Metro/MahApps.Metro.csproj
+++ b/src/MahApps.Metro/MahApps.Metro.csproj
@@ -8,12 +8,15 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-        <Reference Include="System.ComponentModel.DataAnnotations"/>
-        <Reference Include="System.Configuration"/>
+        <Reference Include="System.ComponentModel.DataAnnotations" />
+        <Reference Include="System.Configuration" />
     </ItemGroup>
     <!-- Items include -->
     <ItemGroup>
-        <None Include="paket.references"/>
+        <None Include="paket.references" />
     </ItemGroup>
-    <Import Project="..\.paket\Paket.Restore.targets"/>
+    <ItemGroup>
+        <Compile DependentUpon="%(Filename)" SubType="Code" Update="$(MSBuildProjectDirectory)\obj\**\*.g$(_SdkLanguageExtension)" />
+    </ItemGroup>
+    <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/MahApps.Metro/ThemeManager/Accent.cs
+++ b/src/MahApps.Metro/ThemeManager/Accent.cs
@@ -1,9 +1,11 @@
 // ReSharper disable once CheckNamespace
+
 namespace MahApps.Metro
 {
     using System;
     using System.Diagnostics;
     using System.Windows;
+    using JetBrains.Annotations;
 
     /// <summary>
     /// An object that represents the foreground color for a <see cref="AppTheme"/>.
@@ -25,20 +27,35 @@ namespace MahApps.Metro
         /// Initializes a new instance of the Accent class.
         /// </summary>
         public Accent()
-        { }
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the Accent class.
         /// </summary>
         /// <param name="name">The name of the new Accent.</param>
         /// <param name="resourceAddress">The URI of the accent ResourceDictionary.</param>
-        public Accent(string name, Uri resourceAddress)
+        public Accent([NotNull] string name, [NotNull] Uri resourceAddress)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
             if (resourceAddress == null) throw new ArgumentNullException(nameof(resourceAddress));
 
             this.Name = name;
-            this.Resources = new ResourceDictionary {Source = resourceAddress};
+            this.Resources = new ResourceDictionary { Source = resourceAddress };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the Accent class.
+        /// </summary>
+        /// <param name="name">The name of the new Accent.</param>
+        /// <param name="resourceDictionary">The ResourceDictionary of the accent.</param>
+        public Accent([NotNull] string name, [NotNull] ResourceDictionary resourceDictionary)
+        {
+            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
+
+            this.Name = name;
+            this.Resources = resourceDictionary;
         }
     }
 }

--- a/src/MahApps.Metro/ThemeManager/AppTheme.cs
+++ b/src/MahApps.Metro/ThemeManager/AppTheme.cs
@@ -1,9 +1,11 @@
 // ReSharper disable once CheckNamespace
+
 namespace MahApps.Metro
 {
     using System;
     using System.Diagnostics;
     using System.Windows;
+    using JetBrains.Annotations;
 
     internal class AppName
     {
@@ -19,7 +21,7 @@ namespace MahApps.Metro
         /// <summary>
         /// The ResourceDictionary that represents this application theme.
         /// </summary>
-        public ResourceDictionary Resources {get; }
+        public ResourceDictionary Resources { get; }
 
         /// <summary>
         /// Gets the name of the application theme.
@@ -30,14 +32,28 @@ namespace MahApps.Metro
         /// Initializes a new instance of the AppTheme class.
         /// </summary>
         /// <param name="name">The name of the new AppTheme.</param>
-        /// <param name="resourceAddress">The URI of the accent ResourceDictionary.</param>
-        public AppTheme(string name, Uri resourceAddress)
+        /// <param name="resourceAddress">The URI of the AppTheme ResourceDictionary.</param>
+        public AppTheme([NotNull] string name, [NotNull] Uri resourceAddress)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
             if (resourceAddress == null) throw new ArgumentNullException(nameof(resourceAddress));
 
             this.Name = name;
-            this.Resources = new ResourceDictionary {Source = resourceAddress};
+            this.Resources = new ResourceDictionary { Source = resourceAddress };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AppTheme class.
+        /// </summary>
+        /// <param name="name">The name of the new AppTheme.</param>
+        /// <param name="resourceDictionary">The ResourceDictionary of the accent.</param>
+        public AppTheme([NotNull] string name, [NotNull] ResourceDictionary resourceDictionary)
+        {
+            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
+
+            this.Name = name;
+            this.Resources = resourceDictionary;
         }
     }
 }

--- a/src/MahApps.Metro/ThemeManager/ThemeManager.cs
+++ b/src/MahApps.Metro/ThemeManager/ThemeManager.cs
@@ -84,10 +84,12 @@ namespace MahApps.Metro
         }
 
         /// <summary>
-        /// Adds an accent with the given name.
+        /// Adds an accent with the given name and uniform resource identfier.
         /// </summary>
+        /// <param name="name">The name of the new Accent.</param>
+        /// <param name="resourceAddress">The URI of the accent ResourceDictionary.</param>
         /// <returns>true if the accent does not exists and can be added.</returns>
-        public static bool AddAccent(string name, Uri resourceAddress)
+        public static bool AddAccent([NotNull] string name, [NotNull] Uri resourceAddress)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
             if (resourceAddress == null) throw new ArgumentNullException(nameof(resourceAddress));
@@ -103,10 +105,33 @@ namespace MahApps.Metro
         }
 
         /// <summary>
+        /// Adds an accent with the given name and resource dictionary.
+        /// </summary>
+        /// <param name="name">The name of the new Accent.</param>
+        /// <param name="resourceDictionary">The ResourceDictionary of the accent.</param>
+        /// <returns>true if the accent does not exists and can be added.</returns>
+        public static bool AddAccent(string name, ResourceDictionary resourceDictionary)
+        {
+            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
+
+            var accentExists = GetAccent(name) != null;
+            if (accentExists)
+            {
+                return false;
+            }
+
+            _accents.Add(new Accent(name, resourceDictionary));
+            return true;
+        }
+
+        /// <summary>
         /// Adds an app theme with the given name.
         /// </summary>
+        /// <param name="name">The name of the new AppTheme.</param>
+        /// <param name="resourceAddress">The URI of the AppTheme ResourceDictionary.</param>
         /// <returns>true if the app theme does not exists and can be added.</returns>
-        public static bool AddAppTheme(string name, Uri resourceAddress)
+        public static bool AddAppTheme([NotNull] string name, [NotNull] Uri resourceAddress)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
             if (resourceAddress == null) throw new ArgumentNullException(nameof(resourceAddress));
@@ -118,6 +143,27 @@ namespace MahApps.Metro
             }
 
             _appThemes.Add(new AppTheme(name, resourceAddress));
+            return true;
+        }
+
+        /// <summary>
+        /// Adds an app theme with the given name.
+        /// </summary>
+        /// <param name="name">The name of the new AppTheme.</param>
+        /// <param name="resourceDictionary">The ResourceDictionary of the accent.</param>
+        /// <returns>true if the app theme does not exists and can be added.</returns>
+        public static bool AddAppTheme([NotNull] string name, [NotNull] ResourceDictionary resourceDictionary)
+        {
+            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (resourceDictionary == null) throw new ArgumentNullException(nameof(resourceDictionary));
+
+            var appThemeExists = GetAppTheme(name) != null;
+            if (appThemeExists)
+            {
+                return false;
+            }
+
+            _appThemes.Add(new AppTheme(name, resourceDictionary));
             return true;
         }
 

--- a/src/Mahapps.Metro.Tests/MahApps.Metro.Tests.csproj
+++ b/src/Mahapps.Metro.Tests/MahApps.Metro.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="MSBuild.Sdk.Extras/1.3.0">
   <!-- Project properties -->
   <PropertyGroup>
-    <TargetFrameworks>net47;net46;net45;net40</TargetFrameworks>
+    <TargetFrameworks>net45;net40</TargetFrameworks>
     <AssemblyName>MahApps.Metro.Tests</AssemblyName>
     <RootNamespace>MahApps.Metro.Tests</RootNamespace>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/src/Mahapps.Metro.Tests/MahApps.Metro.Tests.csproj
+++ b/src/Mahapps.Metro.Tests/MahApps.Metro.Tests.csproj
@@ -1,31 +1,33 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/1.3.0">
-    <!-- Project properties -->
-    <PropertyGroup>
-        <!-- <TargetFrameworks>net45;net40</TargetFrameworks> -->
-        <TargetFrameworks>net40</TargetFrameworks>
-        <AssemblyName>MahApps.Metro.Tests</AssemblyName>
-        <RootNamespace>MahApps.Metro.Tests</RootNamespace>
-        <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    </PropertyGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\MahApps.Metro\MahApps.Metro.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-        <Reference Include="Microsoft.CSharp" />
-        <Reference Include="System.ComponentModel.DataAnnotations" />
-        <Reference Include="System.Configuration" />
-    </ItemGroup>
-    <!-- Items include -->
-    <ItemGroup>
-        <None Include="paket.references" />
-        <None Remove="App.config" />
-        <AppConfigWithTargetPath Include="App.$(TargetFramework).config">
-            <TargetPath>$(AssemblyName).config</TargetPath>
-        </AppConfigWithTargetPath>
-    </ItemGroup>
-    <ItemGroup>
-      <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-    </ItemGroup>
-    <Import Project="..\.paket\Paket.Restore.targets" />
+  <!-- Project properties -->
+  <PropertyGroup>
+    <TargetFrameworks>net47;net46;net45;net40</TargetFrameworks>
+    <AssemblyName>MahApps.Metro.Tests</AssemblyName>
+    <RootNamespace>MahApps.Metro.Tests</RootNamespace>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MahApps.Metro\MahApps.Metro.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
+  </ItemGroup>
+  <!-- Items include -->
+  <ItemGroup>
+    <None Include="paket.references" />
+    <None Remove="App.config" />
+    <AppConfigWithTargetPath Include="App.$(TargetFramework).config">
+      <TargetPath>$(AssemblyName).config</TargetPath>
+    </AppConfigWithTargetPath>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile DependentUpon="%(Filename)" SubType="Code" Update="$(MSBuildProjectDirectory)\obj\**\*.g$(_SdkLanguageExtension)" />
+  </ItemGroup>
+  <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/src/Mahapps.Metro.Tests/TestApp.xaml.cs
+++ b/src/Mahapps.Metro.Tests/TestApp.xaml.cs
@@ -1,6 +1,8 @@
-﻿namespace MahApps.Metro.Tests
+﻿using System.Windows;
+
+namespace MahApps.Metro.Tests
 {
-    public partial class TestApp
+    public partial class TestApp : Application
     {
         public TestApp()
         {

--- a/src/Mahapps.Metro.Tests/TestHelpers/AccentHelper.cs
+++ b/src/Mahapps.Metro.Tests/TestHelpers/AccentHelper.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace MahApps.Metro.Tests.TestHelpers
+{
+    public static class AccentHelper
+    {
+        public static void ApplyColor(Color color, string accentName = null)
+        {
+            // create a runtime accent resource dictionary
+
+            var resDictName = accentName ?? $"ApplicationAccent_{color.ToString().Replace("#", string.Empty)}.xaml";
+
+            var resourceDictionary = new ResourceDictionary();
+
+            resourceDictionary.Add("HighlightColor", color);
+            resourceDictionary.Add("AccentBaseColor", color);
+            resourceDictionary.Add("AccentColor", Color.FromArgb((byte)(204), color.R, color.G, color.B));
+            resourceDictionary.Add("AccentColor2", Color.FromArgb((byte)(153), color.R, color.G, color.B));
+            resourceDictionary.Add("AccentColor3", Color.FromArgb((byte)(102), color.R, color.G, color.B));
+            resourceDictionary.Add("AccentColor4", Color.FromArgb((byte)(51), color.R, color.G, color.B));
+
+            resourceDictionary.Add("HighlightBrush", GetSolidColorBrush((Color)resourceDictionary["HighlightColor"]));
+            resourceDictionary.Add("AccentBaseColorBrush", GetSolidColorBrush((Color)resourceDictionary["AccentBaseColor"]));
+            resourceDictionary.Add("AccentColorBrush", GetSolidColorBrush((Color)resourceDictionary["AccentColor"]));
+            resourceDictionary.Add("AccentColorBrush2", GetSolidColorBrush((Color)resourceDictionary["AccentColor2"]));
+            resourceDictionary.Add("AccentColorBrush3", GetSolidColorBrush((Color)resourceDictionary["AccentColor3"]));
+            resourceDictionary.Add("AccentColorBrush4", GetSolidColorBrush((Color)resourceDictionary["AccentColor4"]));
+
+            resourceDictionary.Add("WindowTitleColorBrush", GetSolidColorBrush((Color)resourceDictionary["AccentColor"]));
+
+            resourceDictionary.Add("ProgressBrush", new LinearGradientBrush(
+                                       new GradientStopCollection(new[]
+                                                                  {
+                                                                      new GradientStop((Color)resourceDictionary["HighlightColor"], 0),
+                                                                      new GradientStop((Color)resourceDictionary["AccentColor3"], 1)
+                                                                  }),
+                                       // StartPoint="1.002,0.5" EndPoint="0.001,0.5"
+                                       startPoint: new Point(1.002, 0.5), endPoint: new Point(0.001, 0.5)));
+
+            resourceDictionary.Add("CheckmarkFill", GetSolidColorBrush((Color)resourceDictionary["AccentColor"]));
+            resourceDictionary.Add("RightArrowFill", GetSolidColorBrush((Color)resourceDictionary["AccentColor"]));
+
+            resourceDictionary.Add("IdealForegroundColor", IdealTextColor(color));
+            resourceDictionary.Add("IdealForegroundColorBrush", GetSolidColorBrush((Color)resourceDictionary["IdealForegroundColor"]));
+            resourceDictionary.Add("IdealForegroundDisabledBrush", GetSolidColorBrush((Color)resourceDictionary["IdealForegroundColor"], 0.4));
+            resourceDictionary.Add("AccentSelectedColorBrush", GetSolidColorBrush((Color)resourceDictionary["IdealForegroundColor"]));
+
+            resourceDictionary.Add("MetroDataGrid.HighlightBrush", GetSolidColorBrush((Color)resourceDictionary["AccentColor"]));
+            resourceDictionary.Add("MetroDataGrid.HighlightTextBrush", GetSolidColorBrush((Color)resourceDictionary["IdealForegroundColor"]));
+            resourceDictionary.Add("MetroDataGrid.MouseOverHighlightBrush", GetSolidColorBrush((Color)resourceDictionary["AccentColor3"]));
+            resourceDictionary.Add("MetroDataGrid.FocusBorderBrush", GetSolidColorBrush((Color)resourceDictionary["AccentColor"]));
+            resourceDictionary.Add("MetroDataGrid.InactiveSelectionHighlightBrush", GetSolidColorBrush((Color)resourceDictionary["AccentColor2"]));
+            resourceDictionary.Add("MetroDataGrid.InactiveSelectionHighlightTextBrush", GetSolidColorBrush((Color)resourceDictionary["IdealForegroundColor"]));
+
+            resourceDictionary.Add("MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10", GetSolidColorBrush((Color)resourceDictionary["AccentColor"]));
+            resourceDictionary.Add("MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10", GetSolidColorBrush((Color)resourceDictionary["AccentColor2"]));
+            resourceDictionary.Add("MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10", GetSolidColorBrush((Color)resourceDictionary["IdealForegroundColor"]));
+
+            // applying theme to MahApps
+            ThemeManager.AddAccent(resDictName, resourceDictionary);
+            var newAccent = ThemeManager.GetAccent(resDictName);
+            // detect current application theme
+            Tuple<AppTheme, Accent> applicationTheme = ThemeManager.DetectAppStyle(Application.Current);
+            ThemeManager.ChangeAppStyle(Application.Current, newAccent, applicationTheme.Item1);
+        }
+
+        /// <summary>
+        /// Determining Ideal Text Color Based on Specified Background Color
+        /// http://www.codeproject.com/KB/GDI-plus/IdealTextColor.aspx
+        /// </summary>
+        /// <param name = "color">The bg.</param>
+        /// <returns></returns>
+        private static Color IdealTextColor(Color color)
+        {
+            const int nThreshold = 105;
+            var bgDelta = System.Convert.ToInt32((color.R * 0.299) + (color.G * 0.587) + (color.B * 0.114));
+            var foreColor = (255 - bgDelta < nThreshold) ? Colors.Black : Colors.White;
+            return foreColor;
+        }
+
+        private static SolidColorBrush GetSolidColorBrush(Color color, double opacity = 1d)
+        {
+            var brush = new SolidColorBrush(color) { Opacity = opacity };
+            brush.Freeze();
+            return brush;
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/TestHelpers/TestHost.cs
+++ b/src/Mahapps.Metro.Tests/TestHelpers/TestHost.cs
@@ -50,6 +50,7 @@ namespace MahApps.Metro.Tests.TestHelpers
                     var message = $"Exit TestApp with Thread.CurrentThread: {Thread.CurrentThread.ManagedThreadId}" +
                                   $" and Current.Dispatcher.Thread: {Application.Current.Dispatcher.Thread.ManagedThreadId}";
                     Debug.WriteLine(message);
+                    
                 };
             app.Startup += (sender, args) =>
                 {

--- a/src/Mahapps.Metro.Tests/Tests/FlyoutTest.cs
+++ b/src/Mahapps.Metro.Tests/Tests/FlyoutTest.cs
@@ -192,11 +192,12 @@ namespace MahApps.Metro.Tests
 
             var window = await WindowHelpers.CreateInvisibleWindowAsync<FlyoutWindow>();
 
-            Assert.DoesNotThrow(() => {
+            var ex = Record.Exception(() => {
                                     var flyouts = (window.Content as DependencyObject).FindChildren<Flyout>(true);
                                     var flyoutOnGrid = flyouts.FirstOrDefault(f => f.Name == "FlyoutOnGrid");
                                     Assert.NotNull(flyoutOnGrid);
                                 });
+            Assert.Null(ex);
         }
 
         [Fact]

--- a/src/Mahapps.Metro.Tests/Tests/ThemeManagerTest.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ThemeManagerTest.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Media;
 using MahApps.Metro.Tests.TestHelpers;
 using MahApps.Metro.Controls;
 using Xunit;
@@ -161,6 +162,31 @@ namespace MahApps.Metro.Tests
 
             Assert.NotNull(detected);
             Assert.Equal("Blue", detected.Name);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public async Task CreateDynamicAccentWithColor()
+        {
+            await TestHost.SwitchToAppThread();
+
+            var applicationTheme = ThemeManager.DetectAppStyle(Application.Current);
+
+            var ex = Record.Exception(() => AccentHelper.ApplyColor(Colors.Red, "CustomAccentRed"));
+            Assert.Null(ex);
+            
+            var detected = ThemeManager.DetectAppStyle(Application.Current);
+            Assert.NotNull(detected);
+            Assert.Equal("CustomAccentRed", detected.Item2.Name);
+
+            ex = Record.Exception(() => AccentHelper.ApplyColor(Colors.Green, "CustomAccentGreen"));
+            Assert.Null(ex);
+            
+            detected = ThemeManager.DetectAppStyle(Application.Current);
+            Assert.NotNull(detected);
+            Assert.Equal("CustomAccentGreen", detected.Item2.Name);
+
+            ThemeManager.ChangeAppStyle(Application.Current, applicationTheme.Item2, applicationTheme.Item1);
         }
     }
 }

--- a/src/Mahapps.Metro.Tests/Views/AnimatedTabControlWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/AnimatedTabControlWindow.xaml.cs
@@ -1,10 +1,11 @@
-﻿namespace MahApps.Metro.Tests
-{
-    using System.Collections.ObjectModel;
-    using System.Windows;
-    using System.Windows.Controls;
+﻿using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+using MahApps.Metro.Controls;
 
-    public partial class AnimatedTabControlWindow
+namespace MahApps.Metro.Tests
+{
+    public partial class AnimatedTabControlWindow : MetroWindow
     {
         public AnimatedTabControlWindow()
         {

--- a/src/Mahapps.Metro.Tests/Views/AutoWatermarkTestWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/AutoWatermarkTestWindow.xaml.cs
@@ -1,11 +1,11 @@
-﻿namespace MahApps.Metro.Tests
-{
-    using System;
-    using System.Collections.ObjectModel;
-    using System.ComponentModel.DataAnnotations;
-    using MahApps.Metro.Controls;
+﻿using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
+using MahApps.Metro.Controls;
 
-    public partial class AutoWatermarkTestWindow
+namespace MahApps.Metro.Tests
+{
+    public partial class AutoWatermarkTestWindow : MetroWindow
     {
         public AutoWatermarkTestWindow()
         {

--- a/src/Mahapps.Metro.Tests/Views/ButtonWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/ButtonWindow.xaml.cs
@@ -1,6 +1,8 @@
-﻿namespace MahApps.Metro.Tests
+﻿using MahApps.Metro.Controls;
+
+namespace MahApps.Metro.Tests
 {
-    public partial class ButtonWindow
+    public partial class ButtonWindow : MetroWindow
     {
         public ButtonWindow()
         {

--- a/src/Mahapps.Metro.Tests/Views/CleanWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/CleanWindow.xaml.cs
@@ -1,6 +1,8 @@
-﻿namespace MahApps.Metro.Tests
+﻿using MahApps.Metro.Controls;
+
+namespace MahApps.Metro.Tests
 {
-    public partial class CleanWindow
+    public partial class CleanWindow : MetroWindow
     {
         public CleanWindow()
         {

--- a/src/Mahapps.Metro.Tests/Views/DateAndTimePickerWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/DateAndTimePickerWindow.xaml.cs
@@ -1,6 +1,8 @@
-﻿namespace MahApps.Metro.Tests
+﻿using MahApps.Metro.Controls;
+
+namespace MahApps.Metro.Tests
 {
-    public partial class DateAndTimePickerWindow
+    public partial class DateAndTimePickerWindow : MetroWindow
     {
         public DateAndTimePickerWindow()
         {

--- a/src/Mahapps.Metro.Tests/Views/DialogWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/DialogWindow.xaml.cs
@@ -1,6 +1,8 @@
-﻿namespace MahApps.Metro.Tests
+﻿using MahApps.Metro.Controls;
+
+namespace MahApps.Metro.Tests
 {
-    public partial class DialogWindow 
+    public partial class DialogWindow : MetroWindow
     {
         public DialogWindow()
         {

--- a/src/Mahapps.Metro.Tests/Views/FlyoutWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/FlyoutWindow.xaml.cs
@@ -1,6 +1,8 @@
-﻿namespace MahApps.Metro.Tests
+﻿using MahApps.Metro.Controls;
+
+namespace MahApps.Metro.Tests
 {
-    public partial class FlyoutWindow
+    public partial class FlyoutWindow : MetroWindow
     {
         public FlyoutWindow()
         {

--- a/src/Mahapps.Metro.Tests/Views/HiddenMinMaxCloseButtonsWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/HiddenMinMaxCloseButtonsWindow.xaml.cs
@@ -1,6 +1,8 @@
-﻿namespace MahApps.Metro.Tests
+﻿using MahApps.Metro.Controls;
+
+namespace MahApps.Metro.Tests
 {
-    public partial class HiddenMinMaxCloseButtonsWindow
+    public partial class HiddenMinMaxCloseButtonsWindow : MetroWindow
     {
         public HiddenMinMaxCloseButtonsWindow()
         {

--- a/src/Mahapps.Metro.Tests/Views/TextBoxHelperTestWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/TextBoxHelperTestWindow.xaml.cs
@@ -1,6 +1,8 @@
-﻿namespace MahApps.Metro.Tests
+﻿using MahApps.Metro.Controls;
+
+namespace MahApps.Metro.Tests
 {
-    public partial class TextBoxHelperTestWindow
+    public partial class TextBoxHelperTestWindow : MetroWindow
     {
         public TextBoxHelperTestWindow()
         {

--- a/src/Mahapps.Metro.Tests/paket.references
+++ b/src/Mahapps.Metro.Tests/paket.references
@@ -1,8 +1,12 @@
 JetBrains.Annotations
-xunit
-xunit.extensions
 ExposedObject
 
 Microsoft.Bcl redirects: on, framework: net40
 Microsoft.Bcl.Async framework: net40
 Microsoft.Bcl.Build import_targets: true, framework: net40
+
+group xunit40
+    xunit framework: net40
+
+group xunit45
+    xunit framework: >=net45

--- a/src/build.cake
+++ b/src/build.cake
@@ -123,9 +123,9 @@ Task("Unit-Tests")
     //.WithCriteria(ShouldRunRelease())
     .Does(() =>
 {
-    XUnit(
+    XUnit2(
         "./Mahapps.Metro.Tests/bin/" + configuration + "/**/*.Tests.dll",
-        new XUnitSettings { ToolPath = "./packages/cake/xunit.runner.console/tools/net452/xunit.console.exe" }
+        new XUnit2Settings { ToolTimeout = TimeSpan.FromMinutes(5) }
     );
 });
 

--- a/src/paket.dependencies
+++ b/src/paket.dependencies
@@ -13,14 +13,27 @@ nuget MahApps.Metro.IconPacks
 nuget MaterialDesignThemes prerelease
 nuget NHotkey 1.2.1
 nuget NHotkey.Wpf 1.2.1
-nuget xunit ~> 1.9
-nuget xunit.extensions ~> 1.9
 nuget ControlzEx < 4.0
 nuget ExposedObject < 1.3
 
 nuget Microsoft.Bcl
 nuget Microsoft.Bcl.Async
 nuget Microsoft.Bcl.Build
+
+group xunit40
+	framework: net40
+	source https://nuget.org/api/v2
+
+	nuget xunit ~> 1.9
+	nuget xunit.extensions ~> 1.9
+
+group xunit45
+	framework: >= net45
+	source https://nuget.org/api/v2
+
+	nuget xunit
+	nuget Microsoft.NET.Test.Sdk
+	nuget xunit.runner.visualstudio
 
 group cake
 	framework: net45

--- a/src/paket.lock
+++ b/src/paket.lock
@@ -25,10 +25,7 @@ NUGET
     NHotkey (1.2.1)
     NHotkey.Wpf (1.2.1)
       NHotkey (>= 1.2.1)
-    WpfAnalyzers (2.1.2)
-    xunit (1.9.2)
-    xunit.extensions (1.9.2)
-      xunit (1.9.2)
+    WpfAnalyzers (2.1.2.1)
 
 GROUP cake
 RESTRICTION: == net45
@@ -41,3 +38,42 @@ NUGET
     gitreleasemanager (0.7)
     GitVersion.CommandLine (4.0.0-beta0012)
     xunit.runner.console (2.3.1)
+
+GROUP xunit40
+RESTRICTION: == net40
+NUGET
+  remote: https://www.nuget.org/api/v2
+    xunit (1.9.2)
+    xunit.extensions (1.9.2)
+      xunit (1.9.2)
+
+GROUP xunit45
+RESTRICTION: >= net45
+NUGET
+  remote: https://www.nuget.org/api/v2
+    Microsoft.CodeCoverage (1.0.3)
+    Microsoft.NET.Test.Sdk (15.7)
+      Microsoft.CodeCoverage (>= 1.0.3)
+    Microsoft.NETCore.Platforms (2.0.2) - restriction: || (&& (>= net45) (< net452) (< netstandard1.3)) (&& (>= net45) (>= netcoreapp2.0)) (&& (>= net45) (< netstandard1.0)) (&& (>= net45) (< netstandard1.3) (>= wpa81)) (&& (>= net45) (< netstandard1.5) (>= uap10.0)) (&& (>= net45) (< portable-net45+win8+wpa81)) (&& (>= net45) (>= uap10.1)) (&& (>= net45) (>= wp8)) (&& (< net452) (>= net46) (< netstandard1.4)) (&& (< net452) (>= net461))
+    NETStandard.Library (2.0.2) - restriction: && (>= net45) (< net452)
+      Microsoft.NETCore.Platforms (>= 1.1)
+      System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - restriction: || (&& (>= net45) (< netstandard1.0)) (&& (>= net45) (< netstandard1.3)) (&& (>= net45) (< netstandard1.5) (>= uap10.0)) (&& (>= net46) (< netstandard1.4))
+    System.Runtime.InteropServices.RuntimeInformation (4.3) - restriction: || (&& (>= net45) (< net452) (< netstandard1.3)) (&& (>= net45) (< netstandard1.0)) (&& (>= net45) (< netstandard1.3) (>= wpa81)) (&& (>= net45) (< netstandard1.5) (>= uap10.0)) (&& (< net452) (>= net46) (< netstandard1.4))
+    xunit (2.3.1)
+      xunit.analyzers (>= 0.7)
+      xunit.assert (2.3.1)
+      xunit.core (2.3.1)
+    xunit.abstractions (2.0.1)
+    xunit.analyzers (0.8)
+    xunit.assert (2.3.1)
+      NETStandard.Library (>= 1.6.1) - restriction: && (>= net45) (< net452)
+    xunit.core (2.3.1)
+      xunit.extensibility.core (2.3.1)
+      xunit.extensibility.execution (2.3.1)
+    xunit.extensibility.core (2.3.1)
+      NETStandard.Library (>= 1.6.1) - restriction: && (>= net45) (< net452)
+      xunit.abstractions (>= 2.0.1)
+    xunit.extensibility.execution (2.3.1)
+      NETStandard.Library (>= 1.6.1) - restriction: && (>= net45) (< net452)
+      xunit.extensibility.core (2.3.1)
+    xunit.runner.visualstudio (2.3.1)


### PR DESCRIPTION
## What changed?

ThemeManager: overloaded ctors and methods to allow add accent and theme with resource 
 dictionaries instead URIs.

_Closed issues._

Closes #3227 