### PR TITLE
(GH-3040) Fix grouping virtualization for DataGrid (ItemsControls)

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SelectionExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SelectionExamples.xaml
@@ -247,14 +247,13 @@
                 <ComboBox x:Name="groupingComboBox"
                           Width="200"
                           Margin="0 10 0 0"
-                          Controls:ComboBoxHelper.EnableVirtualizationWithGrouping="True"
-                          Controls:TextBoxHelper.Watermark="Autocompletion with grouping/virtualization"
+                          Controls:TextBoxHelper.Watermark="Autocompletion with grouping"
                           DisplayMemberPath="Title"
                           IsEditable="True"
                           IsEnabled="True"
                           ItemsSource="{Binding Albums}"
-                          Text="{Binding Path=Title}"
-                          ToolTip="grouping/virtualization works only with .NET 4.5">
+                          Style="{DynamicResource VirtualisedMetroComboBox}"
+                          Text="{Binding Path=Title}">
                     <ComboBox.GroupStyle>
                         <GroupStyle>
                             <GroupStyle.HeaderTemplate>

--- a/src/MahApps.Metro/Controls/Helper/ComboBoxHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ComboBoxHelper.cs
@@ -9,38 +9,6 @@ namespace MahApps.Metro.Controls
     /// </summary>
     public class ComboBoxHelper
     {
-        // TODO remove this
-        public static readonly DependencyProperty EnableVirtualizationWithGroupingProperty
-            = DependencyProperty.RegisterAttached("EnableVirtualizationWithGrouping",
-                                                  typeof(bool),
-                                                  typeof(ComboBoxHelper),
-                                                  new FrameworkPropertyMetadata(false, OnEnableVirtualizationWithGroupingChanged));
-
-        private static void OnEnableVirtualizationWithGroupingChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
-        {
-            var comboBox = dependencyObject as ComboBox;
-            if (comboBox != null && e.NewValue != e.OldValue)
-            {
-                comboBox.SetCurrentValue(VirtualizingStackPanel.IsVirtualizingProperty, e.NewValue);
-                comboBox.SetCurrentValue(VirtualizingPanel.IsVirtualizingWhenGroupingProperty, e.NewValue);
-                comboBox.SetCurrentValue(ScrollViewer.CanContentScrollProperty, e.NewValue);
-            }
-        }
-
-        [Category(AppName.MahApps)]
-        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
-        public static void SetEnableVirtualizationWithGrouping(DependencyObject obj, bool value)
-        {
-            obj.SetValue(EnableVirtualizationWithGroupingProperty, value);
-        }
-
-        [Category(AppName.MahApps)]
-        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
-        public static bool GetEnableVirtualizationWithGrouping(DependencyObject obj)
-        {
-            return (bool)obj.GetValue(EnableVirtualizationWithGroupingProperty);
-        }
-
         public static readonly DependencyProperty MaxLengthProperty
             = DependencyProperty.RegisterAttached("MaxLength",
                                                   typeof(int),

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -278,7 +278,7 @@
         <Setter Property="MinHeight" Value="26" />
         <Setter Property="Padding" Value="2" />
         <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
-        <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+        <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
         <!--  change SnapsToDevicePixels to true to view a better border and validation error  -->
@@ -597,6 +597,14 @@
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderBrush)}" />
                         </Trigger>
 
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
+                        </MultiTrigger>
+
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Visibility" Value="Visible" />
                         </Trigger>
@@ -606,27 +614,29 @@
         </Setter>
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource ValidationErrorTemplate}" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Style.Triggers>
+            <Trigger Property="VirtualizingStackPanel.IsVirtualizing" Value="True">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel IsItemsHost="True"
+                                                    IsVirtualizing="True"
+                                                    IsVirtualizingWhenGrouping="True"
+                                                    VirtualizationMode="Recycling" />
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style x:Key="VirtualisedMetroComboBox"
            BasedOn="{StaticResource MetroComboBox}"
            TargetType="{x:Type ComboBox}">
