### PR TITLE
Fix WpfAnalyzers warnings

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HamburgerMenuDefault.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HamburgerMenuDefault.xaml.cs
@@ -58,11 +58,11 @@ namespace MetroDemo.ExampleViews
 
     public static class ShowAboutCommand
     {
-        public static readonly RoutedCommand Command = new RoutedCommand();
+        public static readonly RoutedCommand Command = new RoutedCommand("Command", typeof(ShowAboutCommand));
 
         static ShowAboutCommand()
         {
-            Application.Current.MainWindow.CommandBindings.Add(new CommandBinding(Command, Execute, CanExecute));
+            Application.Current.MainWindow?.CommandBindings.Add(new CommandBinding(Command, Execute, CanExecute));
         }
 
         private static void CanExecute(object sender, CanExecuteRoutedEventArgs e)
@@ -74,7 +74,7 @@ namespace MetroDemo.ExampleViews
         private static async void Execute(object sender, ExecutedRoutedEventArgs e)
         {
             var menuItem = e.Parameter as HamburgerMenuItem;
-            await ((MainWindow)sender).ShowMessageAsync("", $"You clicked on {menuItem.Label} button");
+            await ((MainWindow)sender).ShowMessageAsync("", $"You clicked on {menuItem?.Label} button");
         }
     }
 }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
@@ -9,7 +9,7 @@ using MetroDemo.ExampleWindows;
 
 namespace MetroDemo
 {
-    public partial class MainWindow
+    public partial class MainWindow : MetroWindow
     {
         private bool _shutdown;
         private readonly MainWindowViewModel _viewModel;
@@ -47,22 +47,22 @@ namespace MetroDemo
 
         private static void OnToggleFullScreenChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
-            var metroWindow = (MetroWindow)dependencyObject;
             if (e.OldValue != e.NewValue)
             {
+                var window = (MainWindow)dependencyObject;
                 var fullScreen = (bool)e.NewValue;
                 if (fullScreen)
                 {
-                    metroWindow.IgnoreTaskbarOnMaximize = true;
-                    metroWindow.WindowState = WindowState.Maximized;
-                    metroWindow.UseNoneWindowStyle = true;
+                    window.SetCurrentValue(IgnoreTaskbarOnMaximizeProperty, true);
+                    window.SetCurrentValue(WindowStateProperty, WindowState.Maximized);
+                    window.SetCurrentValue(UseNoneWindowStyleProperty, true);
                 }
                 else
                 {
-                    metroWindow.WindowState = WindowState.Normal;
-                    metroWindow.UseNoneWindowStyle = false;
-                    metroWindow.ShowTitleBar = true; // <-- this must be set to true
-                    metroWindow.IgnoreTaskbarOnMaximize = false;
+                    window.SetCurrentValue(WindowStateProperty, WindowState.Normal);
+                    window.SetCurrentValue(UseNoneWindowStyleProperty, false);
+                    window.SetCurrentValue(ShowTitleBarProperty, true); // <-- this must be set to true
+                    window.SetCurrentValue(IgnoreTaskbarOnMaximizeProperty, false);
                 }
             }
         }
@@ -81,11 +81,11 @@ namespace MetroDemo
 
         private static void OnUseAccentForDialogsChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
-            var metroWindow = (MetroWindow)dependencyObject;
             if (e.OldValue != e.NewValue)
             {
+                var window = (MainWindow)dependencyObject;
                 var useAccentForDialogs = (bool)e.NewValue;
-                metroWindow.MetroDialogOptions.ColorScheme = useAccentForDialogs ? MetroDialogColorScheme.Accented : MetroDialogColorScheme.Theme;
+                window.MetroDialogOptions.ColorScheme = useAccentForDialogs ? MetroDialogColorScheme.Accented : MetroDialogColorScheme.Theme;
             }
         }
 

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
@@ -43,9 +43,9 @@ namespace MetroDemo
             DependencyProperty.Register("ToggleFullScreen",
                                         typeof(bool),
                                         typeof(MainWindow),
-                                        new PropertyMetadata(default(bool), ToggleFullScreenPropertyChangedCallback));
+                                        new PropertyMetadata(default(bool), OnToggleFullScreenChanged));
 
-        private static void ToggleFullScreenPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        private static void OnToggleFullScreenChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
             var metroWindow = (MetroWindow)dependencyObject;
             if (e.OldValue != e.NewValue)
