### PR TITLE
Add a Style for the GridSplitter-Control

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SplitViewExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SplitViewExamples.xaml
@@ -61,7 +61,6 @@
                                Text="DisplayMode" />
                     <ComboBox Grid.Row="1"
                               Grid.Column="1"
-                              Width="100"
                               Margin="2"
                               VerticalAlignment="Center"
                               SelectedValue="{Binding DisplayMode}">
@@ -78,7 +77,6 @@
                                Text="PanePlacement" />
                     <ComboBox Grid.Row="2"
                               Grid.Column="1"
-                              Width="100"
                               Margin="2"
                               VerticalAlignment="Center"
                               SelectedValue="{Binding PanePlacement}">
@@ -105,8 +103,9 @@
     <Grid>
 
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" MinWidth="200" />
+            <ColumnDefinition Width="3" />
+            <ColumnDefinition Width="4*" MinWidth="100" />
         </Grid.ColumnDefinitions>
 
         <Grid.RowDefinitions>
@@ -117,7 +116,7 @@
 
         <Label Grid.Row="0"
                Grid.Column="0"
-               Grid.ColumnSpan="2"
+               Grid.ColumnSpan="3"
                HorizontalAlignment="Left"
                Content="Simple SplitView example"
                Style="{DynamicResource DescriptionHeaderStyle}" />
@@ -128,9 +127,11 @@
                         DataContext="{Binding ElementName=SimpleSplitview}"
                         Template="{StaticResource ConfigDataTemplate}" />
 
+        <GridSplitter Grid.Column="1" Grid.Row="1" ResizeBehavior="PreviousAndNext" />
+
         <controls:SplitView x:Name="SimpleSplitview"
                             Grid.Row="1"
-                            Grid.Column="1"
+                            Grid.Column="2"
                             Margin="5"
                             DisplayMode="Inline"
                             IsPaneOpen="True"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SplitViewExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SplitViewExamples.xaml
@@ -127,7 +127,9 @@
                         DataContext="{Binding ElementName=SimpleSplitview}"
                         Template="{StaticResource ConfigDataTemplate}" />
 
-        <GridSplitter Grid.Column="1" Grid.Row="1" ResizeBehavior="PreviousAndNext" />
+        <GridSplitter Grid.Row="1"
+                      Grid.Column="1"
+                      ResizeBehavior="PreviousAndNext" />
 
         <controls:SplitView x:Name="SimpleSplitview"
                             Grid.Row="1"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -187,7 +187,7 @@
                              SpellCheck.IsEnabled="True">
                     <!--
                         Workaround for: RichTextBox behaves oddly inside a ScrollViewer
-
+                        
                         The workaround would be to bind the Documents PageWidth to the RichTextBox's ActualWidth
                     -->
                     <FlowDocument PageWidth="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type RichTextBox}}, Path=ActualWidth}">

--- a/src/MahApps.Metro/MahApps.Metro.csproj
+++ b/src/MahApps.Metro/MahApps.Metro.csproj
@@ -43,4 +43,9 @@
         <Compile DependentUpon="%(Filename)" SubType="Code" Update="**\obj\**\*.g$(DefaultLanguageSourceExtension)" />
         <Compile DependentUpon="%(Filename)" SubType="Designer" Update="**\*.xaml$(DefaultLanguageSourceExtension)" />
     </ItemGroup>
+    <ItemGroup>
+      <None Update="Styles\Controls.GridSplitter">
+        <Generator>MSBuild:Compile</Generator>
+      </None>
+    </ItemGroup>
 </Project>

--- a/src/MahApps.Metro/Styles/Controls.GridSplitter.xaml
+++ b/src/MahApps.Metro/Styles/Controls.GridSplitter.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    
-    <Style x:Key="MahApps.Styles.GridSplitter.Preview" >
+
+    <Style x:Key="MahApps.Styles.GridSplitter.Preview">
         <Setter Property="Control.Template">
             <Setter.Value>
                 <ControlTemplate>
