### PR TITLE
Fixing light theme setting detection

### DIFF
--- a/src/MahApps.Metro/ThemeManager/ThemeManager.cs
+++ b/src/MahApps.Metro/ThemeManager/ThemeManager.cs
@@ -725,7 +725,11 @@ namespace MahApps.Metro
         {
             try
             {
-                return Convert.ToBoolean(Registry.GetValue(@"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize", "AppsUseLightTheme", true));
+                var registryValue = Registry.GetValue(@"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize", "AppsUseLightTheme", true);
+                if (registryValue != null)
+                {
+                    return Convert.ToBoolean(registryValue);
+                }
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
In case that the reg-key does not exists it returns `null` which is interpreted as `false` by `Convert.ToBoolean`