### PR TITLE
Improvement for title bar and window commands

### DIFF
--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -1040,16 +1040,16 @@ namespace MahApps.Metro.Controls
 
             var dLeft = distanceFromLeft + distanceToCenter + horizontalMargin;
             var dRight = distanceFromRight + distanceToCenter + horizontalMargin;
-            if ((dLeft < halfDistance) && (dRight < halfDistance))
-            {
-                Grid.SetColumn(this.titleBar, 0);
-                Grid.SetColumnSpan(this.titleBar, 7);
-            }
-            else
-            {
-                Grid.SetColumn(this.titleBar, 3);
-                Grid.SetColumnSpan(this.titleBar, 1);
-            }
+            // if ((dLeft < halfDistance) && (dRight < halfDistance))
+            // {
+            //     Grid.SetColumn(this.titleBar, 0);
+            //     Grid.SetColumnSpan(this.titleBar, 3);
+            // }
+            // else
+            // {
+            //     Grid.SetColumn(this.titleBar, 1);
+            //     Grid.SetColumnSpan(this.titleBar, 1);
+            // }
         }
 
         private void ThemeManagerOnIsThemeChanged(object sender, OnThemeChangedEventArgs e)

--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -1030,7 +1030,8 @@ namespace MahApps.Metro.Controls
             // Half of this MetroWindow
             var halfDistance = this.ActualWidth / 2;
             // Distance between center and left/right
-            var distanceToCenter = this.titleBar.DesiredSize.Width / 2;
+            var margin = (Thickness)this.titleBar.GetValue(MarginProperty);
+            var distanceToCenter = (this.titleBar.DesiredSize.Width - margin.Left - margin.Right) / 2;
             // Distance between right edge from LeftWindowCommands to left window side
             var distanceFromLeft = this.icon.ActualWidth + this.LeftWindowCommands.ActualWidth;
             // Distance between left edge from RightWindowCommands to right window side
@@ -1040,16 +1041,18 @@ namespace MahApps.Metro.Controls
 
             var dLeft = distanceFromLeft + distanceToCenter + horizontalMargin;
             var dRight = distanceFromRight + distanceToCenter + horizontalMargin;
-            // if ((dLeft < halfDistance) && (dRight < halfDistance))
-            // {
-            //     Grid.SetColumn(this.titleBar, 0);
-            //     Grid.SetColumnSpan(this.titleBar, 3);
-            // }
-            // else
-            // {
-            //     Grid.SetColumn(this.titleBar, 1);
-            //     Grid.SetColumnSpan(this.titleBar, 1);
-            // }
+            if ((dLeft < halfDistance) && (dRight < halfDistance))
+            {
+                this.titleBar.SetCurrentValue(MarginProperty, default(Thickness));
+                Grid.SetColumn(this.titleBar, 0);
+                Grid.SetColumnSpan(this.titleBar, 5);
+            }
+            else
+            {
+                this.titleBar.SetCurrentValue(MarginProperty, new Thickness(this.LeftWindowCommands.ActualWidth, 0, this.RightWindowCommands.ActualWidth, 0));
+                Grid.SetColumn(this.titleBar, 2);
+                Grid.SetColumnSpan(this.titleBar, 1);
+            }
         }
 
         private void ThemeManagerOnIsThemeChanged(object sender, OnThemeChangedEventArgs e)

