### PR TITLE
Fix issue with P, % and ‰ used in StringFormat outside of the format item

### DIFF
--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1040,7 +1040,7 @@ namespace MahApps.Metro.Controls
 
         private static double ConvertStringFormatValue(double value, string format)
         {
-            if (format.ToUpper().Contains("P") || format.Contains("%"))
+            if (format.ToUpperInvariant().Contains("P") || format.Contains("%"))
             {
                 value /= 100d;
             }
@@ -1051,7 +1051,7 @@ namespace MahApps.Metro.Controls
             return value;
         }        
 
-        private bool TryFormatHexadecimal(double? newValue, string format, CultureInfo culture, out string output)
+        private static bool TryFormatHexadecimal(double? newValue, string format, CultureInfo culture, out string output)
         {
             var match = RegexStringFormatHexadecimal.Match(format);
             if (match.Success)

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -187,7 +187,6 @@ namespace MahApps.Metro.Controls
         }
 
         private static readonly Regex RegexStringFormatHexadecimal = new Regex(@"^(?<complexHEX>.*{\d:X\d+}.*)?(?<simpleHEX>X\d+)?$", RegexOptions.Compiled);
-        //private static readonly Regex RegexNumber = new Regex(@"[-+]?(?<![0-9][.,])\b[0-9]+(?:[.,\s][0-9]+)*[.,]?[0-9]?(?:[eE][-+]?[0-9]+)?\b(?!\.[0-9])", RegexOptions.Compiled);
         private static readonly Regex RegexNumber = new Regex(@"[-+]?(?<![0-9][.,])[.,]?[0-9]+(?:[.,\s][0-9]+)*[.,]?[0-9]?(?:[eE][-+]?[0-9]+)?(?!\.[0-9])", RegexOptions.Compiled);
         private static readonly Regex RegexHexadecimal = new Regex(@"^([a-fA-F0-9]{1,2}\s?)+$", RegexOptions.Compiled);
         private static readonly Regex RegexStringFormat = new Regex(@"\{0\s*(:(?<format>.*))?\}", RegexOptions.Compiled);
@@ -586,7 +585,7 @@ namespace MahApps.Metro.Controls
                 throw new InvalidOperationException($"You have missed to specify {PART_NumericUp}, {PART_NumericDown} or {PART_TextBox} in your template!");
             }
 
-            this.ToggleReadOnlyMode(this.IsReadOnly | !this.InterceptManualEnter);
+            this.ToggleReadOnlyMode(this.IsReadOnly || !this.InterceptManualEnter);
 
             this.repeatUp.Click += (o, e) =>
                 {
@@ -683,23 +682,22 @@ namespace MahApps.Metro.Controls
                 return;
             }
 
-            switch (e.Key)
+            if (e.Key == Key.Enter)
             {
-                case Key.Enter:
-                    if (!this.ChangeValueOnTextChanged)
-                    {
-                        this.ChangeValueFromTextInput(e.OriginalSource as TextBox);
-                    }
-
-                    break;
-                case Key.Up:
-                    this.ChangeValueWithSpeedUp(true);
-                    e.Handled = true;
-                    break;
-                case Key.Down:
-                    this.ChangeValueWithSpeedUp(false);
-                    e.Handled = true;
-                    break;
+                if (!this.ChangeValueOnTextChanged)
+                {
+                    this.ChangeValueFromTextInput(e.OriginalSource as TextBox);
+                }
+            }
+            else if (e.Key == Key.Up)
+            {
+                this.ChangeValueWithSpeedUp(true);
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Down)
+            {
+                this.ChangeValueWithSpeedUp(false);
+                e.Handled = true;
             }
 
             if (e.Handled)
@@ -943,27 +941,6 @@ namespace MahApps.Metro.Controls
             var numericUpDown = (NumericUpDown)d;
 
             numericUpDown.OnValueChanged((double?)e.OldValue, (double?)e.NewValue);
-        }
-
-        private static void OnHasDecimalsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var numericUpDown = (NumericUpDown)d;
-            if (e.NewValue != e.OldValue && e.NewValue is bool && numericUpDown.Value != null)
-            {
-                var hasDecimals = (bool)e.NewValue;
-                var numericInput = numericUpDown.NumericInputMode;
-                if (!hasDecimals)
-                {
-                    numericUpDown.Value = Math.Truncate(numericUpDown.Value.GetValueOrDefault());
-                    numericInput &= ~NumericInput.Decimal;
-                }
-                else
-                {
-                    numericInput |= NumericInput.Decimal;
-                }
-
-                numericUpDown.SetCurrentValue(NumericInputModeProperty, numericInput);
-            }
         }
 
         private static void OnNumericInputModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -1305,7 +1282,7 @@ namespace MahApps.Metro.Controls
                         || this.ParsingNumberStyle.HasFlag(NumberStyles.AllowHexSpecifier)
                         || this.ParsingNumberStyle == NumberStyles.HexNumber;
 
