### PR TITLE
Updates MA.M font namespaces to be more uniform

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ColorExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ColorExample.xaml
@@ -36,12 +36,12 @@
                     <TextBlock Grid.Column="1"
                                Margin="10"
                                VerticalAlignment="Center"
-                               FontSize="{DynamicResource MahApps.Font.Size.Normal}"
+                               FontSize="{DynamicResource MahApps.Font.Size.Default}"
                                Text="{Binding ElementName=BrushResource, Path=(Shape.Fill)}" />
                     <TextBlock Grid.Column="2"
                                Margin="10"
                                VerticalAlignment="Center"
-                               FontSize="{DynamicResource MahApps.Font.Size.Normal}"
+                               FontSize="{DynamicResource MahApps.Font.Size.Default}"
                                Text="{Binding}" />
                 </Grid>
             </DataTemplate>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ColorExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ColorExample.xaml
@@ -36,12 +36,12 @@
                     <TextBlock Grid.Column="1"
                                Margin="10"
                                VerticalAlignment="Center"
-                               FontSize="{DynamicResource MahApps.Sizes.Font.Normal}"
+                               FontSize="{DynamicResource MahApps.Font.Size.Normal}"
                                Text="{Binding ElementName=BrushResource, Path=(Shape.Fill)}" />
                     <TextBlock Grid.Column="2"
                                Margin="10"
                                VerticalAlignment="Center"
-                               FontSize="{DynamicResource MahApps.Sizes.Font.Normal}"
+                               FontSize="{DynamicResource MahApps.Font.Size.Normal}"
                                Text="{Binding}" />
                 </Grid>
             </DataTemplate>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
@@ -59,7 +59,7 @@
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                 <TextBlock Margin="0 -1 8 0"
                            VerticalAlignment="Center"
-                           FontFamily="{DynamicResource MahApps.Fonts.Header}"
+                           FontFamily="{DynamicResource MahApps.Fonts.Family.WindowTitle}"
                            FontSize="{DynamicResource MahApps.Sizes.Font.WindowTitle}"
                            Text="{TemplateBinding Content}"
                            TextTrimming="CharacterEllipsis" />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
@@ -60,7 +60,7 @@
                 <TextBlock Margin="0 -1 8 0"
                            VerticalAlignment="Center"
                            FontFamily="{DynamicResource MahApps.Fonts.Family.Window.Title}"
-                           FontSize="{DynamicResource MahApps.Sizes.Font.WindowTitle}"
+                           FontSize="{DynamicResource MahApps.Font.Size.WindowTitle}"
                            Text="{TemplateBinding Content}"
                            TextTrimming="CharacterEllipsis" />
                 <Button Margin="1 0 1 1"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
@@ -60,7 +60,7 @@
                 <TextBlock Margin="0 -1 8 0"
                            VerticalAlignment="Center"
                            FontFamily="{DynamicResource MahApps.Fonts.Family.Window.Title}"
-                           FontSize="{DynamicResource MahApps.Font.Size.WindowTitle}"
+                           FontSize="{DynamicResource MahApps.Font.Size.Window.Title}"
                            Text="{TemplateBinding Content}"
                            TextTrimming="CharacterEllipsis" />
                 <Button Margin="1 0 1 1"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
@@ -59,7 +59,7 @@
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                 <TextBlock Margin="0 -1 8 0"
                            VerticalAlignment="Center"
-                           FontFamily="{DynamicResource MahApps.Fonts.Family.WindowTitle}"
+                           FontFamily="{DynamicResource MahApps.Fonts.Family.Window.Title}"
                            FontSize="{DynamicResource MahApps.Sizes.Font.WindowTitle}"
                            Text="{TemplateBinding Content}"
                            TextTrimming="CharacterEllipsis" />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/HamburgerMenuRipple/HamburgerMenuRipple.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/HamburgerMenuRipple/HamburgerMenuRipple.xaml
@@ -294,7 +294,7 @@
                             <TextBlock Grid.Row="0"
                                        Margin="0 15 0 5"
                                        Padding="0"
-                                       FontFamily="{DynamicResource MahApps.Fonts.Header}"
+                                       FontFamily="{DynamicResource MahApps.Fonts.Family.Header}"
                                        FontSize="{DynamicResource MahApps.Sizes.Font.Header}"
                                        Text="{Binding Label}" />
                             <ScrollViewer Grid.Row="1"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/HamburgerMenuRipple/HamburgerMenuRipple.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/HamburgerMenuRipple/HamburgerMenuRipple.xaml
@@ -295,7 +295,7 @@
                                        Margin="0 15 0 5"
                                        Padding="0"
                                        FontFamily="{DynamicResource MahApps.Fonts.Family.Header}"
-                                       FontSize="{DynamicResource MahApps.Sizes.Font.Header}"
+                                       FontSize="{DynamicResource MahApps.Font.Size.Header}"
                                        Text="{Binding Label}" />
                             <ScrollViewer Grid.Row="1"
                                           Focusable="False"