--- a/src/MahApps.Metro/Controls/WindowCommands.cs
+++ b/src/MahApps.Metro/Controls/WindowCommands.cs
@@ -11,7 +11,7 @@ using ControlzEx;
 namespace MahApps.Metro.Controls
 {
     [StyleTypedProperty(Property = "ItemContainerStyle", StyleTargetType = typeof(WindowCommands))]
-    public class WindowCommands : ItemsControl, INotifyPropertyChanged
+    public class WindowCommands : ToolBar, INotifyPropertyChanged
     {
         public static readonly DependencyProperty ThemeProperty =
             DependencyProperty.Register("Theme", typeof(Theme), typeof(WindowCommands),
@@ -270,6 +270,13 @@ namespace MahApps.Metro.Controls
         private void WindowCommands_Loaded(object sender, RoutedEventArgs e)
         {
             this.Loaded -= WindowCommands_Loaded;
+
+            var contentPresenter = this.TryFindParent<ContentPresenter>();
+            if (contentPresenter != null)
+            {
+                this.SetCurrentValue(DockPanel.DockProperty, contentPresenter.GetValue(DockPanel.DockProperty));
+            }
+
             var parentWindow = this.ParentWindow;
             if (null == parentWindow)
             {

--- a/src/MahApps.Metro/Controls/WindowCommands.cs
+++ b/src/MahApps.Metro/Controls/WindowCommands.cs
@@ -319,26 +319,34 @@ namespace MahApps.Metro.Controls
         internal PropertyChangeNotifier VisibilityPropertyChangeNotifier { get; set; }
 
         public static readonly DependencyProperty IsSeparatorVisibleProperty =
-            DependencyProperty.Register("IsSeparatorVisible", typeof(bool), typeof(WindowCommandsItem),
-                                        new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.Inherits|FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender));
+            DependencyProperty.Register(
+                nameof(IsSeparatorVisible),
+                typeof(bool),
+                typeof(WindowCommandsItem),
+                new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
         /// Gets or sets the value indicating whether to show the separator.
         /// </summary>
         public bool IsSeparatorVisible
         {
-            get { return (bool)GetValue(IsSeparatorVisibleProperty); }
-            set { SetValue(IsSeparatorVisibleProperty, value); }
+            get { return (bool)this.GetValue(IsSeparatorVisibleProperty); }
+            set { this.SetValue(IsSeparatorVisibleProperty, value); }
         }
 
-        public static readonly DependencyPropertyKey ParentWindowCommandsPropertyKey = DependencyProperty.RegisterReadOnly(nameof(ParentWindowCommands), typeof(WindowCommands), typeof(WindowCommandsItem), new PropertyMetadata(null));
+        public static readonly DependencyPropertyKey ParentWindowCommandsPropertyKey =
+            DependencyProperty.RegisterReadOnly(
+                nameof(ParentWindowCommands),
+                typeof(WindowCommands),
+                typeof(WindowCommandsItem),
+                new PropertyMetadata(null));
 
         public static readonly DependencyProperty ParentWindowCommandsProperty = ParentWindowCommandsPropertyKey.DependencyProperty;
 
         public WindowCommands ParentWindowCommands
         {
-            get { return (WindowCommands)GetValue(ParentWindowCommandsProperty); }
-            private set { SetValue(ParentWindowCommandsPropertyKey, value); }
+            get { return (WindowCommands)this.GetValue(ParentWindowCommandsProperty); }
+            private set { this.SetValue(ParentWindowCommandsPropertyKey, value); }
         }
 
         static WindowCommandsItem()

--- a/src/MahApps.Metro/Controls/WindowCommands.cs
+++ b/src/MahApps.Metro/Controls/WindowCommands.cs
@@ -331,9 +331,28 @@ namespace MahApps.Metro.Controls
             set { SetValue(IsSeparatorVisibleProperty, value); }
         }
 
+        public static readonly DependencyPropertyKey ParentWindowCommandsPropertyKey = DependencyProperty.RegisterReadOnly(nameof(ParentWindowCommands), typeof(WindowCommands), typeof(WindowCommandsItem), new PropertyMetadata(null));
+
+        public static readonly DependencyProperty ParentWindowCommandsProperty = ParentWindowCommandsPropertyKey.DependencyProperty;
+
+        public WindowCommands ParentWindowCommands
+        {
+            get { return (WindowCommands)GetValue(ParentWindowCommandsProperty); }
+            private set { SetValue(ParentWindowCommandsPropertyKey, value); }
+        }
+
         static WindowCommandsItem()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(WindowCommandsItem), new FrameworkPropertyMetadata(typeof(WindowCommandsItem)));
+        }
+
+        /// <inheritdoc />
+        public override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+
+            var windowCommands = ItemsControl.ItemsControlFromItemContainer(this) as WindowCommands;
+            this.SetValue(WindowCommandsItem.ParentWindowCommandsPropertyKey, windowCommands);
         }
     }
 }

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -321,6 +321,31 @@
                                     Style="{StaticResource WindowTitleThumbStyle}"
                                     UseLayoutRounding="True" />
 
+                    <!--  the title bar  -->
+                    <mah:MetroThumbContentControl x:Name="PART_TitleBar"
+                                                  Grid.Row="1"
+                                                  Grid.Column="0"
+                                                  Grid.ColumnSpan="5"
+                                                  Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                  HorizontalAlignment="{TemplateBinding TitleAlignment}"
+                                                  HorizontalContentAlignment="Center"
+                                                  VerticalContentAlignment="Center"
+                                                  Content="{TemplateBinding Title}"
+                                                  ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
+                                                  ContentTemplate="{TemplateBinding TitleTemplate}"
+                                                  Focusable="False">
+                        <ContentControl.Foreground>
+                            <MultiBinding Converter="{x:Static converters:BackgroundToForegroundConverter.Instance}">
+                                <Binding ElementName="PART_WindowTitleBackground"
+                                         Mode="OneWay"
+                                         Path="Fill" />
+                                <Binding Mode="OneWay"
+                                         Path="TitleForeground"
+                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                            </MultiBinding>
+                        </ContentControl.Foreground>
+                    </mah:MetroThumbContentControl>
+
                     <DockPanel Grid.Row="1"
                                Grid.Column="2"
                                Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
@@ -341,27 +366,8 @@
                                           Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                           DockPanel.Dock="Right"
                                           Focusable="False" />
-                        <!--  the title bar  -->
-                        <mah:MetroThumbContentControl x:Name="PART_TitleBar"
-                                                      Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                      HorizontalAlignment="{TemplateBinding TitleAlignment}"
-                                                      HorizontalContentAlignment="Center"
-                                                      VerticalContentAlignment="Center"
-                                                      Content="{TemplateBinding Title}"
-                                                      ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
-                                                      ContentTemplate="{TemplateBinding TitleTemplate}"
-                                                      Focusable="False">
-                            <ContentControl.Foreground>
-                                <MultiBinding Converter="{x:Static converters:BackgroundToForegroundConverter.Instance}">
-                                    <Binding ElementName="PART_WindowTitleBackground"
-                                             Mode="OneWay"
-                                             Path="Fill" />
-                                    <Binding Mode="OneWay"
-                                             Path="TitleForeground"
-                                             RelativeSource="{RelativeSource TemplatedParent}" />
-                                </MultiBinding>
-                            </ContentControl.Foreground>
-                        </mah:MetroThumbContentControl>
+                        <!--  the fake title bar  -->
+                        <Grid />
                     </DockPanel>
 
                     <!--  the window button commands  -->

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -25,12 +25,8 @@
                         <ColumnDefinition Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}, ConverterParameter={x:Static converters:ThicknessSideType.Left}}" />
                         <!--  icon  -->
                         <ColumnDefinition Width="Auto" />
