### PR TITLE
Added more choices for positioning buttons on NumericUpDown control

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/OtherExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/OtherExamples.xaml
@@ -211,15 +211,12 @@
                         DataContext="{Binding ElementName=FlipView2nd, Mode=OneWay}"
                         Orientation="Horizontal">
                 <Controls:NumericUpDown Controls:TextBoxHelper.SelectAllOnFocus="True"
-                                        ButtonsAlignment="Left"
+                                        ButtonsAlignment="OpposingSides"
                                         Interval="1"
                                         Maximum="{Binding Path=Items.Count, Mode=OneWay}"
                                         Minimum="1"
+                                        SwitchUpDownButtons="True"
                                         Value="{Binding Path=SelectedIndex, Mode=TwoWay, Converter={vc:Int32IndexToNumberConverter}}" />
-                <TextBlock Margin="8 0 0 0" VerticalAlignment="Center">
-                    <Run Text="/" />
-                    <Run Text="{Binding Path=Items.Count, Mode=OneWay}" />
-                </TextBlock>
             </StackPanel>
         </StackPanel>
 

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/OtherExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/OtherExamples.xaml
@@ -211,7 +211,7 @@
                         DataContext="{Binding ElementName=FlipView2nd, Mode=OneWay}"
                         Orientation="Horizontal">
                 <Controls:NumericUpDown Controls:TextBoxHelper.SelectAllOnFocus="True"
-                                        ButtonsAlignment="OpposingSides"
+                                        ButtonsAlignment="Opposite"
                                         Interval="1"
                                         Maximum="{Binding Path=Items.Count, Mode=OneWay}"
                                         Minimum="1"

--- a/src/MahApps.Metro/Controls/ButtonsAlignment.cs
+++ b/src/MahApps.Metro/Controls/ButtonsAlignment.cs
@@ -3,6 +3,7 @@
    public enum ButtonsAlignment
    {
       Left,
-      Right
+      Right,
+      OpposingSides
    }
 }

--- a/src/MahApps.Metro/Controls/ButtonsAlignment.cs
+++ b/src/MahApps.Metro/Controls/ButtonsAlignment.cs
@@ -4,6 +4,6 @@
    {
       Left,
       Right,
-      OpposingSides
-   }
+      Opposite
+    }
 }

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -147,6 +147,12 @@ namespace MahApps.Metro.Controls
             typeof(NumericUpDown),
             new PropertyMetadata(NumberStyles.Any));
 
+        public static readonly DependencyProperty SwitchUpDownButtonsProperty = DependencyProperty.Register(
+            "SwitchUpDownButtons",
+            typeof(bool),
+            typeof(NumericUpDown),
+            new PropertyMetadata(false));
+
         private static void IsReadOnlyPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
         {
             if (e.OldValue != e.NewValue && e.NewValue != null)
@@ -482,6 +488,17 @@ namespace MahApps.Metro.Controls
         {
             get { return (NumberStyles)GetValue(ParsingNumberStyleProperty); }
             set { SetValue(ParsingNumberStyleProperty, value); }
+        }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether the up down buttons are switched.
+        /// </summary>
+        [Category("Appearance")]
+        [DefaultValue(false)]
+        public bool SwitchUpDownButtons
+        {
+            get { return (bool)GetValue(SwitchUpDownButtonsProperty); }
+            set { SetValue(SwitchUpDownButtonsProperty, value); }
         }
 
         /// <summary> 

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -42,8 +42,9 @@
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         <Grid Margin="{TemplateBinding BorderThickness}">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="PART_TextBoxColumn" Width="*" />
-                                <ColumnDefinition x:Name="PART_ButtonsColumn" Width="Auto" />
+                                <ColumnDefinition x:Name="PART_LeftColumn" Width="*" />
+                                <ColumnDefinition x:Name="PART_MiddleColumn" Width="Auto" />
+                                <ColumnDefinition x:Name="PART_RightColumn" Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBox x:Name="PART_TextBox"
                                      Grid.Column="0"
@@ -82,16 +83,14 @@
                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                      TabIndex="{TemplateBinding TabIndex}"
                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
-                            <StackPanel x:Name="PART_Buttons"
-                                        Grid.Column="1"
-                                        Margin="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}"
-                                        Orientation="Horizontal">
-                                <RepeatButton x:Name="PART_NumericUp"
+                            <RepeatButton x:Name="PART_NumericUp"
+                                              Grid.Column="1"
                                               Width="{TemplateBinding UpDownButtonsWidth}"
                                               Delay="{TemplateBinding Delay}"
                                               Foreground="{TemplateBinding Foreground}"
                                               IsTabStop="False"
-                                              Style="{DynamicResource ChromelessButtonStyle}">
+                                              Style="{DynamicResource ChromelessButtonStyle}"
+                                              Margin="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}">
                                     <Path x:Name="PolygonUp"
                                           Width="14"
                                           Height="14"
@@ -99,21 +98,22 @@
                                           Fill="{DynamicResource GrayBrush1}"
                                           Stretch="Fill" />
                                 </RepeatButton>
-                                <RepeatButton x:Name="PART_NumericDown"
+                            <RepeatButton x:Name="PART_NumericDown"
+                                              Grid.Column="2"
                                               Width="{TemplateBinding UpDownButtonsWidth}"
                                               VerticalContentAlignment="Center"
                                               Delay="{TemplateBinding Delay}"
                                               Foreground="{TemplateBinding Foreground}"
                                               IsTabStop="False"
-                                              Style="{DynamicResource ChromelessButtonStyle}">
-                                    <Path x:Name="PolygonDown"
+                                              Style="{DynamicResource ChromelessButtonStyle}"
+                                              Margin="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}">
+                                <Path x:Name="PolygonDown"
                                           Width="14"
                                           Height="3"
                                           Data="F1 M 19,38L 57,38L 57,44L 19,44L 19,38 Z "
                                           Fill="{DynamicResource GrayBrush1}"
                                           Stretch="Fill" />
-                                </RepeatButton>
-                            </StackPanel>
+                            </RepeatButton>
                         </Grid>
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource ControlsDisabledBrush}"
@@ -126,15 +126,86 @@
                                 Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}" />
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="ButtonsAlignment" Value="Left">
-                            <Setter TargetName="PART_Buttons" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_Buttons" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
-                            <Setter TargetName="PART_ButtonsColumn" Property="Width" Value="*" />
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="ButtonsAlignment" Value="Left" />
+                                <Condition Property="SwitchUpDownButtons" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_NumericUp" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}" />
+                            <Setter TargetName="PART_MiddleColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
+                            <Setter TargetName="PART_RightColumn" Property="Width" Value="*" />
+                            <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="2" />
+                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
+                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="ButtonsAlignment" Value="OpposingSides" />
+                                <Condition Property="SwitchUpDownButtons" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_NumericUp" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
+                            <Setter TargetName="PART_MiddleColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="1" />
                             <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
                             <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