--- a/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml
+++ b/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml
@@ -25,7 +25,7 @@
                  Controls:TextBoxHelper.Watermark="{Binding UsernameWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  Controls:VisibilityHelper.IsCollapsed="{Binding ShouldHideUsername, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  CharacterCasing="{Binding UsernameCharacterCasing, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                 FontSize="{DynamicResource MahApps.Sizes.Font.DialogMessage}"
+                 FontSize="{DynamicResource MahApps.Font.Size.DialogMessage}"
                  Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  Text="{Binding Username, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  TextWrapping="Wrap" />
@@ -35,13 +35,13 @@
                      Behaviors:PasswordBoxBindingBehavior.Password="{Binding Password, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                      Controls:TextBoxHelper.SelectAllOnFocus="True"
                      Controls:TextBoxHelper.Watermark="{Binding PasswordWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                     FontSize="{DynamicResource MahApps.Sizes.Font.DialogMessage}"
+                     FontSize="{DynamicResource MahApps.Font.Size.DialogMessage}"
                      Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         <CheckBox x:Name="PART_RememberCheckBox"
                   Grid.Row="3"
                   Margin="0 5 0 0"
                   Content="{Binding RememberCheckBoxText, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                  FontSize="{DynamicResource MahApps.Sizes.Font.DialogMessage}"
+                  FontSize="{DynamicResource MahApps.Font.Size.DialogMessage}"
                   IsChecked="{Binding RememberCheckBoxChecked, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                   Visibility="{Binding RememberCheckBoxVisibility, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         <StackPanel Grid.Row="4"

--- a/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml
+++ b/src/MahApps.Metro/Controls/Dialogs/LoginDialog.xaml
@@ -25,7 +25,7 @@
                  Controls:TextBoxHelper.Watermark="{Binding UsernameWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  Controls:VisibilityHelper.IsCollapsed="{Binding ShouldHideUsername, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  CharacterCasing="{Binding UsernameCharacterCasing, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                 FontSize="{DynamicResource MahApps.Font.Size.DialogMessage}"
+                 FontSize="{Binding DialogMessageFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  Text="{Binding Username, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                  TextWrapping="Wrap" />
@@ -35,13 +35,13 @@
                      Behaviors:PasswordBoxBindingBehavior.Password="{Binding Password, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                      Controls:TextBoxHelper.SelectAllOnFocus="True"
                      Controls:TextBoxHelper.Watermark="{Binding PasswordWatermark, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                     FontSize="{DynamicResource MahApps.Font.Size.DialogMessage}"
+                     FontSize="{Binding DialogMessageFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                      Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         <CheckBox x:Name="PART_RememberCheckBox"
                   Grid.Row="3"
                   Margin="0 5 0 0"
                   Content="{Binding RememberCheckBoxText, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
-                  FontSize="{DynamicResource MahApps.Font.Size.DialogMessage}"
+                  FontSize="{Binding DialogMessageFontSize, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                   IsChecked="{Binding RememberCheckBoxChecked, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}"
                   Visibility="{Binding RememberCheckBoxVisibility, RelativeSource={RelativeSource AncestorType=Dialogs:LoginDialog, Mode=FindAncestor}, UpdateSourceTrigger=PropertyChanged}" />
         <StackPanel Grid.Row="4"

--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -24,7 +24,7 @@
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.FlatButton.Background}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource MahApps.Styles.Button.FocusVisualStyle.Flat}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.FlatButton}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Button.Flat}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.FlatButton.Foreground}" />
         <Setter Property="Padding" Value="10 5 10 5" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -72,7 +72,7 @@
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.FlatButton.Background}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource MahApps.Styles.Button.FocusVisualStyle.Flat}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.FlatButton}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Button.Flat}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.FlatButton.Foreground}" />
         <Setter Property="Padding" Value="10 5 10 5" />
         <Setter Property="SnapsToDevicePixels" Value="True" />

--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -391,7 +391,7 @@
         <Setter Property="Controls:ControlsHelper.CornerRadius" Value="3" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.MouseOverBorder}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderThickness" Value="2" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Default}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Button}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.UpperCaseContent}" />
         <Setter Property="FontWeight" Value="Bold" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
@@ -453,7 +453,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Lower" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Default}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Button}" />
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="MinHeight" Value="25" />
@@ -692,7 +692,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Controls:ControlsHelper.CornerRadius" Value="3" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.MouseOverBorder}" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Default}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Button}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.UpperCaseContent}" />
         <Setter Property="FontWeight" Value="Bold" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
@@ -775,7 +775,7 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="BorderThickness" Value="2" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Default}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Button}" />
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="HorizontalAlignment" Value="Left" />

--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -392,7 +392,7 @@
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.MouseOverBorder}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderThickness" Value="2" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Button}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.UpperCaseContent}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Button}" />
         <Setter Property="FontWeight" Value="Bold" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="MinHeight" Value="25" />
@@ -693,7 +693,7 @@
         <Setter Property="Controls:ControlsHelper.CornerRadius" Value="3" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.MouseOverBorder}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Button}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.UpperCaseContent}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Button}" />
         <Setter Property="FontWeight" Value="Bold" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="MinHeight" Value="25" />

--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -24,7 +24,7 @@
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.FlatButton.Background}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource MahApps.Styles.Button.FocusVisualStyle.Flat}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.FlatButton}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.FlatButton}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.FlatButton.Foreground}" />
         <Setter Property="Padding" Value="10 5 10 5" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -72,7 +72,7 @@
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.FlatButton.Background}" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource MahApps.Styles.Button.FocusVisualStyle.Flat}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.FlatButton}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.FlatButton}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.FlatButton.Foreground}" />
         <Setter Property="Padding" Value="10 5 10 5" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -392,7 +392,7 @@
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.MouseOverBorder}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderThickness" Value="2" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Button}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.UpperCaseContent}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.UpperCaseContent}" />
         <Setter Property="FontWeight" Value="Bold" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="MinHeight" Value="25" />
@@ -693,7 +693,7 @@
         <Setter Property="Controls:ControlsHelper.CornerRadius" Value="3" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.MouseOverBorder}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Button}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.UpperCaseContent}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.UpperCaseContent}" />
         <Setter Property="FontWeight" Value="Bold" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="MinHeight" Value="25" />

--- a/src/MahApps.Metro/Styles/Controls.Calendar.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Calendar.xaml
@@ -564,7 +564,7 @@
            BasedOn="{StaticResource MahApps.Styles.Calendar.Base}"
            TargetType="{x:Type Calendar}">
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
     </Style>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro/Styles/Controls.Calendar.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Calendar.xaml
@@ -563,7 +563,7 @@
     <Style x:Key="MahApps.Styles.Calendar"
            BasedOn="{StaticResource MahApps.Styles.Calendar.Base}"
            TargetType="{x:Type Calendar}">
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
     </Style>
 

--- a/src/MahApps.Metro/Styles/Controls.CheckBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.CheckBox.xaml
@@ -10,7 +10,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Highlight}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.CheckBox.MouseOver}" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Label.Text}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />

--- a/src/MahApps.Metro/Styles/Controls.CheckBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.CheckBox.xaml
@@ -11,7 +11,7 @@
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Highlight}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.CheckBox.MouseOver}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Label.Text}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="Padding" Value="6 0 0 0" />

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -254,7 +254,7 @@
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
         <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.ClearTextButton}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -252,10 +252,10 @@
         <Setter Property="BorderThickness" Value="{DynamicResource ComboBoxBorderThemeThickness}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.ComboBox.MouseOverInnerBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="MinHeight" Value="26" />

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -252,7 +252,7 @@
         <Setter Property="BorderThickness" Value="{DynamicResource ComboBoxBorderThemeThickness}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.ComboBox.MouseOverInnerBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />

