### PR TITLE
Handle NumericUpDown percentage StringFormat correctly

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -395,6 +395,7 @@
                                         NumericInputMode="{Binding ElementName=NumericInputCheckBox, Path=SelectedItem, Mode=TwoWay}"
                                         StringFormat="0,000.00"
                                         Value="5" />
+                <TextBox x:Name="TextBox" Margin="{StaticResource ControlMargin}" Text="{Binding ElementName=StringFormatNumUpDown, Path=Value, Mode=TwoWay}" />
 
                 <Label Content="Select all on focus" />
                 <Controls:NumericUpDown Controls:TextBoxHelper.SelectAllOnFocus="True"

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -983,7 +983,7 @@ namespace MahApps.Metro.Controls
                 return;
             }
 
-            this.valueTextBox.Text = this.FormattedValue(newValue, this.StringFormat, this.SpecificCultureInfo);
+            this.valueTextBox.Text = this.FormattedValueString(newValue.Value, this.StringFormat, this.SpecificCultureInfo);
 
             if ((bool)this.GetValue(TextBoxHelper.IsMonitoringProperty))
             {
@@ -991,7 +991,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        private string FormattedValue(double? newValue, string format, CultureInfo culture)
+        private string FormattedValueString(double newValue, string format, CultureInfo culture)
         {
             format = format.Replace("{}", string.Empty);
             if (!string.IsNullOrWhiteSpace(format))
@@ -1006,15 +1006,36 @@ namespace MahApps.Metro.Controls
                     if (match.Success)
                     {
                         // we have a format template such as "{0:N0}"
-                        return string.Format(culture, format, ConvertStringFormatValue(newValue.Value, match.Groups["format"].Value));
+                        return string.Format(culture, format, newValue);
                     }
                     // we have a format such as "N0"
-                    var value = ConvertStringFormatValue(newValue.Value, format);
-                    return value.ToString(format, culture);
+                    return newValue.ToString(format, culture);
                 }
             }
 
-            return newValue.Value.ToString(culture);
+            return newValue.ToString(culture);
+        }        
+
+        private double FormattedValue(double newValue, string format, CultureInfo culture)
+        {
+            format = format.Replace("{}", string.Empty);
+            if (!string.IsNullOrWhiteSpace(format))
+            {
+                if (!TryFormatHexadecimal(newValue, format, culture, out string hexValue))
+                {
+                    var match = RegexStringFormat.Match(format);
+                    if (match.Success)
+                    {
+                        // we have a format template such as "{0:N0}"
+                        return ConvertStringFormatValue(newValue, match.Groups["format"].Value);
+                    }
+
+                    // we have a format such as "N0"
+                    return ConvertStringFormatValue(newValue, format);
+                }
+            }
+
+            return newValue;
         }        
 
         private static double ConvertStringFormatValue(double value, string format)
@@ -1030,7 +1051,7 @@ namespace MahApps.Metro.Controls
             return value;
         }        
 
-        private static bool TryFormatHexadecimal(double? newValue, string format, CultureInfo culture, out string output)
+        private static bool TryFormatHexadecimal(double newValue, string format, CultureInfo culture, out string output)
         {
             var match = RegexStringFormatHexadecimal.Match(format);
             if (match.Success)
@@ -1038,13 +1059,13 @@ namespace MahApps.Metro.Controls
                 if (match.Groups["simpleHEX"].Success)
                 {
                     // HEX DOES SUPPORT INT ONLY.
-                    output = ((int)newValue.Value).ToString(match.Groups["simpleHEX"].Value, culture);
+                    output = ((int)newValue).ToString(match.Groups["simpleHEX"].Value, culture);
                     return true;
                 }
 
                 if (match.Groups["complexHEX"].Success)
                 {
-                    output = string.Format(culture, match.Groups["complexHEX"].Value, (int)newValue.Value);
+                    output = string.Format(culture, match.Groups["complexHEX"].Value, (int)newValue);
                     return true;
                 }
             }
@@ -1186,6 +1207,7 @@ namespace MahApps.Metro.Controls
                 double convertedValue;
                 if (this.ValidateText(textBox.Text, out convertedValue))
                 {
+                    convertedValue = this.FormattedValue(convertedValue, this.StringFormat, this.SpecificCultureInfo);
                     this.SetValueTo(convertedValue);
                 }
             }
@@ -1209,7 +1231,8 @@ namespace MahApps.Metro.Controls
                 double convertedValue;
                 if (this.ValidateText(((TextBox)sender).Text, out convertedValue))
                 {
-                    this.SetCurrentValue(ValueProperty, convertedValue);
+                    convertedValue = this.FormattedValue(convertedValue, this.StringFormat, this.SpecificCultureInfo);
+                    this.SetValueTo(convertedValue);
                 }
             }
         }

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -984,7 +984,7 @@ namespace MahApps.Metro.Controls
                 return;
             }
 
