### PR TITLE
Added a Trigger to MouseOver Property of ValidationMessage

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.xaml
@@ -19,6 +19,7 @@
 
             <Style BasedOn="{StaticResource MetroValidationPopup}" TargetType="{x:Type controls:CustomValidationPopup}">
                 <Setter Property="CloseOnMouseLeftButtonDown" Value="False" />
+                <Setter Property="ShowValidationErrorOnMouseOver" Value="False" />
             </Style>
 
             <!--  quick change of the collapse storyboard duration  -->

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
@@ -240,7 +240,7 @@
                                    Style="{StaticResource MahApps.Metro.Styles.ToggleSwitch.Win10}" />
             <Controls:ToggleSwitch x:Name="visibleSwitch"
                                    Margin="{StaticResource ControlMargin}"
-                                   IsChecked="False"
+                                   IsChecked="{Binding IsToggleSwitchVisible, ValidatesOnDataErrors=True}"
                                    OffLabel="Collapsed"
                                    OnLabel="Visible"
                                    Style="{StaticResource MahApps.Metro.Styles.ToggleSwitch.Win10}" />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
@@ -239,6 +239,7 @@
                                    OnLabel="Enabled"
                                    Style="{StaticResource MahApps.Metro.Styles.ToggleSwitch.Win10}" />
             <Controls:ToggleSwitch x:Name="visibleSwitch"
+                                   Controls:ValidationHelper.ShowValidationErrorOnMouseOver="True"
                                    Margin="{StaticResource ControlMargin}"
                                    IsChecked="{Binding IsToggleSwitchVisible, ValidatesOnDataErrors=True}"
                                    OffLabel="Collapsed"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
@@ -240,6 +240,7 @@
                                    Style="{StaticResource MahApps.Metro.Styles.ToggleSwitch.Win10}" />
             <Controls:ToggleSwitch x:Name="visibleSwitch"
                                    Controls:ValidationHelper.ShowValidationErrorOnMouseOver="True"
+                                   Controls:ValidationHelper.CloseOnMouseLeftButtonDown="True"
                                    Margin="{StaticResource ControlMargin}"
                                    IsChecked="{Binding IsToggleSwitchVisible, ValidatesOnDataErrors=True}"
                                    OffLabel="Collapsed"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
@@ -300,6 +300,11 @@ namespace MetroDemo
                     return "No time given!";
                 }
 
+                if (columnName == nameof(IsToggleSwitchVisible) && !IsToggleSwitchVisible)
+                {
+                    return "There is something hidden... \nActivate me to show it up.";
+                }
+
                 return null;
             }
         }
@@ -455,5 +460,7 @@ namespace MetroDemo
         public bool IsScaleDownLargerFrame => ((MetroWindow)Application.Current.MainWindow).IconScalingMode == MultiFrameImageMode.ScaleDownLargerFrame;
 
         public bool IsNoScaleSmallerFrame => ((MetroWindow)Application.Current.MainWindow).IconScalingMode == MultiFrameImageMode.NoScaleSmallerFrame;
+
+        public bool IsToggleSwitchVisible { get; set; }
     }
 }

--- a/src/MahApps.Metro/Controls/CustomValidationPopup.cs
+++ b/src/MahApps.Metro/Controls/CustomValidationPopup.cs
@@ -27,12 +27,12 @@ namespace MahApps.Metro.Controls
                                           new PropertyMetadata(true));
 
         /// <summary>
-        /// Gets/sets if the popup can be closed by left mouse button down.
+        /// Gets or sets if the popup can be closed by left mouse button down.
         /// </summary>
         public bool CloseOnMouseLeftButtonDown
         {
-            get { return (bool)GetValue(CloseOnMouseLeftButtonDownProperty); }
-            set { SetValue(CloseOnMouseLeftButtonDownProperty, value); }
+            get { return (bool)this.GetValue(CloseOnMouseLeftButtonDownProperty); }
+            set { this.SetValue(CloseOnMouseLeftButtonDownProperty, value); }
         }
 
         public static readonly DependencyProperty ShowValidationErrorOnMouseOverProperty
@@ -41,10 +41,13 @@ namespace MahApps.Metro.Controls
                                                   typeof(CustomValidationPopup),
                                                   new PropertyMetadata(false));
 
+        /// <summary>
+        /// Gets or sets whether the validation error text will be shown when hovering the validation triangle.
+        /// </summary>
         public bool ShowValidationErrorOnMouseOver
         {
-            get { return (bool)GetValue(ShowValidationErrorOnMouseOverProperty); }
-            set { SetValue(ShowValidationErrorOnMouseOverProperty, value); }
+            get { return (bool)this.GetValue(ShowValidationErrorOnMouseOverProperty); }
+            set { this.SetValue(ShowValidationErrorOnMouseOverProperty, value); }
         }
 
         public CustomValidationPopup()