--- a/src/MahApps.Metro/Styles/Controls.ContextMenu.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ContextMenu.xaml
@@ -37,7 +37,7 @@
     <Style x:Key="MahApps.Styles.Menu" TargetType="{x:Type Menu}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Menu.Background}" />
         <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.MenuFontFamilyKey}}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Menu}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Menu}" />
         <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.MenuFontStyleKey}}" />
         <Setter Property="FontWeight" Value="{DynamicResource {x:Static SystemFonts.MenuFontWeightKey}}" />
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.MenuTextBrushKey}}" />
@@ -65,7 +65,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.ContextMenu.Border}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.MenuFontFamilyKey}}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.ContextMenu}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.ContextMenu}" />
         <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.MenuFontStyleKey}}" />
         <Setter Property="FontWeight" Value="{DynamicResource {x:Static SystemFonts.MenuFontWeightKey}}" />
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.MenuTextBrushKey}}" />

--- a/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -37,7 +37,7 @@
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="IsTodayHighlighted" Value="True" />
         <Setter Property="MinHeight" Value="26" />
@@ -214,7 +214,7 @@
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="Padding" Value="4" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />

--- a/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -36,7 +36,7 @@
         <Setter Property="Controls:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="IsTodayHighlighted" Value="True" />
@@ -213,7 +213,7 @@
         <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="Padding" Value="4" />

--- a/src/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -328,7 +328,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Accent}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Upper" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Controls:ExpanderHelper.HeaderDownStyle" Value="{StaticResource MahApps.Styles.ToggleButton.ExpanderHeader.Down}" />
         <Setter Property="Controls:ExpanderHelper.HeaderLeftStyle" Value="{StaticResource MahApps.Styles.ToggleButton.ExpanderHeader.Left}" />
         <Setter Property="Controls:ExpanderHelper.HeaderRightStyle" Value="{StaticResource MahApps.Styles.ToggleButton.ExpanderHeader.Right}" />

--- a/src/MahApps.Metro/Styles/Controls.GroupBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.GroupBox.xaml
@@ -12,7 +12,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Accent}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Upper" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Controls:HeaderedControlHelper.HeaderBackground" Value="{DynamicResource MahApps.Brushes.Accent}" />
         <Setter Property="Controls:HeaderedControlHelper.HeaderForeground" Value="{x:Null}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />

--- a/src/MahApps.Metro/Styles/Controls.Page.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Page.xaml
@@ -4,7 +4,7 @@
     <Style x:Key="MahApps.Styles.Page" TargetType="{x:Type Page}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.White}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
-        <Setter Property="TextElement.FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="TextElement.FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
     </Style>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -86,11 +86,11 @@
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
         <Setter Property="Controls:PasswordBoxHelper.CapsLockIcon" Value="{StaticResource MahApps.Controls.Grid.DefaultCapsLockIcon}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />
         <Setter Property="Padding" Value="4" />

--- a/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -89,7 +89,7 @@
         <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.ClearTextButton}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />

--- a/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -86,7 +86,7 @@
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
         <Setter Property="Controls:PasswordBoxHelper.CapsLockIcon" Value="{StaticResource MahApps.Controls.Grid.DefaultCapsLockIcon}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />

--- a/src/MahApps.Metro/Styles/Controls.RadioButton.xaml
+++ b/src/MahApps.Metro/Styles/Controls.RadioButton.xaml
@@ -11,7 +11,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Highlight}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.CheckBox.MouseOver}" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Label.Text}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />

--- a/src/MahApps.Metro/Styles/Controls.RadioButton.xaml
+++ b/src/MahApps.Metro/Styles/Controls.RadioButton.xaml
@@ -12,7 +12,7 @@
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Highlight}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.CheckBox.MouseOver}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Label.Text}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="Padding" Value="6 0 0 0" />

--- a/src/MahApps.Metro/Styles/Controls.StatusBar.xaml
+++ b/src/MahApps.Metro/Styles/Controls.StatusBar.xaml
@@ -50,7 +50,7 @@
 
     <Style x:Key="MahApps.Styles.StatusBar" TargetType="{x:Type StatusBar}">
         <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.StatusFontFamilyKey}}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.StatusBar}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.StatusBar}" />
         <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.StatusFontStyleKey}}" />
         <Setter Property="FontWeight" Value="{DynamicResource {x:Static SystemFonts.StatusFontWeightKey}}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.IdealForeground}" />

--- a/src/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -9,7 +9,7 @@
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.White}" />
         <Setter Property="BorderBrush" Value="{x:Null}" />
         <!--  special property for header font size  -->
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Sizes.Font.TabItem}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.TabItem}" />
         <Setter Property="Controls:TabControlHelper.UnderlineBrush" Value="{DynamicResource MahApps.Brushes.GrayNormal}" />
         <Setter Property="Controls:TabControlHelper.UnderlineMouseOverBrush" Value="{DynamicResource MahApps.Brushes.GrayHover}" />
         <Setter Property="Controls:TabControlHelper.UnderlineMouseOverSelectedBrush" Value="{DynamicResource MahApps.Brushes.Highlight}" />

--- a/src/MahApps.Metro/Styles/Controls.TextBlock.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TextBlock.xaml
@@ -14,7 +14,7 @@
     <Style x:Key="MahApps.Styles.TextBlock.AutoCollapsing"
            BasedOn="{StaticResource MahApps.Styles.TextBlock}"
            TargetType="{x:Type TextBlock}">
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.FloatingWatermark}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.FloatingWatermark}" />
         <Setter Property="Opacity" Value="0.6" />
         <Style.Triggers>
             <Trigger Property="Text" Value="">

--- a/src/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -18,7 +18,7 @@
         <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="Controls:TextBoxHelper.IsSpellCheckContextMenuEnabled" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
@@ -547,7 +547,7 @@
         <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="Controls:TextBoxHelper.IsSpellCheckContextMenuEnabled" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />

--- a/src/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -18,13 +18,13 @@
         <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="Controls:TextBoxHelper.IsSpellCheckContextMenuEnabled" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
         <Setter Property="Controls:TextBoxHelper.WatermarkWrapping" Value="{Binding RelativeSource={RelativeSource Self}, Path=TextWrapping, Mode=OneWay}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />
         <Setter Property="Padding" Value="4" />
@@ -547,13 +547,13 @@
         <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="Controls:TextBoxHelper.IsSpellCheckContextMenuEnabled" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />
         <Setter Property="MinWidth" Value="10" />

--- a/src/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -23,7 +23,7 @@
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="Controls:TextBoxHelper.IsSpellCheckContextMenuEnabled" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
         <Setter Property="Controls:TextBoxHelper.WatermarkWrapping" Value="{Binding RelativeSource={RelativeSource Self}, Path=TextWrapping, Mode=OneWay}" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />
@@ -552,7 +552,7 @@
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="Controls:TextBoxHelper.IsSpellCheckContextMenuEnabled" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />

