### PR TITLE
Use TabControlEx from ControlzEx as base class for BaseMetroTabControl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ artifacts/
 *.tmp
 *.tmp_proj
 *.log
+*.binlog
 *.vspscc
 *.vssscc
 .builds
@@ -256,6 +257,7 @@ paket-files/
 *.sln.iml
 
 # Generated files
+*_wpftmp.csproj
 src/MahApps.Metro/Styles/Themes/*.xaml
 
 # Allowed files

--- a/paket.lock
+++ b/paket.lock
@@ -4,7 +4,7 @@ NUGET
     Caliburn.Micro (3.2)
       Caliburn.Micro.Core (3.2)
     Caliburn.Micro.Core (3.2)
-    ControlzEx (4.0.0-alpha0222)
+    ControlzEx (4.0.0-alpha0232)
       Microsoft.Xaml.Behaviors.Wpf (>= 1.0.1)
     Costura.Fody (3.3.2)
       Fody (>= 3.3.5) - restriction: || (== net45) (== net452) (== net46) (== net47) (&& (== netcoreapp3.0) (>= net40))

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/OtherExamples.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/OtherExamples.xaml.cs
@@ -19,6 +19,11 @@ namespace MetroDemo.ExampleViews
 
         void Tick(object sender, EventArgs e)
         {
+            if (this.IsVisible == false)
+            {
+                return;
+            }
+
             var dateTime = DateTime.Now;
             transitioning.Content = new TextBlock { Text = "Transitioning Content! " + dateTime, SnapsToDevicePixels = true };
             customTransitioning.Content = new TextBlock { Text = "Custom transistion! " + dateTime, SnapsToDevicePixels = true };

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TabControlExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TabControlExamples.xaml
@@ -397,6 +397,7 @@
                     </StackPanel>
                     <Controls:MetroTabControl x:Name="MetroTabControl"
                                               Height="200"
+                                              KeepVisualTreeInMemoryWhenChangingTabs="True"
                                               Controls:TabControlHelper.Underlined="{Binding ElementName=MetroTabControlUnderlinedComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                               TabStripPlacement="{Binding ElementName=MetroTabStripPlacementComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                         <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _1">

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TabControlExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TabControlExamples.xaml
@@ -369,6 +369,14 @@
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Margin="5 5"
                                    VerticalAlignment="Center"
+                                   Text="Keep VisualTree in memory" />
+                        <CheckBox x:Name="KeepVisualTreeInMemoryCheckBox"
+                                  Margin="5 5"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  IsChecked="{Binding ElementName=MetroTabControl, Path=KeepVisualTreeInMemoryWhenChangingTabs, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <TextBlock Margin="5 5"
+                                   VerticalAlignment="Center"
                                    Text="Underlined type" />
                         <ComboBox x:Name="MetroTabControlUnderlinedComboBox"
                                   Margin="5 5"
@@ -387,11 +395,15 @@
                                   ItemsSource="{Binding Source={StaticResource TabStripPlacementEnumValues}}"
                                   SelectedItem="{x:Static Dock.Top}" />
                     </StackPanel>
-                    <Controls:MetroTabControl Height="200"
+                    <Controls:MetroTabControl x:Name="MetroTabControl"
+                                              Height="200"
                                               Controls:TabControlHelper.Underlined="{Binding ElementName=MetroTabControlUnderlinedComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                               TabStripPlacement="{Binding ElementName=MetroTabStripPlacementComboBox, Path=SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                         <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _1">
-                            <TextBlock FontSize="30" Text="Content" />
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock FontSize="30" Text="Load-Count: " />
+                                <TextBlock FontSize="30" Text="0" Loaded="TextBlock_OnLoaded" />
+                            </StackPanel>
                         </Controls:MetroTabItem>
                         <Controls:MetroTabItem Controls:ControlsHelper.HeaderFontSize="18" Header="item _2 more">
                             <TextBlock FontSize="30" Text="More content" />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TabControlExamples.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TabControlExamples.xaml.cs
@@ -3,6 +3,8 @@ using MahApps.Metro.Controls;
 
 namespace MetroDemo.ExampleViews
 {
+    using System.Windows;
+
     /// <summary>
     /// Interaction logic for TabControlExamples.xaml
     /// </summary>
@@ -17,6 +19,13 @@ namespace MetroDemo.ExampleViews
         {
             if (e.ClosingTabItem.Header.ToString().StartsWith("sizes"))
                 e.Cancel = true;
+        }
+
+        private void TextBlock_OnLoaded(object sender, RoutedEventArgs e)
+        {
+            var textBlock = (TextBlock)sender;
+
+            textBlock.SetCurrentValue(TextBlock.TextProperty, (int.Parse(textBlock.Text) + 1).ToString());
         }
     }
 }

--- a/src/MahApps.Metro/Controls/MetroTabControl.cs
+++ b/src/MahApps.Metro/Controls/MetroTabControl.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using ControlzEx;
 using JetBrains.Annotations;
 
 namespace MahApps.Metro.Controls
@@ -26,7 +27,7 @@ namespace MahApps.Metro.Controls
     /// <summary>
     /// A base class for every MetroTabControl (Pivot).
     /// </summary>
-    public abstract class BaseMetroTabControl : TabControl
+    public abstract class BaseMetroTabControl : TabControlEx
     {
         public BaseMetroTabControl()
         {

--- a/src/MahApps.Metro/Controls/MetroTabControl.cs
+++ b/src/MahApps.Metro/Controls/MetroTabControl.cs
@@ -24,7 +24,7 @@ namespace MahApps.Metro.Controls
         }
 
         /// <summary>Identifies the <see cref="KeepVisualTreeInMemoryWhenChangingTabs"/> dependency property.</summary>
-        public static readonly DependencyProperty KeepVisualTreeInMemoryWhenChangingTabsProperty = DependencyProperty.Register(nameof(KeepVisualTreeInMemoryWhenChangingTabs), typeof(bool), typeof(MetroTabControl), new PropertyMetadata(true));
+        public static readonly DependencyProperty KeepVisualTreeInMemoryWhenChangingTabsProperty = DependencyProperty.Register(nameof(KeepVisualTreeInMemoryWhenChangingTabs), typeof(bool), typeof(MetroTabControl), new PropertyMetadata(false));
 
         public bool KeepVisualTreeInMemoryWhenChangingTabs
         {

--- a/src/MahApps.Metro/Controls/MetroTabControl.cs
+++ b/src/MahApps.Metro/Controls/MetroTabControl.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using ControlzEx;
+using ControlzEx.Controls;
 using JetBrains.Annotations;
 
 namespace MahApps.Metro.Controls

--- a/src/MahApps.Metro/Controls/MetroTabControl.cs
+++ b/src/MahApps.Metro/Controls/MetroTabControl.cs
@@ -41,7 +41,7 @@ namespace MahApps.Metro.Controls
 
         // Using a DependencyProperty as the backing store for TabStripMargin.  This enables animation, styling, binding, etc...
         public static readonly DependencyProperty TabStripMarginProperty =
-            DependencyProperty.Register("TabStripMargin", typeof(Thickness), typeof(BaseMetroTabControl), new PropertyMetadata(new Thickness(0)));
+            DependencyProperty.Register(nameof(TabStripMargin), typeof(Thickness), typeof(BaseMetroTabControl), new PropertyMetadata(new Thickness(0)));
 
         protected override bool IsItemItsOwnContainerOverride(object item)
         {
@@ -73,7 +73,7 @@ namespace MahApps.Metro.Controls
         }
 
         public static readonly DependencyProperty CloseTabCommandProperty =
-            DependencyProperty.Register("CloseTabCommand", typeof(ICommand), typeof(BaseMetroTabControl), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(CloseTabCommand), typeof(ICommand), typeof(BaseMetroTabControl), new PropertyMetadata(null));
 
         public delegate void TabItemClosingEventHandler(object sender, TabItemClosingEventArgs e);
 

--- a/src/MahApps.Metro/Controls/MetroTabControl.cs
+++ b/src/MahApps.Metro/Controls/MetroTabControl.cs
@@ -18,9 +18,18 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Initializes a new instance of the MahApps.Metro.Controls.MetroTabControl class.
         /// </summary>
-        public MetroTabControl()
+        static MetroTabControl()
         {
-            DefaultStyleKey = typeof(MetroTabControl);
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(MetroTabControl), new FrameworkPropertyMetadata(typeof(MetroTabControl)));
+        }
+
+        /// <summary>Identifies the <see cref="KeepVisualTreeInMemoryWhenChangingTabs"/> dependency property.</summary>
+        public static readonly DependencyProperty KeepVisualTreeInMemoryWhenChangingTabsProperty = DependencyProperty.Register(nameof(KeepVisualTreeInMemoryWhenChangingTabs), typeof(bool), typeof(MetroTabControl), new PropertyMetadata(true));
+
+        public bool KeepVisualTreeInMemoryWhenChangingTabs
+        {
+            get { return (bool)GetValue(KeepVisualTreeInMemoryWhenChangingTabsProperty); }
+            set { SetValue(KeepVisualTreeInMemoryWhenChangingTabsProperty, value); }
         }
     }
 
@@ -29,8 +38,9 @@ namespace MahApps.Metro.Controls
     /// </summary>
     public abstract class BaseMetroTabControl : TabControlEx
     {
-        public BaseMetroTabControl()
+        static BaseMetroTabControl()
         {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(BaseMetroTabControl), new FrameworkPropertyMetadata(typeof(BaseMetroTabControl)));
         }
 
         public Thickness TabStripMargin

--- a/src/MahApps.Metro/ThemeManager/ThemeManager.cs
+++ b/src/MahApps.Metro/ThemeManager/ThemeManager.cs
@@ -91,9 +91,9 @@ namespace MahApps.Metro
         {
             get
             {
-                EnsureThemes(); 
+                EnsureThemes();
 
-                return baseColors; 
+                return baseColors;
             }
         }
 
@@ -102,11 +102,11 @@ namespace MahApps.Metro
         /// </summary>
         public static ReadOnlyObservableCollection<ColorScheme> ColorSchemes
         {
-            get 
-            { 
-                EnsureThemes(); 
+            get
+            {
+                EnsureThemes();
 
-                return colorSchemes; 
+                return colorSchemes;
             }
         }
 

--- a/src/MahApps.Metro/Themes/MetroTabControl.xaml
+++ b/src/MahApps.Metro/Themes/MetroTabControl.xaml
@@ -165,12 +165,12 @@
            TargetType="{x:Type Controls:MetroTabControl}"
            BasedOn="{StaticResource MetroTabControl}">
         <Setter Property="Template"
-                Value="{StaticResource MahApps.Metro.Templates.MetroTabControl.KeepVisualTreeInMemoryWhenChangingTabs}" />
+                Value="{StaticResource MahApps.Metro.Templates.MetroTabControl.DoNotKeepVisualTreeInMemoryWhenChangingTabs}" />
         <Style.Triggers>
             <Trigger Property="KeepVisualTreeInMemoryWhenChangingTabs"
-                     Value="False">
+                     Value="True">
                 <Setter Property="Template"
-                        Value="{StaticResource MahApps.Metro.Templates.MetroTabControl.DoNotKeepVisualTreeInMemoryWhenChangingTabs}" />
+                        Value="{StaticResource MahApps.Metro.Templates.MetroTabControl.KeepVisualTreeInMemoryWhenChangingTabs}" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/src/MahApps.Metro/Themes/MetroTabControl.xaml
+++ b/src/MahApps.Metro/Themes/MetroTabControl.xaml
@@ -44,10 +44,9 @@
                                 KeyboardNavigation.DirectionalNavigation="Contained"
                                 KeyboardNavigation.TabIndex="2"
                                 KeyboardNavigation.TabNavigation="Local">
-                            <ContentPresenter x:Name="PART_SelectedContentHost"
-                                              Margin="{TemplateBinding Padding}"
-                                              ContentSource="SelectedContent"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <Grid x:Name="PART_ItemsHolder"
+                                  Margin="{TemplateBinding Padding}"
+                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
                     </Grid>
                     <ControlTemplate.Triggers>

--- a/src/MahApps.Metro/Themes/MetroTabControl.xaml
+++ b/src/MahApps.Metro/Themes/MetroTabControl.xaml
@@ -6,86 +6,173 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TabControl.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style BasedOn="{StaticResource MetroTabControl}" TargetType="{x:Type Controls:MetroTabControl}">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type Controls:MetroTabControl}">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition x:Name="ColumnDefinition0" />
-                            <ColumnDefinition x:Name="ColumnDefinition1" Width="0" />
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition x:Name="RowDefinition0" Height="Auto" />
-                            <RowDefinition x:Name="RowDefinition1" Height="*" />
-                        </Grid.RowDefinitions>
-                        <Grid x:Name="HeaderPanelGrid"
-                              Grid.Row="0"
-                              Grid.Column="0"
-                              Margin="{TemplateBinding TabStripMargin}"
-                              Panel.ZIndex="1">
-                            <Controls:Underline x:Name="Underline"
-                                                Background="Transparent"
-                                                BorderBrush="{TemplateBinding Controls:TabControlHelper.UnderlineBrush}"
-                                                LineThickness="1"
-                                                Placement="Bottom"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                Visibility="Collapsed" />
-                            <TabPanel x:Name="HeaderPanel"
-                                      IsItemsHost="true"
-                                      KeyboardNavigation.TabIndex="1" />
-                        </Grid>
-                        <Border x:Name="ContentPanel"
-                                Grid.Row="1"
-                                Grid.Column="0"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                KeyboardNavigation.DirectionalNavigation="Contained"
-                                KeyboardNavigation.TabIndex="2"
-                                KeyboardNavigation.TabNavigation="Local">
-                            <Grid x:Name="PART_ItemsHolder"
+    <ControlTemplate x:Key="MahApps.Metro.Templates.MetroTabControl.KeepVisualTreeInMemoryWhenChangingTabs" 
+                     TargetType="{x:Type Controls:MetroTabControl}">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition x:Name="ColumnDefinition0" />
+                <ColumnDefinition x:Name="ColumnDefinition1" Width="0" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition x:Name="RowDefinition0" Height="Auto" />
+                <RowDefinition x:Name="RowDefinition1" Height="*" />
+            </Grid.RowDefinitions>
+            <Grid x:Name="HeaderPanelGrid"
+                  Grid.Row="0"
+                  Grid.Column="0"
+                  Margin="{TemplateBinding TabStripMargin}"
+                  Panel.ZIndex="1">
+                <Controls:Underline x:Name="Underline"
+                                    Background="Transparent"
+                                    BorderBrush="{TemplateBinding Controls:TabControlHelper.UnderlineBrush}"
+                                    LineThickness="1"
+                                    Placement="Bottom"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                    Visibility="Collapsed" />
+                <TabPanel x:Name="HeaderPanel"
+                          IsItemsHost="true"
+                          KeyboardNavigation.TabIndex="1" />
+            </Grid>
+            <Border x:Name="ContentPanel"
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    KeyboardNavigation.DirectionalNavigation="Contained"
+                    KeyboardNavigation.TabIndex="2"
+                    KeyboardNavigation.TabNavigation="Local">
+                <Grid x:Name="PART_ItemsHolder"
+                      Margin="{TemplateBinding Padding}"
+                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+            </Border>
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="Controls:TabControlHelper.Underlined" Value="TabPanel">
+                <Setter TargetName="Underline" Property="Visibility" Value="Visible" />
+            </Trigger>
+            <Trigger Property="TabStripPlacement" Value="Bottom">
+                <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
+                <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="1" />
+                <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
+                <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
+                <Setter TargetName="Underline" Property="Placement" Value="Top" />
+            </Trigger>
+            <Trigger Property="TabStripPlacement" Value="Left">
+                <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
+                <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
+                <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
+                <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
+                <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="0" />
+                <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
+                <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
+                <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                <Setter TargetName="Underline" Property="Placement" Value="Right" />
+            </Trigger>
+            <Trigger Property="TabStripPlacement" Value="Right">
+                <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
+                <Setter TargetName="ColumnDefinition1" Property="Width" Value="Auto" />
+                <Setter TargetName="ContentPanel" Property="Grid.Column" Value="0" />
+                <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
+                <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="1" />
+                <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
+                <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
+                <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                <Setter TargetName="Underline" Property="Placement" Value="Left" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="MahApps.Metro.Templates.MetroTabControl.DoNotKeepVisualTreeInMemoryWhenChangingTabs" 
+                     TargetType="{x:Type Controls:MetroTabControl}">
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition x:Name="ColumnDefinition0" />
+                <ColumnDefinition x:Name="ColumnDefinition1" Width="0" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition x:Name="RowDefinition0" Height="Auto" />
+                <RowDefinition x:Name="RowDefinition1" Height="*" />
+            </Grid.RowDefinitions>
+            <Grid x:Name="HeaderPanelGrid"
+                  Grid.Row="0"
+                  Grid.Column="0"
+                  Margin="{TemplateBinding TabStripMargin}"
+                  Panel.ZIndex="1">
+                <Controls:Underline x:Name="Underline"
+                                    Background="Transparent"
+                                    BorderBrush="{TemplateBinding Controls:TabControlHelper.UnderlineBrush}"
+                                    LineThickness="1"
+                                    Placement="Bottom"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                    Visibility="Collapsed" />
+                <TabPanel x:Name="HeaderPanel"
+                          IsItemsHost="true"
+                          KeyboardNavigation.TabIndex="1" />
+            </Grid>
+            <Border x:Name="ContentPanel"
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    KeyboardNavigation.DirectionalNavigation="Contained"
+                    KeyboardNavigation.TabIndex="2"
+                    KeyboardNavigation.TabNavigation="Local">
+                <ContentPresenter x:Name="PART_SelectedContentHost"
                                   Margin="{TemplateBinding Padding}"
+                                  ContentSource="SelectedContent"
                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </Border>
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="Controls:TabControlHelper.Underlined" Value="TabPanel">
-                            <Setter TargetName="Underline" Property="Visibility" Value="Visible" />
-                        </Trigger>
-                        <Trigger Property="TabStripPlacement" Value="Bottom">
-                            <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="1" />
-                            <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
-                            <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
-                            <Setter TargetName="Underline" Property="Placement" Value="Top" />
-                        </Trigger>
-                        <Trigger Property="TabStripPlacement" Value="Left">
-                            <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
-                            <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
-                            <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
-                            <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
-                            <Setter TargetName="Underline" Property="Placement" Value="Right" />
-                        </Trigger>
-                        <Trigger Property="TabStripPlacement" Value="Right">
-                            <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
-                            <Setter TargetName="ColumnDefinition1" Property="Width" Value="Auto" />
-                            <Setter TargetName="ContentPanel" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
-                            <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
-                            <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
-                            <Setter TargetName="Underline" Property="Placement" Value="Left" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
+            </Border>
+        </Grid>
+        <ControlTemplate.Triggers>
+            <Trigger Property="Controls:TabControlHelper.Underlined" Value="TabPanel">
+                <Setter TargetName="Underline" Property="Visibility" Value="Visible" />
+            </Trigger>
+            <Trigger Property="TabStripPlacement" Value="Bottom">
+                <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
+                <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="1" />
+                <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
+                <Setter TargetName="RowDefinition1" Property="Height" Value="Auto" />
+                <Setter TargetName="Underline" Property="Placement" Value="Top" />
+            </Trigger>
+            <Trigger Property="TabStripPlacement" Value="Left">
+                <Setter TargetName="ColumnDefinition0" Property="Width" Value="Auto" />
+                <Setter TargetName="ColumnDefinition1" Property="Width" Value="*" />
+                <Setter TargetName="ContentPanel" Property="Grid.Column" Value="1" />
+                <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
+                <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="0" />
+                <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
+                <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
+                <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                <Setter TargetName="Underline" Property="Placement" Value="Right" />
+            </Trigger>
+            <Trigger Property="TabStripPlacement" Value="Right">
+                <Setter TargetName="ColumnDefinition0" Property="Width" Value="*" />
+                <Setter TargetName="ColumnDefinition1" Property="Width" Value="Auto" />
+                <Setter TargetName="ContentPanel" Property="Grid.Column" Value="0" />
+                <Setter TargetName="ContentPanel" Property="Grid.Row" Value="0" />
+                <Setter TargetName="HeaderPanelGrid" Property="Grid.Column" Value="1" />
+                <Setter TargetName="HeaderPanelGrid" Property="Grid.Row" Value="0" />
+                <Setter TargetName="RowDefinition0" Property="Height" Value="*" />
+                <Setter TargetName="RowDefinition1" Property="Height" Value="0" />
+                <Setter TargetName="Underline" Property="Placement" Value="Left" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <Style x:Key="{x:Type Controls:MetroTabControl}" 
+           TargetType="{x:Type Controls:MetroTabControl}"
+           BasedOn="{StaticResource MetroTabControl}">
+        <Setter Property="Template"
+                Value="{StaticResource MahApps.Metro.Templates.MetroTabControl.KeepVisualTreeInMemoryWhenChangingTabs}" />
+        <Style.Triggers>
+            <Trigger Property="KeepVisualTreeInMemoryWhenChangingTabs"
+                     Value="False">
+                <Setter Property="Template"
+                        Value="{StaticResource MahApps.Metro.Templates.MetroTabControl.DoNotKeepVisualTreeInMemoryWhenChangingTabs}" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
This PR changes the base class of BaseMetroTabControl from TabControl to TabControlEx from ControlzEx.
This allows us to keep the visual content in memory and prevent reloads of the UI contained in Tabs.
To be as flexible as possible i have added a need property `KeepVisualTreeInMemoryWhenChangingTabs` to `MetroTabControl`.
The default value is currently set to `false` to not break any current usages of the control.