### PR TITLE
Allow MetroWindow to clip content

### DIFF
--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -108,6 +108,8 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty OverlayBrushProperty = DependencyProperty.Register("OverlayBrush", typeof(Brush), typeof(MetroWindow), new PropertyMetadata(null));
         public static readonly DependencyProperty OverlayOpacityProperty = DependencyProperty.Register("OverlayOpacity", typeof(double), typeof(MetroWindow), new PropertyMetadata(0.7d));
 
+        public static readonly DependencyProperty ClipsContentProperty = DependencyProperty.Register("ClipsContent", typeof(bool), typeof(MetroWindow), new PropertyMetadata(false));
+
         /// <summary>
         /// Identifies the <see cref="OverlayFadeIn"/> dependency property.
         /// </summary>
@@ -735,6 +737,15 @@ namespace MahApps.Metro.Controls
         {
             get { return (double)GetValue(OverlayOpacityProperty); }
             set { SetValue(OverlayOpacityProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets/sets whether the window clips its content.
+        /// </summary>
+        public bool ClipsContent
+        {
+            get { return (bool)this.GetValue(ClipsContentProperty); }
+            set { SetValue(ClipsContentProperty, value); }
         }
 
         /// <summary>

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -131,6 +131,7 @@
                                                   FocusVisualStyle="{x:Null}"
                                                   IsTabStop="False"
                                                   OnlyLoadTransition="True"
+                                                  ClipToBounds="{TemplateBinding ClipsContent}"
                                                   TransitionsEnabled="{TemplateBinding WindowTransitionsEnabled}"
                                                   UseLayoutRounding="True">
                         <ContentPresenter Margin="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Top}}" UseLayoutRounding="False" />


### PR DESCRIPTION
## What changed?

The `MetroWindow` title bar/border could have its inner content show over the title bar/border. This PR provides an alternate solution to #3125 by adding a `ClipsContent` property to `MetroWindow` thereby saving you from having to have a control nested in an unnecessary grid.

Context: I am using the [WPF Notifications](https://github.com/Enterwell/Wpf.Notifications) library and want to animate in the notification from the top. Right now, without the nested grid or other alternative fixes, the animated messages animate over the title bar. The nested grid should fix it, but I'd rather just set a property on the `MetroWindow` and know that I'll be safe if other controls start wanting to draw strangely.