### PR TITLE
(GH-3592) Fix HamburgerVisibility "Collapsed" state

### DIFF
--- a/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
@@ -357,7 +357,6 @@
                         </Grid.RowDefinitions>
                         <DockPanel x:Name="PaneHeader"
                                    Grid.Row="0"
-                                   Height="{TemplateBinding HamburgerHeight}"
                                    Margin="{TemplateBinding PaneHeaderMargin}"
                                    LastChildFill="True">
                             <Button x:Name="HamburgerButton"


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

The height of the inner `PaneHeader` DockPanel was set to the HamburgerHeight. This is wrong because it'll already set by the inner `HamburgerButton`.

**Closed Issues**

Closes #3592 