-                        <!--  left window commands  -->
-                        <ColumnDefinition Width="Auto" />
-                        <!--  title  -->
+                        <!--  left window commands, title, right window commands  -->
                         <ColumnDefinition Width="*" />
-                        <!--  right window commands  -->
-                        <ColumnDefinition Width="Auto" />
                         <!--  min,max,close buttons  -->
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}, ConverterParameter={x:Static converters:ThicknessSideType.Right}}" />
@@ -44,7 +40,7 @@
                     <Rectangle x:Name="PART_WindowTitleBackground"
                                Grid.Row="1"
                                Grid.Column="1"
-                               Grid.ColumnSpan="5"
+                               Grid.ColumnSpan="3"
                                Fill="{TemplateBinding WindowTitleBrush}"
                                Focusable="False"
                                StrokeThickness="0" />
@@ -63,61 +59,61 @@
                                     Focusable="False"
                                     Visibility="{TemplateBinding ShowIconOnTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-                    <!--  the left window commands  -->
-                    <ContentPresenter x:Name="PART_LeftWindowCommands"
-                                      Grid.Row="1"
-                                      Grid.Column="2"
-                                      Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      VerticalAlignment="Top"
-                                      Panel.ZIndex="1"
-                                      Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      Focusable="False" />
-
                     <mah:MetroThumb x:Name="PART_WindowTitleThumb"
                                     Grid.Row="1"
                                     Grid.Column="0"
-                                    Grid.ColumnSpan="7"
+                                    Grid.ColumnSpan="5"
                                     Style="{StaticResource WindowTitleThumbStyle}"
                                     UseLayoutRounding="True" />
-                    <!--  the title bar  -->
-                    <mah:MetroThumbContentControl x:Name="PART_TitleBar"
-                                                  Grid.Row="1"
-                                                  Grid.Column="3"
-                                                  Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                  HorizontalAlignment="{TemplateBinding TitleAlignment}"
-                                                  HorizontalContentAlignment="Stretch"
-                                                  VerticalContentAlignment="Stretch"
-                                                  Content="{TemplateBinding Title}"
-                                                  ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
-                                                  ContentTemplate="{TemplateBinding TitleTemplate}"
-                                                  Focusable="False">
-                        <ContentControl.Foreground>
-                            <MultiBinding Converter="{x:Static converters:BackgroundToForegroundConverter.Instance}">
-                                <Binding ElementName="PART_WindowTitleBackground"
-                                         Mode="OneWay"
-                                         Path="Fill" />
-                                <Binding Mode="OneWay"
-                                         Path="TitleForeground"
-                                         RelativeSource="{RelativeSource TemplatedParent}" />
-                            </MultiBinding>
-                        </ContentControl.Foreground>
-                    </mah:MetroThumbContentControl>
 
-                    <!--  the right window commands  -->
-                    <ContentPresenter x:Name="PART_RightWindowCommands"
-                                      Grid.Row="1"
-                                      Grid.Column="4"
-                                      Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      VerticalAlignment="Top"
-                                      Panel.ZIndex="1"
-                                      Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      Focusable="False" />
+                    <DockPanel Grid.Row="1"
+                               Grid.Column="2"
+                               Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                               VerticalAlignment="Top"
+                               Panel.ZIndex="1"
+                               Focusable="False">
+                        <!--  the left window commands  -->
+                        <ContentPresenter x:Name="PART_LeftWindowCommands"
+                                          Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          VerticalAlignment="Top"
+                                          Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          DockPanel.Dock="Left"
+                                          Focusable="False" />
+                        <!--  the right window commands  -->
+                        <ContentPresenter x:Name="PART_RightWindowCommands"
+                                          Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          VerticalAlignment="Top"
+                                          Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          DockPanel.Dock="Right"
+                                          Focusable="False" />
+                        <!--  the title bar  -->
+                        <mah:MetroThumbContentControl x:Name="PART_TitleBar"
+                                                      Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                      HorizontalAlignment="{TemplateBinding TitleAlignment}"
+                                                      HorizontalContentAlignment="Stretch"
+                                                      VerticalContentAlignment="Stretch"
+                                                      Content="{TemplateBinding Title}"
+                                                      ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
+                                                      ContentTemplate="{TemplateBinding TitleTemplate}"
+                                                      Focusable="False">
+                            <ContentControl.Foreground>
+                                <MultiBinding Converter="{x:Static converters:BackgroundToForegroundConverter.Instance}">
+                                    <Binding ElementName="PART_WindowTitleBackground"
+                                             Mode="OneWay"
+                                             Path="Fill" />
+                                    <Binding Mode="OneWay"
+                                             Path="TitleForeground"
+                                             RelativeSource="{RelativeSource TemplatedParent}" />
+                                </MultiBinding>
+                            </ContentControl.Foreground>
+                        </mah:MetroThumbContentControl>
+                    </DockPanel>
 
                     <!--  the window button commands  -->
                     <ContentPresenter x:Name="PART_WindowButtonCommands"
                                       Grid.Row="1"
                                       Grid.RowSpan="2"
-                                      Grid.Column="5"
+                                      Grid.Column="3"
                                       Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                       VerticalAlignment="Top"
                                       Panel.ZIndex="1"
@@ -128,7 +124,7 @@
                     <mah:MetroContentControl x:Name="PART_Content"
                                              Grid.Row="2"
                                              Grid.Column="0"
-                                             Grid.ColumnSpan="7"
+                                             Grid.ColumnSpan="5"
                                              FocusVisualStyle="{x:Null}"
                                              IsTabStop="False"
                                              OnlyLoadTransition="True"
