### PR TITLE
Fix SplitButton contents disappearing on subsequent clicks

### DIFF
--- a/src/MahApps.Metro/Controls/SplitButton.cs
+++ b/src/MahApps.Metro/Controls/SplitButton.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Specialized;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -11,15 +9,16 @@ using System.Windows.Media;
 namespace MahApps.Metro.Controls
 {
     [ContentProperty("ItemsSource")]
-    [DefaultEvent("SelectionChanged"),
-     TemplatePart(Name = "PART_Container", Type = typeof(Grid)),
-     TemplatePart(Name = "PART_Button", Type = typeof(Button)),
-     TemplatePart(Name = "PART_ButtonContent", Type = typeof(ContentControl)),
-     TemplatePart(Name = "PART_Popup", Type = typeof(Popup)),
-     TemplatePart(Name = "PART_Expander", Type = typeof(Button)),
-     TemplatePart(Name = "PART_ListBox", Type = typeof(ListBox))]
-    public class SplitButton : Selector
+    [TemplatePart(Name = "PART_Container", Type = typeof(Grid))]
+    [TemplatePart(Name = "PART_Button", Type = typeof(Button))]
+    [TemplatePart(Name = "PART_ButtonContent", Type = typeof(ContentControl))]
+    [TemplatePart(Name = "PART_Popup", Type = typeof(Popup))]
+    [TemplatePart(Name = "PART_Expander", Type = typeof(Button))]
+    public class SplitButton : ComboBox
     {
+        private Button _clickButton;
+        private Button _expander;
+
         public static readonly RoutedEvent ClickEvent
             = EventManager.RegisterRoutedEvent("Click",
                                                RoutingStrategy.Bubble,
@@ -31,8 +30,6 @@ namespace MahApps.Metro.Controls
             add { this.AddHandler(ClickEvent, value); }
             remove { this.RemoveHandler(ClickEvent, value); }
         }
-
-        public static readonly DependencyProperty IsExpandedProperty = DependencyProperty.Register("IsExpanded", typeof(bool), typeof(SplitButton));
 
         public static readonly DependencyProperty ExtraTagProperty = DependencyProperty.Register("ExtraTag", typeof(object), typeof(SplitButton));
 
@@ -47,7 +44,6 @@ namespace MahApps.Metro.Controls
 
         public static readonly DependencyProperty ButtonStyleProperty = DependencyProperty.Register("ButtonStyle", typeof(Style), typeof(SplitButton), new FrameworkPropertyMetadata(default(Style), FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure));
         public static readonly DependencyProperty ButtonArrowStyleProperty = DependencyProperty.Register("ButtonArrowStyle", typeof(Style), typeof(SplitButton), new FrameworkPropertyMetadata(default(Style), FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure));
-        public static readonly DependencyProperty ListBoxStyleProperty = DependencyProperty.Register("ListBoxStyle", typeof(Style), typeof(SplitButton), new FrameworkPropertyMetadata(default(Style), FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure));
         public static readonly DependencyProperty ArrowBrushProperty = DependencyProperty.Register("ArrowBrush", typeof(Brush), typeof(SplitButton), new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty ArrowMouseOverBrushProperty = DependencyProperty.Register("ArrowMouseOverBrush", typeof(Brush), typeof(SplitButton), new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
         public static readonly DependencyProperty ArrowPressedBrushProperty = DependencyProperty.Register("ArrowPressedBrush", typeof(Brush), typeof(SplitButton), new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
@@ -57,7 +53,7 @@ namespace MahApps.Metro.Controls
         /// </summary>
         public object CommandParameter
         {
-            get { return (object)this.GetValue(CommandParameterProperty); }
+            get { return this.GetValue(CommandParameterProperty); }
             set { this.SetValue(CommandParameterProperty, value); }
         }
 
@@ -77,15 +73,6 @@ namespace MahApps.Metro.Controls
         {
             get { return (ICommand)this.GetValue(CommandProperty); }
             set { this.SetValue(CommandProperty, value); }
-        }
-
-        /// <summary> 
-        /// Indicates whether the Popup is visible. 
-        /// </summary>
-        public bool IsExpanded
-        {
-            get { return (bool)this.GetValue(IsExpandedProperty); }
-            set { this.SetValue(IsExpandedProperty, value); }
         }
 
         /// <summary>
@@ -145,15 +132,6 @@ namespace MahApps.Metro.Controls
         }
 
         /// <summary>
-        /// Gets/sets the popup listbox style.
-        /// </summary>
-        public Style ListBoxStyle
-        {
-            get { return (Style)this.GetValue(ListBoxStyleProperty); }
-            set { this.SetValue(ListBoxStyleProperty, value); }
-        }
-
-        /// <summary>
         /// Gets/sets the brush of the button arrow icon.
         /// </summary>
         public Brush ArrowBrush
@@ -180,39 +158,29 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(ArrowPressedBrushProperty, value); }
         }
 
-        private Button _clickButton;
-        private Button _expander;
-        private ListBox _listBox;
-        private Popup _popup;
-
         static SplitButton()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(SplitButton), new FrameworkPropertyMetadata(typeof(SplitButton)));
+
+            IsEditableProperty.OverrideMetadata(typeof(SplitButton), new FrameworkPropertyMetadata(false, null, new CoerceValueCallback(CoerceIsEnabledProperty)));
         }
 
