### PR TITLE
Renamed SemiTransparentGrey to SemiTransparentGray 

### DIFF
--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -337,7 +337,7 @@
            TargetType="{x:Type Button}">
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.SemiTransparentGrey}" />
+                <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.SemiTransparentGray}" />
             </Trigger>
             <Trigger Property="IsPressed" Value="True">
                 <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Accent}" />

--- a/src/MahApps.Metro/Styles/Themes/Theme.Template.xaml
+++ b/src/MahApps.Metro/Styles/Themes/Theme.Template.xaml
@@ -74,7 +74,7 @@
 
     <SolidColorBrush x:Key="MahApps.Brushes.TransparentWhite" Color="#00FFFFFF" options:Freeze="True" />
     <SolidColorBrush x:Key="MahApps.Brushes.SemiTransparentWhite" Color="#55FFFFFF" options:Freeze="True" />
-    <SolidColorBrush x:Key="MahApps.Brushes.SemiTransparentGrey" Color="#40808080" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.SemiTransparentGray" Color="#40808080" options:Freeze="True" />
     <SolidColorBrush x:Key="MahApps.Brushes.Controls.Disabled" Color="#A5FFFFFF" options:Freeze="True" />
 
     <SolidColorBrush x:Key="MahApps.Brushes.AccentBase" Color="{StaticResource MahApps.Colors.AccentBase}" options:Freeze="True" />

--- a/src/MahApps.Metro/Styles/Themes/Theme.Template.xaml
+++ b/src/MahApps.Metro/Styles/Themes/Theme.Template.xaml
@@ -186,7 +186,7 @@
     <SolidColorBrush x:Key="MahApps.Brushes.MenuItem.DisabledForeground" Color="{{MahApps.Colors.MenuItem.DisabledForeground}}" options:Freeze="True" />
     <SolidColorBrush x:Key="MahApps.Brushes.MenuItem.DisabledGlyphPanel" Color="#848589" options:Freeze="True" />
 
-     <SolidColorBrush x:Key="{x:Static SystemColors.MenuTextBrushKey}" Color="{StaticResource MahApps.Colors.Black}" options:Freeze="True" />
+    <SolidColorBrush x:Key="{x:Static SystemColors.MenuTextBrushKey}" Color="{StaticResource MahApps.Colors.Black}" options:Freeze="True" />
 
     <SolidColorBrush x:Key="MahApps.Brushes.CheckmarkFill" Color="{StaticResource MahApps.Colors.Accent}" options:Freeze="True" />
     <SolidColorBrush x:Key="MahApps.Brushes.RightArrowFill" Color="{StaticResource MahApps.Colors.Accent}" options:Freeze="True" />


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Renamed the ResourceKey `SemiTransparentGrey `to `SemiTransparentGray ` to be consistent with the other `Gray` Resources

**Closed Issues**

Closes #3575 