@@ -142,13 +138,13 @@
                                Grid.Row="1"
                                Grid.RowSpan="2"
                                Grid.Column="1"
-                               Grid.ColumnSpan="5"
+                               Grid.ColumnSpan="3"
                                Fill="{TemplateBinding FlyoutOverlayBrush}"
                                Visibility="Hidden" />
                     <mah:MetroThumb x:Name="PART_FlyoutModalDragMoveThumb"
                                     Grid.Row="1"
                                     Grid.Column="0"
-                                    Grid.ColumnSpan="7"
+                                    Grid.ColumnSpan="5"
                                     Style="{StaticResource WindowTitleThumbStyle}"
                                     Visibility="{Binding ElementName=PART_FlyoutModal, Path=Visibility, Mode=OneWay}" />
 
@@ -156,7 +152,7 @@
                     <ContentControl Grid.Row="1"
                                     Grid.RowSpan="2"
                                     Grid.Column="1"
-                                    Grid.ColumnSpan="5"
+                                    Grid.ColumnSpan="3"
                                     VerticalAlignment="Stretch"
                                     Panel.ZIndex="2"
                                     Content="{Binding Flyouts, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
@@ -168,7 +164,7 @@
                           Grid.Row="1"
                           Grid.RowSpan="2"
                           Grid.Column="1"
-                          Grid.ColumnSpan="5"
+                          Grid.ColumnSpan="3"
                           Panel.ZIndex="3"
                           FocusVisualStyle="{x:Null}" />
 
@@ -177,7 +173,7 @@
                           Grid.Row="1"
                           Grid.RowSpan="2"
                           Grid.Column="1"
-                          Grid.ColumnSpan="5"
+                          Grid.ColumnSpan="3"
                           Panel.ZIndex="4"
                           Background="{TemplateBinding OverlayBrush}"
                           FocusVisualStyle="{x:Null}"
@@ -190,7 +186,7 @@
                           Grid.Row="1"
                           Grid.RowSpan="2"
                           Grid.Column="1"
-                          Grid.ColumnSpan="5"
+                          Grid.ColumnSpan="3"
                           Panel.ZIndex="5"
                           FocusVisualStyle="{x:Null}" />
                 </Grid>
@@ -284,12 +280,8 @@
                         <ColumnDefinition Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}, ConverterParameter={x:Static converters:ThicknessSideType.Left}}" />
                         <!--  icon  -->
                         <ColumnDefinition Width="Auto" />
-                        <!--  left window commands  -->
-                        <ColumnDefinition Width="Auto" />
-                        <!--  title  -->
+                        <!--  left window commands, title, right window commands  -->
                         <ColumnDefinition Width="*" />
-                        <!--  right window commands  -->
-                        <ColumnDefinition Width="Auto" />
                         <!--  min,max,close buttons  -->
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessToDoubleConverter}, ConverterParameter={x:Static converters:ThicknessSideType.Right}}" />
@@ -303,7 +295,7 @@
                     <Rectangle x:Name="PART_WindowTitleBackground"
                                Grid.Row="1"
                                Grid.Column="1"
-                               Grid.ColumnSpan="5"
+                               Grid.ColumnSpan="3"
                                Fill="{TemplateBinding WindowTitleBrush}"
                                Focusable="False"
                                StrokeThickness="0" />
@@ -322,62 +314,61 @@
                                     Focusable="False"
                                     Visibility="{TemplateBinding ShowIconOnTitleBar, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-                    <!--  the left window commands  -->
-                    <ContentPresenter x:Name="PART_LeftWindowCommands"
-                                      Grid.Row="1"
-                                      Grid.Column="2"
-                                      Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      VerticalAlignment="Top"
-                                      Panel.ZIndex="1"
-                                      Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      Focusable="False" />
-
                     <mah:MetroThumb x:Name="PART_WindowTitleThumb"
                                     Grid.Row="1"
                                     Grid.Column="0"
-                                    Grid.ColumnSpan="7"
+                                    Grid.ColumnSpan="5"
                                     Style="{StaticResource WindowTitleThumbStyle}"
                                     UseLayoutRounding="True" />
-                    <!--  the title bar  -->
-                    <mah:MetroThumbContentControl x:Name="PART_TitleBar"
-                                                  Grid.Row="1"
-                                                  Grid.Column="1"
-                                                  Grid.ColumnSpan="5"
-                                                  Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                  HorizontalAlignment="{TemplateBinding TitleAlignment}"
-                                                  HorizontalContentAlignment="Center"
-                                                  VerticalContentAlignment="Center"
-                                                  Content="{TemplateBinding Title}"
-                                                  ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
-                                                  ContentTemplate="{TemplateBinding TitleTemplate}"
-                                                  Focusable="False">
-                        <ContentControl.Foreground>
-                            <MultiBinding Converter="{x:Static converters:BackgroundToForegroundConverter.Instance}">
-                                <Binding ElementName="PART_WindowTitleBackground"
-                                         Mode="OneWay"
-                                         Path="Fill" />
-                                <Binding Mode="OneWay"
-                                         Path="TitleForeground"
-                                         RelativeSource="{RelativeSource TemplatedParent}" />
-                            </MultiBinding>
-                        </ContentControl.Foreground>
-                    </mah:MetroThumbContentControl>
 
