### PR TITLE
(GH-3477) Add new attached property FocusBorderThickness

### DIFF
--- a/src/MahApps.Metro/Controls/Helper/ControlsHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ControlsHelper.cs
@@ -150,38 +150,75 @@ namespace MahApps.Metro.Controls
             element.SetValue(HeaderMarginProperty, value);
         }
 
-        public static readonly DependencyProperty FocusBorderBrushProperty = DependencyProperty.RegisterAttached("FocusBorderBrush", typeof(Brush), typeof(ControlsHelper), new FrameworkPropertyMetadata(Brushes.Transparent, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
-        public static readonly DependencyProperty MouseOverBorderBrushProperty = DependencyProperty.RegisterAttached("MouseOverBorderBrush", typeof(Brush), typeof(ControlsHelper), new FrameworkPropertyMetadata(Brushes.Transparent, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
-
-        /// <summary>
-        /// Sets the brush used to draw the focus border.
-        /// </summary>
-        public static void SetFocusBorderBrush(DependencyObject obj, Brush value)
-        {
-            obj.SetValue(FocusBorderBrushProperty, value);
-        }
+        public static readonly DependencyProperty FocusBorderBrushProperty
+            = DependencyProperty.RegisterAttached("FocusBorderBrush",
+                                                  typeof(Brush),
+                                                  typeof(ControlsHelper),
+                                                  new FrameworkPropertyMetadata(Brushes.Transparent, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
 
         /// <summary>
         /// Gets the brush used to draw the focus border.
         /// </summary>
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(TextBox))]
-        [AttachedPropertyBrowsableForType(typeof(CheckBox))]
-        [AttachedPropertyBrowsableForType(typeof(RadioButton))]
         [AttachedPropertyBrowsableForType(typeof(DatePicker))]
         [AttachedPropertyBrowsableForType(typeof(ComboBox))]
+        [AttachedPropertyBrowsableForType(typeof(ButtonBase))]
         public static Brush GetFocusBorderBrush(DependencyObject obj)
         {
             return (Brush)obj.GetValue(FocusBorderBrushProperty);
         }
 
         /// <summary>
-        /// Sets the brush used to draw the mouse over brush.
+        /// Sets the brush used to draw the focus border.
         /// </summary>
-        public static void SetMouseOverBorderBrush(DependencyObject obj, Brush value)
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TextBox))]
+        [AttachedPropertyBrowsableForType(typeof(DatePicker))]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
+        [AttachedPropertyBrowsableForType(typeof(ButtonBase))]
+        public static void SetFocusBorderBrush(DependencyObject obj, Brush value)
         {
-            obj.SetValue(MouseOverBorderBrushProperty, value);
+            obj.SetValue(FocusBorderBrushProperty, value);
         }
+
+        public static readonly DependencyProperty FocusBorderThicknessProperty
+            = DependencyProperty.RegisterAttached("FocusBorderThickness",
+                                                  typeof(Thickness),
+                                                  typeof(ControlsHelper),
+                                                  new FrameworkPropertyMetadata(default(Thickness), FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
+
+        /// <summary>
+        /// Gets the brush used to draw the focus border.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TextBox))]
+        [AttachedPropertyBrowsableForType(typeof(DatePicker))]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
+        [AttachedPropertyBrowsableForType(typeof(ButtonBase))]
+        public static Thickness GetFocusBorderThickness(DependencyObject obj)
+        {
+            return (Thickness)obj.GetValue(FocusBorderThicknessProperty);
+        }
+
+        /// <summary>
+        /// Sets the brush used to draw the focus border.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TextBox))]
+        [AttachedPropertyBrowsableForType(typeof(DatePicker))]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
+        [AttachedPropertyBrowsableForType(typeof(ButtonBase))]
+        public static void SetFocusBorderThickness(DependencyObject obj, Thickness value)
+        {
+            obj.SetValue(FocusBorderThicknessProperty, value);
+        }
+
+        public static readonly DependencyProperty MouseOverBorderBrushProperty
+            = DependencyProperty.RegisterAttached("MouseOverBorderBrush",
+                                                  typeof(Brush),
+                                                  typeof(ControlsHelper),
+                                                  new FrameworkPropertyMetadata(Brushes.Transparent, FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
 
         /// <summary>
         /// Gets the brush used to draw the mouse over brush.
@@ -196,6 +233,21 @@ namespace MahApps.Metro.Controls
         public static Brush GetMouseOverBorderBrush(DependencyObject obj)
         {
             return (Brush)obj.GetValue(MouseOverBorderBrushProperty);
+        }
+
+        /// <summary>
+        /// Sets the brush used to draw the mouse over brush.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(TextBox))]
+        [AttachedPropertyBrowsableForType(typeof(CheckBox))]
+        [AttachedPropertyBrowsableForType(typeof(RadioButton))]
+        [AttachedPropertyBrowsableForType(typeof(DatePicker))]
+        [AttachedPropertyBrowsableForType(typeof(ComboBox))]
+        [AttachedPropertyBrowsableForType(typeof(Tile))]
+        public static void SetMouseOverBorderBrush(DependencyObject obj, Brush value)
+        {
+            obj.SetValue(MouseOverBorderBrushProperty, value);
         }
 
         /// <summary>

--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -390,6 +390,8 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Upper" />
         <Setter Property="Controls:ControlsHelper.CornerRadius" Value="3" />
+        <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource ButtonMouseOverBorderBrush}" />
+        <Setter Property="Controls:ControlsHelper.FocusBorderThickness" Value="2" />
         <Setter Property="FontFamily" Value="{DynamicResource DefaultFont}" />
         <Setter Property="FontSize" Value="{DynamicResource UpperCaseContentFontSize}" />
         <Setter Property="FontWeight" Value="Bold" />
@@ -434,8 +436,8 @@
                             <Setter TargetName="Border" Property="Background" Value="{DynamicResource GrayBrush7}" />
                         </Trigger>
                         <Trigger Property="IsKeyboardFocusWithin" Value="True">
-                            <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource ButtonMouseOverBorderBrush}" />
-                            <Setter TargetName="Border" Property="BorderThickness" Value="2" />
+                            <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderBrush), Mode=OneWay}" />
+                            <Setter TargetName="Border" Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderThickness), Mode=OneWay}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.7" />
@@ -676,6 +678,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Controls:ControlsHelper.CornerRadius" Value="3" />
+        <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource ButtonMouseOverBorderBrush}" />
         <Setter Property="FontFamily" Value="{DynamicResource DefaultFont}" />
         <Setter Property="FontSize" Value="{DynamicResource UpperCaseContentFontSize}" />
         <Setter Property="FontWeight" Value="Bold" />
@@ -750,7 +753,7 @@
                 <Setter Property="Background" Value="{DynamicResource GrayBrush7}" />
             </Trigger>
             <Trigger Property="IsKeyboardFocusWithin" Value="True">
-                <Setter Property="BorderBrush" Value="{DynamicResource ButtonMouseOverBorderBrush}" />
+                <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.FocusBorderBrush), Mode=OneWay}" />
             </Trigger>
         </Style.Triggers>
     </Style>


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Add a new attached property `FocusBorderThickness` at `ControlsHelper` (which can be used for other styles too) to allow changing the border thickness for the default `MahApps.Metro.Styles.MetroButton` style.

**Closed Issues**

Closes #3477 