--- a/src/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
@@ -141,9 +141,9 @@
         <Setter Property="ContentDirection" Value="RightToLeft" />
         <Setter Property="ContentPadding" Value="0 0 10 0" />
         <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Sizes.Font.ToggleSwitchHeader.Win10}" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.ToggleSwitch.Win10}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.ToggleSwitch.Win10}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.ToggleSwitch.Win10}" />
-        <Setter Property="HeaderFontFamily" Value="{DynamicResource MahApps.Fonts.ToggleSwitch.Header.Win10}" />
+        <Setter Property="HeaderFontFamily" Value="{DynamicResource MahApps.Fonts.Family.ToggleSwitch.Header.Win10}" />
         <Setter Property="OffSwitchBrush" Value="{DynamicResource MahApps.Brushes.ToggleSwitchButton.OffSwitch.Win10}" />
         <Setter Property="OnSwitchBrush" Value="{DynamicResource MahApps.Brushes.ToggleSwitchButton.OnSwitch.Win10}" />
         <Setter Property="ThumbIndicatorBrush" Value="{DynamicResource MahApps.Brushes.ToggleSwitchButton.ThumbIndicator.Win10}" />

--- a/src/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
@@ -140,9 +140,9 @@
            TargetType="{x:Type Controls:ToggleSwitch}">
         <Setter Property="ContentDirection" Value="RightToLeft" />
         <Setter Property="ContentPadding" Value="0 0 10 0" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Sizes.Font.ToggleSwitchHeader.Win10}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.ToggleSwitchHeader.Win10}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.ToggleSwitch.Win10}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.ToggleSwitch.Win10}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.ToggleSwitch.Win10}" />
         <Setter Property="HeaderFontFamily" Value="{DynamicResource MahApps.Fonts.Family.ToggleSwitch.Header.Win10}" />
         <Setter Property="OffSwitchBrush" Value="{DynamicResource MahApps.Brushes.ToggleSwitchButton.OffSwitch.Win10}" />
         <Setter Property="OnSwitchBrush" Value="{DynamicResource MahApps.Brushes.ToggleSwitchButton.OnSwitch.Win10}" />

--- a/src/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ToggleSwitch.xaml
@@ -140,7 +140,7 @@
            TargetType="{x:Type Controls:ToggleSwitch}">
         <Setter Property="ContentDirection" Value="RightToLeft" />
         <Setter Property="ContentPadding" Value="0 0 10 0" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.ToggleSwitchHeader.Win10}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.ToggleSwitch.Header.Win10}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.ToggleSwitch.Win10}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.ToggleSwitch.Win10}" />
         <Setter Property="HeaderFontFamily" Value="{DynamicResource MahApps.Fonts.Family.ToggleSwitch.Header.Win10}" />

--- a/src/MahApps.Metro/Styles/Controls.Tooltip.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Tooltip.xaml
@@ -7,7 +7,7 @@
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}" />
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Gray7}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Tooltip}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Tooltip}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="Padding" Value="6 3" />
         <Setter Property="SnapsToDevicePixels" Value="True" />

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -5,7 +5,7 @@
     <FontFamily x:Key="MahApps.Fonts.Family.Button">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Family.Header">Segoe UI Light, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Family.WindowTitle">Segoe UI Light, Lucida Sans Unicode, Verdana</FontFamily>
-    <FontFamily x:Key="MahApps.Fonts.Content">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
+    <FontFamily x:Key="MahApps.Fonts.Family.Control">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
 
     <FontFamily x:Key="MahApps.Fonts.ToggleSwitch">Segoe UI Semibold, Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.ToggleSwitch.Header">Segoe UI Semibold, Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -13,7 +13,7 @@
 
     <System:Double x:Key="MahApps.Font.Size.Header">40</System:Double>
     <System:Double x:Key="MahApps.Font.Size.SubHeader">29.333</System:Double>
-    <System:Double x:Key="MahApps.Font.Size.WindowTitle">16</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Window.Title">16</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Normal">14</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Content">12</System:Double>
     <System:Double x:Key="MahApps.Font.Size.FlatButton">14</System:Double>

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -4,7 +4,7 @@
 
     <FontFamily x:Key="MahApps.Fonts.Family.Button">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Family.Header">Segoe UI Light, Lucida Sans Unicode, Verdana</FontFamily>
-    <FontFamily x:Key="MahApps.Fonts.Family.WindowTitle">Segoe UI Light, Lucida Sans Unicode, Verdana</FontFamily>
+    <FontFamily x:Key="MahApps.Fonts.Family.Window.Title">Segoe UI Light, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Family.Control">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Family.ToggleSwitch">Segoe UI Semibold, Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Family.ToggleSwitch.Header">Segoe UI Semibold, Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -26,9 +26,9 @@
     <System:Double x:Key="MahApps.Font.Size.ContextMenu">14</System:Double>
     <System:Double x:Key="MahApps.Font.Size.StatusBar">12</System:Double>
 
-    <System:Double x:Key="MahApps.Font.Size.DialogTitle">26</System:Double>
-    <System:Double x:Key="MahApps.Font.Size.DialogMessage">15</System:Double>
-    <System:Double x:Key="MahApps.Font.Size.DialogButton">12</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Dialog.Title">26</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Dialog.Message">15</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Dialog.Button">12</System:Double>
 
     <System:Double x:Key="MahApps.Font.Size.FlyoutHeader">20</System:Double>
 

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -30,7 +30,7 @@
     <System:Double x:Key="MahApps.Font.Size.Dialog.Message">15</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Dialog.Button">12</System:Double>
 
-    <System:Double x:Key="MahApps.Font.Size.FlyoutHeader">20</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Flyout.Header">20</System:Double>
 
     <System:Double x:Key="MahApps.Font.Size.ToggleSwitch">14.667</System:Double>
     <System:Double x:Key="MahApps.Font.Size.ToggleSwitchHeader">16</System:Double>

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -33,8 +33,8 @@
     <System:Double x:Key="MahApps.Font.Size.Flyout.Header">20</System:Double>
 
     <System:Double x:Key="MahApps.Font.Size.ToggleSwitch">14.667</System:Double>
-    <System:Double x:Key="MahApps.Font.Size.ToggleSwitchHeader">16</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.ToggleSwitch.Header">16</System:Double>
     <System:Double x:Key="MahApps.Font.Size.ToggleSwitch.Win10">15</System:Double>
-    <System:Double x:Key="MahApps.Font.Size.ToggleSwitchHeader.Win10">15</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.ToggleSwitch.Header.Win10">15</System:Double>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -11,32 +11,30 @@
     <FontFamily x:Key="MahApps.Fonts.Family.ToggleSwitch.Win10">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Family.ToggleSwitch.Header.Win10">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
 