-                    <!--  the right window commands  -->
-                    <ContentPresenter x:Name="PART_RightWindowCommands"
-                                      Grid.Row="1"
-                                      Grid.Column="4"
-                                      Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      VerticalAlignment="Top"
-                                      Panel.ZIndex="1"
-                                      Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      Focusable="False" />
+                    <DockPanel Grid.Row="1"
+                               Grid.Column="2"
+                               Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                               VerticalAlignment="Top"
+                               Panel.ZIndex="1"
+                               Focusable="False">
+                        <!--  the left window commands  -->
+                        <ContentPresenter x:Name="PART_LeftWindowCommands"
+                                          Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          VerticalAlignment="Top"
+                                          Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          DockPanel.Dock="Left"
+                                          Focusable="False" />
+                        <!--  the right window commands  -->
+                        <ContentPresenter x:Name="PART_RightWindowCommands"
+                                          Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          VerticalAlignment="Top"
+                                          Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                          DockPanel.Dock="Right"
+                                          Focusable="False" />
+                        <!--  the title bar  -->
+                        <mah:MetroThumbContentControl x:Name="PART_TitleBar"
+                                                      Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                      HorizontalAlignment="{TemplateBinding TitleAlignment}"
+                                                      HorizontalContentAlignment="Center"
+                                                      VerticalContentAlignment="Center"
+                                                      Content="{TemplateBinding Title}"
+                                                      ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
+                                                      ContentTemplate="{TemplateBinding TitleTemplate}"
+                                                      Focusable="False">
+                            <ContentControl.Foreground>
+                                <MultiBinding Converter="{x:Static converters:BackgroundToForegroundConverter.Instance}">
+                                    <Binding ElementName="PART_WindowTitleBackground"
+                                             Mode="OneWay"
+                                             Path="Fill" />
+                                    <Binding Mode="OneWay"
+                                             Path="TitleForeground"
+                                             RelativeSource="{RelativeSource TemplatedParent}" />
+                                </MultiBinding>
+                            </ContentControl.Foreground>
+                        </mah:MetroThumbContentControl>
+                    </DockPanel>
 
                     <!--  the window button commands  -->
                     <ContentPresenter x:Name="PART_WindowButtonCommands"
                                       Grid.Row="1"
                                       Grid.RowSpan="2"
-                                      Grid.Column="5"
+                                      Grid.Column="3"
                                       Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                       VerticalAlignment="Top"
                                       Panel.ZIndex="1"
@@ -388,7 +379,7 @@
                     <mah:MetroContentControl x:Name="PART_Content"
                                              Grid.Row="2"
                                              Grid.Column="0"
-                                             Grid.ColumnSpan="7"
+                                             Grid.ColumnSpan="5"
                                              FocusVisualStyle="{x:Null}"
                                              IsTabStop="False"
                                              OnlyLoadTransition="True"
@@ -402,21 +393,21 @@
                                Grid.Row="1"
                                Grid.RowSpan="2"
                                Grid.Column="1"
-                               Grid.ColumnSpan="5"
+                               Grid.ColumnSpan="3"
                                Fill="{TemplateBinding FlyoutOverlayBrush}"
                                Visibility="Hidden" />
                     <mah:MetroThumb x:Name="PART_FlyoutModalDragMoveThumb"
                                     Grid.Row="1"
                                     Grid.Column="0"
-                                    Grid.ColumnSpan="7"
+                                    Grid.ColumnSpan="5"
                                     Style="{StaticResource WindowTitleThumbStyle}"
                                     Visibility="{Binding ElementName=PART_FlyoutModal, Path=Visibility, Mode=OneWay}" />
 
                     <!--  flyouts  -->
                     <ContentControl Grid.Row="0"
                                     Grid.RowSpan="3"
-                                    Grid.Column="0"
-                                    Grid.ColumnSpan="7"
+                                    Grid.Column="1"
+                                    Grid.ColumnSpan="3"
                                     VerticalAlignment="Stretch"
                                     Panel.ZIndex="2"
                                     Content="{Binding Flyouts, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
@@ -428,7 +419,7 @@
                           Grid.Row="1"
                           Grid.RowSpan="2"
                           Grid.Column="1"
-                          Grid.ColumnSpan="5"
+                          Grid.ColumnSpan="3"
                           Panel.ZIndex="3"
                           FocusVisualStyle="{x:Null}" />
 
@@ -437,7 +428,7 @@
                           Grid.Row="1"
                           Grid.RowSpan="2"
                           Grid.Column="1"
-                          Grid.ColumnSpan="5"
+                          Grid.ColumnSpan="3"
                           Panel.ZIndex="4"
                           Background="{TemplateBinding OverlayBrush}"
                           FocusVisualStyle="{x:Null}"
@@ -450,7 +441,7 @@
                           Grid.Row="1"
                           Grid.RowSpan="2"
                           Grid.Column="1"
-                          Grid.ColumnSpan="5"
+                          Grid.ColumnSpan="3"
                           Panel.ZIndex="5"
                           FocusVisualStyle="{x:Null}" />
                 </Grid>

--- a/src/MahApps.Metro/Themes/WindowCommands.xaml
+++ b/src/MahApps.Metro/Themes/WindowCommands.xaml
@@ -53,7 +53,7 @@
         <Setter Property="Background" Value="{DynamicResource TransparentWhiteBrush}" />
         <Setter Property="Foreground" Value="{Binding Foreground, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
-        <Setter Property="Padding" Value="8 0 8 0" />
+        <Setter Property="Padding" Value="8 0" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Style.Triggers>
             <Trigger Property="IsEnabled" Value="False">