-        <Setter Property="ItemsPanel">
-            <Setter.Value>
-                <ItemsPanelTemplate>
-                    <VirtualizingStackPanel IsItemsHost="True"
-                                            IsVirtualizing="True"
-                                            KeyboardNavigation.DirectionalNavigation="Contained"
-                                            VirtualizationMode="Recycling" />
-                </ItemsPanelTemplate>
-            </Setter.Value>
-        </Setter>
         <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
-        <Style.Triggers>
-            <Trigger Property="IsGrouping" Value="True">
-                <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
-            </Trigger>
-        </Style.Triggers>
+        <Setter Property="VirtualizingStackPanel.IsVirtualizing" Value="True" />
+        <Setter Property="VirtualizingStackPanel.IsVirtualizingWhenGrouping" Value="True" />
+        <Setter Property="VirtualizingStackPanel.VirtualizationMode" Value="Recycling" />
     </Style>
 
     <Style x:Key="MetroComboBoxItem" TargetType="ComboBoxItem">

--- a/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -453,6 +453,7 @@
         <Setter Property="MinRowHeight" Value="25" />
         <Setter Property="RowHeaderStyle" Value="{StaticResource MetroDataGridRowHeader}" />
         <Setter Property="RowStyle" Value="{StaticResource MetroDataGridRow}" />
+        <Setter Property="ScrollViewer.CanContentScroll" Value="true" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type DataGrid}">
@@ -520,9 +521,13 @@
         </Setter>
         <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource GrayBrush7}" />
         <Style.Triggers>
-            <Trigger Property="IsGrouping" Value="True">
-                <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
-            </Trigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
+                <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
+            </MultiTrigger>
         </Style.Triggers>
     </Style>
 

--- a/src/MahApps.Metro/Styles/Controls.ListBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ListBox.xaml
@@ -32,9 +32,13 @@
                         </ScrollViewer>
                     </Border>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsGrouping" Value="false">
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
                             <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
-                        </Trigger>
+                        </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -48,11 +52,13 @@
                 <Setter Property="ItemsPanel">
                     <Setter.Value>
                         <ItemsPanelTemplate>
-                            <VirtualizingStackPanel />
+                            <VirtualizingStackPanel IsItemsHost="True"
+                                                    IsVirtualizing="True"
+                                                    IsVirtualizingWhenGrouping="True"
+                                                    VirtualizationMode="Recycling" />
                         </ItemsPanelTemplate>
                     </Setter.Value>
                 </Setter>
-                <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -60,7 +66,9 @@
     <Style x:Key="VirtualisedMetroListBox"
            BasedOn="{StaticResource MetroListBox}"
            TargetType="{x:Type ListBox}">
+        <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
         <Setter Property="VirtualizingStackPanel.IsVirtualizing" Value="True" />
+        <Setter Property="VirtualizingStackPanel.IsVirtualizingWhenGrouping" Value="True" />
         <Setter Property="VirtualizingStackPanel.VirtualizationMode" Value="Recycling" />
     </Style>
 

--- a/src/MahApps.Metro/Styles/Controls.ListView.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ListView.xaml
@@ -122,9 +122,13 @@
                         </ScrollViewer>
                     </Border>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsGrouping" Value="True">
-                            <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
-                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
+                        </MultiTrigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource GrayBrush9}" />
                         </Trigger>
@@ -141,6 +145,7 @@
         <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
         <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="True" />
         <Setter Property="VirtualizingStackPanel.IsVirtualizing" Value="True" />
+        <Setter Property="VirtualizingStackPanel.IsVirtualizingWhenGrouping" Value="True" />
         <Setter Property="VirtualizingStackPanel.VirtualizationMode" Value="Recycling" />
     </Style>
 

--- a/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
@@ -294,9 +294,13 @@
                         </ScrollViewer>
                     </Border>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsGrouping" Value="False">
-                            <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
-                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsGrouping" Value="true" />
+                                <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                            </MultiTrigger.Conditions>
+                            <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
+                        </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Using `IsVirtualizingWhenGrouping` breaks virtualization for DataGrid and ItemsControls, so this PR fix this.

**Additional context**

The obsolete `EnableVirtualizationWithGrouping` attached property will also be deleted.

**Closed Issues**

Closes #3040 
