### PR TITLE
Improve check for RD "equality"

### DIFF
--- a/src/MahApps.Metro/ThemeManager/ThemeManager.cs
+++ b/src/MahApps.Metro/ThemeManager/ThemeManager.cs
@@ -913,8 +913,13 @@ namespace MahApps.Metro
                 return false;
             }
 
-            if (first.Source.IsNull()
+            // If RD does not have a source, but both have keys and the first one has at least as many keys as the second,
+            // then compares their values.
+            if ((first.Source.IsNull()
                 || second.Source.IsNull())
+                && first.Keys.Count > 0
+                && second.Keys.Count > 0
+                && first.Keys.Count >= second.Keys.Count)
             {
                 try
                 {


### PR DESCRIPTION
Only check RDs that have keys and only if first RD has at least as many keys as second.
Otherwise we might detect RDs as equal that have zero keys.
Checking if the first RD has at least as many keys as the second just ensures that we don't compare apples with pineapples ;-)