@@ -62,8 +62,83 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="ToolBarOverflowButtonStyle" TargetType="{x:Type ToggleButton}">
+        <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ToggleButton}">
+                    <Border Name="Bd"
+                            Background="Transparent"
+                            SnapsToDevicePixels="true">
+                        <Grid>
+                            <Path Name="Arrow"
+                                  Margin="4"
+                                  VerticalAlignment="Bottom"
+                                  Data="M -0.5 3 L 5.5 3 L 2.5 6 Z"
+                                  Fill="Black" />
+                            <ContentPresenter />
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource GrayBrush2}" />
+                        </Trigger>
+                        <Trigger Property="IsKeyboardFocused" Value="true">
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource GrayBrush2}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="true">
+                            <Setter TargetName="Bd" Property="Background" Value="{DynamicResource GrayBrush2}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter TargetName="Arrow" Property="Fill" Value="{DynamicResource GrayBrush4}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <ControlTemplate x:Key="LightWindowCommandsTemplate" TargetType="Controls:WindowCommands">
-        <ItemsPresenter />
+        <DockPanel>
+            <ToggleButton x:Name="PART_ToggleButton"
+                          ClickMode="Press"
+                          DockPanel.Dock="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(DockPanel.Dock), Mode=OneWay}"
+                          IsChecked="{Binding Path=IsOverflowOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                          IsEnabled="false"
+                          Style="{StaticResource ToolBarOverflowButtonStyle}"
+                          Visibility="Collapsed">
+                <Popup x:Name="OverflowPopup"
+                       AllowsTransparency="true"
+                       Focusable="false"
+                       IsOpen="{Binding Path=IsOverflowOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                       Placement="Bottom"
+                       PopupAnimation="Slide"
+                       StaysOpen="false">
+                    <Grid x:Name="DropDownBorder" Background="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=Background, Mode=OneWay}">
+                        <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
+                                              HorizontalAlignment="Stretch"
+                                              VerticalAlignment="Stretch"
+                                              Background="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=WindowTitleBrush, Mode=OneWay}"
+                                              FocusVisualStyle="{x:Null}"
+                                              Focusable="true"
+                                              KeyboardNavigation.DirectionalNavigation="Cycle"
+                                              KeyboardNavigation.TabNavigation="Cycle" />
+                    </Grid>
+                </Popup>
+            </ToggleButton>
+            <ToolBarPanel x:Name="PART_ToolBarPanel"
+                          Margin="0"
+                          Background="{TemplateBinding Background}"
+                          IsItemsHost="true" />
+        </DockPanel>
+
+        <ControlTemplate.Triggers>
+            <Trigger Property="HasOverflowItems" Value="true">
+                <Setter TargetName="PART_ToggleButton" Property="IsEnabled" Value="true" />
+                <Setter TargetName="PART_ToggleButton" Property="Visibility" Value="Visible" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+
         <ControlTemplate.Resources>
             <ResourceDictionary>
                 <Style BasedOn="{StaticResource WindowCommandsControlStyle}" TargetType="{x:Type Button}">
@@ -72,12 +147,62 @@
                 <Style BasedOn="{StaticResource WindowCommandsControlStyle}" TargetType="{x:Type ToggleButton}">
                     <Setter Property="Template" Value="{StaticResource WindowCommandsToggleButtonTemplate}" />
                 </Style>
+
+                <Style x:Key="{x:Static ToolBar.ButtonStyleKey}"
+                       BasedOn="{StaticResource WindowCommandsControlStyle}"
+                       TargetType="{x:Type Button}">
+                    <Setter Property="Template" Value="{StaticResource WindowCommandsButtonTemplate}" />
+                </Style>
+                <Style x:Key="{x:Static ToolBar.ToggleButtonStyleKey}"
+                       BasedOn="{StaticResource WindowCommandsControlStyle}"
+                       TargetType="{x:Type ToggleButton}">
+                    <Setter Property="Template" Value="{StaticResource WindowCommandsToggleButtonTemplate}" />
+                </Style>
             </ResourceDictionary>
         </ControlTemplate.Resources>
     </ControlTemplate>
 
     <ControlTemplate x:Key="DarkWindowCommandsTemplate" TargetType="Controls:WindowCommands">
-        <ItemsPresenter />
+        <DockPanel>
+            <ToggleButton x:Name="PART_ToggleButton"
+                          ClickMode="Press"
+                          DockPanel.Dock="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(DockPanel.Dock), Mode=OneWay}"
+                          IsChecked="{Binding Path=IsOverflowOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                          IsEnabled="false"
+                          Style="{StaticResource ToolBarOverflowButtonStyle}"
+                          Visibility="Collapsed">
+                <Popup x:Name="OverflowPopup"
+                       AllowsTransparency="true"
+                       Focusable="false"
+                       IsOpen="{Binding Path=IsOverflowOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                       Placement="Bottom"
+                       PopupAnimation="Slide"
+                       StaysOpen="false">
+                    <Grid x:Name="DropDownBorder" Background="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=Background, Mode=OneWay}">
+                        <ToolBarOverflowPanel x:Name="PART_ToolBarOverflowPanel"
+                                              HorizontalAlignment="Stretch"
+                                              VerticalAlignment="Stretch"
+                                              Background="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=WindowTitleBrush, Mode=OneWay}"
+                                              FocusVisualStyle="{x:Null}"
+                                              Focusable="true"
+                                              KeyboardNavigation.DirectionalNavigation="Cycle"
+                                              KeyboardNavigation.TabNavigation="Cycle" />
+                    </Grid>
+                </Popup>
+            </ToggleButton>
+            <ToolBarPanel x:Name="PART_ToolBarPanel"
+                          Margin="0"
+                          Background="{TemplateBinding Background}"
+                          IsItemsHost="true" />
+        </DockPanel>
+
+        <ControlTemplate.Triggers>
+            <Trigger Property="HasOverflowItems" Value="true">
+                <Setter TargetName="PART_ToggleButton" Property="IsEnabled" Value="true" />
+                <Setter TargetName="PART_ToggleButton" Property="Visibility" Value="Visible" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+
         <ControlTemplate.Resources>
             <ResourceDictionary>
                 <Style BasedOn="{StaticResource WindowCommandsControlStyle}" TargetType="{x:Type Button}">