-    <System:Double x:Key="MahApps.Sizes.Font.Header">40</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.SubHeader">29.333</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.WindowTitle">16</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.Normal">14</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.Content">12</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.FlatButton">14</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.TabItem">26.67</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.UpperCaseContent">10</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.FloatingWatermark">10</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.ClearTextButton">16</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Header">40</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.SubHeader">29.333</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.WindowTitle">16</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Normal">14</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Content">12</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.FlatButton">14</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.TabItem">26.67</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.UpperCaseContent">10</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.FloatingWatermark">10</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.ClearTextButton">16</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Tooltip">12</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Menu">14</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.ContextMenu">14</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.StatusBar">12</System:Double>
 
-    <System:Double x:Key="MahApps.Sizes.Font.Tooltip">12</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.Menu">14</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.ContextMenu">14</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.DialogTitle">26</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.DialogMessage">15</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.DialogButton">12</System:Double>
 
-    <System:Double x:Key="MahApps.Sizes.Font.StatusBar">12</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.FlyoutHeader">20</System:Double>
 
-    <System:Double x:Key="MahApps.Sizes.Font.DialogTitle">26</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.DialogMessage">15</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.DialogButton">12</System:Double>
-
-    <System:Double x:Key="MahApps.Sizes.Font.FlyoutHeader">20</System:Double>
-
-    <System:Double x:Key="MahApps.Sizes.Font.ToggleSwitch">14.667</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.ToggleSwitchHeader">16</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.ToggleSwitch.Win10">15</System:Double>
-    <System:Double x:Key="MahApps.Sizes.Font.ToggleSwitchHeader.Win10">15</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.ToggleSwitch">14.667</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.ToggleSwitchHeader">16</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.ToggleSwitch.Win10">15</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.ToggleSwitchHeader.Win10">15</System:Double>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -18,7 +18,7 @@
     <System:Double x:Key="MahApps.Font.Size.Content">12</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Button.Flat">14</System:Double>
     <System:Double x:Key="MahApps.Font.Size.TabItem">26.67</System:Double>
-    <System:Double x:Key="MahApps.Font.Size.UpperCaseContent">10</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Button">10</System:Double>
     <System:Double x:Key="MahApps.Font.Size.FloatingWatermark">10</System:Double>
     <System:Double x:Key="MahApps.Font.Size.ClearTextButton">16</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Tooltip">12</System:Double>

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -3,7 +3,8 @@
                     xmlns:System="clr-namespace:System;assembly=mscorlib">
 
     <FontFamily x:Key="MahApps.Fonts.Family.Button">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
-    <FontFamily x:Key="MahApps.Fonts.Header">Segoe UI Light, Lucida Sans Unicode, Verdana</FontFamily>
+    <FontFamily x:Key="MahApps.Fonts.Family.Header">Segoe UI Light, Lucida Sans Unicode, Verdana</FontFamily>
+    <FontFamily x:Key="MahApps.Fonts.Family.WindowTitle">Segoe UI Light, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Content">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
 
     <FontFamily x:Key="MahApps.Fonts.ToggleSwitch">Segoe UI Semibold, Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:System="clr-namespace:System;assembly=mscorlib">
 
-    <FontFamily x:Key="MahApps.Fonts.Default">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
+    <FontFamily x:Key="MahApps.Fonts.Family.Button">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Header">Segoe UI Light, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Content">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
 

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -14,7 +14,7 @@
     <System:Double x:Key="MahApps.Font.Size.Header">40</System:Double>
     <System:Double x:Key="MahApps.Font.Size.SubHeader">29.333</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Window.Title">16</System:Double>
-    <System:Double x:Key="MahApps.Font.Size.Normal">14</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Default">14</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Content">12</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Button.Flat">14</System:Double>
     <System:Double x:Key="MahApps.Font.Size.TabItem">26.67</System:Double>

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -6,11 +6,10 @@
     <FontFamily x:Key="MahApps.Fonts.Family.Header">Segoe UI Light, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Family.WindowTitle">Segoe UI Light, Lucida Sans Unicode, Verdana</FontFamily>
     <FontFamily x:Key="MahApps.Fonts.Family.Control">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
-
-    <FontFamily x:Key="MahApps.Fonts.ToggleSwitch">Segoe UI Semibold, Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
-    <FontFamily x:Key="MahApps.Fonts.ToggleSwitch.Header">Segoe UI Semibold, Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
-    <FontFamily x:Key="MahApps.Fonts.ToggleSwitch.Win10">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
-    <FontFamily x:Key="MahApps.Fonts.ToggleSwitch.Header.Win10">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
+    <FontFamily x:Key="MahApps.Fonts.Family.ToggleSwitch">Segoe UI Semibold, Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
+    <FontFamily x:Key="MahApps.Fonts.Family.ToggleSwitch.Header">Segoe UI Semibold, Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
+    <FontFamily x:Key="MahApps.Fonts.Family.ToggleSwitch.Win10">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
+    <FontFamily x:Key="MahApps.Fonts.Family.ToggleSwitch.Header.Win10">Segoe UI, Lucida Sans Unicode, Verdana</FontFamily>
 
     <System:Double x:Key="MahApps.Sizes.Font.Header">40</System:Double>
     <System:Double x:Key="MahApps.Sizes.Font.SubHeader">29.333</System:Double>

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -16,7 +16,7 @@
     <System:Double x:Key="MahApps.Font.Size.Window.Title">16</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Normal">14</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Content">12</System:Double>
-    <System:Double x:Key="MahApps.Font.Size.FlatButton">14</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Button.Flat">14</System:Double>
     <System:Double x:Key="MahApps.Font.Size.TabItem">26.67</System:Double>
     <System:Double x:Key="MahApps.Font.Size.UpperCaseContent">10</System:Double>
     <System:Double x:Key="MahApps.Font.Size.FloatingWatermark">10</System:Double>

--- a/src/MahApps.Metro/Styles/Fonts.xaml
+++ b/src/MahApps.Metro/Styles/Fonts.xaml
@@ -20,7 +20,7 @@
     <System:Double x:Key="MahApps.Font.Size.TabItem">26.67</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Button">10</System:Double>
     <System:Double x:Key="MahApps.Font.Size.FloatingWatermark">10</System:Double>
-    <System:Double x:Key="MahApps.Font.Size.ClearTextButton">16</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.Button.ClearText">16</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Tooltip">12</System:Double>
     <System:Double x:Key="MahApps.Font.Size.Menu">14</System:Double>
     <System:Double x:Key="MahApps.Font.Size.ContextMenu">14</System:Double>