-                            <Setter TargetName="PART_TextBoxColumn" Property="Width" Value="Auto" />
-                        </Trigger>
+                            <Setter TargetName="PART_RightColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="2" />
+                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}" />
+                        </MultiTrigger>   
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="ButtonsAlignment" Value="Left" />
+                                <Condition Property="SwitchUpDownButtons" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}" />
+                            <Setter TargetName="PART_MiddleColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_NumericUp" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
+                            <Setter TargetName="PART_RightColumn" Property="Width" Value="*" />
+                            <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="2" />
+                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
+                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="ButtonsAlignment" Value="OpposingSides" />
+                                <Condition Property="SwitchUpDownButtons" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
+                            <Setter TargetName="PART_MiddleColumn" Property="Width" Value="*" />
+                            <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
+                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
+                            <Setter TargetName="PART_RightColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="2" />
+                            <Setter TargetName="PART_NumericUp" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="ButtonsAlignment" Value="Right" />
+                                <Condition Property="SwitchUpDownButtons" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_LeftColumn" Property="Width" Value="*" />
+                            <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
+                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />                            
+                            <Setter TargetName="PART_MiddleColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}" />
+                            <Setter TargetName="PART_RightColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="2" />
+                            <Setter TargetName="PART_NumericUp" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
+                        </MultiTrigger>                        
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
                         </Trigger>
@@ -174,9 +245,9 @@
                         <Trigger SourceName="PART_TextBox" Property="IsFocused" Value="true">
                             <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderBrush)}" />
                         </Trigger>
-
                         <Trigger Property="HideUpDownButtons" Value="True">
-                            <Setter TargetName="PART_Buttons" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_NumericUp" Property="Visibility" Value="Collapsed" />
+                            <Setter TargetName="PART_NumericDown" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -144,7 +144,7 @@
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="ButtonsAlignment" Value="OpposingSides" />
+                                <Condition Property="ButtonsAlignment" Value="Opposite" />
                                 <Condition Property="SwitchUpDownButtons" Value="False" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
@@ -176,7 +176,7 @@
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="ButtonsAlignment" Value="OpposingSides" />
+                                <Condition Property="ButtonsAlignment" Value="Opposite" />
                                 <Condition Property="SwitchUpDownButtons" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />


### PR DESCRIPTION
Added more choices for positioning buttons on NumericUpDown control namely:
- New **ButtonsAlignment="OpposingSides**" option that will basically have the text box in the middle of the buttons.
- New **SwitchUpDownButtons** property that will switch the buttons places

For testing, I have changed the NumericUpDown that controls the index of FlipView2nd in the OtherExamples.xaml file.