@@ -89,6 +214,27 @@
                     </Style.Triggers>
                 </Style>
                 <Style BasedOn="{StaticResource WindowCommandsControlStyle}" TargetType="{x:Type ToggleButton}">
+                    <Setter Property="Template" Value="{StaticResource WindowCommandsToggleButtonTemplate}" />
+                    <Style.Triggers>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+
+                <Style x:Key="{x:Static ToolBar.ButtonStyleKey}"
+                       BasedOn="{StaticResource WindowCommandsControlStyle}"
+                       TargetType="{x:Type Button}">
+                    <Setter Property="Template" Value="{StaticResource WindowCommandsButtonTemplate}" />
+                    <Style.Triggers>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Foreground" Value="{DynamicResource AccentColorBrush}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+                <Style x:Key="{x:Static ToolBar.ToggleButtonStyleKey}"
+                       BasedOn="{StaticResource WindowCommandsControlStyle}"
+                       TargetType="{x:Type ToggleButton}">
                     <Setter Property="Template" Value="{StaticResource WindowCommandsToggleButtonTemplate}" />
                     <Style.Triggers>
                         <Trigger Property="IsPressed" Value="True">
@@ -102,6 +248,7 @@
 
     <Style x:Key="MahApps.Metro.Styles.WindowCommandsItem" TargetType="{x:Type Controls:WindowCommandsItem}">
         <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="MinHeight" Value="{Binding ParentWindow.TitleBarHeight, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}}" />
         <Setter Property="Padding" Value="1 0" />
         <Setter Property="Template">
             <Setter.Value>
@@ -143,13 +290,6 @@
         <Setter Property="Foreground" Value="{DynamicResource BlackBrush}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="ItemsPanel">
-            <Setter.Value>
-                <ItemsPanelTemplate>
-                    <StackPanel Orientation="Horizontal" />
-                </ItemsPanelTemplate>
-            </Setter.Value>
-        </Setter>
         <Setter Property="LightTemplate" Value="{StaticResource LightWindowCommandsTemplate}" />
         <Setter Property="Template" Value="{StaticResource LightWindowCommandsTemplate}" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />

--- a/src/MahApps.Metro/Themes/WindowCommands.xaml
+++ b/src/MahApps.Metro/Themes/WindowCommands.xaml
@@ -9,7 +9,7 @@
                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                        Content="{TemplateBinding Content}"
-                                       ContentCharacterCasing="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
+                                       ContentCharacterCasing="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}, Path=(Controls:ControlsHelper.ContentCharacterCasing), Mode=OneWay}"
                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
@@ -31,7 +31,7 @@
                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                        Content="{TemplateBinding Content}"
-                                       ContentCharacterCasing="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
+                                       ContentCharacterCasing="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}, Path=(Controls:ControlsHelper.ContentCharacterCasing), Mode=OneWay}"
                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
@@ -51,7 +51,7 @@
 
     <Style x:Key="WindowCommandsControlStyle" TargetType="{x:Type Control}">
         <Setter Property="Background" Value="{DynamicResource TransparentWhiteBrush}" />
-        <Setter Property="Foreground" Value="{Binding Foreground, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}}" />
+        <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground), Mode=OneWay}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="Padding" Value="8 0" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
@@ -63,34 +63,38 @@
     </Style>
 
     <Style x:Key="ToolBarOverflowButtonStyle" TargetType="{x:Type ToggleButton}">
+        <Setter Property="Background" Value="{DynamicResource TransparentWhiteBrush}" />
+        <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground), Mode=OneWay}" />
         <Setter Property="OverridesDefaultStyle" Value="true" />
+        <Setter Property="SnapsToDevicePixels" Value="true" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
-                    <Border Name="Bd"
-                            Background="Transparent"
-                            SnapsToDevicePixels="true">
-                        <Grid>
-                            <Path Name="Arrow"
-                                  Margin="4"
-                                  VerticalAlignment="Bottom"
-                                  Data="M -0.5 3 L 5.5 3 L 2.5 6 Z"
-                                  Fill="Black" />
-                            <ContentPresenter />
-                        </Grid>
-                    </Border>
+                    <Grid Name="Bd"
+                          Background="{TemplateBinding Background}"
+                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Path Name="Arrow"
+                              Margin="4"
+                              VerticalAlignment="Bottom"
+                              Data="M 0 0 L 6 0 3 3 Z"
+                              Fill="{TemplateBinding Foreground}" />
+                        <ContentPresenter />
+                    </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="true">
+                            <Setter TargetName="Arrow" Property="Fill" Value="White" />
                             <Setter TargetName="Bd" Property="Background" Value="{DynamicResource GrayBrush2}" />
                         </Trigger>
                         <Trigger Property="IsKeyboardFocused" Value="true">
+                            <Setter TargetName="Arrow" Property="Fill" Value="White" />
                             <Setter TargetName="Bd" Property="Background" Value="{DynamicResource GrayBrush2}" />
                         </Trigger>
                         <Trigger Property="IsChecked" Value="true">