-            var number = this.TryGetNumberFromText(text, isHex);
+            var number = TryGetNumberFromText(text, isHex);
 
             // If we are only accepting numbers then attempt to parse as an integer.
             if (isNumeric)
@@ -1348,7 +1325,7 @@ namespace MahApps.Metro.Controls
             return true;
         }
 
-        private string TryGetNumberFromText(string text, bool isHex)
+        private static string TryGetNumberFromText(string text, bool isHex)
         {
             if (isHex)
             {

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -243,13 +243,13 @@ namespace MahApps.Metro.Tests
             Assert.Equal(42d, window.TheNUD.Value);
 
             SetText(textBox, "42.2");
-            Assert.Equal(null, window.TheNUD.Value);
+            Assert.Null(window.TheNUD.Value);
 
             SetText(textBox, ".");
-            Assert.Equal(null, window.TheNUD.Value);
+            Assert.Null(window.TheNUD.Value);
 
             SetText(textBox, ".9");
-            Assert.Equal(null, window.TheNUD.Value);
+            Assert.Null(window.TheNUD.Value);
         }
 
         [Fact]

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -124,6 +124,12 @@ namespace MahApps.Metro.Tests
             SetText(textBox, "200.00");
             Assert.Equal(200d, window.TheNUD.Value);
             Assert.Equal("200.00 cm", textBox.Text);
+
+            // GH-3551
+            window.TheNUD.StringFormat = "{}{0}mmHg";
+            SetText(textBox, "15");
+            Assert.Equal(15, window.TheNUD.Value);
+            Assert.Equal("15mmHg", textBox.Text);
         }
 
         [Fact]
@@ -195,6 +201,54 @@ namespace MahApps.Metro.Tests
             SetText(textBox, "-0.39678");
             Assert.Equal(-0.39678d, window.TheNUD.Value);
             Assert.Equal("-0.4 %", textBox.Text);
+
+            window.TheNUD.StringFormat = "{}{0:0.0%}";
+            SetText(textBox, "1");
+            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal("1.0%", textBox.Text);
+
+            window.TheNUD.StringFormat = "{0:0.0%}";
+            SetText(textBox, "1");
+            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal("1.0%", textBox.Text);
+
+            window.TheNUD.StringFormat = "0.0%";
+            SetText(textBox, "1");
+            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal("1.0%", textBox.Text);            
+
+            window.TheNUD.StringFormat = "{}{0:0.0‰}";
+            SetText(textBox, "1");
+            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal("1.0‰", textBox.Text);
+
+            window.TheNUD.StringFormat = "{0:0.0‰}";
+            SetText(textBox, "1");
+            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal("1.0‰", textBox.Text);
+
+            window.TheNUD.StringFormat = "0.0‰";
+            SetText(textBox, "1");
+            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal("1.0‰", textBox.Text);
+
+            // GH-3376 Case 3
+            window.TheNUD.StringFormat = "{0:0.0000}%";
+            SetText(textBox, "0.25");
+            Assert.Equal(0.25, window.TheNUD.Value);
+            Assert.Equal("0.2500%", textBox.Text);
+
+            // GH-3376 Case 4
+            window.TheNUD.StringFormat = "{0:0.0000}‰";
+            SetText(textBox, "0.25");
+            Assert.Equal(0.25, window.TheNUD.Value);
+            Assert.Equal("0.2500‰", textBox.Text);
+
+            // GH-3376#issuecomment-472324787
+            window.TheNUD.StringFormat = "{}{0:G3} mPa·s";
+            SetText(textBox, "0.986");
+            Assert.Equal(0.986, window.TheNUD.Value);
+            Assert.Equal("0.986 mPa·s", textBox.Text);
         }
 
         [Fact]


### PR DESCRIPTION
Fix issue with P, % and ‰ used in the StringFormat property of NumericUpDown but outside of the format item. "{}{0:P}" would work but "{}{0:0.0} P" would not work correctly.

**Unit test**

Added additional asserts in appropriate unit tests.

**Related Issues**

This PR fixes a couple of problems mentioned in #3376 but does not resolve the issue completely. It only deals with using special characters outside of the format item. Other concerns in the issue is left unresolved.