-        public SplitButton()
+        private static object CoerceIsEnabledProperty(DependencyObject dependencyObject, object value)
         {
-            // maybe later
-            //Keyboard.AddKeyDownHandler(this, this.OnKeyDown);
-            Mouse.AddPreviewMouseDownOutsideCapturedElementHandler(this, this.OutsideCapturedElementHandler);
+            // For now SplitButton is not editable
+            return false;
         }
 
         private void ButtonClick(object sender, RoutedEventArgs e)
         {
             e.RoutedEvent = ClickEvent;
             this.RaiseEvent(e);
-            this.SetCurrentValue(IsExpandedProperty, false);
-        }
-
-        private void ListBoxSelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            this.SetCurrentValue(IsExpandedProperty, false);
-            e.Handled = true;
+            this.SetCurrentValue(IsDropDownOpenProperty, false);
         }
 
         private void ExpanderMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
-            this.SetCurrentValue(IsExpandedProperty, !this.IsExpanded);
+            this.SetCurrentValue(IsDropDownOpenProperty, !this.IsDropDownOpen);
             e.Handled = true;
         }
 
@@ -221,233 +189,24 @@ namespace MahApps.Metro.Controls
             base.OnApplyTemplate();
             this._clickButton = this.EnforceInstance<Button>("PART_Button");
             this._expander = this.EnforceInstance<Button>("PART_Expander");
-            this._listBox = this.EnforceInstance<ListBox>("PART_ListBox");
-            this._popup = this.EnforceInstance<Popup>("PART_Popup");
             this.InitializeVisualElementsContainer();
