### PR TITLE
[GH-3544] Add null check for Application.Current

### DIFF
--- a/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
+++ b/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
@@ -42,7 +42,10 @@ namespace MahApps.Metro.Behaviors
             window.Closing += this.AssociatedObject_Closing;
             window.Closed += this.AssociatedObject_Closed;
 
-            Application.Current.SessionEnding += this.CurrentApplicationSessionEnding;
+            if (Application.Current != null) // In case the Window is hosted in a WinForm app
+            {
+                Application.Current.SessionEnding += this.CurrentApplicationSessionEnding;
+            }
         }
 
         private void AssociatedObject_Closing(object sender, System.ComponentModel.CancelEventArgs e)
@@ -63,7 +66,7 @@ namespace MahApps.Metro.Behaviors
         private void AssociatedObject_StateChanged(object sender, EventArgs e)
         {
             // save the settings on this state change, because hidden windows gets no window placements
-            // all the saving stuff could be so much easier with ReactiveUI :-D 
+            // all the saving stuff could be so much easier with ReactiveUI :-D
             if (this.AssociatedObject?.WindowState == WindowState.Minimized)
             {
                 this.SaveWindowState();
@@ -87,7 +90,10 @@ namespace MahApps.Metro.Behaviors
             window.Closed -= this.AssociatedObject_Closed;
             window.SourceInitialized -= this.AssociatedObject_SourceInitialized;
 
-            Application.Current.SessionEnding -= this.CurrentApplicationSessionEnding;
+            if (Application.Current != null) // In case the Window is hosted in a WinForm app
+            {
+                Application.Current.SessionEnding -= this.CurrentApplicationSessionEnding;
+            }
         }
 
 #pragma warning disable 618

--- a/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -139,7 +139,7 @@ namespace MahApps.Metro.Controls.Dialogs
                 }));
             }).Unwrap();
         }
-       
+
         /// <summary>
         /// Creates a MessageDialog inside of the current window.
         /// </summary>
@@ -584,7 +584,7 @@ namespace MahApps.Metro.Controls.Dialogs
         private static Window SetupExternalDialogWindow(BaseMetroDialog dialog, [CanBeNull] Window windowOwner = null)
         {
             var win = CreateExternalWindow();
-            win.Owner = windowOwner ?? Application.Current.MainWindow;
+            win.Owner = windowOwner ?? Application.Current?.MainWindow;
             win.Width = SystemParameters.PrimaryScreenWidth;
             win.MinHeight = SystemParameters.PrimaryScreenHeight / 4.0;
             win.SizeToContent = SizeToContent.Height;
@@ -618,7 +618,7 @@ namespace MahApps.Metro.Controls.Dialogs
             win.Width = window.ActualWidth;
             win.MaxHeight = window.ActualHeight;
             win.SizeToContent = SizeToContent.Height;
-            
+
             return win;
         }
 
@@ -644,7 +644,7 @@ namespace MahApps.Metro.Controls.Dialogs
             };
 
             SetDialogFontSizes(settings, dialog);
-            
+
             win.Content = dialog;
 
             LoginDialogData result = null;

--- a/src/MahApps.Metro/ThemeManager/ThemeManager.cs
+++ b/src/MahApps.Metro/ThemeManager/ThemeManager.cs
@@ -374,10 +374,21 @@ namespace MahApps.Metro
         /// <returns>The resource object or null, if the resource wasn't found.</returns>
         public static object GetResourceFromAppStyle(Window window, string key)
         {
-            var appStyle = (window.IsNull()
+            Theme appStyle;
+
+            if (Application.Current.IsNull()) // In case the Window is hosted in a WinForm app
+            {
+                appStyle = !window.IsNull()
+                                ? DetectTheme(window)
+                                : null;
+            }
+            else
+            {
+                appStyle = (window.IsNull()
                                 ? DetectTheme(Application.Current)
                                 : DetectTheme(window))
-                           ?? DetectTheme(Application.Current);
+                            ?? DetectTheme(Application.Current);
+            }
 
             var resource = appStyle?.Resources[key];
 
@@ -786,8 +797,9 @@ namespace MahApps.Metro
                 }
             }
 
-            // ReSharper disable once AssignNullToNotNullAttribute
-            return DetectTheme(Application.Current);
+            return Application.Current != null // In case the Window is hosted in a WinForm app
+                ? DetectTheme(Application.Current)
+                : null;
         }
 
         /// <summary>
@@ -804,7 +816,9 @@ namespace MahApps.Metro
             }
 
             var detectedStyle = DetectTheme(window.Resources)
-                                ?? DetectTheme(Application.Current.Resources);
+                                ?? (Application.Current != null // In case the Window is hosted in a WinForm app
+                                        ? DetectTheme(Application.Current.Resources)
+                                        : null);
 
             return detectedStyle;
         }
@@ -937,7 +951,10 @@ namespace MahApps.Metro
                                ? BaseColorLight
                                : BaseColorDark;
 
-            ChangeThemeBaseColor(Application.Current, baseColor);
+            if (Application.Current != null) // In case the Window is hosted in a WinForm app
+            {
+                ChangeThemeBaseColor(Application.Current, baseColor);
+            }
         }
 
         private static bool isAutomaticWindowsAppModeSettingSyncEnabled;


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Add null checks for usage of `Application.Current` in the main part of the library. Note that the demo and the unit tests haven't been updated as they are unlikely to be used wrapped in a WinForm App.

**Unit test**

No unit test added but if needed I can add a new test project with a WinForm app hosting the WPF MahApps window.

**Additional context**

**Closed Issues**

Fix #3544 