### PR TITLE
(GH-3308) Fix TabItem HeaderFontSize change leads to freeze

### DIFF
--- a/src/MahApps.Metro/Controls/Extensions.cs
+++ b/src/MahApps.Metro/Controls/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Windows;
 using System.Windows.Threading;
 using JetBrains.Annotations;
 
@@ -63,6 +64,30 @@ namespace MahApps.Metro.Controls
                 throw new ArgumentNullException(nameof(invokeAction));
             }
             dispatcherObject.Dispatcher.BeginInvoke(priority, invokeAction);
+        }
+
+        /// <summary> 
+        ///   Executes the specified action if the element is loaded or at the loaded event if it's not loaded.
+        /// </summary>
+        /// <param name="element">The element where the action should be run.</param>
+        /// <param name="invokeAction">An action that takes no parameters.</param>
+        public static void ExecuteWhenLoaded([NotNull] this FrameworkElement element, [NotNull] Action invokeAction)
+        {
+            if (element.IsLoaded)
+            {
+                element.Invoke(invokeAction);
+            }
+            else
+            {
+                RoutedEventHandler handler = null;
+                handler = (o, a) =>
+                    {
+                        element.Loaded -= handler;
+                        element.Invoke(invokeAction);
+                    };
+
+                element.Loaded += handler;
+            }
         }
     }
 }

--- a/src/MahApps.Metro/Controls/FlipView.cs
+++ b/src/MahApps.Metro/Controls/FlipView.cs
@@ -445,7 +445,7 @@ namespace MahApps.Metro.Controls
         /// </summary>
         public void ShowControlButtons()
         {
-            ExecuteWhenLoaded(this, () => this.DetectControlButtonsStatus());
+            this.ExecuteWhenLoaded(() => this.DetectControlButtonsStatus());
         }
 
         /// <summary>
@@ -453,7 +453,7 @@ namespace MahApps.Metro.Controls
         /// </summary>
         public void HideControlButtons()
         {
-            ExecuteWhenLoaded(this, () => this.DetectControlButtonsStatus(Visibility.Hidden));
+            this.ExecuteWhenLoaded(() => this.DetectControlButtonsStatus(Visibility.Hidden));
         }
 
         private void ShowBanner()
@@ -473,25 +473,6 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        private static void ExecuteWhenLoaded(FlipView flipview, Action body)
-        {
-            if (flipview.IsLoaded)
-            {
-                System.Windows.Threading.Dispatcher.CurrentDispatcher.Invoke(body);
-            }
-            else
-            {
-                RoutedEventHandler handler = null;
-                handler = (o, a) =>
-                    {
-                        flipview.Loaded -= handler;
-                        System.Windows.Threading.Dispatcher.CurrentDispatcher.Invoke(body);
-                    };
-
-                flipview.Loaded += handler;
-            }
-        }
-
         public static readonly DependencyProperty UpTransitionProperty = DependencyProperty.Register("UpTransition", typeof(TransitionType), typeof(FlipView), new PropertyMetadata(TransitionType.Up));
         public static readonly DependencyProperty DownTransitionProperty = DependencyProperty.Register("DownTransition", typeof(TransitionType), typeof(FlipView), new PropertyMetadata(TransitionType.Down));
         public static readonly DependencyProperty LeftTransitionProperty = DependencyProperty.Register("LeftTransition", typeof(TransitionType), typeof(FlipView), new PropertyMetadata(TransitionType.LeftReplace));
@@ -501,7 +482,7 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty MouseHoverBorderThicknessProperty = DependencyProperty.Register("MouseHoverBorderThickness", typeof(Thickness), typeof(FlipView), new PropertyMetadata(new Thickness(4)));
         public static readonly DependencyProperty OrientationProperty = DependencyProperty.Register("Orientation", typeof(Orientation), typeof(FlipView), new PropertyMetadata(Orientation.Horizontal, (d, e) => ((FlipView)d).DetectControlButtonsStatus()));
         public static readonly DependencyProperty IsBannerEnabledProperty = DependencyProperty.Register("IsBannerEnabled", typeof(bool), typeof(FlipView), new UIPropertyMetadata(true, OnIsBannerEnabledPropertyChangedCallback));
