### PR TITLE
(GH-3434) Add new HamburgerMenuSeparatorItem for HamburgerMenu

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HamburgerMenuCreatorsUpdate.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HamburgerMenuCreatorsUpdate.xaml
@@ -187,6 +187,7 @@
                     <Controls:HamburgerMenuItemCollection>
                         <Controls:HamburgerMenuGlyphItem Glyph="/Assets/Photos/BigFourSummerHeat.png" Label="Big four summer heat" />
                         <Controls:HamburgerMenuGlyphItem Glyph="/Assets/Photos/BisonBadlandsChillin.png" Label="Bison badlands Chillin" />
+                        <Controls:HamburgerMenuSeparatorItem />
                         <Controls:HamburgerMenuGlyphItem Glyph="/Assets/Photos/GiantSlabInOregon.png" Label="Giant slab in Oregon" />
                         <Controls:HamburgerMenuGlyphItem Glyph="/Assets/Photos/LakeAnnMushroom.png" Label="Lake Ann Mushroom" />
                     </Controls:HamburgerMenuItemCollection>

--- a/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.Properties.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.Properties.cs
@@ -93,6 +93,11 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty ItemContainerStyleProperty = DependencyProperty.Register(nameof(ItemContainerStyle), typeof(Style), typeof(HamburgerMenu), new PropertyMetadata(null));
 
         /// <summary>
+        /// Identifies the <see cref="SeparatorItemContainerStyle"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty SeparatorItemContainerStyleProperty = DependencyProperty.Register(nameof(SeparatorItemContainerStyle), typeof(Style), typeof(HamburgerMenu), new PropertyMetadata(null));
+
+        /// <summary>
         /// Identifies the <see cref="ItemTemplate"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty ItemTemplateProperty = DependencyProperty.Register(nameof(ItemTemplate), typeof(DataTemplate), typeof(HamburgerMenu), new PropertyMetadata(null));