--- a/src/MahApps.Metro/Styles/VS/Colors.xaml
+++ b/src/MahApps.Metro/Styles/VS/Colors.xaml
@@ -94,7 +94,7 @@
     <SolidColorBrush x:Key="MahApps.Brushes.ContextMenu.Border" Color="#333337" options:Freeze="True" />
     <SolidColorBrush x:Key="{x:Static SystemColors.MenuTextBrushKey}" Color="#FFFFFF" options:Freeze="True" />
 
-    <System:Double x:Key="MahApps.Sizes.Font.ContextMenu">12</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.ContextMenu">12</System:Double>
 
     <!--  Scroll Bar  -->
     <SolidColorBrush x:Key="MahApps.Brushes.ScrollBar.PageButtonBackgroundHighlighted" Color="#05FFFFFF" options:Freeze="True" />

--- a/src/MahApps.Metro/Styles/VS/Menu.xaml
+++ b/src/MahApps.Metro/Styles/VS/Menu.xaml
@@ -26,7 +26,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.ContextMenu.Border}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="FontFamily" Value="{DynamicResource {x:Static SystemFonts.MenuFontFamilyKey}}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.ContextMenu}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.ContextMenu}" />
         <Setter Property="FontStyle" Value="{DynamicResource {x:Static SystemFonts.MenuFontStyleKey}}" />
         <Setter Property="FontWeight" Value="{DynamicResource {x:Static SystemFonts.MenuFontWeightKey}}" />
         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.MenuTextBrushKey}}" />

--- a/src/MahApps.Metro/Styles/VS/TabControl.xaml
+++ b/src/MahApps.Metro/Styles/VS/TabControl.xaml
@@ -9,7 +9,7 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TabControl.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <System:Double x:Key="MahApps.Sizes.Font.TabItem">12</System:Double>
+    <System:Double x:Key="MahApps.Font.Size.TabItem">12</System:Double>
 
     <Style x:Key="MahApps.Styles.TabControl.VisualStudio"
            BasedOn="{StaticResource MahApps.Styles.TabControl}"

--- a/src/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -135,7 +135,7 @@
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="HandVisibility" Value="HourMinute" />
         <Setter Property="MinHeight" Value="26" />

--- a/src/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -134,7 +134,7 @@
         <Setter Property="Controls:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="HandVisibility" Value="HourMinute" />

--- a/src/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/src/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -110,9 +110,9 @@
 
     <Style x:Key="MahApps.Styles.BaseMetroDialog" TargetType="{x:Type Dialogs:BaseMetroDialog}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.WhiteColor}" />
-        <Setter Property="DialogButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.DialogButton}" />
-        <Setter Property="DialogMessageFontSize" Value="{DynamicResource MahApps.Sizes.Font.DialogMessage}" />
-        <Setter Property="DialogTitleFontSize" Value="{DynamicResource MahApps.Sizes.Font.DialogTitle}" />
+        <Setter Property="DialogButtonFontSize" Value="{DynamicResource MahApps.Font.Size.DialogButton}" />
+        <Setter Property="DialogMessageFontSize" Value="{DynamicResource MahApps.Font.Size.DialogMessage}" />
+        <Setter Property="DialogTitleFontSize" Value="{DynamicResource MahApps.Font.Size.DialogTitle}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />

--- a/src/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
+++ b/src/MahApps.Metro/Themes/Dialogs/BaseMetroDialog.xaml
@@ -110,9 +110,9 @@
 
     <Style x:Key="MahApps.Styles.BaseMetroDialog" TargetType="{x:Type Dialogs:BaseMetroDialog}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.WhiteColor}" />
-        <Setter Property="DialogButtonFontSize" Value="{DynamicResource MahApps.Font.Size.DialogButton}" />
-        <Setter Property="DialogMessageFontSize" Value="{DynamicResource MahApps.Font.Size.DialogMessage}" />
-        <Setter Property="DialogTitleFontSize" Value="{DynamicResource MahApps.Font.Size.DialogTitle}" />
+        <Setter Property="DialogButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Dialog.Button}" />
+        <Setter Property="DialogMessageFontSize" Value="{DynamicResource MahApps.Font.Size.Dialog.Message}" />
+        <Setter Property="DialogTitleFontSize" Value="{DynamicResource MahApps.Font.Size.Dialog.Title}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Black}" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />

--- a/src/MahApps.Metro/Themes/DropDownButton.xaml
+++ b/src/MahApps.Metro/Themes/DropDownButton.xaml
@@ -27,7 +27,7 @@
         <Setter Property="FocusVisualStyle" Value="{StaticResource MahApps.Styles.DropDownButton.FocusVisualStyle}" />
         <Setter Property="Focusable" Value="False" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.BlackColor}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="MenuStyle" Value="{DynamicResource MahApps.Styles.ContextMenu}" />

--- a/src/MahApps.Metro/Themes/DropDownButton.xaml
+++ b/src/MahApps.Metro/Themes/DropDownButton.xaml
@@ -26,7 +26,7 @@
         <Setter Property="ButtonStyle" Value="{DynamicResource MahApps.Styles.Button.DropDown}" />
         <Setter Property="FocusVisualStyle" Value="{StaticResource MahApps.Styles.DropDownButton.FocusVisualStyle}" />
         <Setter Property="Focusable" Value="False" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.BlackColor}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />

--- a/src/MahApps.Metro/Themes/Flyout.xaml
+++ b/src/MahApps.Metro/Themes/Flyout.xaml
@@ -222,7 +222,7 @@
     <Style TargetType="{x:Type Controls:Flyout}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Flyout.Background}" />
         <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Sizes.Font.FlyoutHeader}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.FlyoutHeader}" />
         <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="10" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Flyout.Foreground}" />

--- a/src/MahApps.Metro/Themes/Flyout.xaml
+++ b/src/MahApps.Metro/Themes/Flyout.xaml
@@ -222,7 +222,7 @@
     <Style TargetType="{x:Type Controls:Flyout}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Flyout.Background}" />
         <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.FlyoutHeader}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.Flyout.Header}" />
         <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="10" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Flyout.Foreground}" />

--- a/src/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/src/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -11,9 +11,9 @@
         <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Upper" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />
         <Setter Property="Padding" Value="4" />

--- a/src/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/src/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -11,7 +11,7 @@
         <Setter Property="Controls:ControlsHelper.ContentCharacterCasing" Value="Upper" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />

--- a/src/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/src/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -12,7 +12,7 @@
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
         <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.ClearTextButton}" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />

