### PR TITLE
(GH-3484) Allow set Dialogs inner content Column GridLength

### DIFF
--- a/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -18,6 +18,30 @@ namespace MahApps.Metro.Controls.Dialogs
     /// </summary>
     public abstract class BaseMetroDialog : ContentControl
     {
+        /// <summary>Identifies the <see cref="DialogContentMargin"/> dependency property.</summary>
+        public static readonly DependencyProperty DialogContentMarginProperty = DependencyProperty.Register(nameof(DialogContentMargin), typeof(GridLength), typeof(BaseMetroDialog), new PropertyMetadata(new GridLength(25, GridUnitType.Star)));
+
+        /// <summary>
+        /// Gets or sets the left and right margin for the dialog content.
+        /// </summary>
+        public GridLength DialogContentMargin
+        {
+            get { return (GridLength)this.GetValue(DialogContentMarginProperty); }
+            set { this.SetValue(DialogContentMarginProperty, value); }
+        }
+
+        /// <summary>Identifies the <see cref="DialogContentWidth"/> dependency property.</summary>
+        public static readonly DependencyProperty DialogContentWidthProperty = DependencyProperty.Register(nameof(DialogContentWidth), typeof(GridLength), typeof(BaseMetroDialog), new PropertyMetadata(new GridLength(50, GridUnitType.Star)));
+
+        /// <summary>
+        /// Gets or sets the width for the dialog content.
+        /// </summary>
+        public GridLength DialogContentWidth
+        {
+            get { return (GridLength)this.GetValue(DialogContentWidthProperty); }
+            set { this.SetValue(DialogContentWidthProperty, value); }
+        }
+
         /// <summary>Identifies the <see cref="Title"/> dependency property.</summary>
         public static readonly DependencyProperty TitleProperty = DependencyProperty.Register(nameof(Title), typeof(string), typeof(BaseMetroDialog), new PropertyMetadata(default(string)));
 

--- a/src/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/src/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -54,9 +54,9 @@
                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
             <Grid Grid.Row="1">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="25*" />
-                    <ColumnDefinition Width="50*" />
-                    <ColumnDefinition Width="25*" />
+                    <ColumnDefinition Width="{Binding DialogContentMargin, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+                    <ColumnDefinition Width="{Binding DialogContentWidth, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
+                    <ColumnDefinition Width="{Binding DialogContentMargin, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}" />
                 </Grid.ColumnDefinitions>
                 <!--  Content area  -->
                 <Grid Grid.Column="1" Margin="{TemplateBinding Padding}">


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Add properties to allow set the inner Dialog content GridLength.

- `DialogContentMargin`: Gets or sets the left and right margin for the dialog content. (default 25*)
- `DialogContentWidth`: Gets or sets the width for the dialog content. (default 50*)

**Closed Issues**

Closes #3484 

/cc @Evangelink 
