### PR TITLE
Change window commands overlay behavior after title bar changes (GH-3503)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,6 @@ src/MahApps.Metro/Styles/Themes/*.xaml
 
 # cake
 tools/
+
+# MSBuild
+*.binlog

--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -15,7 +15,7 @@
 
     <!-- Add the references for all projects and targets -->
     <ItemGroup>
-        <PackageReference Include="JetBrains.Annotations" Version="2018.*" PrivateAssets="All" />
+        <PackageReference Include="JetBrains.Annotations" Version="2019.*" PrivateAssets="All" />
         <PackageReference Include="WpfAnalyzers" Version="2.2.*" PrivateAssets="All" />
     </ItemGroup>
 

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/MahApps.Metro.Caliburn.Demo.csproj
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/MahApps.Metro.Caliburn.Demo.csproj
@@ -19,8 +19,11 @@
     <ItemGroup>
         <PackageReference Include="MahApps.Metro.IconPacks" Version="3.0.0-alpha*" />
         <PackageReference Include="Caliburn.Micro" Version="3.*" />
-        <PackageReference Include="Fody" Version="4.*" />
-        <PackageReference Include="Costura.Fody" Version="3.*" />
+        <PackageReference Include="Fody" Version="5.*">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Costura.Fody" Version="4.*" />
     </ItemGroup>
     <ItemGroup>
         <Reference Include="System.ComponentModel.Composition"/>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
@@ -17,11 +17,8 @@
                       BorderBrush="{DynamicResource AccentColorBrush}"
                       BorderThickness="1"
                       IconOverlayBehavior="Never"
-                      LeftWindowCommandsOverlayBehavior="Never"
-                      RightWindowCommandsOverlayBehavior="Never"
                       SaveWindowPosition="True"
                       TitleCharacterCasing="Normal"
-                      WindowButtonCommandsOverlayBehavior="Always"
                       WindowStartupLocation="CenterScreen"
                       mc:Ignorable="d">
 
@@ -33,6 +30,14 @@
                                 ObjectType="{x:Type Controls:WindowCommandsOverlayBehavior}">
                 <ObjectDataProvider.MethodParameters>
                     <x:Type TypeName="Controls:WindowCommandsOverlayBehavior" />
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+
+            <ObjectDataProvider x:Key="OverlayBehaviorValues"
+                                MethodName="GetValues"
+                                ObjectType="{x:Type Controls:OverlayBehavior}">
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type TypeName="Controls:OverlayBehavior" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
 
@@ -449,7 +454,7 @@
                           Margin="2"
                           VerticalAlignment="Center"
                           ItemsSource="{Binding Source={StaticResource WindowCommandsOverlayBehaviorValues}}"
-                          SelectedValue="{Binding ElementName=flyoutsDemo, Path=LeftWindowCommandsOverlayBehavior}" />
+                          SelectedValue="{Binding ElementName=flyoutsDemo, Path=LeftWindowCommandsOverlayBehavior, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
 
             <Grid>
@@ -466,7 +471,7 @@
                           Margin="2"
                           VerticalAlignment="Center"
                           ItemsSource="{Binding Source={StaticResource WindowCommandsOverlayBehaviorValues}}"
-                          SelectedValue="{Binding ElementName=flyoutsDemo, Path=RightWindowCommandsOverlayBehavior}" />
+                          SelectedValue="{Binding ElementName=flyoutsDemo, Path=RightWindowCommandsOverlayBehavior, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
 
             <Grid>
@@ -482,8 +487,8 @@
                           Width="100"
                           Margin="2"
                           VerticalAlignment="Center"
-                          ItemsSource="{Binding Source={StaticResource WindowCommandsOverlayBehaviorValues}}"
-                          SelectedValue="{Binding ElementName=flyoutsDemo, Path=WindowButtonCommandsOverlayBehavior}" />
+                          ItemsSource="{Binding Source={StaticResource OverlayBehaviorValues}}"
+                          SelectedValue="{Binding ElementName=flyoutsDemo, Path=WindowButtonCommandsOverlayBehavior, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
 
             <Grid>
@@ -499,8 +504,8 @@
                           Width="100"
                           Margin="2"
                           VerticalAlignment="Center"
-                          ItemsSource="{Binding Source={StaticResource WindowCommandsOverlayBehaviorValues}}"
-                          SelectedValue="{Binding ElementName=flyoutsDemo, Path=IconOverlayBehavior}" />
+                          ItemsSource="{Binding Source={StaticResource OverlayBehaviorValues}}"
+                          SelectedValue="{Binding ElementName=flyoutsDemo, Path=IconOverlayBehavior, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </Grid>
 
             <CheckBox Content="ShowTitleBar" IsChecked="{Binding ElementName=flyoutsDemo, Path=ShowTitleBar, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.csproj
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.csproj
@@ -21,10 +21,13 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="MahApps.Metro.IconPacks" Version="3.0.0-alpha*" />
-        <PackageReference Include="MaterialDesignThemes" Version="2.5.*" />
+        <PackageReference Include="MaterialDesignThemes" Version="2.*" />
         <PackageReference Include="NHotkey.Wpf" Version="1.2.1" />
-        <PackageReference Include="Fody" Version="4.*" />
-        <PackageReference Include="Costura.Fody" Version="3.*" />
+        <PackageReference Include="Fody" Version="5.*">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Costura.Fody" Version="4.*" />
     </ItemGroup>
     <ItemGroup>
         <Reference Include="System.Globalization" />

--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -126,10 +126,10 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty RightWindowCommandsProperty = DependencyProperty.Register("RightWindowCommands", typeof(WindowCommands), typeof(MetroWindow), new PropertyMetadata(null, UpdateLogicalChilds));
         public static readonly DependencyProperty WindowButtonCommandsProperty = DependencyProperty.Register("WindowButtonCommands", typeof(WindowButtonCommands), typeof(MetroWindow), new PropertyMetadata(null, UpdateLogicalChilds));
 
-        public static readonly DependencyProperty LeftWindowCommandsOverlayBehaviorProperty = DependencyProperty.Register("LeftWindowCommandsOverlayBehavior", typeof(WindowCommandsOverlayBehavior), typeof(MetroWindow), new PropertyMetadata(WindowCommandsOverlayBehavior.Flyouts, OnShowTitleBarPropertyChangedCallback));
-        public static readonly DependencyProperty RightWindowCommandsOverlayBehaviorProperty = DependencyProperty.Register("RightWindowCommandsOverlayBehavior", typeof(WindowCommandsOverlayBehavior), typeof(MetroWindow), new PropertyMetadata(WindowCommandsOverlayBehavior.Flyouts, OnShowTitleBarPropertyChangedCallback));
-        public static readonly DependencyProperty WindowButtonCommandsOverlayBehaviorProperty = DependencyProperty.Register("WindowButtonCommandsOverlayBehavior", typeof(WindowCommandsOverlayBehavior), typeof(MetroWindow), new PropertyMetadata(WindowCommandsOverlayBehavior.Always, OnShowTitleBarPropertyChangedCallback));
-        public static readonly DependencyProperty IconOverlayBehaviorProperty = DependencyProperty.Register("IconOverlayBehavior", typeof(WindowCommandsOverlayBehavior), typeof(MetroWindow), new PropertyMetadata(WindowCommandsOverlayBehavior.Never, OnShowTitleBarPropertyChangedCallback));
+        public static readonly DependencyProperty LeftWindowCommandsOverlayBehaviorProperty = DependencyProperty.Register("LeftWindowCommandsOverlayBehavior", typeof(WindowCommandsOverlayBehavior), typeof(MetroWindow), new PropertyMetadata(WindowCommandsOverlayBehavior.HiddenTitleBar, OnShowTitleBarPropertyChangedCallback));
+        public static readonly DependencyProperty RightWindowCommandsOverlayBehaviorProperty = DependencyProperty.Register("RightWindowCommandsOverlayBehavior", typeof(WindowCommandsOverlayBehavior), typeof(MetroWindow), new PropertyMetadata(WindowCommandsOverlayBehavior.HiddenTitleBar, OnShowTitleBarPropertyChangedCallback));
+        public static readonly DependencyProperty WindowButtonCommandsOverlayBehaviorProperty = DependencyProperty.Register("WindowButtonCommandsOverlayBehavior", typeof(OverlayBehavior), typeof(MetroWindow), new PropertyMetadata(OverlayBehavior.Always, OnShowTitleBarPropertyChangedCallback));
+        public static readonly DependencyProperty IconOverlayBehaviorProperty = DependencyProperty.Register("IconOverlayBehavior", typeof(OverlayBehavior), typeof(MetroWindow), new PropertyMetadata(OverlayBehavior.Never, OnShowTitleBarPropertyChangedCallback));
 
         public static readonly DependencyProperty UseNoneWindowStyleProperty = DependencyProperty.Register("UseNoneWindowStyle", typeof(bool), typeof(MetroWindow), new PropertyMetadata(false, OnUseNoneWindowStylePropertyChangedCallback));
         public static readonly DependencyProperty OverrideDefaultWindowCommandsBrushProperty = DependencyProperty.Register("OverrideDefaultWindowCommandsBrush", typeof(SolidColorBrush), typeof(MetroWindow));
@@ -203,15 +203,15 @@ namespace MahApps.Metro.Controls
             set { SetValue(RightWindowCommandsOverlayBehaviorProperty, value); }
         }
 
-        public WindowCommandsOverlayBehavior WindowButtonCommandsOverlayBehavior
+        public OverlayBehavior WindowButtonCommandsOverlayBehavior
         {
-            get { return (WindowCommandsOverlayBehavior)this.GetValue(WindowButtonCommandsOverlayBehaviorProperty); }
+            get { return (OverlayBehavior)this.GetValue(WindowButtonCommandsOverlayBehaviorProperty); }
             set { SetValue(WindowButtonCommandsOverlayBehaviorProperty, value); }
         }
 
-        public WindowCommandsOverlayBehavior IconOverlayBehavior
+        public OverlayBehavior IconOverlayBehavior
         {
-            get { return (WindowCommandsOverlayBehavior)this.GetValue(IconOverlayBehaviorProperty); }
+            get { return (OverlayBehavior)this.GetValue(IconOverlayBehaviorProperty); }
             set { SetValue(IconOverlayBehaviorProperty, value); }
         }
 
@@ -589,7 +589,7 @@ namespace MahApps.Metro.Controls
         {
             if (this.icon != null)
             {
-                var isVisible = (this.IconOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) && !this.ShowTitleBar)
+                var isVisible = (this.IconOverlayBehavior.HasFlag(OverlayBehavior.HiddenTitleBar) && !this.ShowTitleBar)
                                 || (this.ShowIconOnTitleBar && this.ShowTitleBar);
                 var iconVisibility = isVisible ? Visibility.Visible : Visibility.Collapsed;
                 this.icon.Visibility = iconVisibility;
@@ -610,7 +610,7 @@ namespace MahApps.Metro.Controls
             var rightWindowCommandsVisibility = this.RightWindowCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) && !this.UseNoneWindowStyle ? Visibility.Visible : newVisibility;
             this.RightWindowCommandsPresenter?.SetCurrentValue(VisibilityProperty, rightWindowCommandsVisibility);
 
-            var windowButtonCommandsVisibility = this.WindowButtonCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) ? Visibility.Visible : newVisibility;
+            var windowButtonCommandsVisibility = this.WindowButtonCommandsOverlayBehavior.HasFlag(OverlayBehavior.HiddenTitleBar) ? Visibility.Visible : newVisibility;
             this.WindowButtonCommandsPresenter?.SetCurrentValue(VisibilityProperty, windowButtonCommandsVisibility);
 
             this.SetWindowEvents();
@@ -1507,12 +1507,11 @@ namespace MahApps.Metro.Controls
                 //get it's zindex
                 var zIndex = flyout.IsOpen ? Panel.GetZIndex(flyout) + 3 : visibleFlyouts.Count() + 2;
 
-                // Note: ShowWindowCommandsOnTop is here for backwards compatibility reasons
                 //if the the corresponding behavior has the right flag, set the window commands' and icon zIndex to a number that is higher than the flyout's.
-                this.icon?.SetValue(Panel.ZIndexProperty, flyout.IsModal && flyout.IsOpen ? 0 : (this.IconOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.Flyouts) ? zIndex : 1));
-                this.LeftWindowCommandsPresenter?.SetValue(Panel.ZIndexProperty, flyout.IsModal && flyout.IsOpen ? 0 : (this.LeftWindowCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.Flyouts) ? zIndex : 1));
-                this.RightWindowCommandsPresenter?.SetValue(Panel.ZIndexProperty, flyout.IsModal && flyout.IsOpen ? 0 : (this.RightWindowCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.Flyouts) ? zIndex : 1));
-                this.WindowButtonCommandsPresenter?.SetValue(Panel.ZIndexProperty, flyout.IsModal && flyout.IsOpen ? 0 : (this.WindowButtonCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.Flyouts) ? zIndex : 1));
+                this.icon?.SetValue(Panel.ZIndexProperty, flyout.IsModal && flyout.IsOpen ? 0 : (this.IconOverlayBehavior.HasFlag(OverlayBehavior.Flyouts) ? zIndex : 1));
+                this.LeftWindowCommandsPresenter?.SetValue(Panel.ZIndexProperty, flyout.IsModal && flyout.IsOpen ? 0 : 1);
+                this.RightWindowCommandsPresenter?.SetValue(Panel.ZIndexProperty, flyout.IsModal && flyout.IsOpen ? 0 : 1);
+                this.WindowButtonCommandsPresenter?.SetValue(Panel.ZIndexProperty, flyout.IsModal && flyout.IsOpen ? 0 : (this.WindowButtonCommandsOverlayBehavior.HasFlag(OverlayBehavior.Flyouts) ? zIndex : 1));
                 this.HandleWindowCommandsForFlyouts(visibleFlyouts);
             }
 

--- a/src/MahApps.Metro/Controls/OverlayBehavior.cs
+++ b/src/MahApps.Metro/Controls/OverlayBehavior.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace MahApps.Metro.Controls
+{
+    [Flags]
+    public enum OverlayBehavior
+    {
+        /// <summary>
+        /// Doesn't overlay Flyouts nor a hidden TitleBar.
+        /// </summary>
+        Never = 0,
+
+        /// <summary>
+        /// Overlays opened <see cref="Flyout"/> controls.
+        /// </summary>
+        Flyouts = 1 << 0,
+
+        /// <summary>
+        /// Overlays a hidden TitleBar.
+        /// </summary>
+        HiddenTitleBar = 1 << 1,
+
+        Always = ~(-1 << 2)
+    }
+}

--- a/src/MahApps.Metro/Controls/WindowCommandsOverlayBehavior.cs
+++ b/src/MahApps.Metro/Controls/WindowCommandsOverlayBehavior.cs
@@ -6,7 +6,21 @@ namespace MahApps.Metro.Controls
     public enum WindowCommandsOverlayBehavior
     {
         /// <summary>
-        /// Doesn't overlay flyouts nor a hidden TitleBar.
+        /// Doesn't overlay a hidden TitleBar.
+        /// </summary>
+        Never = 0,
+
+        /// <summary>
+        /// Overlays a hidden TitleBar.
+        /// </summary>
+        HiddenTitleBar = 1 << 0
+    }
+
+    [Flags]
+    public enum OverlayBehavior
+    {
+        /// <summary>
+        /// Doesn't overlay Flyouts nor a hidden TitleBar.
         /// </summary>
         Never = 0,
 

--- a/src/MahApps.Metro/Controls/WindowCommandsOverlayBehavior.cs
+++ b/src/MahApps.Metro/Controls/WindowCommandsOverlayBehavior.cs
@@ -15,25 +15,4 @@ namespace MahApps.Metro.Controls
         /// </summary>
         HiddenTitleBar = 1 << 0
     }
-
-    [Flags]
-    public enum OverlayBehavior
-    {
-        /// <summary>
-        /// Doesn't overlay Flyouts nor a hidden TitleBar.
-        /// </summary>
-        Never = 0,
-
-        /// <summary>
-        /// Overlays opened <see cref="Flyout"/> controls.
-        /// </summary>
-        Flyouts = 1 << 0,
-
-        /// <summary>
-        /// Overlays a hidden TitleBar.
-        /// </summary>
-        HiddenTitleBar = 1 << 1,
-
-        Always = ~(-1 << 2)
-    }
 }

--- a/src/MahApps.Metro/MahApps.Metro.csproj
+++ b/src/MahApps.Metro/MahApps.Metro.csproj
@@ -14,8 +14,8 @@
         <Reference Include="System.Configuration"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="ControlzEx" Version="[4.0.0-alpha0290, 5.0)" />
-        <PackageReference Include="Newtonsoft.Json" Version="11.*" PrivateAssets="All" />
+        <PackageReference Include="ControlzEx" Version="[4.0.0-alpha0291, 5.0)" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.*" PrivateAssets="All" />
         <PackageReference Include="XamlColorSchemeGenerator" Version="3.0.0.31" PrivateAssets="All" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2*" PrivateAssets="All" />
     </ItemGroup>

--- a/src/Mahapps.Metro.Tests/MahApps.Metro.Tests.csproj
+++ b/src/Mahapps.Metro.Tests/MahApps.Metro.Tests.csproj
@@ -14,12 +14,12 @@
         <Reference Include="System.ComponentModel.DataAnnotations"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="11.*" PrivateAssets="All" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.*" PrivateAssets="All" />
         <PackageReference Include="XamlColorSchemeGenerator" Version="3.0.0.31" PrivateAssets="All" />
         <PackageReference Include="ExposedObject" Version="1.2.*" PrivateAssets="All" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview*" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
     </ItemGroup>
     <!-- Items include -->
     <ItemGroup>

--- a/src/Mahapps.Metro.Tests/Tests/FlyoutTest.cs
+++ b/src/Mahapps.Metro.Tests/Tests/FlyoutTest.cs
@@ -73,14 +73,14 @@ namespace MahApps.Metro.Tests
             await TestHost.SwitchToAppThread();
 
             var window = await WindowHelpers.CreateInvisibleWindowAsync<FlyoutWindow>();
-            window.LeftWindowCommandsOverlayBehavior = WindowCommandsOverlayBehavior.Never;
+            window.IconOverlayBehavior = OverlayBehavior.Never;
             window.LeftFlyout.IsOpen = true;
 
             var exposedWindow = Exposed.From(window);
-            int windowCommandsZIndex = Panel.GetZIndex(exposedWindow.icon);
+            int iconZIndex = Panel.GetZIndex(exposedWindow.icon);
             int flyoutindex = Panel.GetZIndex(window.LeftFlyout);
 
-            Assert.True(flyoutindex < windowCommandsZIndex);
+            Assert.True(flyoutindex < iconZIndex);
         }
 
         [Fact]

--- a/src/Mahapps.Metro.Tests/Tests/MetroWindowTest.cs
+++ b/src/Mahapps.Metro.Tests/Tests/MetroWindowTest.cs
@@ -40,10 +40,10 @@ namespace MahApps.Metro.Tests
 
             var window = await WindowHelpers.CreateInvisibleWindowAsync<MetroWindow>();
 
-            Assert.Equal(WindowCommandsOverlayBehavior.Never, window.IconOverlayBehavior);
-            Assert.Equal(WindowCommandsOverlayBehavior.Flyouts, window.LeftWindowCommandsOverlayBehavior);
-            Assert.Equal(WindowCommandsOverlayBehavior.Flyouts, window.RightWindowCommandsOverlayBehavior);
-            Assert.Equal(WindowCommandsOverlayBehavior.Always, window.WindowButtonCommandsOverlayBehavior);
+            Assert.Equal(OverlayBehavior.Never, window.IconOverlayBehavior);
+            Assert.Equal(WindowCommandsOverlayBehavior.HiddenTitleBar, window.LeftWindowCommandsOverlayBehavior);
+            Assert.Equal(WindowCommandsOverlayBehavior.HiddenTitleBar, window.RightWindowCommandsOverlayBehavior);
+            Assert.Equal(OverlayBehavior.Always, window.WindowButtonCommandsOverlayBehavior);
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace MahApps.Metro.Tests
             await TestHost.SwitchToAppThread();
 
             var window = await WindowHelpers.CreateInvisibleWindowAsync<MetroWindow>(w => {
-                                                                                         w.IconOverlayBehavior = WindowCommandsOverlayBehavior.HiddenTitleBar;
+                                                                                         w.IconOverlayBehavior = OverlayBehavior.HiddenTitleBar;
                                                                                          w.ShowTitleBar = false;
                                                                                      });
             var icon = window.FindChild<ContentControl>("PART_Icon");
@@ -120,7 +120,7 @@ namespace MahApps.Metro.Tests
             await TestHost.SwitchToAppThread();
 
             var window = await WindowHelpers.CreateInvisibleWindowAsync<MetroWindow>();
-            window.IconOverlayBehavior = WindowCommandsOverlayBehavior.HiddenTitleBar;
+            window.IconOverlayBehavior = OverlayBehavior.HiddenTitleBar;
             window.ShowTitleBar = false;
             var icon = window.FindChild<ContentControl>("PART_Icon");
 


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

After improving the title bar in #3503 the window commands and window button commands needs also a change for the overlay brushes.

Split WindowCommandsOverlayBehavior into 2 separate enumerations.

- `WindowCommandsOverlayBehavior` for Left and Right window commands
- `OverlayBehavior` for Icon and WindowButton commands
- ` WindowCommandsOverlayBehavior` contains now only 2 enumeration values (Never and HiddenTitleBar)

The new overlay behavior of the window commands needs also new overlay brushes. Because the window commands now doesn't overlay the Flyouts and so it's not necessary to set a calculated overlay brush for the foreground.

![2019-05-28_23h09_07](https://user-images.githubusercontent.com/658431/58512554-b18a7300-819d-11e9-888e-190307950fdc.png)

![2019-05-28_23h08_47](https://user-images.githubusercontent.com/658431/58512557-b4856380-819d-11e9-9332-59b5f43ecab3.png)

