### PR TITLE
Removed margin for PaneHeader. Fixes #3284

### DIFF
--- a/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
@@ -335,7 +335,6 @@
                         <DockPanel x:Name="PaneHeader"
                                    Grid.Row="0"
                                    Height="{TemplateBinding HamburgerHeight}"
-                                   Margin="0 0 0 8"
                                    LastChildFill="True">
                             <Grid x:Name="PaneHeaderGap"
                                   Width="{TemplateBinding HamburgerWidth}"


### PR DESCRIPTION
**Removed the margin for PaneHeader**

Under `HamburgerMenuTemplate.xaml` file, `DockPanel` named `PaneHeader` had `Margin` set to `0 0 0 8`. This resulted in small gap between the Menu & HamburgerIcon

**Unit test**

It's a small UI change, Unit Test cannot be written for this. 

**Additional context**
Before:
![image](https://user-images.githubusercontent.com/15025473/45052300-4f716700-b07e-11e8-9db8-18d3c6b00cdf.png)
After:
![image](https://user-images.githubusercontent.com/15025473/45052278-3ff21e00-b07e-11e8-8d86-9b07432429fe.png)

**Closed Issues**
Fixes #3284 