@@ -241,6 +246,15 @@ namespace MahApps.Metro.Controls
         {
             get { return (Style)GetValue(ItemContainerStyleProperty); }
             set { SetValue(ItemContainerStyleProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the Style used for each separator item.
+        /// </summary>
+        public Style SeparatorItemContainerStyle
+        {
+            get { return (Style)GetValue(SeparatorItemContainerStyleProperty); }
+            set { SetValue(SeparatorItemContainerStyleProperty, value); }
         }
 
         /// <summary>

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItem.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItem.cs
@@ -7,7 +7,7 @@ namespace MahApps.Metro.Controls
     /// <summary>
     /// The HamburgerMenuItem provides an implementation for HamburgerMenu entries.
     /// </summary>
-    public class HamburgerMenuItem : Freezable, ICommandSource
+    public class HamburgerMenuItem : HamburgerMenuItemBase, ICommandSource
     {
         /// <summary>
         /// Identifies the <see cref="Label"/> dependency property.
@@ -18,11 +18,6 @@ namespace MahApps.Metro.Controls
         /// Identifies the <see cref="TargetPageType"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty TargetPageTypeProperty = DependencyProperty.Register(nameof(TargetPageType), typeof(Type), typeof(HamburgerMenuItem), new PropertyMetadata(null));
-
-        /// <summary>
-        /// Identifies the <see cref="Tag"/> dependency property.
-        /// </summary>
-        public static readonly DependencyProperty TagProperty = DependencyProperty.Register(nameof(Tag), typeof(object), typeof(HamburgerMenuItem), new PropertyMetadata(null));
 
         /// <summary>
         /// Identifies the <see cref="Command"/> dependency property.
@@ -78,22 +73,6 @@ namespace MahApps.Metro.Controls
             set
             {
                 SetValue(TargetPageTypeProperty, value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value that specifies an user specific value.
-        /// </summary>
-        public object Tag
-        {
-            get
-            {
-                return GetValue(TagProperty);
-            }
-
-            set
-            {
-                SetValue(TagProperty, value);
             }
         }
 

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemBase.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemBase.cs
@@ -1,0 +1,33 @@
+﻿using System.Windows;
+
+namespace MahApps.Metro.Controls
+{
+    public class HamburgerMenuItemBase : Freezable
+    {
+        /// <summary>
+        /// Identifies the <see cref="Tag"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty TagProperty = DependencyProperty.Register(nameof(Tag), typeof(object), typeof(HamburgerMenuItemBase), new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets a value that specifies an user specific value.
+        /// </summary>
+        public object Tag
+        {
+            get
+            {
+                return this.GetValue(TagProperty);
+            }
+
+            set
+            {
+                this.SetValue(TagProperty, value);
+            }
+        }
+
+        protected override Freezable CreateInstanceCore()
+        {
+            return new HamburgerMenuItemBase();
+        }
+    }
+}

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemCollection.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemCollection.cs
@@ -3,9 +3,9 @@
 namespace MahApps.Metro.Controls
 {
     /// <summary>
-    /// The HamburgerMenuItemCollection provides typed collection of HamburgerMenuItem.
+    /// The HamburgerMenuItemCollection provides typed collection of HamburgerMenuItemBase.
     /// </summary>
-    public class HamburgerMenuItemCollection : FreezableCollection<HamburgerMenuItem>
+    public class HamburgerMenuItemCollection : FreezableCollection<HamburgerMenuItemBase>
     {
         protected override Freezable CreateInstanceCore()
         {

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemStyleSelector.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemStyleSelector.cs
@@ -5,6 +5,9 @@ namespace MahApps.Metro.Controls
 {
     public class HamburgerMenuItemStyleSelector : StyleSelector
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether which item container style will be used for the HamburgerMenuItem.
+        /// </summary>
         public bool IsItemOptions { get; set; }
 
         /// <inheritdoc />
@@ -25,7 +28,7 @@ namespace MahApps.Metro.Controls
                     }
                     else if (item is HamburgerMenuItem)
                     {
-                        var itemContainerStyle = this.IsItemOptions ? hamburgerMenu.ItemContainerStyle : hamburgerMenu.OptionsItemContainerStyle;
+                        var itemContainerStyle = this.IsItemOptions ? hamburgerMenu.OptionsItemContainerStyle : hamburgerMenu.ItemContainerStyle;
                         if (itemContainerStyle != null)
                         {
                             return itemContainerStyle;

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemStyleSelector.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemStyleSelector.cs
@@ -1,0 +1,40 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace MahApps.Metro.Controls
+{
+    public class HamburgerMenuItemStyleSelector : StyleSelector
+    {
+        public bool IsItemOptions { get; set; }
+
+        /// <inheritdoc />
+        public override Style SelectStyle(object item, DependencyObject container)
+        {
+            if (container != null)
+            {
+                var listBox = ItemsControl.ItemsControlFromItemContainer(container);
+                var hamburgerMenu = listBox?.TryFindParent<HamburgerMenu>();
+                if (hamburgerMenu != null)
+                {
+                    if (item is HamburgerMenuSeparatorItem)
+                    {
+                        if (hamburgerMenu.SeparatorItemContainerStyle != null)
+                        {
+                            return hamburgerMenu.SeparatorItemContainerStyle;
+                        }
+                    }
+                    else if (item is HamburgerMenuItem)
+                    {
+                        var itemContainerStyle = this.IsItemOptions ? hamburgerMenu.ItemContainerStyle : hamburgerMenu.OptionsItemContainerStyle;
+                        if (itemContainerStyle != null)
+                        {
+                            return itemContainerStyle;
+                        }
+                    }
+                }
+            }
+
+            return base.SelectStyle(item, container);
+        }
+    }
+}

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuSeparatorItem.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuSeparatorItem.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows;
+
+namespace MahApps.Metro.Controls
+{
+    /// <summary>
+    /// The HamburgerMenuSeparatorItem provides an separator based implementation for HamburgerMenu entries.
+    /// </summary>
+    public class HamburgerMenuSeparatorItem : HamburgerMenuItemBase
+    {
+        protected override Freezable CreateInstanceCore()
+        {
+            return new HamburgerMenuSeparatorItem();
+        }
+    }
+}

--- a/src/MahApps.Metro/Themes/HamburgerMenu.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenu.xaml
@@ -31,6 +31,7 @@
         <Setter Property="PaneForeground" Value="{DynamicResource MahApps.Metro.HamburgerMenu.PaneForegroundBrush}" />
         <Setter Property="PaneHeaderMargin" Value="0 0 0 8" />
         <Setter Property="PaneMargin" Value="0 0 0 8" />
+        <Setter Property="SeparatorItemContainerStyle" Value="{StaticResource HamburgerMenuSeparatorItemStyle}" />
         <Setter Property="Template" Value="{DynamicResource HamburgerMenuTemplate}" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
     </Style>

--- a/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
@@ -16,6 +16,8 @@
     <system:Double x:Key="HamburgerMenuSelectionIndicatorThemeHeight">24</system:Double>
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    <Controls:HamburgerMenuItemStyleSelector x:Key="HamburgerMenuItemStyleSelector" />
+    <Controls:HamburgerMenuItemStyleSelector x:Key="HamburgerMenuItemOptionsStyleSelector" IsItemOptions="True" />
 
     <Style x:Key="HamburgerButtonStyle"
            BasedOn="{StaticResource ChromelessButtonStyle}"
@@ -266,6 +268,28 @@
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
     </Style>
 
+    <Style x:Key="HamburgerMenuSeparatorItemStyle"
+           BasedOn="{StaticResource HamburgerMenuItemStyle}"
+           TargetType="{x:Type ListBoxItem}">
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="IsHitTestVisible" Value="False" />
+        <Setter Property="Padding" Value="0 5" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                    <Grid Background="{TemplateBinding Background}" RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}">
+                        <Separator Margin="{TemplateBinding Padding}"
+                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <Style x:Key="HamburgerMenuListStyle"
            BasedOn="{StaticResource MetroListBox}"
            TargetType="{x:Type ListBox}">
@@ -354,7 +378,7 @@
                                  AutomationProperties.Name="Menu items"
                                  Foreground="{TemplateBinding PaneForeground}"
                                  IsTextSearchEnabled="False"
-                                 ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
+                                 ItemContainerStyleSelector="{StaticResource HamburgerMenuItemStyleSelector}"
                                  ItemTemplate="{TemplateBinding ItemTemplate}"
                                  ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                                  ItemsSource="{TemplateBinding ItemsSource}"
@@ -372,7 +396,7 @@
                                  AutomationProperties.Name="Option items"
                                  Foreground="{TemplateBinding PaneForeground}"
                                  IsTextSearchEnabled="False"
-                                 ItemContainerStyle="{TemplateBinding OptionsItemContainerStyle}"
+                                 ItemContainerStyleSelector="{StaticResource HamburgerMenuItemOptionsStyleSelector}"
                                  ItemTemplate="{TemplateBinding OptionsItemTemplate}"
                                  ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
                                  ItemsSource="{TemplateBinding OptionsItemsSource}"

--- a/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
@@ -179,20 +179,26 @@
                    UseLayoutRounding="True" />
     </ControlTemplate>
 
-    <Style x:Key="HamburgerMenuItemStyle"
+    <Style x:Key="HamburgerMenuItemBaseStyle"
            BasedOn="{StaticResource MetroListBoxItem}"
            TargetType="{x:Type ListBoxItem}">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="Controls:ItemHelper.SelectedBackgroundBrush" Value="{DynamicResource AccentColorBrush}" />
-        <Setter Property="FocusVisualStyle" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:HamburgerMenu}}, Path=ItemFocusVisualStyle, Mode=OneWay, FallbackValue={x:Null}}" />
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ItemsControl}}, Path=Foreground, Mode=OneWay}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="IsEnabled" Value="{Binding IsEnabled, Mode=OneWay, FallbackValue=true}" />
-        <Setter Property="IsTabStop" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:HamburgerMenu}}, Path=IsTabStop, Mode=OneWay, FallbackValue=True}" />
         <Setter Property="Margin" Value="0" />
         <Setter Property="MinHeight" Value="0" />
         <Setter Property="Padding" Value="0" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    </Style>
+
+    <Style x:Key="HamburgerMenuItemStyle"
+           BasedOn="{StaticResource HamburgerMenuItemBaseStyle}"
+           TargetType="{x:Type ListBoxItem}">
+        <Setter Property="Controls:ItemHelper.SelectedBackgroundBrush" Value="{DynamicResource AccentColorBrush}" />
+        <Setter Property="FocusVisualStyle" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:HamburgerMenu}}, Path=ItemFocusVisualStyle, Mode=OneWay, FallbackValue={x:Null}}" />
+        <Setter Property="IsEnabled" Value="{Binding IsEnabled, Mode=OneWay, FallbackValue=true}" />
+        <Setter Property="IsTabStop" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:HamburgerMenu}}, Path=IsTabStop, Mode=OneWay, FallbackValue=True}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
@@ -265,16 +271,15 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="VerticalContentAlignment" Value="Stretch" />
     </Style>
 
     <Style x:Key="HamburgerMenuSeparatorItemStyle"
-           BasedOn="{StaticResource HamburgerMenuItemStyle}"
+           BasedOn="{StaticResource HamburgerMenuItemBaseStyle}"
            TargetType="{x:Type ListBoxItem}">
-        <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Focusable" Value="False" />
         <Setter Property="IsHitTestVisible" Value="False" />
+        <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Padding" Value="0 5" />
         <Setter Property="Template">
             <Setter.Value>


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Add new `HamburgerMenuSeparatorItem` for `HamburgerMenu` to allow add seperators between the `HamburgerMenuItems`.

![image](https://user-images.githubusercontent.com/658431/57107561-9ceac480-6d30-11e9-8c73-dabb66f731be.png)

**Closed Issues**

Closes #3434 