@@ -55,9 +58,9 @@ namespace MahApps.Metro.Controls
 
         protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
         {
-            if (CloseOnMouseLeftButtonDown)
+            if (this.CloseOnMouseLeftButtonDown)
             {
-                this.SetCurrentValue(Popup.IsOpenProperty, false);
+                this.SetCurrentValue(IsOpenProperty, false);
             }
         }
 

--- a/src/MahApps.Metro/Controls/CustomValidationPopup.cs
+++ b/src/MahApps.Metro/Controls/CustomValidationPopup.cs
@@ -18,15 +18,13 @@ namespace MahApps.Metro.Controls
     /// </summary>
     public class CustomValidationPopup : Popup
     {
-        public static readonly DependencyProperty CloseOnMouseLeftButtonDownProperty = DependencyProperty.Register("CloseOnMouseLeftButtonDown", typeof(bool), typeof(CustomValidationPopup), new PropertyMetadata(true));
-
         private Window hostWindow;
 
-        public CustomValidationPopup()
-        {
-            this.Loaded += this.CustomValidationPopup_Loaded;
-            this.Opened += this.CustomValidationPopup_Opened;
-        }
+        public static readonly DependencyProperty CloseOnMouseLeftButtonDownProperty
+            = DependencyProperty.Register(nameof(CloseOnMouseLeftButtonDown),
+                                          typeof(bool),
+                                          typeof(CustomValidationPopup),
+                                          new PropertyMetadata(true));
 
         /// <summary>
         /// Gets/sets if the popup can be closed by left mouse button down.
@@ -35,6 +33,24 @@ namespace MahApps.Metro.Controls
         {
             get { return (bool)GetValue(CloseOnMouseLeftButtonDownProperty); }
             set { SetValue(CloseOnMouseLeftButtonDownProperty, value); }
+        }
+
+        public static readonly DependencyProperty ShowValidationErrorOnMouseOverProperty
+            = DependencyProperty.RegisterAttached(nameof(ShowValidationErrorOnMouseOver),
+                                                  typeof(bool),
+                                                  typeof(CustomValidationPopup),
+                                                  new PropertyMetadata(false));
+
+        public bool ShowValidationErrorOnMouseOver
+        {
+            get { return (bool)GetValue(ShowValidationErrorOnMouseOverProperty); }
+            set { SetValue(ShowValidationErrorOnMouseOverProperty, value); }
+        }
+
+        public CustomValidationPopup()
+        {
+            this.Loaded += this.CustomValidationPopup_Loaded;
+            this.Opened += this.CustomValidationPopup_Opened;
         }
 
         protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
@@ -98,6 +114,7 @@ namespace MahApps.Metro.Controls
             {
                 target.SizeChanged -= this.hostWindow_SizeOrLocationChanged;
             }
+
             if (this.hostWindow != null)
             {
                 this.hostWindow.LocationChanged -= this.hostWindow_SizeOrLocationChanged;
@@ -106,6 +123,7 @@ namespace MahApps.Metro.Controls
                 this.hostWindow.Activated -= this.hostWindow_Activated;
                 this.hostWindow.Deactivated -= this.hostWindow_Deactivated;
             }
+
             this.Unloaded -= this.CustomValidationPopup_Unloaded;
             this.Opened -= this.CustomValidationPopup_Opened;
             this.hostWindow = null;
@@ -157,6 +175,7 @@ namespace MahApps.Metro.Controls
             {
                 return;
             }
+
             var hwnd = hwndSource.Handle;
 
 #pragma warning disable 618

--- a/src/MahApps.Metro/Controls/CustomValidationPopup.cs
+++ b/src/MahApps.Metro/Controls/CustomValidationPopup.cs
@@ -27,7 +27,7 @@ namespace MahApps.Metro.Controls
                                           new PropertyMetadata(true));
 
         /// <summary>
-        /// Gets or sets if the popup can be closed by left mouse button down.
+        /// Gets or sets whether if the popup can be closed by left mouse button down.
         /// </summary>
         public bool CloseOnMouseLeftButtonDown
         {
@@ -61,6 +61,18 @@ namespace MahApps.Metro.Controls
             if (this.CloseOnMouseLeftButtonDown)
             {
                 this.SetCurrentValue(IsOpenProperty, false);
+            }
+            else
+            {
+                var adornedElement = this.GetAdornedElement();
+                if (adornedElement != null && ValidationHelper.GetCloseOnMouseLeftButtonDown(adornedElement))
+                {
+                    this.SetCurrentValue(IsOpenProperty, false);
+                }
+                else
+                {
+                    e.Handled = true;
+                }
             }
         }
 