-            this.valueTextBox.Text = this.FormattedValueString(newValue.Value, this.StringFormat, this.SpecificCultureInfo);
+            this.valueTextBox.Text = FormattedValueString(newValue.Value, this.StringFormat, this.SpecificCultureInfo);
 
             if ((bool)this.GetValue(TextBoxHelper.IsMonitoringProperty))
             {
@@ -992,7 +992,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        private string FormattedValueString(double newValue, string format, CultureInfo culture)
+        private static string FormattedValueString(double newValue, string format, CultureInfo culture)
         {
             format = format.Replace("{}", string.Empty);
             if (!string.IsNullOrWhiteSpace(format))
@@ -1017,7 +1017,7 @@ namespace MahApps.Metro.Controls
             return newValue.ToString(culture);
         }        
 
-        private double FormattedValue(double newValue, string format, CultureInfo culture)
+        private static double FormattedValue(double newValue, string format, CultureInfo culture)
         {
             format = format.Replace("{}", string.Empty);
             if (!string.IsNullOrWhiteSpace(format))
@@ -1208,7 +1208,7 @@ namespace MahApps.Metro.Controls
                 double convertedValue;
                 if (this.ValidateText(textBox.Text, out convertedValue))
                 {
-                    convertedValue = this.FormattedValue(convertedValue, this.StringFormat, this.SpecificCultureInfo);
+                    convertedValue = FormattedValue(convertedValue, this.StringFormat, this.SpecificCultureInfo);
                     this.SetValueTo(convertedValue);
                 }
             }
@@ -1232,7 +1232,7 @@ namespace MahApps.Metro.Controls
                 double convertedValue;
                 if (this.ValidateText(((TextBox)sender).Text, out convertedValue))
                 {
-                    convertedValue = this.FormattedValue(convertedValue, this.StringFormat, this.SpecificCultureInfo);
+                    convertedValue = FormattedValue(convertedValue, this.StringFormat, this.SpecificCultureInfo);
                     this.SetValueTo(convertedValue);
                 }
             }

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -187,7 +187,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        private static readonly Regex RegexStringFormatHexadecimal = new Regex(@"^(?<complexHEX>.*{\d:X\d+}.*)?(?<simpleHEX>X\d+)?$", RegexOptions.Compiled);
+        private static readonly Regex RegexStringFormatHexadecimal = new Regex(@"^(?<complexHEX>.*{\d\s*:[Xx]\d*}.*)?(?<simpleHEX>[Xx]\d*)?$", RegexOptions.Compiled);
         private const string RawRegexNumberString = @"[-+]?(?<![0-9][<DecimalSeparator><GroupSeparator>])[<DecimalSeparator><GroupSeparator>]?[0-9]+(?:[<DecimalSeparator><GroupSeparator>\s][0-9]+)*[<DecimalSeparator><GroupSeparator>]?[0-9]?(?:[eE][-+]?[0-9]+)?(?!\.[0-9])";
         private Regex regexNumber = null;
         private static readonly Regex RegexHexadecimal = new Regex(@"^([a-fA-F0-9]{1,2}\s?)+$", RegexOptions.Compiled);
@@ -930,10 +930,11 @@ namespace MahApps.Metro.Controls
                 nud.InternalSetText(nud.Value);
             }
 
-            var value = (string)e.NewValue;
+            var format = (string)e.NewValue;
 