-            if (this._listBox != null && this.Items != null && this.ItemsSource == null)
-            {
-                foreach (var newItem in this.Items)
-                {
-                    this.TryRemoveVisualFromOldTree(newItem);
-                    this._listBox.Items.Add(newItem);
-                }
-            }
-        }
-
-        private void TryRemoveVisualFromOldTree(object newItem)
-        {
-            var visual = newItem as Visual;
-            if (visual != null)
-            {
-                var fe = LogicalTreeHelper.GetParent(visual) as FrameworkElement ?? VisualTreeHelper.GetParent(visual) as FrameworkElement;
-                if (Equals(this, fe))
-                {
-                    this.RemoveLogicalChild(visual);
-                    this.RemoveVisualChild(visual);
-                }
-            }
-        }
-
-        /// <summary>Updates the current selection when an item in the <see cref="T:System.Windows.Controls.Primitives.Selector" /> has changed</summary>
-        /// <param name="e">The event data.</param>
-        protected override void OnItemsChanged(NotifyCollectionChangedEventArgs e)
-        {
-            base.OnItemsChanged(e);
-            if (this._listBox == null || this.ItemsSource != null || this._listBox.ItemsSource != null)
-            {
-                return;
-            }
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                    if (e.NewItems != null)
-                    {
-                        foreach (var newItem in e.NewItems)
-                        {
-                            this.TryRemoveVisualFromOldTree(newItem);
-                            this._listBox.Items.Add(newItem);
-                        }
-                    }
-                    break;
-                case NotifyCollectionChangedAction.Remove:
-                    if (e.OldItems != null)
-                    {
-                        foreach (var oldItem in e.OldItems)
-                        {
-                            this._listBox.Items.Remove(oldItem);
-                        }
-                    }
-                    break;
-                case NotifyCollectionChangedAction.Move:
-                case NotifyCollectionChangedAction.Replace:
-                    if (e.OldItems != null)
-                    {
-                        foreach (var oldItem in e.OldItems)
-                        {
-                            this._listBox.Items.Remove(oldItem);
-                        }
-                    }
-                    if (e.NewItems != null)
-                    {
-                        foreach (var newItem in e.NewItems)
-                        {
-                            this.TryRemoveVisualFromOldTree(newItem);
-                            this._listBox.Items.Add(newItem);
-                        }
-                    }
-                    break;
-                case NotifyCollectionChangedAction.Reset:
-                    if (this.Items != null)
-                    {
-                        this._listBox.Items.Clear();
-                        foreach (var newItem in this.Items)
-                        {
-                            this.TryRemoveVisualFromOldTree(newItem);
-                            this._listBox.Items.Add(newItem);
-                        }
-                    }
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        //Get element from name. If it exist then element instance return, if not, new will be created
-        private T EnforceInstance<T>(string partName) where T : FrameworkElement, new()
-        {
-            T element = this.GetTemplateChild(partName) as T ?? new T();
-            return element;
         }
 
         private void InitializeVisualElementsContainer()
         {
             this._expander.PreviewMouseLeftButtonDown -= this.ExpanderMouseLeftButtonDown;
-            this._clickButton.Click -= this.ButtonClick;
-            this._listBox.SelectionChanged -= this.ListBoxSelectionChanged;
-            this._listBox.PreviewMouseLeftButtonDown -= this.ListBoxPreviewMouseLeftButtonDown;
-            this._popup.Opened -= this.PopupOpened;
-            this._popup.Closed -= this.PopupClosed;
-
             this._expander.PreviewMouseLeftButtonDown += this.ExpanderMouseLeftButtonDown;
+
+            this._clickButton.Click -= this.ButtonClick;
             this._clickButton.Click += this.ButtonClick;
-            this._listBox.SelectionChanged += this.ListBoxSelectionChanged;
-            this._listBox.PreviewMouseLeftButtonDown += this.ListBoxPreviewMouseLeftButtonDown;
-            this._popup.Opened += this.PopupOpened;
-            this._popup.Closed += this.PopupClosed;
         }
 
-        //Make popup close even if no selectionchanged event fired (case when user select the same item as before)
-        private void ListBoxPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        //Get element from name. If it exist then element instance return, if not, new will be created
+        private T EnforceInstance<T>(string partName)
+            where T : FrameworkElement, new()
         {
-            var source = e.OriginalSource as DependencyObject;
-            if (source != null)
-            {
-                var item = ContainerFromElement(this._listBox, source) as ListBoxItem;
-                if (item != null)
-                {
-                    this.SetCurrentValue(IsExpandedProperty, false);
-                }
-            }
+            T element = this.GetTemplateChild(partName) as T ?? new T();
+            return element;
         }
-
-        private void PopupClosed(object sender, EventArgs e)
-        {
-            this.OnPopupClose();
-        }
-
-        private void OnPopupClose()
-        {
-            this.SetCurrentValue(IsExpandedProperty, false);
-            this.ReleaseMouseCapture();
-            Mouse.RemoveLostMouseCaptureHandler(this._popup, this.LostMouseCaptureHandler);
-            if (this.IsKeyboardFocusWithin)
-            {
-                this._expander?.Focus();
-            }
-        }
-
-        private void PopupOpened(object sender, EventArgs e)
-        {
-            this.NavigateToContainer();
-
-            // Mouse capture can be lost on 'this' when the user clicks on the scroll bar, which can cause
-            // OutsideCapturedElementHandler to never be called. If we monitor the popup for lost mouse capture
-            // (which the popup gains on mouse down of the scroll bar), then we can recapture the mouse at that point
-            // to cause OutsideCapturedElementHandler to be called again.
-            Mouse.AddLostMouseCaptureHandler(this._popup, this.LostMouseCaptureHandler);
-        }
-
-        private void NavigateToContainer()
-        {
-            Mouse.Capture(this, CaptureMode.SubTree);
-            if (this._listBox.Focusable)
-            {
-                Keyboard.Focus(this._listBox);
-            }
-            else
-            {
-                this._listBox.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
-            }
-        }
-
-        private void LostMouseCaptureHandler(object sender, MouseEventArgs e)
-        {
-            // If the list is still expanded, recapture the SplitButton subtree
-            // so that we still can know when the user has clicked outside of the popup.
-            // This happens on scroll bar mouse up, so this doesn't disrupt the scroll bar functionality
-            // at all.
-            if (this.IsExpanded)
-            {
-                this.NavigateToContainer();
-            }
-        }
-
-        private void OutsideCapturedElementHandler(object sender, MouseButtonEventArgs e)
-        {
-            this.OnPopupClose();
-        }
-
-        protected override void OnIsKeyboardFocusWithinChanged(DependencyPropertyChangedEventArgs e)
-        {
-            base.OnIsKeyboardFocusWithinChanged(e);
-            // To hide the popup when the user e.g. alt+tabs, monitor for when the window becomes a background window.
-            if (!(bool)e.NewValue)
-            {
-                this.OnPopupClose();
-            }
-        }
-
-        /* maybe later
-        private static bool IsKeyModifyingPopupState(KeyEventArgs e)
-        {
-            return (((Keyboard.Modifiers & ModifierKeys.Alt) == ModifierKeys.Alt) && ((e.SystemKey == Key.Down) || (e.SystemKey == Key.Up)))
-                    || (e.Key == Key.F4);
-        }
-
-        private void OnKeyDown(object sender, KeyEventArgs e)
-        {
-            if (!this.IsExpanded)
-            {
-                if (IsKeyModifyingPopupState(e))
-                {
-                    this.IsExpanded = true;
-                    e.Handled = true;
-                }
-            }
-            else
-            {
-                if (IsKeyModifyingPopupState(e))
-                {
-                    this.PopupClosed(sender, e);
-                    e.Handled = true;
-                }
-                else if (e.Key == Key.Escape)
-                {
-                    this.PopupClosed(sender, e);
-                    e.Handled = true;
-                }
-            }
-        }
-        */
     }
 }

--- a/src/MahApps.Metro/Controls/SplitButton.cs
+++ b/src/MahApps.Metro/Controls/SplitButton.cs
@@ -28,6 +28,7 @@ namespace MahApps.Metro.Controls
             remove { this.RemoveHandler(ClickEvent, value); }
         }
 
