### PR TITLE
Add an OverlayBrush to the SplitView

### DIFF
--- a/src/MahApps.Metro/Controls/SplitView/SplitView.cs
+++ b/src/MahApps.Metro/Controls/SplitView/SplitView.cs
@@ -131,6 +131,23 @@
         }
 
         /// <summary>
+        /// Identifies the <see cref="OverlayBrush"/> dependency property. 
+        /// </summary>
+        /// <returns>The identifier for the <see cref="OverlayBrush" /> dependency property.</returns>
+        public static readonly DependencyProperty OverlayBrushProperty =
+            DependencyProperty.Register("OverlayBrush", typeof(Brush), typeof(SplitView), new PropertyMetadata(Brushes.Transparent));
+
+        /// <summary>
+        /// Gets or sets a value that specifies the OverlayBrush 
+        /// </summary>
+        /// <returns>The current OverlayBrush</returns>
+        public Brush OverlayBrush
+        {
+            get { return (Brush)this.GetValue(OverlayBrushProperty); }
+            set { this.SetValue(OverlayBrushProperty, value); }
+        }
+
+        /// <summary>
         ///     Identifies the <see cref="OpenPaneLength" /> dependency property.
         /// </summary>
         /// <returns>The identifier for the <see cref="OpenPaneLength" /> dependency property.</returns>

--- a/src/MahApps.Metro/Themes/SplitView.xaml
+++ b/src/MahApps.Metro/Themes/SplitView.xaml
@@ -436,7 +436,7 @@
                                             Focusable="False"
                                             IsTabStop="False" />
                             <Rectangle x:Name="LightDismissLayer"
-                                       Fill="Transparent"
+                                       Fill="{TemplateBinding OverlayBrush}"
                                        Visibility="Collapsed" />
                         </Grid>
 


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

- Adds a new `OverlayBrush` dependency property to the `SplitView`. 

![Overlay](https://user-images.githubusercontent.com/47110241/67638115-97d29080-f8e1-11e9-9765-c8079bfe86b6.gif)

**Closed Issues**

Closes #3661 