@@ -11,12 +11,12 @@
         </Setter>
     </Style>
 
-    <Style x:Key="MahApps.Styles.GridSplitter" TargetType="{x:Type GridSplitter}" >
+    <Style x:Key="MahApps.Styles.GridSplitter" TargetType="{x:Type GridSplitter}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-        <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
-        <Setter Property="ShowsPreview" Value="True" />
         <Setter Property="PreviewStyle" Value="{StaticResource MahApps.Styles.GridSplitter.Preview}" />
+        <Setter Property="ShowsPreview" Value="True" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
     </Style>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro/Styles/Controls.GridSplitter.xaml
+++ b/src/MahApps.Metro/Styles/Controls.GridSplitter.xaml
@@ -1,0 +1,22 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    
+    <Style x:Key="MahApps.Styles.GridSplitter.Preview" >
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Rectangle Fill="{DynamicResource MahApps.Brushes.Black}" Opacity="0.5" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="MahApps.Styles.GridSplitter" TargetType="{x:Type GridSplitter}" >
+        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="ShowsPreview" Value="True" />
+        <Setter Property="PreviewStyle" Value="{StaticResource MahApps.Styles.GridSplitter.Preview}" />
+    </Style>
+
+</ResourceDictionary>

--- a/src/MahApps.Metro/Styles/Controls.xaml
+++ b/src/MahApps.Metro/Styles/Controls.xaml
@@ -118,5 +118,5 @@
     <Style BasedOn="{StaticResource MahApps.Styles.StatusBarItem}" TargetType="StatusBarItem" />
     <Style BasedOn="{StaticResource MahApps.Styles.ScrollViewer}" TargetType="ScrollViewer" />
     <Style BasedOn="{StaticResource MahApps.Styles.GridSplitter}" TargetType="GridSplitter" />
-    
+
 </ResourceDictionary>

--- a/src/MahApps.Metro/Styles/Controls.xaml
+++ b/src/MahApps.Metro/Styles/Controls.xaml
@@ -18,6 +18,7 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.DatePicker.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.DataGrid.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Expander.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.GridSplitter.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.GroupBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.ListBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.PasswordBox.xaml" />
@@ -116,5 +117,6 @@
     <Style BasedOn="{StaticResource MahApps.Styles.StatusBar}" TargetType="StatusBar" />
     <Style BasedOn="{StaticResource MahApps.Styles.StatusBarItem}" TargetType="StatusBarItem" />
     <Style BasedOn="{StaticResource MahApps.Styles.ScrollViewer}" TargetType="ScrollViewer" />
-
+    <Style BasedOn="{StaticResource MahApps.Styles.GridSplitter}" TargetType="GridSplitter" />
+    
 </ResourceDictionary>

--- a/src/MahApps.Metro/Styles/VS/ListBox.xaml
+++ b/src/MahApps.Metro/Styles/VS/ListBox.xaml
@@ -15,9 +15,9 @@
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
                     <Grid Margin="4 0 4 4">
                         <Border Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="1"
-                                        SnapsToDevicePixels="True" />
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="1"
+                                SnapsToDevicePixels="True" />
                         <ContentPresenter Margin="8 5" />
                     </Grid>
                     <ControlTemplate.Triggers>


### PR DESCRIPTION
**Describe the changes you have made to improve this project**
- Added a Style for the `GridSplitter`-Control
- Make the new Style the default
- Updated the `SplitView`-Example with a `GridSplitter`

**Unit test**
I don't know, sorry!

**Additional context**
Light-Mode:
![image](https://user-images.githubusercontent.com/47110241/65424371-b12c7c80-de0b-11e9-8c3e-dd2f32948598.png)

Dark-Mode:
![image](https://user-images.githubusercontent.com/47110241/65424404-c73a3d00-de0b-11e9-861f-f548337722ba.png)

**Closed Issues**

Closes #3612 