+        /// <summary>Identifies the <see cref="ExtraTag"/> dependency property.</summary>
         public static readonly DependencyProperty ExtraTagProperty
             = DependencyProperty.Register(
                 nameof(ExtraTag),
@@ -43,6 +44,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(ExtraTagProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="Orientation"/> dependency property.</summary>
         public static readonly DependencyProperty OrientationProperty
             = DependencyProperty.Register(
                 nameof(Orientation),
@@ -59,6 +61,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(OrientationProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="Icon"/> dependency property.</summary>
         public static readonly DependencyProperty IconProperty
             = DependencyProperty.Register(
                 nameof(Icon),
@@ -66,7 +69,7 @@ namespace MahApps.Metro.Controls
                 typeof(SplitButton));
 
         /// <summary>
-        ///  Gets or sets the Content used to generate the icon part.
+        /// Gets or sets the content for the icon part.
         /// </summary>
         [Bindable(true)]
         public object Icon
@@ -75,6 +78,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(IconProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="IconTemplate"/> dependency property.</summary>
         public static readonly DependencyProperty IconTemplateProperty
             = DependencyProperty.Register(
                 nameof(IconTemplate),
@@ -82,7 +86,7 @@ namespace MahApps.Metro.Controls
                 typeof(SplitButton));
 
         /// <summary> 
-        /// Gets or sets the ContentTemplate used to display the content of the icon part. 
+        /// Gets or sets the DataTemplate for the icon part.
         /// </summary>
         [Bindable(true)]
         public DataTemplate IconTemplate
@@ -91,6 +95,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(IconTemplateProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="Command"/> dependency property.</summary>
         public static readonly DependencyProperty CommandProperty
             = DependencyProperty.Register(
                 nameof(Command),
@@ -98,7 +103,7 @@ namespace MahApps.Metro.Controls
                 typeof(SplitButton));
 
         /// <summary>
-        /// Get or sets the Command property. 
+        /// Gets or sets the command to invoke when the content button is pressed.
         /// </summary>
         public ICommand Command
         {
@@ -106,6 +111,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(CommandProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="CommandTarget"/> dependency property.</summary>
         public static readonly DependencyProperty CommandTargetProperty
             = DependencyProperty.Register(
                 nameof(CommandTarget),
@@ -113,7 +119,7 @@ namespace MahApps.Metro.Controls
                 typeof(SplitButton));
 
         /// <summary>
-        /// Gets or sets the target element on which to fire the command.
+        /// Gets or sets the element on which to raise the specified command.
         /// </summary>
         public IInputElement CommandTarget
         {
@@ -121,6 +127,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(CommandTargetProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="CommandParameter"/> dependency property.</summary>
         public static readonly DependencyProperty CommandParameterProperty
             = DependencyProperty.Register(
                 nameof(CommandParameter),
@@ -128,7 +135,7 @@ namespace MahApps.Metro.Controls
                 typeof(SplitButton));
 
         /// <summary>
-        /// Reflects the parameter to pass to the CommandProperty upon execution. 
+        /// Gets or sets the parameter to pass to the command property.
         /// </summary>
         public object CommandParameter
         {
@@ -136,6 +143,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(CommandParameterProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="ButtonStyle"/> dependency property.</summary>
         public static readonly DependencyProperty ButtonStyleProperty
             = DependencyProperty.Register(
                 nameof(ButtonStyle),
@@ -144,7 +152,7 @@ namespace MahApps.Metro.Controls
                 new FrameworkPropertyMetadata(default(Style), FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure));
 
         /// <summary>
-        /// Gets/sets the button style.
+        /// Gets or sets the button content style.
         /// </summary>
         public Style ButtonStyle
         {
@@ -152,6 +160,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(ButtonStyleProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="ButtonArrowStyle"/> dependency property.</summary>
         public static readonly DependencyProperty ButtonArrowStyleProperty
             = DependencyProperty.Register(
                 nameof(ButtonArrowStyle),
@@ -160,7 +169,7 @@ namespace MahApps.Metro.Controls
                 new FrameworkPropertyMetadata(default(Style), FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure));
 
         /// <summary>
-        /// Gets/sets the button arrow style.
+        /// Gets or sets the button arrow style.
         /// </summary>
         public Style ButtonArrowStyle
         {
@@ -168,6 +177,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(ButtonArrowStyleProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="ArrowBrush"/> dependency property.</summary>
         public static readonly DependencyProperty ArrowBrushProperty
             = DependencyProperty.Register(
                 nameof(ArrowBrush),
@@ -176,7 +186,7 @@ namespace MahApps.Metro.Controls
                 new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
-        /// Gets/sets the brush of the button arrow icon.
+        /// Gets or sets the foreground brush for the button arrow icon.
         /// </summary>
         public Brush ArrowBrush
         {
@@ -184,6 +194,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(ArrowBrushProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="ArrowMouseOverBrush"/> dependency property.</summary>
         public static readonly DependencyProperty ArrowMouseOverBrushProperty
             = DependencyProperty.Register(
                 nameof(ArrowMouseOverBrush),
@@ -192,7 +203,7 @@ namespace MahApps.Metro.Controls
                 new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
-        /// Gets/sets the brush of the button arrow icon if the mouse is over the split button.
+        /// Gets or sets the foreground brush of the button arrow icon if the mouse is over the split button.
         /// </summary>
         public Brush ArrowMouseOverBrush
         {
@@ -200,6 +211,7 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(ArrowMouseOverBrushProperty, value); }
         }
 
+        /// <summary>Identifies the <see cref="ArrowPressedBrush"/> dependency property.</summary>
         public static readonly DependencyProperty ArrowPressedBrushProperty
             = DependencyProperty.Register(
                 nameof(ArrowPressedBrush),
@@ -208,7 +220,7 @@ namespace MahApps.Metro.Controls
                 new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
-        /// Gets/sets the brush of the button arrow icon if the arrow button is pressed.
+        /// Gets or sets the foreground brush of the button arrow icon if the arrow button is pressed.
         /// </summary>
         public Brush ArrowPressedBrush
         {

--- a/src/MahApps.Metro/Controls/SplitButton.cs
+++ b/src/MahApps.Metro/Controls/SplitButton.cs
@@ -16,11 +16,8 @@ namespace MahApps.Metro.Controls
     [TemplatePart(Name = "PART_Expander", Type = typeof(Button))]
     public class SplitButton : ComboBox
     {
-        private Button _clickButton;
-        private Button _expander;
-
         public static readonly RoutedEvent ClickEvent
-            = EventManager.RegisterRoutedEvent("Click",
+            = EventManager.RegisterRoutedEvent(nameof(Click),
                                                RoutingStrategy.Bubble,
                                                typeof(RoutedEventHandler),
                                                typeof(SplitButton));
@@ -31,49 +28,11 @@ namespace MahApps.Metro.Controls
             remove { this.RemoveHandler(ClickEvent, value); }
         }
 
-        public static readonly DependencyProperty ExtraTagProperty = DependencyProperty.Register("ExtraTag", typeof(object), typeof(SplitButton));
-
-        public static readonly DependencyProperty OrientationProperty = DependencyProperty.Register("Orientation", typeof(Orientation), typeof(SplitButton), new FrameworkPropertyMetadata(Orientation.Horizontal, FrameworkPropertyMetadataOptions.AffectsMeasure));
-
-        public static readonly DependencyProperty IconProperty = DependencyProperty.Register("Icon", typeof(object), typeof(SplitButton));
-        public static readonly DependencyProperty IconTemplateProperty = DependencyProperty.Register("IconTemplate", typeof(DataTemplate), typeof(SplitButton));
-
-        public static readonly DependencyProperty CommandProperty = DependencyProperty.Register("Command", typeof(ICommand), typeof(SplitButton));
-        public static readonly DependencyProperty CommandTargetProperty = DependencyProperty.Register("CommandTarget", typeof(IInputElement), typeof(SplitButton));
-        public static readonly DependencyProperty CommandParameterProperty = DependencyProperty.Register("CommandParameter", typeof(object), typeof(SplitButton));
-
-        public static readonly DependencyProperty ButtonStyleProperty = DependencyProperty.Register("ButtonStyle", typeof(Style), typeof(SplitButton), new FrameworkPropertyMetadata(default(Style), FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure));
-        public static readonly DependencyProperty ButtonArrowStyleProperty = DependencyProperty.Register("ButtonArrowStyle", typeof(Style), typeof(SplitButton), new FrameworkPropertyMetadata(default(Style), FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure));
-        public static readonly DependencyProperty ArrowBrushProperty = DependencyProperty.Register("ArrowBrush", typeof(Brush), typeof(SplitButton), new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
-        public static readonly DependencyProperty ArrowMouseOverBrushProperty = DependencyProperty.Register("ArrowMouseOverBrush", typeof(Brush), typeof(SplitButton), new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
-        public static readonly DependencyProperty ArrowPressedBrushProperty = DependencyProperty.Register("ArrowPressedBrush", typeof(Brush), typeof(SplitButton), new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
-
-        /// <summary>
-        /// Reflects the parameter to pass to the CommandProperty upon execution. 
-        /// </summary>
-        public object CommandParameter
-        {
-            get { return this.GetValue(CommandParameterProperty); }
-            set { this.SetValue(CommandParameterProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets the target element on which to fire the command.
-        /// </summary>
-        public IInputElement CommandTarget
-        {
-            get { return (IInputElement)this.GetValue(CommandTargetProperty); }
-            set { this.SetValue(CommandTargetProperty, value); }
-        }
-
-        /// <summary>
-        /// Get or sets the Command property. 
-        /// </summary>
-        public ICommand Command
-        {
-            get { return (ICommand)this.GetValue(CommandProperty); }
-            set { this.SetValue(CommandProperty, value); }
-        }
+        public static readonly DependencyProperty ExtraTagProperty
+            = DependencyProperty.Register(
+                nameof(ExtraTag),
+                typeof(object),
+                typeof(SplitButton));
 
         /// <summary>
         /// Gets or sets an extra tag.
@@ -84,14 +43,27 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(ExtraTagProperty, value); }
         }
 
+        public static readonly DependencyProperty OrientationProperty
+            = DependencyProperty.Register(
+                nameof(Orientation),
+                typeof(Orientation),
+                typeof(SplitButton),
+                new FrameworkPropertyMetadata(Orientation.Horizontal, FrameworkPropertyMetadataOptions.AffectsMeasure));
+
         /// <summary>
-        /// Gets or sets the dimension of children stacking.
+        /// Gets or sets the orientation of children stacking.
         /// </summary>
         public Orientation Orientation
         {
             get { return (Orientation)this.GetValue(OrientationProperty); }
             set { this.SetValue(OrientationProperty, value); }
         }
+
+        public static readonly DependencyProperty IconProperty
+            = DependencyProperty.Register(
+                nameof(Icon),
+                typeof(object),
+                typeof(SplitButton));
 
         /// <summary>
         ///  Gets or sets the Content used to generate the icon part.
@@ -103,6 +75,12 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(IconProperty, value); }
         }
 
+        public static readonly DependencyProperty IconTemplateProperty
+            = DependencyProperty.Register(
+                nameof(IconTemplate),
+                typeof(DataTemplate),
+                typeof(SplitButton));
+
         /// <summary> 
         /// Gets or sets the ContentTemplate used to display the content of the icon part. 
         /// </summary>
@@ -113,6 +91,58 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(IconTemplateProperty, value); }
         }
 
+        public static readonly DependencyProperty CommandProperty
+            = DependencyProperty.Register(
+                nameof(Command),
+                typeof(ICommand),
+                typeof(SplitButton));
+
+        /// <summary>
+        /// Get or sets the Command property. 
+        /// </summary>
+        public ICommand Command
+        {
+            get { return (ICommand)this.GetValue(CommandProperty); }
+            set { this.SetValue(CommandProperty, value); }
+        }
+
+        public static readonly DependencyProperty CommandTargetProperty
+            = DependencyProperty.Register(
+                nameof(CommandTarget),
+                typeof(IInputElement),
+                typeof(SplitButton));
+
+        /// <summary>
+        /// Gets or sets the target element on which to fire the command.
+        /// </summary>
+        public IInputElement CommandTarget
+        {
+            get { return (IInputElement)this.GetValue(CommandTargetProperty); }
+            set { this.SetValue(CommandTargetProperty, value); }
+        }
+
+        public static readonly DependencyProperty CommandParameterProperty
+            = DependencyProperty.Register(
+                nameof(CommandParameter),
+                typeof(object),
+                typeof(SplitButton));
+
+        /// <summary>
+        /// Reflects the parameter to pass to the CommandProperty upon execution. 
+        /// </summary>
+        public object CommandParameter
+        {
+            get { return this.GetValue(CommandParameterProperty); }
+            set { this.SetValue(CommandParameterProperty, value); }
+        }
+
+        public static readonly DependencyProperty ButtonStyleProperty
+            = DependencyProperty.Register(
+                nameof(ButtonStyle),
+                typeof(Style),
+                typeof(SplitButton),
+                new FrameworkPropertyMetadata(default(Style), FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure));
+
         /// <summary>
         /// Gets/sets the button style.
         /// </summary>
@@ -121,6 +151,13 @@ namespace MahApps.Metro.Controls
             get { return (Style)this.GetValue(ButtonStyleProperty); }
             set { this.SetValue(ButtonStyleProperty, value); }
         }
+
+        public static readonly DependencyProperty ButtonArrowStyleProperty
+            = DependencyProperty.Register(
+                nameof(ButtonArrowStyle),
+                typeof(Style),
+                typeof(SplitButton),
+                new FrameworkPropertyMetadata(default(Style), FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure));
 
         /// <summary>
         /// Gets/sets the button arrow style.
@@ -131,6 +168,13 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(ButtonArrowStyleProperty, value); }
         }
 
+        public static readonly DependencyProperty ArrowBrushProperty
+            = DependencyProperty.Register(
+                nameof(ArrowBrush),
+                typeof(Brush),
+                typeof(SplitButton),
+                new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
+
         /// <summary>
         /// Gets/sets the brush of the button arrow icon.
         /// </summary>
@@ -140,6 +184,13 @@ namespace MahApps.Metro.Controls
             set { this.SetValue(ArrowBrushProperty, value); }
         }
 
+        public static readonly DependencyProperty ArrowMouseOverBrushProperty
+            = DependencyProperty.Register(
+                nameof(ArrowMouseOverBrush),
+                typeof(Brush),
+                typeof(SplitButton),
+                new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
+
         /// <summary>
         /// Gets/sets the brush of the button arrow icon if the mouse is over the split button.
         /// </summary>
@@ -148,6 +199,13 @@ namespace MahApps.Metro.Controls
             get { return (Brush)this.GetValue(ArrowMouseOverBrushProperty); }
             set { this.SetValue(ArrowMouseOverBrushProperty, value); }
         }
+
+        public static readonly DependencyProperty ArrowPressedBrushProperty
+            = DependencyProperty.Register(
+                nameof(ArrowPressedBrush),
+                typeof(Brush),
+                typeof(SplitButton),
+                new FrameworkPropertyMetadata(default(Brush), FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
         /// Gets/sets the brush of the button arrow icon if the arrow button is pressed.
@@ -187,26 +245,38 @@ namespace MahApps.Metro.Controls
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
-            this._clickButton = this.EnforceInstance<Button>("PART_Button");
-            this._expander = this.EnforceInstance<Button>("PART_Expander");
-            this.InitializeVisualElementsContainer();
+
+            if (this._clickButton != null)
+            {
+                this._clickButton.Click -= this.ButtonClick;
+                this._clickButton.IsEnabledChanged -= this.ButtonIsEnabledChanged;
+            }
+
+            this._clickButton = this.GetTemplateChild("PART_Button") as Button;
+            if (this._clickButton != null)
+            {
+                this._clickButton.Click += this.ButtonClick;
+                this._clickButton.IsEnabledChanged += this.ButtonIsEnabledChanged;
+            }
+
+            if (this._expander != null)
+            {
+                this._expander.PreviewMouseLeftButtonDown -= this.ExpanderMouseLeftButtonDown;
+            }
+
+            this._expander = this.GetTemplateChild("PART_Expander") as Button;
+            if (this._expander != null)
+            {
+                this._expander.PreviewMouseLeftButtonDown += this.ExpanderMouseLeftButtonDown;
+            }
         }
 
-        private void InitializeVisualElementsContainer()
+        private void ButtonIsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            this._expander.PreviewMouseLeftButtonDown -= this.ExpanderMouseLeftButtonDown;
-            this._expander.PreviewMouseLeftButtonDown += this.ExpanderMouseLeftButtonDown;
-
-            this._clickButton.Click -= this.ButtonClick;
-            this._clickButton.Click += this.ButtonClick;
+            this.SetCurrentValue(IsEnabledProperty, e.NewValue);
         }
 
-        //Get element from name. If it exist then element instance return, if not, new will be created
-        private T EnforceInstance<T>(string partName)
-            where T : FrameworkElement, new()
-        {
-            T element = this.GetTemplateChild(partName) as T ?? new T();
-            return element;
-        }
+        private Button _clickButton;
+        private Button _expander;
     }
 }

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -721,7 +721,7 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Style.Triggers>
             <Trigger Property="IsVisible" Value="True">
-                <Setter Property="RenderOptions.ClearTypeHint" Value="{Binding Path=(RenderOptions.ClearTypeHint), FallbackValue=Auto, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ComboBox}}}" />
+                <Setter Property="RenderOptions.ClearTypeHint" Value="{Binding Path=(RenderOptions.ClearTypeHint), FallbackValue=Auto, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Selector}}}" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/src/MahApps.Metro/Themes/SplitButton.xaml
+++ b/src/MahApps.Metro/Themes/SplitButton.xaml
@@ -51,11 +51,12 @@
                                                            VerticalAlignment="Center"
                                                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                           Content="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                                           Content="{TemplateBinding SelectionBoxItem}"
                                                            ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
-                                                           ContentStringFormat="{TemplateBinding ItemStringFormat}"
-                                                           ContentTemplate="{TemplateBinding ItemTemplate}"
+                                                           ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                                                           ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
                                                            ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                                           IsHitTestVisible="False"
                                                            RecognizesAccessKey="True"
                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                            UseLayoutRounding="False" />
@@ -82,34 +83,26 @@
             <Popup x:Name="PART_Popup"
                    AllowsTransparency="True"
                    Focusable="False"
-                   IsOpen="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                   PlacementTarget="{Binding ElementName=PART_Border}"
-                   PopupAnimation="Fade"
-                   StaysOpen="True">
-                <ListBox x:Name="PART_ListBox"
-                         MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
-                         Margin="0"
-                         BorderBrush="{TemplateBinding BorderBrush}"
-                         BorderThickness="1"
-                         DisplayMemberPath="{TemplateBinding DisplayMemberPath}"
-                         FocusVisualStyle="{x:Null}"
-                         IsSelected="{TemplateBinding IsSelected}"
-                         IsSynchronizedWithCurrentItem="{TemplateBinding IsSynchronizedWithCurrentItem}"
-                         ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
-                         ItemContainerStyleSelector="{TemplateBinding ItemContainerStyleSelector}"
-                         ItemStringFormat="{TemplateBinding ItemStringFormat}"
-                         ItemTemplate="{TemplateBinding ItemTemplate}"
-                         ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                         ItemsPanel="{TemplateBinding ItemsPanel}"
-                         ItemsSource="{TemplateBinding ItemsSource}"
-                         RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}"
-                         SelectedIndex="{Binding SelectedIndex, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                         SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                         SelectedValue="{Binding SelectedValue, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                         SelectedValuePath="{TemplateBinding SelectedValuePath}"
-                         SelectionMode="Single"
-                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                         Style="{TemplateBinding ListBoxStyle}" />
+                   IsOpen="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                   Placement="Bottom"
+                   PopupAnimation="Fade">
+                <Grid MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}" MaxHeight="{Binding MaxDropDownHeight, RelativeSource={RelativeSource TemplatedParent}}">
+                    <Border x:Name="PopupBorder"
+                            Height="Auto"
+                            HorizontalAlignment="Stretch"
+                            Background="{DynamicResource MahApps.Brushes.White}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="1"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <ScrollViewer Padding="1" BorderThickness="0">
+                            <Grid RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}">
+                                <ItemsPresenter x:Name="ItemsPresenter"
+                                                KeyboardNavigation.DirectionalNavigation="Contained"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
             </Popup>
         </Grid>
         <ControlTemplate.Triggers>
@@ -127,6 +120,13 @@
                 <Setter Property="Opacity" Value=".55" />
                 <Setter TargetName="PART_Expander" Property="IsEnabled" Value="False" />
             </Trigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
+                <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
+            </MultiTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
@@ -179,11 +179,12 @@
                                                            VerticalAlignment="Center"
                                                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                           Content="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                                           Content="{TemplateBinding SelectionBoxItem}"
                                                            ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.ContentCharacterCasing)}"
-                                                           ContentStringFormat="{TemplateBinding ItemStringFormat}"
-                                                           ContentTemplate="{TemplateBinding ItemTemplate}"
+                                                           ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                                                           ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
                                                            ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                                           IsHitTestVisible="False"
                                                            RecognizesAccessKey="True"
                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                            UseLayoutRounding="False" />
@@ -210,34 +211,26 @@
             <Popup x:Name="PART_Popup"
                    AllowsTransparency="True"
                    Focusable="False"
-                   IsOpen="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                   PlacementTarget="{Binding ElementName=PART_Border}"
-                   PopupAnimation="Fade"
-                   StaysOpen="True">
-                <ListBox x:Name="PART_ListBox"
-                         MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
-                         Margin="0"
-                         BorderBrush="{TemplateBinding BorderBrush}"
-                         BorderThickness="1"
-                         DisplayMemberPath="{TemplateBinding DisplayMemberPath}"
-                         FocusVisualStyle="{x:Null}"
-                         IsSelected="{TemplateBinding IsSelected}"
-                         IsSynchronizedWithCurrentItem="{TemplateBinding IsSynchronizedWithCurrentItem}"
-                         ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
-                         ItemContainerStyleSelector="{TemplateBinding ItemContainerStyleSelector}"
-                         ItemStringFormat="{TemplateBinding ItemStringFormat}"
-                         ItemTemplate="{TemplateBinding ItemTemplate}"
-                         ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                         ItemsPanel="{TemplateBinding ItemsPanel}"
-                         ItemsSource="{TemplateBinding ItemsSource}"
-                         RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}"
-                         SelectedIndex="{Binding SelectedIndex, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                         SelectedItem="{Binding SelectedItem, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                         SelectedValue="{Binding SelectedValue, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                         SelectedValuePath="{TemplateBinding SelectedValuePath}"
-                         SelectionMode="Single"
-                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                         Style="{TemplateBinding ListBoxStyle}" />
+                   IsOpen="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                   Placement="Bottom"
+                   PopupAnimation="Fade">
+                <Grid MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}" MaxHeight="{Binding MaxDropDownHeight, RelativeSource={RelativeSource TemplatedParent}}">
+                    <Border x:Name="PopupBorder"
+                            Height="Auto"
+                            HorizontalAlignment="Stretch"
+                            Background="{DynamicResource MahApps.Brushes.White}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="1"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <ScrollViewer Padding="1" BorderThickness="0">
+                            <Grid RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}">
+                                <ItemsPresenter x:Name="ItemsPresenter"
+                                                KeyboardNavigation.DirectionalNavigation="Contained"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
             </Popup>
         </Grid>
         <ControlTemplate.Triggers>
@@ -255,6 +248,13 @@
                 <Setter Property="Opacity" Value=".55" />
                 <Setter TargetName="PART_Expander" Property="IsEnabled" Value="False" />
             </Trigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="IsGrouping" Value="true" />
+                    <Condition Property="VirtualizingPanel.IsVirtualizingWhenGrouping" Value="false" />
+                </MultiTrigger.Conditions>
+                <Setter Property="ScrollViewer.CanContentScroll" Value="false" />
+            </MultiTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
@@ -282,19 +282,37 @@
         <Setter Property="ButtonArrowStyle" Value="{DynamicResource MahApps.Styles.Button.SplitArrow}" />
         <Setter Property="ButtonStyle" Value="{DynamicResource MahApps.Styles.Button.Split}" />
         <Setter Property="FocusVisualStyle" Value="{StaticResource MahApps.Styles.FocusVisualStyle.ButtonSplit}" />
-        <Setter Property="Focusable" Value="False" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.BlackColor}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
-        <Setter Property="ListBoxStyle" Value="{DynamicResource MahApps.Styles.ListBox.Virtualized}" />
         <Setter Property="MinHeight" Value="26" />
         <Setter Property="Padding" Value="2" />
         <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
+        <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+        <Setter Property="ScrollViewer.PanningMode" Value="Both" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="Template" Value="{StaticResource MahApps.Templates.SplitButton.Horizontal}" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="VirtualizingStackPanel.IsVirtualizing" Value="True" />
+        <Setter Property="VirtualizingStackPanel.IsVirtualizingWhenGrouping" Value="True" />
+        <Setter Property="VirtualizingStackPanel.VirtualizationMode" Value="Recycling" />
         <Style.Triggers>
+            <Trigger Property="VirtualizingStackPanel.IsVirtualizing" Value="True">
+                <Setter Property="ItemsPanel">
+                    <Setter.Value>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel IsItemsHost="True"
+                                                    IsVirtualizing="True"
+                                                    IsVirtualizingWhenGrouping="True"
+                                                    VirtualizationMode="Recycling" />
+                        </ItemsPanelTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
             <Trigger Property="Orientation" Value="Vertical">
                 <Setter Property="Template" Value="{StaticResource MahApps.Templates.SplitButton.Vertical}" />
             </Trigger>


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Derive `SplitButton` from ComboBox to fix disappearing Items. Implementing only the interesting stuff from the ComboBox is not possible because of too many internal things.

- Derive from ComboBox
- `IsExpanded` DP is now `IsDropDownOpen`
- Remove `ListBoxStyle` DP
- The `SplitButton` template uses now an ItemsPresenter like the ComboBox instead a full ListBox
- The `IsEditable` property will be ignored and is always set to false
- Update documentation

**Closed Issues**

Closes #3513 