-        public static readonly DependencyProperty BannerTextProperty = DependencyProperty.Register("BannerText", typeof(string), typeof(FlipView), new FrameworkPropertyMetadata("Banner", FrameworkPropertyMetadataOptions.AffectsRender, (d, e) => ExecuteWhenLoaded(((FlipView)d), () => ((FlipView)d).ChangeBannerText((string)e.NewValue))));
+        public static readonly DependencyProperty BannerTextProperty = DependencyProperty.Register("BannerText", typeof(string), typeof(FlipView), new FrameworkPropertyMetadata("Banner", FrameworkPropertyMetadataOptions.AffectsRender, (d, e) => ((FlipView)d).ExecuteWhenLoaded(() => ((FlipView)d).ChangeBannerText((string)e.NewValue))));
         public static readonly DependencyProperty CircularNavigationProperty = DependencyProperty.Register("CircularNavigation", typeof(bool), typeof(FlipView), new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.AffectsRender, (d, e) => ((FlipView)d).DetectControlButtonsStatus()));
         public static readonly DependencyProperty IsNavigationEnabledProperty = DependencyProperty.Register("IsNavigationEnabled", typeof(bool), typeof(FlipView), new PropertyMetadata(true, (d, e) => ((FlipView)d).DetectControlButtonsStatus()));
 
@@ -634,7 +615,7 @@ namespace MahApps.Metro.Controls
             }
             else
             {
-                ExecuteWhenLoaded(this, () => { this.bannerLabel.Content = value ?? this.BannerText; });
+                this.ExecuteWhenLoaded(() => { this.bannerLabel.Content = value ?? this.BannerText; });
             }
         }
 
@@ -645,7 +626,7 @@ namespace MahApps.Metro.Controls
             if (!flipview.IsLoaded)
             {
                 //wait to be loaded?
-                ExecuteWhenLoaded(flipview, () =>
+                flipview.ExecuteWhenLoaded(() =>
                                       {
                                           flipview.ApplyTemplate();
 

--- a/src/MahApps.Metro/Controls/Underline.cs
+++ b/src/MahApps.Metro/Controls/Underline.cs
@@ -56,6 +56,7 @@ namespace MahApps.Metro.Controls
             base.OnApplyTemplate();
 
             this._underlineBorder = this.GetTemplateChild(UnderlineBorderPartName) as Border;
+
             this.ApplyBorderProperties();
         }
 
@@ -66,31 +67,37 @@ namespace MahApps.Metro.Controls
                 return;
             }
 
-            this._underlineBorder.Height = Double.NaN;
-            this._underlineBorder.Width = Double.NaN;
-            this._underlineBorder.BorderThickness = new Thickness();
-            switch (this.Placement)
-            {
-                case Dock.Left:
-                    this._underlineBorder.Width = this.LineExtent;
-                    this._underlineBorder.BorderThickness = new Thickness(this.LineThickness, 0d, 0d, 0d);
-                    break;
-                case Dock.Top:
-                    this._underlineBorder.Height = this.LineExtent;
-                    this._underlineBorder.BorderThickness = new Thickness(0d, this.LineThickness, 0d, 0d);
-                    break;
-                case Dock.Right:
-                    this._underlineBorder.Width = this.LineExtent;
-                    this._underlineBorder.BorderThickness = new Thickness(0d, 0d, this.LineThickness, 0d);
-                    break;
-                case Dock.Bottom:
-                    this._underlineBorder.Height = this.LineExtent;
-                    this._underlineBorder.BorderThickness = new Thickness(0d, 0d, 0d, this.LineThickness);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-            this.InvalidateVisual();
+            Action applyAction = () =>
+                {
+                    this._underlineBorder.Height = Double.NaN;
+                    this._underlineBorder.Width = Double.NaN;
+                    this._underlineBorder.BorderThickness = new Thickness();
+                    switch (this.Placement)
+                    {
+                        case Dock.Left:
+                            this._underlineBorder.Width = this.LineExtent;
+                            this._underlineBorder.BorderThickness = new Thickness(this.LineThickness, 0d, 0d, 0d);
+                            break;
+                        case Dock.Top:
+                            this._underlineBorder.Height = this.LineExtent;
+                            this._underlineBorder.BorderThickness = new Thickness(0d, this.LineThickness, 0d, 0d);
+                            break;
+                        case Dock.Right:
+                            this._underlineBorder.Width = this.LineExtent;
+                            this._underlineBorder.BorderThickness = new Thickness(0d, 0d, this.LineThickness, 0d);
+                            break;
+                        case Dock.Bottom:
+                            this._underlineBorder.Height = this.LineExtent;
+                            this._underlineBorder.BorderThickness = new Thickness(0d, 0d, 0d, this.LineThickness);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+
+                    this.InvalidateVisual();
+                };
+
+            this.ExecuteWhenLoaded(applyAction);
         }
     }
 }


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

- Fix TabItem HeaderFontSize change leads to freeze
- Use new extension method ExecuteWhenLoaded

**Additional context**

This issue appears only with  .Net 4.7.x. The reason for this is not clear, but it was  the Underline control, which sets some properties before the control is loaded.

**Closed Issues**

Closes #3308 