### PR TITLE
Add the ability to control button font size in dialogs via MetroDialogSettings

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
@@ -153,6 +153,7 @@
                           IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:MetroWindow}}, Path=ShowDialogsOverTitleBar}" />
                 <Separator />
                 <MenuItem Click="ShowInputDialog" Header="Show InputDialog" />
+                <MenuItem Click="ShowInputDialogCustomButtonSizes" Header="Show InputDialog (with custom button font sizes)" />
                 <MenuItem Click="ShowLoginDialog" Header="Show LoginDialog" />
                 <MenuItem Click="ShowLoginDialogPasswordPreview" Header="Show Password Preview LoginDialog" />
                 <MenuItem Click="ShowLoginDialogOnlyPassword" Header="Show LoginDialog (Only Password)" />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
@@ -146,7 +146,8 @@ namespace MetroDemo
                 AffirmativeButtonText = "Hi",
                 NegativeButtonText = "Go away!",
                 FirstAuxiliaryButtonText = "Cancel",
-                ColorScheme = MetroDialogOptions.ColorScheme
+                ColorScheme = MetroDialogOptions.ColorScheme,
+                DialogButtonFontSize = 20D
             };
 
             MessageDialogResult result = await this.ShowMessageAsync("Hello!", "Welcome to the world of metro!",
@@ -314,6 +315,20 @@ namespace MetroDemo
         private async void ShowInputDialog(object sender, RoutedEventArgs e)
         {
             var result = await this.ShowInputAsync("Hello!", "What is your name?");
+
+            if (result == null) //user pressed cancel
+                return;
+
+            await this.ShowMessageAsync("Hello", "Hello " + result + "!");
+        }
+
+        private async void ShowInputDialogCustomButtonSizes(object sender, RoutedEventArgs e)
+        {
+            var settings = new MetroDialogSettings
+            {
+                DialogButtonFontSize = 30D
+            };
+            var result = await this.ShowInputAsync("Hello!", "What is your name?", settings);
 
             if (result == null) //user pressed cancel
                 return;

--- a/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -103,12 +103,13 @@ namespace MahApps.Metro.Controls.Dialogs
         }
 
         /// <summary>Identifies the <see cref="DialogButtonFontSize"/> dependency property.</summary>
-        public static readonly DependencyProperty DialogButtonFontSizeProperty = DependencyProperty.Register(nameof(DialogButtonFontSize), typeof(double), typeof(BaseMetroDialog), new PropertyMetadata(12D));
+        public static readonly DependencyProperty DialogButtonFontSizeProperty = DependencyProperty.Register(nameof(DialogButtonFontSize), typeof(double), typeof(BaseMetroDialog), new PropertyMetadata(SystemFonts.MessageFontSize));
 
         /// <summary>
         /// Gets or sets the font size of any dialog buttons.
         /// </summary>
-        public double DialogButtonFontSize {
+        public double DialogButtonFontSize
+        {
             get { return (double)this.GetValue(DialogButtonFontSizeProperty); }
             set { this.SetValue(DialogButtonFontSizeProperty, value); }
         }

--- a/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -102,6 +102,17 @@ namespace MahApps.Metro.Controls.Dialogs
             set { this.SetValue(DialogMessageFontSizeProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="DialogButtonFontSize"/> dependency property.</summary>
+        public static readonly DependencyProperty DialogButtonFontSizeProperty = DependencyProperty.Register(nameof(DialogButtonFontSize), typeof(double), typeof(BaseMetroDialog), new PropertyMetadata(12D));
+
+        /// <summary>
+        /// Gets or sets the font size of any dialog buttons.
+        /// </summary>
+        public double DialogButtonFontSize {
+            get { return (double)this.GetValue(DialogButtonFontSizeProperty); }
+            set { this.SetValue(DialogButtonFontSizeProperty, value); }
+        }
+
         public MetroDialogSettings DialogSettings { get; private set; }
 
         internal SizeChangedEventHandler SizeChangedHandler { get; set; }

--- a/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -759,6 +759,10 @@ namespace MahApps.Metro.Controls.Dialogs
             {
                 dialog.DialogMessageFontSize = settings.DialogMessageFontSize;
             }
+            if (!double.IsNaN(settings.DialogButtonFontSize))
+            {
+                dialog.DialogButtonFontSize = settings.DialogButtonFontSize;
+            }
         }
 
         public static event EventHandler<DialogStateChangedEventArgs> DialogOpened;

--- a/src/MahApps.Metro/Controls/Dialogs/InputDialog.xaml
+++ b/src/MahApps.Metro/Controls/Dialogs/InputDialog.xaml
@@ -31,10 +31,12 @@
                     Orientation="Horizontal">
             <Button x:Name="PART_AffirmativeButton"
                     Margin="0 0 5 0"
+                    FontSize="{Binding DialogButtonFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Style="{DynamicResource MahApps.Styles.Button.Dialogs.Accent}" />
             <Button x:Name="PART_NegativeButton"
                     Margin="5 0 5 0"
+                    FontSize="{Binding DialogButtonFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:InputDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Style="{DynamicResource MahApps.Styles.Button.Dialogs}" />
         </StackPanel>

--- a/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml
+++ b/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml
@@ -50,10 +50,12 @@
                     Orientation="Horizontal">
             <Button x:Name="PART_AffirmativeButton"
                     Margin="0 0 5 0"
+                    FontSize="{Binding DialogButtonFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Style="{DynamicResource MahApps.Styles.Button.Dialogs.Accent}" />
             <Button x:Name="PART_NegativeButton"
                     Margin="5 0 5 0"
+                    FontSize="{Binding DialogButtonFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Style="{DynamicResource MahApps.Styles.Button.Dialogs}"
                     Visibility="{Binding NegativeButtonButtonVisibility, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />

--- a/src/MahApps.Metro/Controls/Dialogs/MessageDialog.xaml
+++ b/src/MahApps.Metro/Controls/Dialogs/MessageDialog.xaml
@@ -29,19 +29,23 @@
                     Orientation="Horizontal">
             <Button x:Name="PART_AffirmativeButton"
                     Margin="0 0 5 0"
+                    FontSize="{Binding DialogButtonFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Content="{Binding AffirmativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Style="{DynamicResource MahApps.Styles.Button.Dialogs}" />
             <Button x:Name="PART_NegativeButton"
                     Margin="5 0 5 0"
+                    FontSize="{Binding DialogButtonFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Style="{DynamicResource MahApps.Styles.Button.Dialogs}" />
             <Button x:Name="PART_FirstAuxiliaryButton"
                     Margin="5 0 5 0"
+                    FontSize="{Binding DialogButtonFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Content="{Binding FirstAuxiliaryButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Style="{DynamicResource MahApps.Styles.Button.Dialogs}"
                     Visibility="Collapsed" />
             <Button x:Name="PART_SecondAuxiliaryButton"
                     Margin="5 0 0 0"
+                    FontSize="{Binding DialogButtonFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Content="{Binding SecondAuxiliaryButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:MessageDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                     Style="{DynamicResource MahApps.Styles.Button.Dialogs}"
                     Visibility="Collapsed" />

--- a/src/MahApps.Metro/Controls/Dialogs/MetroDialogSettings.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/MetroDialogSettings.cs
@@ -26,6 +26,7 @@ namespace MahApps.Metro.Controls.Dialogs
             this.CancellationToken = CancellationToken.None;
             this.DialogTitleFontSize = Double.NaN;
             this.DialogMessageFontSize = Double.NaN;
+            this.DialogButtonFontSize = Double.NaN;
             this.DialogResultOnCancel = null;
         }
 
@@ -85,6 +86,14 @@ namespace MahApps.Metro.Controls.Dialogs
         /// The size of the dialog message font.
         /// </value>
         public double DialogMessageFontSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size of the dialog button font.
+        /// </summary>
+        /// <value>
+        /// The size of the dialog button font.
+        /// </value>
+        public double DialogButtonFontSize { get; set; }
 
         /// <summary>
         /// Gets or sets the dialog result when the user cancelled the dialog with 'ESC' key

--- a/src/MahApps.Metro/Controls/Dialogs/ProgressDialog.xaml
+++ b/src/MahApps.Metro/Controls/Dialogs/ProgressDialog.xaml
@@ -23,6 +23,7 @@
                         Orientation="Horizontal">
                 <Button x:Name="PART_NegativeButton"
                         Margin="5 0 0 0"
+                        FontSize="{Binding DialogButtonFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:ProgressDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                         Content="{Binding NegativeButtonText, RelativeSource={RelativeSource AncestorType=Dialogs:ProgressDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                         Cursor="Arrow"
                         Style="{DynamicResource MahApps.Styles.Button.Dialogs.Accent}"

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -30,6 +30,7 @@
 
     <System:Double x:Key="MahApps.Sizes.Font.DialogTitle">26</System:Double>
     <System:Double x:Key="MahApps.Sizes.Font.DialogMessage">15</System:Double>
+    <System:Double x:Key="MahApps.Sizes.Font.DialogButton">12</System:Double>
 
     <System:Double x:Key="MahApps.Sizes.Font.FlyoutHeader">20</System:Double>
 

--- a/src/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/src/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -112,6 +112,7 @@
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.WhiteColor}" />
         <Setter Property="DialogMessageFontSize" Value="{DynamicResource MahApps.Sizes.Font.DialogMessage}" />
         <Setter Property="DialogTitleFontSize" Value="{DynamicResource MahApps.Sizes.Font.DialogTitle}" />
+        <Setter Property="DialogButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.DialogButton}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Added the DialogButtonFontSize Property to MetroDialogSettings and integrated them in sync with the existing implementations of DialogTitleFontSize and DialogMessageFontSize.


**Additional Context**
In a second commit (without issue reference) i also added an entry to the demo app sampling the usage of the new property. I didn't know whether this is appreciated or not.

Defaulting to 12pt:
![image](https://user-images.githubusercontent.com/6466560/66155590-4d326100-e620-11e9-94f5-f6deadf8d1f9.png)

Using override 30pt:
![aZKhog0rfX](https://user-images.githubusercontent.com/6466560/66155656-6fc47a00-e620-11e9-9247-3a0fb37eb97a.png)

**Closed Issues**
Closes #3618 