--- a/src/MahApps.Metro/Themes/MetroHeader.xaml
+++ b/src/MahApps.Metro/Themes/MetroHeader.xaml
@@ -3,7 +3,7 @@
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
     <Style x:Key="MahApps.Styles.MetroHeader" TargetType="{x:Type Controls:MetroHeader}">
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.Normal}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.Default}" />
         <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="0 0 0 2" />
         <Setter Property="Controls:HeaderedControlHelper.HeaderBackground" Value="{Binding RelativeSource={RelativeSource Self}, Path=Background, Mode=OneWay}" />
         <Setter Property="Controls:HeaderedControlHelper.HeaderForeground" Value="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Mode=OneWay}" />

--- a/src/MahApps.Metro/Themes/MetroHeader.xaml
+++ b/src/MahApps.Metro/Themes/MetroHeader.xaml
@@ -3,7 +3,7 @@
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
     <Style x:Key="MahApps.Styles.MetroHeader" TargetType="{x:Type Controls:MetroHeader}">
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Sizes.Font.Normal}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.Normal}" />
         <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="0 0 0 2" />
         <Setter Property="Controls:HeaderedControlHelper.HeaderBackground" Value="{Binding RelativeSource={RelativeSource Self}, Path=Background, Mode=OneWay}" />
         <Setter Property="Controls:HeaderedControlHelper.HeaderForeground" Value="{Binding RelativeSource={RelativeSource Self}, Path=Foreground, Mode=OneWay}" />

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -569,7 +569,7 @@
         <Setter Property="OverlayFadeOut" Value="{StaticResource OverlayFastSemiFadeOut}" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template" Value="{StaticResource MahApps.Templates.MetroWindow}" />
-        <Setter Property="TextElement.FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="TextElement.FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="TitleForeground" Value="{DynamicResource MahApps.Brushes.IdealForeground}" />
         <Setter Property="TitleTemplate">
             <Setter.Value>
@@ -577,7 +577,7 @@
                     <TextBlock Margin="8 -1 1 0"
                                VerticalAlignment="Center"
                                FontFamily="{DynamicResource MahApps.Fonts.Family.Window.Title}"
-                               FontSize="{DynamicResource MahApps.Sizes.Font.WindowTitle}"
+                               FontSize="{DynamicResource MahApps.Font.Size.WindowTitle}"
                                Text="{TemplateBinding Content}"
                                TextTrimming="CharacterEllipsis" />
                 </DataTemplate>

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -576,7 +576,7 @@
                 <DataTemplate>
                     <TextBlock Margin="8 -1 1 0"
                                VerticalAlignment="Center"
-                               FontFamily="{DynamicResource MahApps.Fonts.Family.WindowTitle}"
+                               FontFamily="{DynamicResource MahApps.Fonts.Family.Window.Title}"
                                FontSize="{DynamicResource MahApps.Sizes.Font.WindowTitle}"
                                Text="{TemplateBinding Content}"
                                TextTrimming="CharacterEllipsis" />

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -576,7 +576,7 @@
                 <DataTemplate>
                     <TextBlock Margin="8 -1 1 0"
                                VerticalAlignment="Center"
-                               FontFamily="{DynamicResource MahApps.Fonts.Header}"
+                               FontFamily="{DynamicResource MahApps.Fonts.Family.WindowTitle}"
                                FontSize="{DynamicResource MahApps.Sizes.Font.WindowTitle}"
                                Text="{TemplateBinding Content}"
                                TextTrimming="CharacterEllipsis" />

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -577,7 +577,7 @@
                     <TextBlock Margin="8 -1 1 0"
                                VerticalAlignment="Center"
                                FontFamily="{DynamicResource MahApps.Fonts.Family.Window.Title}"
-                               FontSize="{DynamicResource MahApps.Font.Size.WindowTitle}"
+                               FontSize="{DynamicResource MahApps.Font.Size.Window.Title}"
                                Text="{TemplateBinding Content}"
                                TextTrimming="CharacterEllipsis" />
                 </DataTemplate>

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -18,7 +18,7 @@
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="HorizontalContentAlignment" Value="Right" />

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -14,7 +14,7 @@
         <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -14,12 +14,12 @@
         <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.ClearTextButton}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.ClearTextButton}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="HorizontalContentAlignment" Value="Right" />
         <Setter Property="MinHeight" Value="26" />

--- a/src/MahApps.Metro/Themes/Pivot.xaml
+++ b/src/MahApps.Metro/Themes/Pivot.xaml
@@ -4,7 +4,7 @@
 
     <DataTemplate x:Key="MahApps.Templates.PivotHeader">
         <TextBlock FontFamily="{DynamicResource MahApps.Fonts.Family.Header}"
-                   FontSize="{DynamicResource MahApps.Sizes.Font.Header}"
+                   FontSize="{DynamicResource MahApps.Font.Size.Header}"
                    Text="{Binding}" />
     </DataTemplate>
 

--- a/src/MahApps.Metro/Themes/Pivot.xaml
+++ b/src/MahApps.Metro/Themes/Pivot.xaml
@@ -3,7 +3,7 @@
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls">
 
     <DataTemplate x:Key="MahApps.Templates.PivotHeader">
-        <TextBlock FontFamily="{DynamicResource MahApps.Fonts.Header}"
+        <TextBlock FontFamily="{DynamicResource MahApps.Fonts.Family.Header}"
                    FontSize="{DynamicResource MahApps.Sizes.Font.Header}"
                    Text="{Binding}" />
     </DataTemplate>
@@ -73,7 +73,7 @@
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate DataType="{x:Type Controls:PivotItem}">
                                     <TextBlock Margin="0 0 25 0"
-                                               FontFamily="{DynamicResource MahApps.Fonts.Header}"
+                                               FontFamily="{DynamicResource MahApps.Fonts.Family.Header}"
                                                FontSize="{DynamicResource SubMahApps.Sizes.HeaderFont}"
                                                Text="{Binding Header}" />
                                 </DataTemplate>

--- a/src/MahApps.Metro/Themes/SplitButton.xaml
+++ b/src/MahApps.Metro/Themes/SplitButton.xaml
@@ -283,7 +283,7 @@
         <Setter Property="ButtonStyle" Value="{DynamicResource MahApps.Styles.Button.Split}" />
         <Setter Property="FocusVisualStyle" Value="{StaticResource MahApps.Styles.FocusVisualStyle.ButtonSplit}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.BlackColor}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="MinHeight" Value="26" />

