### PR TITLE
Read available themes from assembly

### DIFF
--- a/src/MahApps.Metro/ThemeManager/Theme.cs
+++ b/src/MahApps.Metro/ThemeManager/Theme.cs
@@ -14,22 +14,26 @@ namespace MahApps.Metro
     public class Theme
     {
         /// <summary>
+        /// Gets the key for the theme name.
+        /// </summary>
+        public const string ThemeNameKey = "Theme.Name";
+
+        private const string ThemeDisplayNameKey = "Theme.DisplayName";
+        private const string ThemeBaseColorSchemeKey = "Theme.BaseColorScheme";
+        private const string ThemeColorSchemeKey = "Theme.ColorScheme";
+        private const string ThemeShowcaseBrushKey = "Theme.ShowcaseBrush";
+
+        /// <summary>
         /// Initializes a new instance.
         /// </summary>
         /// <param name="resourceAddress">The URI of the theme ResourceDictionary.</param>
         public Theme([NotNull] Uri resourceAddress)
+            : this(new ResourceDictionary { Source = resourceAddress })
         {
             if (resourceAddress == null)
             {
                 throw new ArgumentNullException(nameof(resourceAddress));
             }
-
-            this.Resources = new ResourceDictionary { Source = resourceAddress };
-            this.Name = (string)this.Resources["Theme.Name"];
-            this.DisplayName = (string)this.Resources["Theme.DisplayName"];
-            this.BaseColorScheme = (string)this.Resources["Theme.BaseColorScheme"];
-            this.ColorScheme = (string)this.Resources["Theme.ColorScheme"];
-            this.ShowcaseBrush = (SolidColorBrush)this.Resources["Theme.ShowcaseBrush"];
         }
 
         /// <summary>
@@ -39,11 +43,12 @@ namespace MahApps.Metro
         public Theme([NotNull] ResourceDictionary resourceDictionary)
         {
             this.Resources = resourceDictionary ?? throw new ArgumentNullException(nameof(resourceDictionary));
-            this.Name = (string)this.Resources["Theme.Name"];
-            this.DisplayName = (string)this.Resources["Theme.DisplayName"];
-            this.BaseColorScheme = (string)this.Resources["Theme.BaseColorScheme"];
-            this.ColorScheme = (string)this.Resources["Theme.ColorScheme"];
-            this.ShowcaseBrush = (SolidColorBrush)this.Resources["Theme.ShowcaseBrush"];
+
+            this.Name = (string)this.Resources[ThemeNameKey];
+            this.DisplayName = (string)this.Resources[ThemeDisplayNameKey];
+            this.BaseColorScheme = (string)this.Resources[ThemeBaseColorSchemeKey];
+            this.ColorScheme = (string)this.Resources[ThemeColorSchemeKey];
+            this.ShowcaseBrush = (SolidColorBrush)this.Resources[ThemeShowcaseBrushKey];
         }
 
         /// <summary>

--- a/src/Mahapps.Metro.Tests/Tests/ThemeManagerTest.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ThemeManagerTest.cs
@@ -122,7 +122,7 @@ namespace MahApps.Metro.Tests
             var theme = ThemeManager.GetTheme("dark.blue");
 
             Assert.NotNull(theme);
-            Assert.Equal(new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Themes/Dark.Blue.xaml"), theme.Resources.Source);
+            Assert.Equal("pack://application:,,,/MahApps.Metro;component/Styles/Themes/Dark.Blue.xaml".ToLower(), theme.Resources.Source.ToString().ToLower());
         }
 
         [Fact]


### PR DESCRIPTION
This PR changes the ThemeManager so that it reads the available themes from the assembly itself instead of using a hard coded list.
I will create a separate PR in which i will also eliminate the hard coded list of theme recognition resources keys to an embedded file.

The broader goal is to be able to fully share the ThemeManager code between MahApps.Metro and Fluent.Ribbon. ;-)