@@ -132,19 +144,24 @@ namespace MahApps.Metro.Controls
             this.hostWindow = null;
         }
 
+        private UIElement GetAdornedElement()
+        {
+            var placeholder = this.PlacementTarget is FrameworkElement target ? target.DataContext as AdornedElementPlaceholder : null;
+            return placeholder?.AdornedElement;
+        }
+
         private void hostWindow_StateChanged(object sender, EventArgs e)
         {
             if (this.hostWindow != null && this.hostWindow.WindowState != WindowState.Minimized)
             {
-                var target = this.PlacementTarget as FrameworkElement;
-                var holder = target != null ? target.DataContext as AdornedElementPlaceholder : null;
-                if (holder != null && holder.AdornedElement != null)
+                var adornedElement = this.GetAdornedElement();
+                if (adornedElement != null)
                 {
                     this.PopupAnimation = PopupAnimation.None;
                     this.IsOpen = false;
-                    var errorTemplate = holder.AdornedElement.GetValue(Validation.ErrorTemplateProperty);
-                    holder.AdornedElement.SetValue(Validation.ErrorTemplateProperty, null);
-                    holder.AdornedElement.SetValue(Validation.ErrorTemplateProperty, errorTemplate);
+                    var errorTemplate = adornedElement.GetValue(Validation.ErrorTemplateProperty);
+                    adornedElement.SetValue(Validation.ErrorTemplateProperty, null);
+                    adornedElement.SetValue(Validation.ErrorTemplateProperty, errorTemplate);
                 }
             }
         }

--- a/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+using System.Windows;
+
+namespace MahApps.Metro.Controls
+{
+    public static class ValidationHelper
+    {
+        public static readonly DependencyProperty ShowValidationErrorOnMouseOverProperty
+            = DependencyProperty.RegisterAttached("ShowValidationErrorOnMouseOver",
+                                                  typeof(bool),
+                                                  typeof(ValidationHelper),
+                                                  new PropertyMetadata(false));
+
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static bool GetShowValidationErrorOnMouseOver(UIElement element)
+        {
+            return (bool)element.GetValue(ShowValidationErrorOnMouseOverProperty);
+        }
+
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetShowValidationErrorOnMouseOver(UIElement element, bool value)
+        {
+            element.SetValue(ShowValidationErrorOnMouseOverProperty, value);
+        }
+    }
+}

--- a/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
@@ -6,6 +6,35 @@ namespace MahApps.Metro.Controls
     public static class ValidationHelper
     {
         /// <summary>
+        /// Identifies the CloseOnMouseLeftButtonDown attached property.
+        /// </summary>
+        public static readonly DependencyProperty CloseOnMouseLeftButtonDownProperty
+            = DependencyProperty.RegisterAttached("CloseOnMouseLeftButtonDown",
+                                                  typeof(bool),
+                                                  typeof(ValidationHelper),
+                                                  new PropertyMetadata(false));
+
+        /// <summary>
+        /// Gets whether if the popup can be closed by left mouse button down.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static bool GetCloseOnMouseLeftButtonDown(UIElement element)
+        {
+            return (bool)element.GetValue(CloseOnMouseLeftButtonDownProperty);
+        }
+
+        /// <summary>
+        /// Sets whether if the popup can be closed by left mouse button down.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetCloseOnMouseLeftButtonDown(UIElement element, bool value)
+        {
+            element.SetValue(CloseOnMouseLeftButtonDownProperty, value);
+        }
+
+        /// <summary>
         /// Identifies the ShowValidationErrorOnMouseOver attached property.
         /// </summary>
         public static readonly DependencyProperty ShowValidationErrorOnMouseOverProperty

--- a/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
@@ -5,12 +5,18 @@ namespace MahApps.Metro.Controls
 {
     public static class ValidationHelper
     {
+        /// <summary>
+        /// Identifies the ShowValidationErrorOnMouseOver attached property.
+        /// </summary>
         public static readonly DependencyProperty ShowValidationErrorOnMouseOverProperty
             = DependencyProperty.RegisterAttached("ShowValidationErrorOnMouseOver",
                                                   typeof(bool),
                                                   typeof(ValidationHelper),
                                                   new PropertyMetadata(false));
 
+        /// <summary>
+        /// Gets whether the validation error text will be shown when hovering the validation triangle.
+        /// </summary>
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(UIElement))]
         public static bool GetShowValidationErrorOnMouseOver(UIElement element)
@@ -18,6 +24,9 @@ namespace MahApps.Metro.Controls
             return (bool)element.GetValue(ShowValidationErrorOnMouseOverProperty);
         }
 