--- a/src/MahApps.Metro/Themes/SplitButton.xaml
+++ b/src/MahApps.Metro/Themes/SplitButton.xaml
@@ -282,7 +282,7 @@
         <Setter Property="ButtonArrowStyle" Value="{DynamicResource MahApps.Styles.Button.SplitArrow}" />
         <Setter Property="ButtonStyle" Value="{DynamicResource MahApps.Styles.Button.Split}" />
         <Setter Property="FocusVisualStyle" Value="{StaticResource MahApps.Styles.FocusVisualStyle.ButtonSplit}" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.BlackColor}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />

--- a/src/MahApps.Metro/Themes/ToggleSwitch.xaml
+++ b/src/MahApps.Metro/Themes/ToggleSwitch.xaml
@@ -90,7 +90,7 @@
 
     <Style x:Key="MahApps.Styles.ToggleSwitch" TargetType="{x:Type Controls:ToggleSwitch}">
         <Setter Property="ContentPadding" Value="0 0 4 0" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.ToggleSwitchHeader}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.ToggleSwitch.Header}" />
         <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="0 0 0 5" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.ToggleSwitch}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.ToggleSwitch}" />

--- a/src/MahApps.Metro/Themes/ToggleSwitch.xaml
+++ b/src/MahApps.Metro/Themes/ToggleSwitch.xaml
@@ -90,10 +90,10 @@
 
     <Style x:Key="MahApps.Styles.ToggleSwitch" TargetType="{x:Type Controls:ToggleSwitch}">
         <Setter Property="ContentPadding" Value="0 0 4 0" />
-        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Sizes.Font.ToggleSwitchHeader}" />
+        <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Font.Size.ToggleSwitchHeader}" />
         <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="0 0 0 5" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.ToggleSwitch}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.ToggleSwitch}" />
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.ToggleSwitch}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="HeaderFontFamily" Value="{DynamicResource MahApps.Fonts.Family.ToggleSwitch.Header}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />

--- a/src/MahApps.Metro/Themes/ToggleSwitch.xaml
+++ b/src/MahApps.Metro/Themes/ToggleSwitch.xaml
@@ -92,10 +92,10 @@
         <Setter Property="ContentPadding" Value="0 0 4 0" />
         <Setter Property="Controls:ControlsHelper.HeaderFontSize" Value="{DynamicResource MahApps.Sizes.Font.ToggleSwitchHeader}" />
         <Setter Property="Controls:ControlsHelper.HeaderMargin" Value="0 0 0 5" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.ToggleSwitch}" />
+        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.ToggleSwitch}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.ToggleSwitch}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
-        <Setter Property="HeaderFontFamily" Value="{DynamicResource MahApps.Fonts.ToggleSwitch.Header}" />
+        <Setter Property="HeaderFontFamily" Value="{DynamicResource MahApps.Fonts.Family.ToggleSwitch.Header}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="IsTabStop" Value="True" />
         <Setter Property="OffSwitchBrush" Value="{DynamicResource MahApps.Brushes.Gray4}" />


### PR DESCRIPTION
#### Describe the changes you have made to improve this project

- MA.M font namespacing was inconsistent between sizes and families
- This commit places "MahApps.Fonts" first, followed by "Size" or "Family"
- Further granularity is applied for specificity (e.g. "Content", "Header")
- Items such as "DialogTitle" and "FlyoutHeader" are separated (e.g. "Dialog.Title", "Flyout.Header")

| Old Font Family keys                    | New Font Family keys                     |
|-----------------------------------------|------------------------------------------|
| MahApps.Fonts.Default                   | MahApps.Fonts.Family.Button              |
| MahApps.Fonts.Header                    | MahApps.Fonts.Family.Header              |
|                                         | MahApps.Fonts.Family.Window.Title        |
| MahApps.Fonts.Content                   | MahApps.Fonts.Family.Control             |
| MahApps.Fonts.ToggleSwitch              | MahApps.Fonts.Family.ToggleSwitch        |
| MahApps.Fonts.ToggleSwitch.Header       | MahApps.Fonts.Family.ToggleSwitch.Header |
| MahApps.Fonts.ToggleSwitch.Win10        | MahApps.Fonts.Family.ToggleSwitch.Win10  |
| MahApps.Fonts.ToggleSwitch.Header.Win10 | MahApps.Fonts.Family.ToggleSwitch.Header.Win10 |

| Old Font Size keys                       | New Font Size keys                       |
|------------------------------------------|------------------------------------------|
| MahApps.Sizes.Font.Header                | MahApps.Font.Size.Header                 |
| MahApps.Sizes.Font.SubHeader             | MahApps.Font.Size.SubHeader              |
| MahApps.Sizes.Font.WindowTitle           | MahApps.Font.Size.Window.Title           |
| MahApps.Sizes.Font.Normal                | MahApps.Font.Size.Default                |
| MahApps.Sizes.Font.Content               | MahApps.Font.Size.Content                |
| MahApps.Sizes.Font.FlatButton            | MahApps.Font.Size.Button.Flat            |
| MahApps.Sizes.Font.TabItem               | MahApps.Font.Size.TabItem                |
| MahApps.Sizes.Font.UpperCaseContent      | MahApps.Font.Size.Button                 |
| MahApps.Sizes.Font.FloatingWatermark     | MahApps.Font.Size.FloatingWatermark      |
| MahApps.Sizes.Font.ClearTextButton       | MahApps.Font.Size.Button.ClearText       |
| MahApps.Sizes.Font.Tooltip               | MahApps.Font.Size.Tooltip                |
| MahApps.Sizes.Font.Menu                  | MahApps.Font.Size.Menu                   |
| MahApps.Sizes.Font.ContextMenu           | MahApps.Font.Size.ContextMenu            |
| MahApps.Sizes.Font.StatusBar             | MahApps.Font.Size.StatusBar              |
| MahApps.Sizes.Font.DialogTitle           | MahApps.Font.Size.Dialog.Title           |
| MahApps.Sizes.Font.DialogMessage         | MahApps.Font.Size.Dialog.Message         |
| MahApps.Sizes.Font.DialogButton          | MahApps.Font.Size.Dialog.Button          |
| MahApps.Sizes.Font.FlyoutHeader          | MahApps.Font.Size.Flyout.Header          |
| MahApps.Sizes.Font.ToggleSwitch          | MahApps.Font.Size.ToggleSwitch           |
| MahApps.Sizes.Font.ToggleSwitchHeader    | MahApps.Font.Size.ToggleSwitch.Header    |
| MahApps.Sizes.Font.ToggleSwitch.Win10    | MahApps.Font.Size.ToggleSwitch.Win10     |
| MahApps.Sizes.Font.ToggleSwitchHeader.Win10 | MahApps.Font.Size.ToggleSwitch.Header.Win10 |

#### Closed Issues

Closes #3584 
