### PR TITLE
Fix for Track's height in FlatSlider style

### DIFF
--- a/src/MahApps.Metro/Styles/FlatSlider.xaml
+++ b/src/MahApps.Metro/Styles/FlatSlider.xaml
@@ -84,7 +84,7 @@
                      Style="{DynamicResource MahApps.Metro.Styles.FlatSlider.TickBar}" />
             <Track x:Name="PART_Track"
                    Grid.Row="1"
-                   Height="{TemplateBinding Slider.MinHeight}">
+                   Height="{TemplateBinding Slider.Height}">
                 <Track.DecreaseRepeatButton>
                     <RepeatButton Background="{TemplateBinding Slider.Foreground}"
                                   Command="Slider.DecreaseLarge"


### PR DESCRIPTION
## What changed?

Changed binding for the `Height` property in the Horizontal FlatSlider style to bind to the Slider's `Height` property instead of `MinHeight`.

_Closed issues_

Closes https://github.com/MahApps/MahApps.Metro/issues/3238
