### PR TITLE
(GH-3504) Add initial remember checkbox checked

### DIFF
--- a/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml.cs
@@ -148,6 +148,7 @@ namespace MahApps.Metro.Controls.Dialogs
             this.ShouldHideUsername = settings.ShouldHideUsername;
             this.RememberCheckBoxVisibility = settings.RememberCheckBoxVisibility;
             this.RememberCheckBoxText = settings.RememberCheckBoxText;
+            this.RememberCheckBoxChecked = settings.InitialRememberCheckBoxChecked;
         }
 
         internal Task<LoginDialogData> WaitForButtonPressAsync()

--- a/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml.cs
@@ -148,7 +148,7 @@ namespace MahApps.Metro.Controls.Dialogs
             this.ShouldHideUsername = settings.ShouldHideUsername;
             this.RememberCheckBoxVisibility = settings.RememberCheckBoxVisibility;
             this.RememberCheckBoxText = settings.RememberCheckBoxText;
-            this.RememberCheckBoxChecked = settings.InitialRememberCheckBoxChecked;
+            this.RememberCheckBoxChecked = settings.RememberCheckBoxChecked;
         }
 
         internal Task<LoginDialogData> WaitForButtonPressAsync()

--- a/src/MahApps.Metro/Controls/Dialogs/LoginDialogSettings.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/LoginDialogSettings.cs
@@ -20,6 +20,7 @@ namespace MahApps.Metro.Controls.Dialogs
             this.EnablePasswordPreview = false;
             this.RememberCheckBoxVisibility = Visibility.Collapsed;
             this.RememberCheckBoxText = DefaultRememberCheckBoxText;
+            this.InitialRememberCheckBoxChecked = false;
         }
 
         public string InitialUsername { get; set; }
@@ -41,5 +42,7 @@ namespace MahApps.Metro.Controls.Dialogs
         public Visibility RememberCheckBoxVisibility { get; set; }
 
         public string RememberCheckBoxText { get; set; }
+
+        public bool InitialRememberCheckBoxChecked { get; set; }
     }
 }

--- a/src/MahApps.Metro/Controls/Dialogs/LoginDialogSettings.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/LoginDialogSettings.cs
@@ -20,7 +20,7 @@ namespace MahApps.Metro.Controls.Dialogs
             this.EnablePasswordPreview = false;
             this.RememberCheckBoxVisibility = Visibility.Collapsed;
             this.RememberCheckBoxText = DefaultRememberCheckBoxText;
-            this.InitialRememberCheckBoxChecked = false;
+            this.RememberCheckBoxChecked = false;
         }
 
         public string InitialUsername { get; set; }
@@ -43,6 +43,6 @@ namespace MahApps.Metro.Controls.Dialogs
 
         public string RememberCheckBoxText { get; set; }
 
-        public bool InitialRememberCheckBoxChecked { get; set; }
+        public bool RememberCheckBoxChecked { get; set; }
     }
 }


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Adds a new boolean property `RememberCheckBoxChecked` to the `LoginDialogSettings` which allows to configure the initial checked state of the remember checkbox.

**Closed Issues**

Fix #3504 