-            if (!nud.NumericInputMode.HasFlag(NumericInput.Decimal) && !string.IsNullOrEmpty(value) && RegexStringFormatHexadecimal.IsMatch(value))
+            if (!string.IsNullOrEmpty(format) && RegexStringFormatHexadecimal.IsMatch(format))
             {
+                nud.SetCurrentValue(ParsingNumberStyleProperty, NumberStyles.HexNumber);
                 nud.SetCurrentValue(NumericInputModeProperty, nud.NumericInputMode | NumericInput.Decimal);
             }
         }

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownFixture.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownFixture.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using Xunit;
+
+namespace MahApps.Metro.Tests
+{
+    public class NumericUpDownFixture : IAsyncLifetime
+    {
+        public NumericUpDownWindow Window { get; private set; }
+
+        public TextBox TextBox { get; private set; }
+
+        public RepeatButton NumUp { get; private set; }
+
+        public RepeatButton NumDown { get; private set; }
+
+        /// <summary>
+        /// Called immediately after the class has been created, before it is used.
+        /// </summary>
+        public async Task InitializeAsync()
+        {
+            await TestHost.SwitchToAppThread();
+
+            this.Window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
+            this.TextBox = this.Window.TheNUD.FindChild<TextBox>();
+            this.NumUp = this.Window.TheNUD.FindChild<RepeatButton>("PART_NumericUp");
+            this.NumDown = this.Window.TheNUD.FindChild<RepeatButton>("PART_NumericDown");
+        }
+
+        public static IEnumerable<DependencyProperty> EnumerateDependencyProperties(DependencyObject obj)
+        {
+            if (obj != null)
+            {
+                LocalValueEnumerator lve = obj.GetLocalValueEnumerator();
+                while (lve.MoveNext())
+                {
+                    yield return lve.Current.Property;
+                }
+            }
+        }
+
+        public async Task PrepareForTestAsync()
+        {
+            await TestHost.SwitchToAppThread();
+
+            foreach (var property in EnumerateDependencyProperties(this.Window.TheNUD))
+            {
+                this.Window.TheNUD.ClearValue(property);
+            }
+        }
+
+        /// <summary>
+        /// Called when an object is no longer needed. Called just before <see cref="M:System.IDisposable.Dispose" />
+        /// if the class also implements that.
+        /// </summary>
+        public Task DisposeAsync()
+        {
+            this.TextBox = null;
+            this.NumUp = null;
+            this.NumDown = null;
+            this.Window = null;
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -26,12 +26,12 @@ namespace MahApps.Metro.Tests
             double absB = Math.Abs(b);
             double diff = Math.Abs(a - b);
 
-            if (a == b)
+            if (a.Equals(b))
             {
                 // shortcut, handles infinities
                 return true;
             }
-            else if (a == 0 || b == 0 || diff < Double.Epsilon)
+            else if (a.Equals(0) || b.Equals(0) || diff < double.Epsilon)
             {
                 // a or b is zero or both are extremely close to it
                 // relative error is less meaningful here
@@ -170,25 +170,25 @@ namespace MahApps.Metro.Tests
         }
 
         [Theory]
-        [InlineData("100", "{}{0:P0}", "en-EN", 1d, "100%")]
-        [InlineData("100 %", "{}{0:P0}", "en-EN", 1d, "100%")]
-        [InlineData("100%", "{}{0:P0}", "en-EN", 1d, "100%")]
+        [InlineData("100", "{}{0:P0}", "en-EN", 1d, "100%", false)]
+        [InlineData("100 %", "{}{0:P0}", "en-EN", 1d, "100%", false)]
+        [InlineData("100%", "{}{0:P0}", "en-EN", 1d, "100%", false)]
         [InlineData("-0.39678", "{}{0:P1}", "en-EN", -0.0039678d, "-0.4%", true)]
-        [InlineData("50", "P0", "en-EN", 0.5d, "50%")]
-        [InlineData("50", "P1", "en-EN", 0.5d, "50.0%")]
+        [InlineData("50", "P0", "en-EN", 0.5d, "50%", false)]
+        [InlineData("50", "P1", "en-EN", 0.5d, "50.0%", false)]
         [InlineData("-0.39678", "P1", "en-EN", -0.0039678d, "-0.4%", true)]
-        [InlineData("10", "{}{0:P0}", null, 0.1d, "10 %")]
+        [InlineData("10", "{}{0:P0}", null, 0.1d, "10 %", false)]
         [InlineData("-0.39678", "{}{0:P1}", null, -0.0039678d, "-0.4 %", true)]
-        [InlineData("1", "P0", null, 0.01d, "1 %")]
+        [InlineData("1", "P0", null, 0.01d, "1 %", false)]
         [InlineData("-0.39678", "P1", null, -0.0039678d, "-0.4 %", true)]
-        [InlineData("1", "{}{0:0.0%}", null, 0.01d, "1.0%")]
-        [InlineData("1", "0.0%", null, 0.01d, "1.0%")]
-        [InlineData("0.25", "{0:0.0000}%", null, 0.25d, "0.2500%")] // GH-3376 Case 3
-        [InlineData("100", "{}{0}%", null, 100d, "100%")]
-        [InlineData("100%", "{}{0}%", null, 100d, "100%")]
-        [InlineData("100 %", "{}{0}%", null, 100d, "100%")]
+        [InlineData("1", "{}{0:0.0%}", null, 0.01d, "1.0%", false)]
+        [InlineData("1", "0.0%", null, 0.01d, "1.0%", false)]
+        [InlineData("0.25", "{0:0.0000}%", null, 0.25d, "0.2500%", false)] // GH-3376 Case 3
+        [InlineData("100", "{}{0}%", null, 100d, "100%", false)]
+        [InlineData("100%", "{}{0}%", null, 100d, "100%", false)]
+        [InlineData("100 %", "{}{0}%", null, 100d, "100%", false)]
         [DisplayTestMethodName]
-        public async Task ShouldConvertTextInputWithPercentageStringFormat(string text, string format, string culture, object expectedValue, string expectedText, bool useEpsilon = false)
+        public async Task ShouldConvertTextInputWithPercentageStringFormat(string text, string format, string culture, object expectedValue, string expectedText, bool useEpsilon)
         {
             await this.fixture.PrepareForTestAsync().ConfigureAwait(false);
             await TestHost.SwitchToAppThread();
@@ -232,7 +232,7 @@ namespace MahApps.Metro.Tests
         [InlineData("1 ‰", "0.0‰", "en-EN", 0.001d, "1.0‰")]
         [InlineData("0.25", "{0:0.0000}‰", null, 0.25d, "0.2500‰")]
         [DisplayTestMethodName]
-        public async Task ShouldConvertTextInputWithPermilleStringFormat(string text, string format, string culture, object expectedValue, string expectedText, bool useEpsilon = false)
+        public async Task ShouldConvertTextInputWithPermilleStringFormat(string text, string format, string culture, object expectedValue, string expectedText)
         {
             await this.fixture.PrepareForTestAsync().ConfigureAwait(false);
             await TestHost.SwitchToAppThread();
@@ -243,15 +243,7 @@ namespace MahApps.Metro.Tests
 
             SetText(this.fixture.TextBox, text);
 
-            if (useEpsilon)
-            {
-                Assert.True(NearlyEqual((double)expectedValue, this.fixture.Window.TheNUD.Value.Value, 0.000005), $"The input '{text}' should be '{expectedValue} ({expectedText})', but value is '{this.fixture.Window.TheNUD.Value.Value}'");
-            }
-            else
-            {
-                Assert.Equal(expectedValue, this.fixture.Window.TheNUD.Value);
-            }
-
+            Assert.Equal(expectedValue, this.fixture.Window.TheNUD.Value);
             Assert.Equal(expectedText, this.fixture.TextBox.Text);
         }
 

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -11,8 +11,35 @@ using Xunit;
 
 namespace MahApps.Metro.Tests
 {
-    public class NumericUpDownTests : AutomationTestBase
+    public class NumericUpDownTests : AutomationTestBase, IAsyncLifetime
     {
+        private NumericUpDownWindow window;
+        private TextBox textBox;
+        private RepeatButton numUp;
+        private RepeatButton numDown;
+
+        /// <summary>
+        /// Called immediately after the class has been created, before it is used.
+        /// </summary>
+        public async Task InitializeAsync()
+        {
+            await TestHost.SwitchToAppThread();
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
+
+            this.textBox = this.window.TheNUD.FindChild<TextBox>();
+            this.numUp = this.window.TheNUD.FindChild<RepeatButton>("PART_NumericUp");
+            this.numDown = this.window.TheNUD.FindChild<RepeatButton>("PART_NumericDown");
+        }
+
+        /// <summary>
+        /// Called when an object is no longer needed. Called just before <see cref="M:System.IDisposable.Dispose" />
+        /// if the class also implements that.
+        /// </summary>
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
         public static bool NearlyEqual(double a, double b, double epsilon)
         {
             double absA = Math.Abs(a);
@@ -42,32 +69,22 @@ namespace MahApps.Metro.Tests
         public async Task ShouldConvertTextInputWithSnapToMultipleOfInterval()
         {
             await TestHost.SwitchToAppThread();
-            var window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
-            await TestHost.SwitchToAppThread();
 
-            var textBox = window.TheNUD.FindChild<TextBox>(string.Empty);
-            Assert.NotNull(textBox);
+            this.window.TheNUD.Interval = 0.1;
+            this.window.TheNUD.SnapToMultipleOfInterval = true;
 
-            var numUp = window.TheNUD.FindChild<RepeatButton>("PART_NumericUp");
-            Assert.NotNull(numUp);
-            var numDown = window.TheNUD.FindChild<RepeatButton>("PART_NumericDown");
-            Assert.NotNull(numDown);
-
-            window.TheNUD.Interval = 0.1;
-            window.TheNUD.SnapToMultipleOfInterval = true;
-
-            window.TheNUD.Value = 0;
+            this.window.TheNUD.Value = 0;
             for (int i = 1; i < 15; i++)
             {
                 numUp.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
-                Assert.Equal(0d + 0.1 * i, window.TheNUD.Value);
+                Assert.Equal(0d + 0.1 * i, this.window.TheNUD.Value);
             }
 
-            window.TheNUD.Value = 0;
+            this.window.TheNUD.Value = 0;
             for (int i = 1; i < 15; i++)
             {
                 numDown.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
-                Assert.Equal(0d - 0.1 * i, window.TheNUD.Value);
+                Assert.Equal(0d - 0.1 * i, this.window.TheNUD.Value);
             }
         }
 
@@ -76,28 +93,23 @@ namespace MahApps.Metro.Tests
         public async Task ShouldConvertTextInput()
         {
             await TestHost.SwitchToAppThread();
-            var window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
-            await TestHost.SwitchToAppThread();
 
-            var textBox = window.TheNUD.FindChild<TextBox>(string.Empty);
-            Assert.NotNull(textBox);
-
-            window.TheNUD.NumericInputMode = NumericInput.All;
+            this.window.TheNUD.NumericInputMode = NumericInput.All;
 
             SetText(textBox, "42");
-            Assert.Equal(42d, window.TheNUD.Value);
+            Assert.Equal(42d, this.window.TheNUD.Value);
 
             SetText(textBox, "42.2");
-            Assert.Equal(42.2d, window.TheNUD.Value);
+            Assert.Equal(42.2d, this.window.TheNUD.Value);
 
             SetText(textBox, ".");
-            Assert.Equal(0d, window.TheNUD.Value);
+            Assert.Equal(0d, this.window.TheNUD.Value);
 
             SetText(textBox, ".9");
-            Assert.Equal(0.9d, window.TheNUD.Value);
+            Assert.Equal(0.9d, this.window.TheNUD.Value);
 
             SetText(textBox, ".0115");
-            Assert.Equal(0.0115d, window.TheNUD.Value);
+            Assert.Equal(0.0115d, this.window.TheNUD.Value);
         }
 
         [Fact]
@@ -105,55 +117,50 @@ namespace MahApps.Metro.Tests
         public async Task ShouldConvertTextInputWithStringFormat()
         {
             await TestHost.SwitchToAppThread();
-            var window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
-            await TestHost.SwitchToAppThread();
 
-            var textBox = window.TheNUD.FindChild<TextBox>(string.Empty);
-            Assert.NotNull(textBox);
-
-            window.TheNUD.NumericInputMode = NumericInput.All;
-            window.TheNUD.StringFormat = "{}{0:N2} cm";
+            this.window.TheNUD.NumericInputMode = NumericInput.All;
+            this.window.TheNUD.StringFormat = "{}{0:N2} cm";
 
             SetText(textBox, "42");
-            Assert.Equal(42d, window.TheNUD.Value);
+            Assert.Equal(42d, this.window.TheNUD.Value);
             Assert.Equal("42.00 cm", textBox.Text);
 
             SetText(textBox, "42.2");
-            Assert.Equal(42.2d, window.TheNUD.Value);
+            Assert.Equal(42.2d, this.window.TheNUD.Value);
             Assert.Equal("42.20 cm", textBox.Text);
 
             SetText(textBox, ".");
-            Assert.Equal(0d, window.TheNUD.Value);
+            Assert.Equal(0d, this.window.TheNUD.Value);
             Assert.Equal("0.00 cm", textBox.Text);
 
             SetText(textBox, ".9");
-            Assert.Equal(0.9d, window.TheNUD.Value);
+            Assert.Equal(0.9d, this.window.TheNUD.Value);
             Assert.Equal("0.90 cm", textBox.Text);
 
             SetText(textBox, ".0115");
-            Assert.Equal(0.0115d, window.TheNUD.Value);
+            Assert.Equal(0.0115d, this.window.TheNUD.Value);
             Assert.Equal("0.01 cm", textBox.Text);
 
             SetText(textBox, ".0155");
-            Assert.Equal(0.0155d, window.TheNUD.Value);
+            Assert.Equal(0.0155d, this.window.TheNUD.Value);
             Assert.Equal("0.02 cm", textBox.Text);
 
             SetText(textBox, "100.00 cm");
-            Assert.Equal(100d, window.TheNUD.Value);
+            Assert.Equal(100d, this.window.TheNUD.Value);
             Assert.Equal("100.00 cm", textBox.Text);
 
             SetText(textBox, "200.00cm");
-            Assert.Equal(200d, window.TheNUD.Value);
+            Assert.Equal(200d, this.window.TheNUD.Value);
             Assert.Equal("200.00 cm", textBox.Text);
 
             SetText(textBox, "200.00");
-            Assert.Equal(200d, window.TheNUD.Value);
+            Assert.Equal(200d, this.window.TheNUD.Value);
             Assert.Equal("200.00 cm", textBox.Text);
 
             // GH-3551
-            window.TheNUD.StringFormat = "{}{0}mmHg";
+            this.window.TheNUD.StringFormat = "{}{0}mmHg";
             SetText(textBox, "15");
-            Assert.Equal(15, window.TheNUD.Value);
+            Assert.Equal(15, this.window.TheNUD.Value);
             Assert.Equal("15mmHg", textBox.Text);
         }
 
@@ -162,117 +169,112 @@ namespace MahApps.Metro.Tests
         public async Task ShouldConvertTextInputWithPercentStringFormat()
         {
             await TestHost.SwitchToAppThread();
-            var window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
-            await TestHost.SwitchToAppThread();
 
-            var textBox = window.TheNUD.FindChild<TextBox>(string.Empty);
-            Assert.NotNull(textBox);
+            this.window.TheNUD.NumericInputMode = NumericInput.All;
 
-            window.TheNUD.NumericInputMode = NumericInput.All;
+            this.window.TheNUD.Culture = CultureInfo.GetCultureInfo("en-EN");
 
-            window.TheNUD.Culture = CultureInfo.GetCultureInfo("en-EN");
-
-            window.TheNUD.StringFormat = "{}{0:P0}";
+            this.window.TheNUD.StringFormat = "{}{0:P0}";
             SetText(textBox, "100");
-            Assert.Equal(1d, window.TheNUD.Value);
+            Assert.Equal(1d, this.window.TheNUD.Value);
             Assert.Equal("100%", textBox.Text);
 
             SetText(textBox, "100 %");
-            Assert.Equal(1d, window.TheNUD.Value);
+            Assert.Equal(1d, this.window.TheNUD.Value);
             Assert.Equal("100%", textBox.Text);
 
             SetText(textBox, "100%");
-            Assert.Equal(1d, window.TheNUD.Value);
+            Assert.Equal(1d, this.window.TheNUD.Value);
             Assert.Equal("100%", textBox.Text);
 
-            window.TheNUD.StringFormat = "{}{0:P1}";
+            this.window.TheNUD.StringFormat = "{}{0:P1}";
             SetText(textBox, "-0.39678");
-            Assert.True(NearlyEqual(-0.0039678d, window.TheNUD.Value.Value, 0.000005));
+            Assert.True(NearlyEqual(-0.0039678d, this.window.TheNUD.Value.Value, 0.000005));
             Assert.Equal("-0.4%", textBox.Text);
 
-            window.TheNUD.StringFormat = "{}{0:0%}";
+            this.window.TheNUD.StringFormat = "{}{0:0%}";
             SetText(textBox, "100%");
-            Assert.Equal(1d, window.TheNUD.Value);
+            Assert.Equal(1d, this.window.TheNUD.Value);
             Assert.Equal("100%", textBox.Text);
 
-            window.TheNUD.StringFormat = "P0";
+            this.window.TheNUD.StringFormat = "P0";
             SetText(textBox, "50");
-            Assert.Equal(0.5d, window.TheNUD.Value);
+            Assert.Equal(0.5d, this.window.TheNUD.Value);
             Assert.Equal("50%", textBox.Text);
 
-            window.TheNUD.StringFormat = "P1";
+            this.window.TheNUD.StringFormat = "P1";
             SetText(textBox, "-0.39678");
-            Assert.True(NearlyEqual(-0.0039678d, window.TheNUD.Value.Value, 0.000005));
+            Assert.True(NearlyEqual(-0.0039678d, this.window.TheNUD.Value.Value, 0.000005));
             Assert.Equal("-0.4%", textBox.Text);
 
-            window.TheNUD.Culture = CultureInfo.InvariantCulture;
+            this.window.TheNUD.Culture = CultureInfo.InvariantCulture;
 
-            window.TheNUD.StringFormat = "{}{0:P0}";
+            this.window.TheNUD.StringFormat = "{}{0:P0}";
             SetText(textBox, "10");
-            Assert.Equal(0.1d, window.TheNUD.Value);
+            Assert.Equal(0.1d, this.window.TheNUD.Value);
             Assert.Equal("10 %", textBox.Text);
 
-            window.TheNUD.StringFormat = "{}{0:P1}";
+            this.window.TheNUD.StringFormat = "{}{0:P1}";
             SetText(textBox, "-0.39678");
-            Assert.True(NearlyEqual(-0.0039678d, window.TheNUD.Value.Value, 0.000005));
+            Assert.True(NearlyEqual(-0.0039678d, this.window.TheNUD.Value.Value, 0.000005));
             Assert.Equal("-0.4 %", textBox.Text);
 
-            window.TheNUD.StringFormat = "P0";
+            this.window.TheNUD.StringFormat = "P0";
             SetText(textBox, "1");
-            Assert.Equal(0.01d, window.TheNUD.Value);
+            Assert.Equal(0.01d, this.window.TheNUD.Value);
             Assert.Equal("1 %", textBox.Text);
 
-            window.TheNUD.StringFormat = "P1";
+            this.window.TheNUD.StringFormat = "P1";
             SetText(textBox, "-0.39678");
-            Assert.True(NearlyEqual(-0.0039678d, window.TheNUD.Value.Value, 0.000005));
+            Assert.True(NearlyEqual(-0.0039678d, this.window.TheNUD.Value.Value, 0.000005));
             Assert.Equal("-0.4 %", textBox.Text);
 
-            window.TheNUD.StringFormat = "{}{0:0.0%}";
+            this.window.TheNUD.StringFormat = "{}{0:0.0%}";
             SetText(textBox, "1");
-            Assert.Equal(0.01d, window.TheNUD.Value);
+            Assert.Equal(0.01d, this.window.TheNUD.Value);
             Assert.Equal("1.0%", textBox.Text);
 
-            window.TheNUD.StringFormat = "{0:0.0%}";
+            this.window.TheNUD.StringFormat = "{0:0.0%}";
             SetText(textBox, "1");
-            Assert.Equal(0.01d, window.TheNUD.Value);
+            Assert.Equal(0.01d, this.window.TheNUD.Value);
             Assert.Equal("1.0%", textBox.Text);
 
-            window.TheNUD.StringFormat = "0.0%";
+            this.window.TheNUD.StringFormat = "0.0%";
             SetText(textBox, "1");
-            Assert.Equal(0.01d, window.TheNUD.Value);
-            Assert.Equal("1.0%", textBox.Text);            
+            Assert.Equal(0.01d, this.window.TheNUD.Value);
+            Assert.Equal("1.0%", textBox.Text);
 
-            window.TheNUD.StringFormat = "{}{0:0.0‰}";
+            this.window.TheNUD.StringFormat = "{}{0:0.0‰}";
             SetText(textBox, "1");
-            Assert.Equal(0.001d, window.TheNUD.Value);
+            Assert.Equal(0.001d, this.window.TheNUD.Value);
             Assert.Equal("1.0‰", textBox.Text);
 
-            window.TheNUD.StringFormat = "{0:0.0‰}";
+            this.window.TheNUD.StringFormat = "{0:0.0‰}";
             SetText(textBox, "1");
-            Assert.Equal(0.001d, window.TheNUD.Value);
+            Assert.Equal(0.001d, this.window.TheNUD.Value);
             Assert.Equal("1.0‰", textBox.Text);
 
-            window.TheNUD.StringFormat = "0.0‰";
+            this.window.TheNUD.StringFormat = "0.0‰";
             SetText(textBox, "1");
-            Assert.Equal(0.001d, window.TheNUD.Value);
+            Assert.Equal(0.001d, this.window.TheNUD.Value);
             Assert.Equal("1.0‰", textBox.Text);
 
             // GH-3376 Case 3
-            window.TheNUD.StringFormat = "{0:0.0000}%";
+            this.window.TheNUD.StringFormat = "{0:0.0000}%";
             SetText(textBox, "0.25");
-            Assert.Equal(0.25d, window.TheNUD.Value);
+            Assert.Equal(0.25d, this.window.TheNUD.Value);
             Assert.Equal("0.2500%", textBox.Text);
 
             // GH-3376 Case 4
-            window.TheNUD.StringFormat = "{0:0.0000}‰";
+            this.window.TheNUD.StringFormat = "{0:0.0000}‰";
             SetText(textBox, "0.25");
-            Assert.Equal(0.25d, window.TheNUD.Value);
+            Assert.Equal(0.25d, this.window.TheNUD.Value);
             Assert.Equal("0.2500‰", textBox.Text);
 
             // GH-3376#issuecomment-472324787
-            window.TheNUD.StringFormat = "{}{0:G3} mPa·s";
+            this.window.TheNUD.StringFormat = "{}{0:G3} mPa·s";
             SetText(textBox, "0.986");
-            Assert.Equal(0.986d, window.TheNUD.Value);
+            Assert.Equal(0.986d, this.window.TheNUD.Value);
             Assert.Equal("0.986 mPa·s", textBox.Text);
         }
 
@@ -281,28 +283,23 @@ namespace MahApps.Metro.Tests
         public async Task ShouldConvertDecimalTextInput()
         {
             await TestHost.SwitchToAppThread();
-            var window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
-            await TestHost.SwitchToAppThread();
 
-            var textBox = window.TheNUD.FindChild<TextBox>(string.Empty);
-            Assert.NotNull(textBox);
-
-            window.TheNUD.NumericInputMode = NumericInput.Decimal;
+            this.window.TheNUD.NumericInputMode = NumericInput.Decimal;
 
             SetText(textBox, "42");
-            Assert.Equal(42d, window.TheNUD.Value);
+            Assert.Equal(42d, this.window.TheNUD.Value);
 
             SetText(textBox, "42.2");
-            Assert.Equal(42.2d, window.TheNUD.Value);
+            Assert.Equal(42.2d, this.window.TheNUD.Value);
 
             SetText(textBox, ".");
-            Assert.Equal(0d, window.TheNUD.Value);
+            Assert.Equal(0d, this.window.TheNUD.Value);
 
             SetText(textBox, ".9");
-            Assert.Equal(0.9d, window.TheNUD.Value);
+            Assert.Equal(0.9d, this.window.TheNUD.Value);
 
             SetText(textBox, ".0115");
-            Assert.Equal(0.0115d, window.TheNUD.Value);
+            Assert.Equal(0.0115d, this.window.TheNUD.Value);
         }
 
         [Fact]
@@ -310,30 +307,25 @@ namespace MahApps.Metro.Tests
         public async Task ShouldConvertDecimalTextInputWithSpecialCulture()
         {
             await TestHost.SwitchToAppThread();
-            var window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
-            await TestHost.SwitchToAppThread();
 
-            var textBox = window.TheNUD.FindChild<TextBox>(string.Empty);
-            Assert.NotNull(textBox);
+            this.window.TheNUD.NumericInputMode = NumericInput.Decimal;
 
-            window.TheNUD.NumericInputMode = NumericInput.Decimal;
-
-            window.TheNUD.Culture = CultureInfo.GetCultureInfo("fa-IR");
+            this.window.TheNUD.Culture = CultureInfo.GetCultureInfo("fa-IR");
 
             SetText(textBox, "42");
-            Assert.Equal(42d, window.TheNUD.Value);
+            Assert.Equal(42d, this.window.TheNUD.Value);
 
             SetText(textBox, "42/751");
-            Assert.Equal(42.751d, window.TheNUD.Value);
+            Assert.Equal(42.751d, this.window.TheNUD.Value);
 
             SetText(textBox, "/");
-            Assert.Equal(0d, window.TheNUD.Value);
+            Assert.Equal(0d, this.window.TheNUD.Value);
 
             SetText(textBox, "/9");
-            Assert.Equal(0.9d, window.TheNUD.Value);
+            Assert.Equal(0.9d, this.window.TheNUD.Value);
 
             SetText(textBox, "/0115");
-            Assert.Equal(0.0115d, window.TheNUD.Value);
+            Assert.Equal(0.0115d, this.window.TheNUD.Value);
         }
 
         [Fact]
@@ -341,25 +333,20 @@ namespace MahApps.Metro.Tests
         public async Task ShouldConvertNumericTextInput()
         {
             await TestHost.SwitchToAppThread();
-            var window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
-            await TestHost.SwitchToAppThread();
 
-            var textBox = window.TheNUD.FindChild<TextBox>(string.Empty);
-            Assert.NotNull(textBox);
-
-            window.TheNUD.NumericInputMode = NumericInput.Numbers;
+            this.window.TheNUD.NumericInputMode = NumericInput.Numbers;
 
             SetText(textBox, "42");
-            Assert.Equal(42d, window.TheNUD.Value);
+            Assert.Equal(42d, this.window.TheNUD.Value);
 
             SetText(textBox, "42.2");
-            Assert.Null(window.TheNUD.Value);
+            Assert.Null(this.window.TheNUD.Value);
 
             SetText(textBox, ".");
-            Assert.Null(window.TheNUD.Value);
+            Assert.Null(this.window.TheNUD.Value);
 
             SetText(textBox, ".9");
-            Assert.Null(window.TheNUD.Value);
+            Assert.Null(this.window.TheNUD.Value);
         }
 
         [Fact]
@@ -367,46 +354,41 @@ namespace MahApps.Metro.Tests
         public async Task ShouldConvertHexadecimalTextInput()
         {
             await TestHost.SwitchToAppThread();
-            var window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
-            await TestHost.SwitchToAppThread();
 
-            var textBox = window.TheNUD.FindChild<TextBox>(string.Empty);
-            Assert.NotNull(textBox);
-
-            window.TheNUD.NumericInputMode = NumericInput.Numbers;
-            window.TheNUD.ParsingNumberStyle = NumberStyles.HexNumber;
+            this.window.TheNUD.NumericInputMode = NumericInput.Numbers;
+            this.window.TheNUD.ParsingNumberStyle = NumberStyles.HexNumber;
 
             SetText(textBox, "F");
-            Assert.Equal(15d, window.TheNUD.Value);
+            Assert.Equal(15d, this.window.TheNUD.Value);
 
             SetText(textBox, "1F");
-            Assert.Equal(31d, window.TheNUD.Value);
+            Assert.Equal(31d, this.window.TheNUD.Value);
 
             SetText(textBox, "37C5");
-            Assert.Equal(14277d, window.TheNUD.Value);
+            Assert.Equal(14277d, this.window.TheNUD.Value);
 
             SetText(textBox, "ACDC");
-            Assert.Equal(44252d, window.TheNUD.Value);
+            Assert.Equal(44252d, this.window.TheNUD.Value);
 
             SetText(textBox, "10000");
-            Assert.Equal(65536d, window.TheNUD.Value);
+            Assert.Equal(65536d, this.window.TheNUD.Value);
 
             SetText(textBox, "AFFE");
-            Assert.Equal(45054d, window.TheNUD.Value);
+            Assert.Equal(45054d, this.window.TheNUD.Value);
 
             SetText(textBox, "AFFE0815");
-            Assert.Equal(2952661013d, window.TheNUD.Value);
+            Assert.Equal(2952661013d, this.window.TheNUD.Value);
         }
 
         private static void SetText(TextBox textBox, string text)
         {
             textBox.Clear();
             var textCompositionEventArgs = new TextCompositionEventArgs(Keyboard.PrimaryDevice, new TextComposition(InputManager.Current, textBox, text));
-            textCompositionEventArgs.RoutedEvent = TextBox.PreviewTextInputEvent;
+            textCompositionEventArgs.RoutedEvent = UIElement.PreviewTextInputEvent;
             textBox.RaiseEvent(textCompositionEventArgs);
-            textCompositionEventArgs.RoutedEvent = TextBox.TextInputEvent;
+            textCompositionEventArgs.RoutedEvent = UIElement.TextInputEvent;
             textBox.RaiseEvent(textCompositionEventArgs);
-            textBox.RaiseEvent(new RoutedEventArgs(TextBox.LostFocusEvent));
+            textBox.RaiseEvent(new RoutedEventArgs(UIElement.LostFocusEvent));
         }
     }
 }

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows;
@@ -12,6 +13,30 @@ namespace MahApps.Metro.Tests
 {
     public class NumericUpDownTests : AutomationTestBase
     {
+        public static bool NearlyEqual(double a, double b, double epsilon)
+        {
+            double absA = Math.Abs(a);
+            double absB = Math.Abs(b);
+            double diff = Math.Abs(a - b);
+
+            if (a == b)
+            {
+                // shortcut, handles infinities
+                return true;
+            }
+            else if (a == 0 || b == 0 || diff < Double.Epsilon)
+            {
+                // a or b is zero or both are extremely close to it
+                // relative error is less meaningful here
+                return diff < epsilon;
+            }
+            else
+            {
+                // use relative error
+                return diff / (absA + absB) < epsilon;
+            }
+        }
+
         [Fact]
         [DisplayTestMethodName]
         public async Task ShouldConvertTextInputWithSnapToMultipleOfInterval()
@@ -149,105 +174,105 @@ namespace MahApps.Metro.Tests
 
             window.TheNUD.StringFormat = "{}{0:P0}";
             SetText(textBox, "100");
-            Assert.Equal(100d, window.TheNUD.Value);
+            Assert.Equal(1d, window.TheNUD.Value);
             Assert.Equal("100%", textBox.Text);
 
             SetText(textBox, "100 %");
-            Assert.Equal(100d, window.TheNUD.Value);
+            Assert.Equal(1d, window.TheNUD.Value);
             Assert.Equal("100%", textBox.Text);
 
             SetText(textBox, "100%");
-            Assert.Equal(100d, window.TheNUD.Value);
+            Assert.Equal(1d, window.TheNUD.Value);
             Assert.Equal("100%", textBox.Text);
 
             window.TheNUD.StringFormat = "{}{0:P1}";
             SetText(textBox, "-0.39678");
-            Assert.Equal(-0.39678d, window.TheNUD.Value);
+            Assert.True(NearlyEqual(-0.0039678d, window.TheNUD.Value.Value, 0.000005));
             Assert.Equal("-0.4%", textBox.Text);
 
             window.TheNUD.StringFormat = "{}{0:0%}";
             SetText(textBox, "100%");
-            Assert.Equal(100d, window.TheNUD.Value);
+            Assert.Equal(1d, window.TheNUD.Value);
             Assert.Equal("100%", textBox.Text);
 
             window.TheNUD.StringFormat = "P0";
             SetText(textBox, "50");
-            Assert.Equal(50d, window.TheNUD.Value);
+            Assert.Equal(0.5d, window.TheNUD.Value);
             Assert.Equal("50%", textBox.Text);
 
             window.TheNUD.StringFormat = "P1";
             SetText(textBox, "-0.39678");
-            Assert.Equal(-0.39678d, window.TheNUD.Value);
+            Assert.True(NearlyEqual(-0.0039678d, window.TheNUD.Value.Value, 0.000005));
             Assert.Equal("-0.4%", textBox.Text);
 
             window.TheNUD.Culture = CultureInfo.InvariantCulture;
 
             window.TheNUD.StringFormat = "{}{0:P0}";
             SetText(textBox, "10");
-            Assert.Equal(10d, window.TheNUD.Value);
+            Assert.Equal(0.1d, window.TheNUD.Value);
             Assert.Equal("10 %", textBox.Text);
 
             window.TheNUD.StringFormat = "{}{0:P1}";
             SetText(textBox, "-0.39678");
-            Assert.Equal(-0.39678d, window.TheNUD.Value);
+            Assert.True(NearlyEqual(-0.0039678d, window.TheNUD.Value.Value, 0.000005));
             Assert.Equal("-0.4 %", textBox.Text);
 
             window.TheNUD.StringFormat = "P0";
             SetText(textBox, "1");
-            Assert.Equal(1d, window.TheNUD.Value);
+            Assert.Equal(0.01d, window.TheNUD.Value);
             Assert.Equal("1 %", textBox.Text);
 
             window.TheNUD.StringFormat = "P1";
             SetText(textBox, "-0.39678");
-            Assert.Equal(-0.39678d, window.TheNUD.Value);
+            Assert.True(NearlyEqual(-0.0039678d, window.TheNUD.Value.Value, 0.000005));
             Assert.Equal("-0.4 %", textBox.Text);
 
             window.TheNUD.StringFormat = "{}{0:0.0%}";
             SetText(textBox, "1");
-            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal(0.01d, window.TheNUD.Value);
             Assert.Equal("1.0%", textBox.Text);
 
             window.TheNUD.StringFormat = "{0:0.0%}";
             SetText(textBox, "1");
-            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal(0.01d, window.TheNUD.Value);
             Assert.Equal("1.0%", textBox.Text);
 
             window.TheNUD.StringFormat = "0.0%";
             SetText(textBox, "1");
-            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal(0.01d, window.TheNUD.Value);
             Assert.Equal("1.0%", textBox.Text);            
 
             window.TheNUD.StringFormat = "{}{0:0.0‰}";
             SetText(textBox, "1");
-            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal(0.001d, window.TheNUD.Value);
             Assert.Equal("1.0‰", textBox.Text);
 
             window.TheNUD.StringFormat = "{0:0.0‰}";
             SetText(textBox, "1");
-            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal(0.001d, window.TheNUD.Value);
             Assert.Equal("1.0‰", textBox.Text);
 
             window.TheNUD.StringFormat = "0.0‰";
             SetText(textBox, "1");
-            Assert.Equal(1, window.TheNUD.Value);
+            Assert.Equal(0.001d, window.TheNUD.Value);
             Assert.Equal("1.0‰", textBox.Text);
 
             // GH-3376 Case 3
             window.TheNUD.StringFormat = "{0:0.0000}%";
             SetText(textBox, "0.25");
-            Assert.Equal(0.25, window.TheNUD.Value);
+            Assert.Equal(0.25d, window.TheNUD.Value);
             Assert.Equal("0.2500%", textBox.Text);
 
             // GH-3376 Case 4
             window.TheNUD.StringFormat = "{0:0.0000}‰";
             SetText(textBox, "0.25");
-            Assert.Equal(0.25, window.TheNUD.Value);
+            Assert.Equal(0.25d, window.TheNUD.Value);
             Assert.Equal("0.2500‰", textBox.Text);
 
             // GH-3376#issuecomment-472324787
             window.TheNUD.StringFormat = "{}{0:G3} mPa·s";
             SetText(textBox, "0.986");
-            Assert.Equal(0.986, window.TheNUD.Value);
+            Assert.Equal(0.986d, window.TheNUD.Value);
             Assert.Equal("0.986 mPa·s", textBox.Text);
         }
 

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -89,6 +89,36 @@ namespace MahApps.Metro.Tests
         }
 
         [Theory]
+        [InlineData(42d, "", "42")]
+        [InlineData(null, "", "")]
+        [InlineData(0.25d, "{}{0:0.00%}", "25.00%")] // 3376 Case 1
+        [InlineData(0.25d, "{0:0.00%}", "25.00%")] // 3376 Case 1
+        [InlineData(0.25d, "0.00%", "25.00%")] // 3376 Case 1
+        [InlineData(0.25d, "{}{0:0.00‰}", "250.00‰")] // 3376 Case 2
+        [InlineData(0.25d, "{0:0.00‰}", "250.00‰")] // 3376 Case 2
+        [InlineData(0.25d, "0.00‰", "250.00‰")] // 3376 Case 2
+        [InlineData(0.25d, "{}{0:0.0000}%", "0.2500%")] // 3376 Case 3
+        [InlineData(0.25d, "{0:0.0000}%", "0.2500%")] // 3376 Case 3
+        [InlineData(0.25d, "{}{0:0.00000}‰", "0.25000‰")] // 3376 Case 4
+        [InlineData(0.25d, "{0:0.00000}‰", "0.25000‰")] // 3376 Case 4
+        [InlineData(0.25d, "{}{0:P}", "25.00%")] // 3376 Case 5
+        [InlineData(0.25d, "{0:P}", "25.00%")] // 3376 Case 5
+        [InlineData(0.25d, "P", "25.00%")] // 3376 Case 5
+        [DisplayTestMethodName]
+        public async Task ShouldFormatValueInput(object value, string format, string expectedText)
+        {
+            await TestHost.SwitchToAppThread();
+
+            this.window.TheNUD.NumericInputMode = NumericInput.All;
+            this.window.TheNUD.StringFormat = format;
+
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.ValueProperty, value);
+
+            Assert.Equal(expectedText, this.textBox.Text);
+            Assert.Equal(value, this.window.TheNUD.Value);
+        }
+
+        [Theory]
         [InlineData("42", NumericInput.All, 42d)]
         [InlineData("42.", NumericInput.All, 42d)]
         [InlineData("42.2", NumericInput.All, 42.2d)]


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

The current behavior for e.g. percentage text input with StringFotmat like P0 or {0:0.00%} converts the input one-to-one to the value:

100% = 100

This is not what the user expects, because the .Net default works different:

100% = 1

So this PR changes this behavior to the .Net default one.

**Unit test**

- [x] ShouldConvertTextInputWithPercentageStringFormat
- [x] ShouldConvertTextInputWithPermilleStringFormat
- [x] ShouldFormatValueInput

**Additional context**

- [x] If the stringformat is HEX the control has to accept [a..f] as Input as well.
- [x] The DemoApp crashes on an invalid (Hex) Stringformat.

![mahapps_numericupdown](https://user-images.githubusercontent.com/658431/68315549-374d0b80-00b8-11ea-922e-671ed9e6eef0.gif)

**Closed Issues**

Closes #3376 

/cc @mgnslndh @timunie 