+        /// <summary>
+        /// Sets whether the validation error text will be shown when hovering the validation triangle.
+        /// </summary>
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(UIElement))]
         public static void SetShowValidationErrorOnMouseOver(UIElement element, bool value)

--- a/src/MahApps.Metro/Styles/ValidationErrorTemplate.xaml
+++ b/src/MahApps.Metro/Styles/ValidationErrorTemplate.xaml
@@ -22,7 +22,8 @@
                         BorderThickness="1"
                         DataContext="{Binding ElementName=placeholder}">
 
-                    <Grid Width="12"
+                    <Grid x:Name="RedTriangle" 
+                          Width="12"
                           Height="12"
                           Margin="1 -4 -4 0"
                           HorizontalAlignment="Right"
@@ -121,6 +122,13 @@
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay}" Value="True" />
+                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.HasError), Mode=OneWay}" Value="True" />
+                </MultiDataTrigger.Conditions>
+                <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding ElementName=RedTriangle, Path=IsMouseOver, Mode=OneWay}" Value="True" />
                     <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.HasError), Mode=OneWay}" Value="True" />
                 </MultiDataTrigger.Conditions>
                 <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />

--- a/src/MahApps.Metro/Styles/ValidationErrorTemplate.xaml
+++ b/src/MahApps.Metro/Styles/ValidationErrorTemplate.xaml
@@ -1,8 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
 
-    <Style x:Key="MetroValidationPopup" TargetType="{x:Type Controls:CustomValidationPopup}">
+    <Style x:Key="MetroValidationPopup" TargetType="{x:Type mah:CustomValidationPopup}">
         <Setter Property="HorizontalAlignment" Value="Right" />
         <Setter Property="HorizontalOffset" Value="0" />
         <Setter Property="Placement" Value="Right" />
@@ -22,7 +22,7 @@
                         BorderThickness="1"
                         DataContext="{Binding ElementName=placeholder}">
 
-                    <Grid x:Name="RedTriangle" 
+                    <Grid x:Name="RedTriangle"
                           Width="12"
                           Height="12"
                           Margin="1 -4 -4 0"
@@ -38,10 +38,10 @@
                     </Grid>
                 </Border>
 
-                <Controls:CustomValidationPopup x:Name="ValidationPopup"
-                                                AllowsTransparency="True"
-                                                IsOpen="False"
-                                                PlacementTarget="{Binding ElementName=PopupTargetElement, Mode=OneWay}">
+                <mah:CustomValidationPopup x:Name="ValidationPopup"
+                                           AllowsTransparency="True"
+                                           IsOpen="False"
+                                           PlacementTarget="{Binding ElementName=PopupTargetElement, Mode=OneWay}">
                     <Grid x:Name="Root" Margin="4">
                         <Grid.Resources>
                             <Style TargetType="Border">
@@ -114,7 +114,7 @@
                             <ItemsControl ItemsSource="{Binding}" />
                         </Border>
                     </Grid>
-                </Controls:CustomValidationPopup>
+                </mah:CustomValidationPopup>
             </Grid>
         </AdornedElementPlaceholder>
 
@@ -130,6 +130,15 @@
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding ElementName=RedTriangle, Path=IsMouseOver, Mode=OneWay}" Value="True" />
                     <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.HasError), Mode=OneWay}" Value="True" />
+                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(mah:ValidationHelper.ShowValidationErrorOnMouseOver), Mode=OneWay}" Value="True" />
+                </MultiDataTrigger.Conditions>
+                <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding ElementName=RedTriangle, Path=IsMouseOver, Mode=OneWay}" Value="True" />
+                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.HasError), Mode=OneWay}" Value="True" />
+                    <Condition Binding="{Binding ElementName=ValidationPopup, Path=ShowValidationErrorOnMouseOver, Mode=OneWay}" Value="True" />
                 </MultiDataTrigger.Conditions>
                 <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
             </MultiDataTrigger>


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Added a MouseOver Trigger to the Validation Template to show the Error Message.

- Add a new `ValidationHelper` static class for Validation.
- Add an attached property `ShowValidationErrorOnMouseOver` which can control this feature for a single control.
- Add also the same property to the `CustomValidationPopup` class to allow setting this behavior to all controls.
- Add an attached property `CloseOnMouseLeftButtonDown` to the `ValidationHelper` to enable setting this behavior for a single control.

**Additional context**

![image](https://user-images.githubusercontent.com/47110241/60399163-e3a64080-9b60-11e9-8d3c-1066b3957f71.png)

**Closed Issues**

Closes #3539 
