### PR TITLE
Fix that makes ContextMenu work with VS theme

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/VSDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/VSDemo.xaml
@@ -172,6 +172,29 @@
                         </Expander>
                     </Grid>
                 </TabItem>
+                <TabItem Header="Demo">
+                    <Grid>
+                        <Button HorizontalAlignment="Center" VerticalAlignment="Center" Content="This button has a context menu" Padding="4,0,4,0">
+                            <Button.ContextMenu>
+                                <ContextMenu>
+                                    <MenuItem Header="Item One"/>
+                                    <MenuItem Header="Item Two"/>
+                                    <MenuItem Header="Rockets">
+                                        <MenuItem Header="Rocket slot 1">
+                                            <MenuItem Header="Fire slot" />
+                                            <Separator />
+                                            <MenuItem Header="Reload slot" />
+                                            <MenuItem Header="Report damage to control room" />
+                                        </MenuItem>
+                                        <MenuItem Header="Rocket slot 2">
+                                            <MenuItem Header="damaged .. being repaired" IsEnabled="False" />
+                                        </MenuItem>
+                                    </MenuItem>
+                                </ContextMenu>
+                            </Button.ContextMenu>
+                        </Button>
+                    </Grid>
+                </TabItem>
                 <TabItem Header="Manage Rockets">
                     <DockPanel>
                         <Button Width="200"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/VSDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/VSDemo.xaml
@@ -174,11 +174,14 @@
                 </TabItem>
                 <TabItem Header="Demo">
                     <Grid>
-                        <Button HorizontalAlignment="Center" VerticalAlignment="Center" Content="This button has a context menu" Padding="4,0,4,0">
+                        <Button Padding="4 0 4 0"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Content="This button has a context menu">
                             <Button.ContextMenu>
                                 <ContextMenu>
-                                    <MenuItem Header="Item One"/>
-                                    <MenuItem Header="Item Two"/>
+                                    <MenuItem Header="Item One" />
+                                    <MenuItem Header="Item Two" />
                                     <MenuItem Header="Rockets">
                                         <MenuItem Header="Rocket slot 1">
                                             <MenuItem Header="Fire slot" />

--- a/src/MahApps.Metro/Styles/VS/Button.xaml
+++ b/src/MahApps.Metro/Styles/VS/Button.xaml
@@ -5,6 +5,10 @@
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Background.Normal}" />
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Border.Normal}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Foreground}" />
+        <Setter Property="Height" Value="23"/>
+        <Setter Property="Padding" Value="1"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -13,7 +17,9 @@
                             BorderThickness="1"
                             SnapsToDevicePixels="True">
                         <Grid>
-                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            <ContentPresenter Margin="{TemplateBinding Padding}" 
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>

--- a/src/MahApps.Metro/Styles/VS/Button.xaml
+++ b/src/MahApps.Metro/Styles/VS/Button.xaml
@@ -5,10 +5,9 @@
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Background.Normal}" />
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Border.Normal}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Foreground}" />
-        <Setter Property="Height" Value="23"/>
-        <Setter Property="Padding" Value="1"/>
-        <Setter Property="HorizontalContentAlignment" Value="Center"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Height" Value="23" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="Padding" Value="1" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -17,8 +16,8 @@
                             BorderThickness="1"
                             SnapsToDevicePixels="True">
                         <Grid>
-                            <ContentPresenter Margin="{TemplateBinding Padding}" 
-                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                            <ContentPresenter Margin="{TemplateBinding Padding}"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                         </Grid>
                     </Border>
@@ -38,6 +37,7 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 
     <Style x:Key="MahApps.Styles.Button.Link.VisualStudio" TargetType="Button">

--- a/src/MahApps.Metro/Styles/VS/Colors.xaml
+++ b/src/MahApps.Metro/Styles/VS/Colors.xaml
@@ -1,8 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:System="clr-namespace:System;assembly=mscorlib"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
-                    xmlns:System="clr-namespace:System;assembly=mscorlib"
                     mc:Ignorable="options">
 
     <!--  Background  -->
@@ -12,6 +12,7 @@
     <Color x:Key="MahApps.Colors.Accent">#2D2D30</Color>
     <Color x:Key="MahApps.Colors.Black">#FFFFFFFF</Color>
     <Color x:Key="MahApps.Colors.White">#2D2D30</Color>
+    <Color x:Key="MahApps.Colors.MenuShadow">#FF000000</Color>
 
     <!--  re-set brushes too  -->
     <SolidColorBrush x:Key="MahApps.Brushes.Highlight" Color="{StaticResource MahApps.Colors.Highlight}" options:Freeze="True" />