@@ -77,9 +77,9 @@ namespace MetroDemo
             DependencyProperty.Register("UseAccentForDialogs",
                                         typeof(bool),
                                         typeof(MainWindow),
-                                        new PropertyMetadata(default(bool), ToggleUseAccentForDialogsPropertyChangedCallback));
+                                        new PropertyMetadata(default(bool), OnUseAccentForDialogsChanged));
 
-        private static void ToggleUseAccentForDialogsPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        private static void OnUseAccentForDialogsChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
             var metroWindow = (MetroWindow)dependencyObject;
             if (e.OldValue != e.NewValue)

--- a/src/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
+++ b/src/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
@@ -175,7 +175,7 @@ namespace MahApps.Metro.Controls
             EventManager.RegisterClassHandler(typeof(TimePickerBase), UIElement.GotFocusEvent, new RoutedEventHandler(OnGotFocus));
             DefaultStyleKeyProperty.OverrideMetadata(typeof(TimePickerBase), new FrameworkPropertyMetadata(typeof(TimePickerBase)));
             VerticalContentAlignmentProperty.OverrideMetadata(typeof(TimePickerBase), new FrameworkPropertyMetadata(VerticalAlignment.Center));
-            LanguageProperty.OverrideMetadata(typeof(TimePickerBase), new FrameworkPropertyMetadata(OnCultureChanged));
+            LanguageProperty.OverrideMetadata(typeof(TimePickerBase), new FrameworkPropertyMetadata(OnLanguageChanged));
         }
 
         protected TimePickerBase()
@@ -586,18 +586,17 @@ namespace MahApps.Metro.Controls
         {
             var timePartPickerBase = (TimePickerBase)d;
 
-            if (e.NewValue is XmlLanguage)
-            {
-                timePartPickerBase.Language = (XmlLanguage)e.NewValue;
-            }
-            else if (e.NewValue is CultureInfo)
-            {
-                timePartPickerBase.Language = XmlLanguage.GetLanguage(((CultureInfo)e.NewValue).IetfLanguageTag);
-            }
-            else
-            {
-                timePartPickerBase.Language = XmlLanguage.Empty;
-            }
+            var info = e.NewValue as CultureInfo;
+            timePartPickerBase.Language = info != null ? XmlLanguage.GetLanguage(info.IetfLanguageTag) : XmlLanguage.Empty;
+
+            timePartPickerBase.ApplyCulture();
+        }
+
+        private static void OnLanguageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var timePartPickerBase = (TimePickerBase)d;
+
+            timePartPickerBase.Language = e.NewValue as XmlLanguage ?? XmlLanguage.Empty;
 
             timePartPickerBase.ApplyCulture();
         }

--- a/src/paket.dependencies
+++ b/src/paket.dependencies
@@ -7,7 +7,7 @@ source https://api.nuget.org/v3/index.json
 nuget Fody
 nuget Costura.Fody
 
-nuget WpfAnalyzers < 2.1.4
+nuget WpfAnalyzers
 nuget JetBrains.Annotations copy_local:false
 nuget XamlColorSchemeGenerator
 nuget gitlink

--- a/src/paket.lock
+++ b/src/paket.lock
@@ -16,11 +16,13 @@ NUGET
     MaterialDesignColors (1.1.3)
     MaterialDesignThemes (2.5.0-ci1169)
       MaterialDesignColors (>= 1.1)
+    Newtonsoft.Json (11.0.2)
     NHotkey (1.2.1)
     NHotkey.Wpf (1.2.1)
       NHotkey (>= 1.2.1)
-    WpfAnalyzers (2.1.3.2)
-    XamlColorSchemeGenerator (2.0.0.25)
+    WpfAnalyzers (2.1.7.1)
+    XamlColorSchemeGenerator (3.0.0.31)
+      Newtonsoft.Json (>= 10.1)
 
 GROUP cake
 RESTRICTION: == net45


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

- TimePicker: fix WPF0014 SetValue must use registered type.
- Demo MainWindow: WPF0005 Name of PropertyChangedCallback should match registered name.
- Demo MainWindow: WPF0019 Cast sender to correct type.
- Demo HamburgerMenuDefault:
  + WPF0120 Register containing member name as name for routed command.
  + WPF0122 Register name and owning type for routed command.