### PR TITLE
HamburgerMenu: Allow using own items together with the new HamburgerMenuItemStyleSelector

### DIFF
--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItem.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItem.cs
@@ -7,7 +7,7 @@ namespace MahApps.Metro.Controls
     /// <summary>
     /// The HamburgerMenuItem provides an implementation for HamburgerMenu entries.
     /// </summary>
-    public class HamburgerMenuItem : HamburgerMenuItemBase, ICommandSource
+    public class HamburgerMenuItem : HamburgerMenuItemBase, IHamburgerMenuItem, ICommandSource
     {
         /// <summary>
         /// Identifies the <see cref="Label"/> dependency property.

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemStyleSelector.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemStyleSelector.cs
@@ -19,14 +19,14 @@ namespace MahApps.Metro.Controls
                 var hamburgerMenu = listBox?.TryFindParent<HamburgerMenu>();
                 if (hamburgerMenu != null)
                 {
-                    if (item is HamburgerMenuSeparatorItem)
+                    if (item is IHamburgerMenuSeparatorItem)
                     {
                         if (hamburgerMenu.SeparatorItemContainerStyle != null)
                         {
                             return hamburgerMenu.SeparatorItemContainerStyle;
                         }
                     }
-                    else if (item is HamburgerMenuItem)
+                    else
                     {
                         var itemContainerStyle = this.IsItemOptions ? hamburgerMenu.OptionsItemContainerStyle : hamburgerMenu.ItemContainerStyle;
                         if (itemContainerStyle != null)

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuSeparatorItem.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuSeparatorItem.cs
@@ -5,7 +5,7 @@ namespace MahApps.Metro.Controls
     /// <summary>
     /// The HamburgerMenuSeparatorItem provides an separator based implementation for HamburgerMenu entries.
     /// </summary>
-    public class HamburgerMenuSeparatorItem : HamburgerMenuItemBase
+    public class HamburgerMenuSeparatorItem : HamburgerMenuItemBase, IHamburgerMenuSeparatorItem
     {
         protected override Freezable CreateInstanceCore()
         {

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/IHamburgerMenuItem.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/IHamburgerMenuItem.cs
@@ -1,0 +1,13 @@
+﻿namespace MahApps.Metro.Controls
+{
+    public interface IHamburgerMenuItem
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether this item is enabled in the user interface (UI).
+        /// </summary>
+        /// <returns>
+        /// true if the item is enabled; otherwise, false. The default value is true.
+        /// </returns>
+        bool IsEnabled { get; set; }
+    }
+}

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/IHamburgerMenuSeparatorItem.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/IHamburgerMenuSeparatorItem.cs
@@ -1,0 +1,6 @@
+﻿namespace MahApps.Metro.Controls
+{
+    public interface IHamburgerMenuSeparatorItem
+    {
+    }
+}


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

The new style selector doesn't work together with other items then directly derived from HamburgerMenuItem class. This commit fixes this, so it's possible to use any other classes too. Additionally it's possible to use classes derived from the new interface IHamburgerMenuItem.