+                            <Setter TargetName="Arrow" Property="Fill" Value="White" />
                             <Setter TargetName="Bd" Property="Background" Value="{DynamicResource GrayBrush2}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
-                            <Setter TargetName="Arrow" Property="Fill" Value="{DynamicResource GrayBrush4}" />
+                            <Setter TargetName="Arrow" Property="Fill" Value="{DynamicResource DarkIdealForegroundDisabledBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -103,14 +107,14 @@
             <ToggleButton x:Name="PART_ToggleButton"
                           ClickMode="Press"
                           DockPanel.Dock="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(DockPanel.Dock), Mode=OneWay}"
-                          IsChecked="{Binding Path=IsOverflowOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                          IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsOverflowOpen, Mode=TwoWay}"
                           IsEnabled="false"
                           Style="{StaticResource ToolBarOverflowButtonStyle}"
                           Visibility="Collapsed">
                 <Popup x:Name="OverflowPopup"
                        AllowsTransparency="true"
                        Focusable="false"
-                       IsOpen="{Binding Path=IsOverflowOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                       IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsOverflowOpen}"
                        Placement="Bottom"
                        PopupAnimation="Slide"
                        StaysOpen="false">
@@ -167,14 +171,14 @@
             <ToggleButton x:Name="PART_ToggleButton"
                           ClickMode="Press"
                           DockPanel.Dock="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(DockPanel.Dock), Mode=OneWay}"
-                          IsChecked="{Binding Path=IsOverflowOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                          IsChecked="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsOverflowOpen, Mode=TwoWay}"
                           IsEnabled="false"
                           Style="{StaticResource ToolBarOverflowButtonStyle}"
                           Visibility="Collapsed">
                 <Popup x:Name="OverflowPopup"
                        AllowsTransparency="true"
                        Focusable="false"
-                       IsOpen="{Binding Path=IsOverflowOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                       IsOpen="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=IsOverflowOpen}"
                        Placement="Bottom"
                        PopupAnimation="Slide"
                        StaysOpen="false">
@@ -247,14 +251,15 @@
     </ControlTemplate>
 
     <Style x:Key="MahApps.Metro.Styles.WindowCommandsItem" TargetType="{x:Type Controls:WindowCommandsItem}">
+        <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource Self}, Path=ParentWindowCommands.Foreground, Mode=OneWay}" />
         <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="MinHeight" Value="{Binding ParentWindow.TitleBarHeight, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}}" />
+        <Setter Property="MinHeight" Value="{Binding RelativeSource={RelativeSource Self}, Path=ParentWindowCommands.ParentWindow.TitleBarHeight, Mode=OneWay}" />
         <Setter Property="Padding" Value="1 0" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Controls:WindowCommandsItem}">
-                    <StackPanel HorizontalAlignment="{Binding HorizontalContentAlignment, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}}"
-                                VerticalAlignment="{Binding VerticalContentAlignment, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}}"
+                    <StackPanel HorizontalAlignment="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommandsItem}}, Path=ParentWindowCommands.HorizontalContentAlignment, Mode=OneWay}"
+                                VerticalAlignment="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommandsItem}}, Path=ParentWindowCommands.VerticalContentAlignment, Mode=OneWay}"
                                 Orientation="Horizontal">
                         <ContentPresenter x:Name="PART_ContentPresenter"
                                           Margin="{TemplateBinding Padding}"
@@ -265,8 +270,8 @@
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         <Rectangle x:Name="PART_Separator"
                                    Width="1"
-                                   Height="{Binding SeparatorHeight, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}}"
-                                   Fill="{Binding Foreground, Mode=OneWay, RelativeSource={RelativeSource AncestorType={x:Type Controls:WindowCommands}}}"
+                                   Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommandsItem}}, Path=ParentWindowCommands.SeparatorHeight, Mode=OneWay}"
+                                   Fill="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:WindowCommandsItem}}, Path=ParentWindowCommands.Foreground, Mode=OneWay}"
                                    IsHitTestVisible="False"
                                    Opacity="0.25"
                                    SnapsToDevicePixels="True"
@@ -294,7 +299,7 @@
         <Setter Property="Template" Value="{StaticResource LightWindowCommandsTemplate}" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Style.Triggers>
-            <DataTrigger Binding="{Binding ParentWindow.ShowTitleBar, RelativeSource={RelativeSource Self}}" Value="True">
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=ParentWindow.ShowTitleBar}" Value="True">
                 <Setter Property="Foreground" Value="{DynamicResource IdealForegroundColorBrush}" />
             </DataTrigger>
         </Style.Triggers>


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

If there are more then 2 or 3 window commands on the right or left site and the user resizes the window then the Min, Max, Close buttons move out the window and open dialogs will not resize to a slower size.

To solve this I changed the window commands control from ItemsControl to ToolBar class which allows us to use the overlow mechanism of this control.

- The default and centered window style will now use this new overflow mechanism.

**Additional context**

These changes causes also a breaking change to the window commands overlay behavior. This feature will be removed, because a window command can now not overlay a Flyout if it's open.

**Closed Issues**

Closes #1936 
Closes #3408 

![mahapps_titlebar_overlap](https://user-images.githubusercontent.com/658431/58052702-d3f50e80-7b55-11e9-9839-fd1cdd674e87.gif)

![mahapps_title_overlow](https://user-images.githubusercontent.com/658431/58130908-8cd25080-7c1d-11e9-9c7e-deecc48aefb6.gif)
