### PR TITLE
Change Dialog Button Styles

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/CustomDialogExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/CustomDialogExample.xaml
@@ -43,6 +43,7 @@
                 Margin="8 8 0 8"
                 HorizontalAlignment="Right"
                 Command="{Binding CloseCommand}"
-                Content="OK" />
+                Content="OK"
+                Style="{DynamicResource MahApps.Metro.Styles.Dialogs.Button}" />
     </Grid>
 </UserControl>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
@@ -80,7 +80,9 @@
                                Foreground="{DynamicResource AccentColorBrush}"
                                Text="This dialog allows arbitrary content. You have to close it yourself by clicking the close button below."
                                TextWrapping="Wrap" />
-                    <Button Click="CloseCustomDialog" Content="Close Me!" />
+                    <Button Click="CloseCustomDialog"
+                            Content="Close Me!"
+                            Style="{DynamicResource MahApps.Metro.Styles.Dialogs.Button}" />
                 </StackPanel>
 
             </Dialog:CustomDialog>

--- a/src/MahApps.Metro/Controls/Dialogs/InputDialog.xaml
+++ b/src/MahApps.Metro/Controls/Dialogs/InputDialog.xaml
@@ -34,12 +34,13 @@
                     MinWidth="80"
                     Margin="0 0 5 0"
                     Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                    Style="{DynamicResource AccentedDialogSquareButton}" />
+                    Style="{DynamicResource MahApps.Metro.Styles.Dialogs.AccentButton}" />
             <Button x:Name="PART_NegativeButton"
                     Height="35"
                     MinWidth="80"
                     Margin="5 0 5 0"
-                    Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+                    Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Style="{DynamicResource MahApps.Metro.Styles.Dialogs.Button}" />
         </StackPanel>
     </Grid>
 </Dialogs:BaseMetroDialog>