--- a/src/MahApps.Metro/Styles/VS/Colors.xaml
+++ b/src/MahApps.Metro/Styles/VS/Colors.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:System="clr-namespace:System;assembly=mscorlib"
                     mc:Ignorable="options">
 
     <!--  Background  -->
@@ -84,6 +85,11 @@
     <SolidColorBrush x:Key="MahApps.Brushes.SubmenuItem.Background" Color="#1B1B1C" options:Freeze="True" />
     <SolidColorBrush x:Key="MahApps.Brushes.SubmenuItem.BackgroundHighlighted" Color="#333334" options:Freeze="True" />
     <SolidColorBrush x:Key="MahApps.Brushes.Menu.ForegroundDisabled" Color="#656565" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.ContextMenu.Background" Color="#1B1B1C" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.ContextMenu.Border" Color="#333337" options:Freeze="True" />
+    <SolidColorBrush x:Key="{x:Static SystemColors.MenuTextBrushKey}" Color="#FFFFFF" options:Freeze="True" />
+    <System:Double x:Key="MahApps.Sizes.Font.ContextMenu">12</System:Double>
+
 
     <!--  Scroll Bar  -->
     <SolidColorBrush x:Key="MahApps.Brushes.ScrollBar.PageButtonBackgroundHighlighted" Color="#05FFFFFF" options:Freeze="True" />

--- a/src/MahApps.Metro/Styles/VS/Menu.xaml
+++ b/src/MahApps.Metro/Styles/VS/Menu.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}" TargetType="Separator">
@@ -20,7 +20,7 @@
     </Style>
 
     <Style x:Key="MahApps.Styles.MenuItem.VisualStudio" TargetType="{x:Type MenuItem}">
-        <Setter Property="Foreground" Value="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type Menu}}}" />
+        <Setter Property="Foreground" Value="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type MenuBase}}}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type MenuItem}">

--- a/src/MahApps.Metro/Styles/VS/Menu.xaml
+++ b/src/MahApps.Metro/Styles/VS/Menu.xaml
@@ -250,4 +250,10 @@
         </Setter>
     </Style>
 
+    <ContextMenu x:Key="MahApps.TextBox.ContextMenu" Style="{StaticResource MahApps.Styles.ContextMenu.VisualStudio}">
+        <MenuItem Command="ApplicationCommands.Cut" Style="{DynamicResource MahApps.Styles.MenuItem.VisualStudio}" />
+        <MenuItem Command="ApplicationCommands.Copy" Style="{DynamicResource MahApps.Styles.MenuItem.VisualStudio}" />
+        <MenuItem Command="ApplicationCommands.Paste" Style="{DynamicResource MahApps.Styles.MenuItem.VisualStudio}" />
+    </ContextMenu>
+
 </ResourceDictionary>

--- a/src/MahApps.Metro/Styles/VS/Menu.xaml
+++ b/src/MahApps.Metro/Styles/VS/Menu.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}" TargetType="Separator">
@@ -16,7 +16,65 @@
 
     <Style x:Key="MahApps.Styles.Menu.VisualStudio" TargetType="{x:Type Menu}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.LightBackground}" />
-        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Foreground}" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.MenuTextBrushKey}}" />
+    </Style>
+
+    <Style x:Key="MahApps.Styles.ContextMenu.VisualStudio" TargetType="{x:Type ContextMenu}">
+        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.ContextMenu.Background}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.ContextMenu.Border}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.MenuFontFamilyKey}}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.ContextMenu}" />
+        <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.MenuFontStyleKey}}" />
+        <Setter Property="FontWeight" Value="{DynamicResource {x:Static SystemFonts.MenuFontWeightKey}}" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.MenuTextBrushKey}}" />
+        <Setter Property="Grid.IsSharedSizeScope" Value="True" />
+        <Setter Property="HasDropShadow" Value="True" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Padding" Value="2" />
+        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ContextMenu}">
+                    <Grid>
+                        <Rectangle x:Name="LayoutRoot" Fill="{TemplateBinding Background}" />
+                        <Border x:Name="Border"
+                                Padding="{TemplateBinding Padding}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+
+                            <ScrollViewer x:Name="SubMenuScrollViewer"
+                                          CanContentScroll="True"
+                                          Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                                <ItemsPresenter x:Name="ItemsPresenter"
+                                                Margin="0"
+                                                Grid.IsSharedSizeScope="True"
+                                                KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                KeyboardNavigation.TabNavigation="Cycle"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </ScrollViewer>
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="HasDropShadow" Value="True">
+                            <Setter TargetName="Border" Property="Margin" Value="0 0 5 5" />
+                            <Setter TargetName="LayoutRoot" Property="Effect">
+                                <Setter.Value>
+                                    <DropShadowEffect ShadowDepth="2" Color="{DynamicResource MahApps.Colors.MenuShadow}" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter TargetName="LayoutRoot" Property="Margin" Value="0 0 5 5" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Ideal" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 
     <Style x:Key="MahApps.Styles.MenuItem.VisualStudio" TargetType="{x:Type MenuItem}">
