### PR TITLE
Provide event for hamburger button click

### DIFF
--- a/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.Events.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.Events.cs
@@ -24,9 +24,16 @@ namespace MahApps.Metro.Controls
         /// </summary>
         public event EventHandler<HamburgerMenuItemInvokedEventArgs> ItemInvoked;
 
-        private void HamburgerButton_Click(object sender, RoutedEventArgs e)
+        /// <summary>
+        /// Event raised when the hamburger button is clicked
+        /// </summary>
+        public event EventHandler<ItemClickEventArgs> HamburgerButtonClick;
+
+        private void OnHamburgerButtonClick(object sender, RoutedEventArgs e)
         {
             IsPaneOpen = !IsPaneOpen;
+
+            HamburgerButtonClick?.Invoke(this, new ItemClickEventArgs(_hamburgerButton));
         }
 
         private void OnItemClick()

--- a/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.cs
@@ -30,7 +30,7 @@ namespace MahApps.Metro.Controls
         {
             if (_hamburgerButton != null)
             {
-                _hamburgerButton.Click -= HamburgerButton_Click;
+                _hamburgerButton.Click -= this.OnHamburgerButtonClick;
             }
 
             if (_buttonsListView != null)
@@ -49,7 +49,7 @@ namespace MahApps.Metro.Controls
 
             if (_hamburgerButton != null)
             {
-                _hamburgerButton.Click += HamburgerButton_Click;
+                _hamburgerButton.Click += this.OnHamburgerButtonClick;
             }
 
             if (_buttonsListView != null)


### PR DESCRIPTION
This adds a HamburgerButtonClick event to the HamburgerMenu control.

I needed this particular event for saving the UI settings, that is save the current "pane open" state when the button has been clicked, as opposed to other situations where IsPaneOpen may be changed programmatically.

I used the ItemClickEventArgs for this event with the hamburger button as value. I didn't need this particular implementation (without would have been fine as well) but it might be useful for other purposes and shouldn't hurt.