--- a/src/MahApps.Metro/Controls/Dialogs/InputDialog.xaml.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/InputDialog.xaml.cs
@@ -169,7 +169,7 @@ namespace MahApps.Metro.Controls.Dialogs
             switch (this.DialogSettings.ColorScheme)
             {
                 case MetroDialogColorScheme.Accented:
-                    this.PART_NegativeButton.SetResourceReference(StyleProperty, "AccentedDialogHighlightedSquareButton");
+                    this.PART_NegativeButton.SetResourceReference(StyleProperty, "MahApps.Metro.Styles.Dialogs.AccentHighlightButton");
                     this.PART_TextBox.SetResourceReference(ForegroundProperty, "BlackColorBrush");
                     this.PART_TextBox.SetResourceReference(ControlsHelper.FocusBorderBrushProperty, "TextBoxFocusBorderBrush");
                     break;

--- a/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml
+++ b/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml
@@ -53,12 +53,13 @@
                     MinWidth="80"
                     Margin="0 0 5 0"
                     Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                    Style="{DynamicResource AccentedDialogSquareButton}" />
+                    Style="{DynamicResource MahApps.Metro.Styles.Dialogs.AccentButton}" />
             <Button x:Name="PART_NegativeButton"
                     Height="35"
                     MinWidth="80"
                     Margin="5 0 5 0"
                     Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Style="{DynamicResource MahApps.Metro.Styles.Dialogs.Button}"
                     Visibility="{Binding NegativeButtonButtonVisibility, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         </StackPanel>
     </Grid>

--- a/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml.cs
@@ -290,7 +290,7 @@ namespace MahApps.Metro.Controls.Dialogs
             switch (this.DialogSettings.ColorScheme)
             {
                 case MetroDialogColorScheme.Accented:
-                    this.PART_NegativeButton.SetResourceReference(StyleProperty, "AccentedDialogHighlightedSquareButton");
+                    this.PART_NegativeButton.SetResourceReference(StyleProperty, "MahApps.Metro.Styles.Dialogs.AccentHighlightButton");
                     this.PART_TextBox.SetResourceReference(ForegroundProperty, "BlackColorBrush");
                     this.PART_TextBox2.SetResourceReference(ForegroundProperty, "BlackColorBrush");
                     break;

--- a/src/MahApps.Metro/Controls/Dialogs/MessageDialog.xaml
+++ b/src/MahApps.Metro/Controls/Dialogs/MessageDialog.xaml
@@ -31,23 +31,27 @@
                     Height="35"
                     MinWidth="80"
                     Margin="0 0 5 0"
-                    Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+                    Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Style="{DynamicResource MahApps.Metro.Styles.Dialogs.Button}" />
             <Button x:Name="PART_NegativeButton"
                     Height="35"
                     MinWidth="80"
                     Margin="5 0 5 0"
-                    Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
+                    Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Style="{DynamicResource MahApps.Metro.Styles.Dialogs.Button}" />
             <Button x:Name="PART_FirstAuxiliaryButton"
                     Height="35"
                     MinWidth="80"
                     Margin="5 0 5 0"
                     Content="{Binding FirstAuxiliaryButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Style="{DynamicResource MahApps.Metro.Styles.Dialogs.Button}"
                     Visibility="Collapsed" />
             <Button x:Name="PART_SecondAuxiliaryButton"
                     Height="35"
                     MinWidth="80"
                     Margin="5 0 0 0"
                     Content="{Binding SecondAuxiliaryButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
+                    Style="{DynamicResource MahApps.Metro.Styles.Dialogs.Button}"
                     Visibility="Collapsed" />
         </StackPanel>
     </Grid>

--- a/src/MahApps.Metro/Controls/Dialogs/MessageDialog.xaml.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/MessageDialog.xaml.cs
@@ -11,6 +11,9 @@ namespace MahApps.Metro.Controls.Dialogs
     /// </summary>
     public partial class MessageDialog : BaseMetroDialog
     {
+        private const string ACCENT_BUTTON_STYLE = "MahApps.Metro.Styles.Dialogs.AccentButton";
+        private const string ACCENT_HIGHLIGHT_BUTTON_STYLE = "MahApps.Metro.Styles.Dialogs.AccentHighlightButton";
+
         /// <summary>Identifies the <see cref="Message"/> dependency property.</summary>
         public static readonly DependencyProperty MessageProperty = DependencyProperty.Register(nameof(Message), typeof(string), typeof(MessageDialog), new PropertyMetadata(default(string)));
 
@@ -111,19 +114,19 @@ namespace MahApps.Metro.Controls.Dialogs
                     switch (defaultButtonFocus)
                     {
                         case MessageDialogResult.Affirmative:
-                            this.PART_AffirmativeButton.SetResourceReference(StyleProperty, "AccentedDialogSquareButton");
+                            this.PART_AffirmativeButton.SetResourceReference(StyleProperty, ACCENT_BUTTON_STYLE);
                             KeyboardNavigationEx.Focus(this.PART_AffirmativeButton);
                             break;
                         case MessageDialogResult.Negative:
-                            this.PART_NegativeButton.SetResourceReference(StyleProperty, "AccentedDialogSquareButton");
+                            this.PART_NegativeButton.SetResourceReference(StyleProperty, ACCENT_BUTTON_STYLE);
                             KeyboardNavigationEx.Focus(this.PART_NegativeButton);
                             break;
                         case MessageDialogResult.FirstAuxiliary:
-                            this.PART_FirstAuxiliaryButton.SetResourceReference(StyleProperty, "AccentedDialogSquareButton");
+                            this.PART_FirstAuxiliaryButton.SetResourceReference(StyleProperty, ACCENT_BUTTON_STYLE);
                             KeyboardNavigationEx.Focus(this.PART_FirstAuxiliaryButton);
                             break;
                         case MessageDialogResult.SecondAuxiliary:
-                            this.PART_SecondAuxiliaryButton.SetResourceReference(StyleProperty, "AccentedDialogSquareButton");
+                            this.PART_SecondAuxiliaryButton.SetResourceReference(StyleProperty, ACCENT_BUTTON_STYLE);
                             KeyboardNavigationEx.Focus(this.PART_SecondAuxiliaryButton);
                             break;
                     }
@@ -320,10 +323,10 @@ namespace MahApps.Metro.Controls.Dialogs
             switch (md.DialogSettings.ColorScheme)
             {
                 case MetroDialogColorScheme.Accented:
-                    md.PART_AffirmativeButton.SetResourceReference(StyleProperty, "AccentedDialogHighlightedSquareButton");
-                    md.PART_NegativeButton.SetResourceReference(StyleProperty, "AccentedDialogHighlightedSquareButton");
-                    md.PART_FirstAuxiliaryButton.SetResourceReference(StyleProperty, "AccentedDialogHighlightedSquareButton");
-                    md.PART_SecondAuxiliaryButton.SetResourceReference(StyleProperty, "AccentedDialogHighlightedSquareButton");
+                    md.PART_AffirmativeButton.SetResourceReference(StyleProperty, ACCENT_HIGHLIGHT_BUTTON_STYLE);
+                    md.PART_NegativeButton.SetResourceReference(StyleProperty, ACCENT_HIGHLIGHT_BUTTON_STYLE);
+                    md.PART_FirstAuxiliaryButton.SetResourceReference(StyleProperty, ACCENT_HIGHLIGHT_BUTTON_STYLE);
+                    md.PART_SecondAuxiliaryButton.SetResourceReference(StyleProperty, ACCENT_HIGHLIGHT_BUTTON_STYLE);
                     break;
             }
         }

--- a/src/MahApps.Metro/Controls/Dialogs/ProgressDialog.xaml
+++ b/src/MahApps.Metro/Controls/Dialogs/ProgressDialog.xaml
@@ -27,7 +27,7 @@
                         Margin="5 0 0 0"
                         Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:ProgressDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                         Cursor="Arrow"
-                        Style="{DynamicResource AccentedDialogSquareButton}"
+                        Style="{DynamicResource MahApps.Metro.Styles.Dialogs.AccentButton}"
                         Visibility="Hidden" />
             </StackPanel>
         </Grid>

--- a/src/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/src/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -7,13 +7,19 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Buttons.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style x:Key="AccentedDialogSquareButton"
+    <Style x:Key="MahApps.Metro.Styles.Dialogs.Button"
+           BasedOn="{StaticResource SquareButtonStyle}"
+           TargetType="{x:Type Button}">
+        <Setter Property="controls:ControlsHelper.ContentCharacterCasing" Value="Normal" />
+    </Style>
+
+    <Style x:Key="MahApps.Metro.Styles.Dialogs.AccentButton"
            BasedOn="{StaticResource AccentedSquareButtonStyle}"
            TargetType="{x:Type ButtonBase}">
         <Setter Property="controls:ControlsHelper.ContentCharacterCasing" Value="Normal" />
     </Style>
 
-    <Style x:Key="AccentedDialogHighlightedSquareButton"
+    <Style x:Key="MahApps.Metro.Styles.Dialogs.AccentHighlightButton"
            BasedOn="{StaticResource HighlightedSquareButtonStyle}"
            TargetType="{x:Type ButtonBase}">
         <Setter Property="controls:ControlsHelper.ContentCharacterCasing" Value="Normal" />
@@ -94,11 +100,6 @@
     </ControlTemplate>
 
     <Style x:Key="MahApps.Metro.Styles.MetroDialog" TargetType="{x:Type Dialogs:BaseMetroDialog}">
-        <Style.Resources>
-            <Style BasedOn="{StaticResource SquareButtonStyle}" TargetType="{x:Type Button}">
-                <Setter Property="controls:ControlsHelper.ContentCharacterCasing" Value="Normal" />
-            </Style>
-        </Style.Resources>
         <Setter Property="Background" Value="{DynamicResource WhiteColorBrush}" />
         <Setter Property="DialogMessageFontSize" Value="{DynamicResource DialogMessageFontSize}" />
         <Setter Property="DialogTitleFontSize" Value="{DynamicResource DialogTitleFontSize}" />


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Fix for: Styling of buttons within a BaseMetroDialog should be facilitated

Change key style names and add style for normal button style in dialogs.

| old | new |
| --- | --- |
| AccentedDialogSquareButton | MahApps.Metro.Styles.Dialogs.AccentButton |
| AccentedDialogHighlightedSquareButton | MahApps.Metro.Styles.Dialogs.AccentHighlightButton |
| | MahApps.Metro.Styles.Dialogs.Button |

**Note**

A custom dialog must use the `MahApps.Metro.Styles.Dialogs.Button` style now explicit on every button.

**Closed Issues**

Closes #3310 