@@ -85,7 +143,7 @@
                                             <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
                                         </Grid>
                                         <Border.Effect>
-                                            <DropShadowEffect ShadowDepth="2" Color="Black" />
+                                            <DropShadowEffect ShadowDepth="2" Color="{DynamicResource MahApps.Colors.MenuShadow}" />
                                         </Border.Effect>
                                     </Border>
                                     <!--  Border 3  -->

--- a/src/MahApps.Metro/Styles/VS/Styles.xaml
+++ b/src/MahApps.Metro/Styles/VS/Styles.xaml
@@ -13,12 +13,12 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/VS/Expander.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style BasedOn="{StaticResource MahApps.Styles.Button.VisualStudio}" TargetType="Button" />
-    <Style BasedOn="{StaticResource MahApps.Styles.ListBox.VisualStudio}" TargetType="ListBox" />
-    <Style BasedOn="{StaticResource MahApps.Styles.ListBoxItem.VisualStudio}" TargetType="ListBoxItem" />
     <Style BasedOn="{StaticResource MahApps.Styles.MenuItem.VisualStudio}" TargetType="MenuItem" />
     <Style BasedOn="{StaticResource MahApps.Styles.Menu.VisualStudio}" TargetType="Menu" />
     <Style BasedOn="{StaticResource MahApps.Styles.ContextMenu.VisualStudio}" TargetType="ContextMenu" />
+    <Style BasedOn="{StaticResource MahApps.Styles.Button.VisualStudio}" TargetType="Button" />
+    <Style BasedOn="{StaticResource MahApps.Styles.ListBox.VisualStudio}" TargetType="ListBox" />
+    <Style BasedOn="{StaticResource MahApps.Styles.ListBoxItem.VisualStudio}" TargetType="ListBoxItem" />
     <Style BasedOn="{StaticResource MahApps.Styles.ScrollBar.VisualStudio}" TargetType="ScrollBar" />
     <Style BasedOn="{StaticResource MahApps.Styles.TabItem.VisualStudio}" TargetType="TabItem" />
     <Style BasedOn="{StaticResource MahApps.Styles.TabControl.VisualStudio}" TargetType="TabControl" />

--- a/src/MahApps.Metro/Styles/VS/Styles.xaml
+++ b/src/MahApps.Metro/Styles/VS/Styles.xaml
@@ -18,6 +18,7 @@
     <Style BasedOn="{StaticResource MahApps.Styles.ListBoxItem.VisualStudio}" TargetType="ListBoxItem" />
     <Style BasedOn="{StaticResource MahApps.Styles.MenuItem.VisualStudio}" TargetType="MenuItem" />
     <Style BasedOn="{StaticResource MahApps.Styles.Menu.VisualStudio}" TargetType="Menu" />
+    <Style BasedOn="{StaticResource MahApps.Styles.ContextMenu.VisualStudio}" TargetType="ContextMenu" />
     <Style BasedOn="{StaticResource MahApps.Styles.ScrollBar.VisualStudio}" TargetType="ScrollBar" />
     <Style BasedOn="{StaticResource MahApps.Styles.TabItem.VisualStudio}" TargetType="TabItem" />
     <Style BasedOn="{StaticResource MahApps.Styles.TabControl.VisualStudio}" TargetType="TabControl" />

--- a/src/MahApps.Metro/Styles/VS/TextBox.xaml
+++ b/src/MahApps.Metro/Styles/VS/TextBox.xaml
@@ -4,6 +4,7 @@
     <Style x:Key="MahApps.Styles.TextBox.VisualStudio" TargetType="{x:Type TextBox}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.TextBox.Background}" />
         <Setter Property="CaretBrush" Value="{DynamicResource MahApps.Brushes.Foreground}" />
+        <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Foreground}" />
         <Setter Property="Padding" Value="1" />
         <Setter Property="SnapsToDevicePixels" Value="True" />


### PR DESCRIPTION
- Added resources to make the ContextMenu look correct when using the VS theme
- Made minor improvements to the default Button style for the VS theme

This PR is a fix for #2864 

![ContextMenu](https://user-images.githubusercontent.com/1139118/66125520-708cea00-e5e7-11e9-959f-d71bc54370b0.gif)

- Add VS Context Menu style MahApps.Styles.ContextMenu.VisualStudio
- Override MahApps.TextBox.ContextMenu with the VS styles

![2019-10-03_18h15_14](https://user-images.githubusercontent.com/658431/66146032-397cff80-e60c-11e9-9c5c-1dfd14cf9a88.png)
