### PR TITLE
Fix padding for input controls

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/DateExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/DateExamples.xaml
@@ -31,7 +31,7 @@
                             HorizontalAlignment="Center"
                             HorizontalContentAlignment="Stretch"
                             Controls:TextBoxHelper.UseFloatingWatermark="True"
-                            Controls:TextBoxHelper.Watermark="Select a date"
+                            Controls:TextBoxHelper.Watermark="Please select a date"
                             Controls:TextBoxHelper.WatermarkAlignment="Right" />
                 <DatePicker Width="200"
                             Margin="0 10 0 0"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/DateExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/DateExamples.xaml
@@ -15,6 +15,11 @@
              d:DesignWidth="800"
              mc:Ignorable="d">
 
+    <UserControl.Resources>
+        <Thickness x:Key="ColumnMargin">10 5 10 5</Thickness>
+        <Thickness x:Key="ControlMargin">0 5 0 0</Thickness>
+    </UserControl.Resources>
+
     <AdornerDecorator>
         <Grid>
             <Grid.ColumnDefinitions>
@@ -23,41 +28,34 @@
                 <ColumnDefinition />
             </Grid.ColumnDefinitions>
 
-            <StackPanel VerticalAlignment="Top">
+            <StackPanel Grid.Column="0" Margin="{StaticResource ColumnMargin}">
                 <Label Content="Date picker" Style="{DynamicResource DescriptionHeaderStyle}" />
 
                 <DatePicker Width="200"
-                            Margin="0 10 0 0"
-                            HorizontalAlignment="Center"
+                            Margin="{StaticResource ControlMargin}"
                             HorizontalContentAlignment="Stretch"
                             Controls:TextBoxHelper.UseFloatingWatermark="True"
                             Controls:TextBoxHelper.Watermark="Please select a date"
                             Controls:TextBoxHelper.WatermarkAlignment="Right" />
                 <DatePicker Width="200"
-                            Margin="0 10 0 0"
-                            HorizontalAlignment="Center"
+                            Margin="{StaticResource ControlMargin}"
                             Controls:ControlsHelper.IsReadOnly="True"
                             SelectedDate="{x:Static system:DateTime.Now}" />
                 <DatePicker Width="200"
-                            Margin="0 10 0 0"
-                            HorizontalAlignment="Center"
+                            Margin="{StaticResource ControlMargin}"
                             Controls:TextBoxHelper.Watermark="" />
                 <DatePicker Width="200"
-                            Margin="0 10 0 0"
-                            HorizontalAlignment="Center"
+                            Margin="{StaticResource ControlMargin}"
                             Controls:TextBoxHelper.Watermark="{x:Null}" />
                 <DatePicker Width="200"
-                            Margin="0 10 0 0"
-                            HorizontalAlignment="Center"
+                            Margin="{StaticResource ControlMargin}"
                             IsEnabled="False" />
                 <DatePicker Width="200"
-                            Margin="0 10 0 0"
-                            HorizontalAlignment="Center"
+                            Margin="{StaticResource ControlMargin}"
                             Controls:TextBoxHelper.AutoWatermark="True"
                             SelectedDate="{Binding DatePickerDate}" />
-                <DatePicker Width="300"
-                            Margin="0 10 0 0"
-                            HorizontalAlignment="Center"
+                <DatePicker Width="200"
+                            Margin="{StaticResource ControlMargin}"
                             Controls:TextBoxHelper.Watermark="Select a date"
                             FontSize="22"
                             SelectedDate="{Binding DatePickerDate, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}">
@@ -73,43 +71,40 @@
                 </DatePicker>
             </StackPanel>
 
-            <StackPanel Grid.Row="0"
-                        Grid.Column="1"
-                        VerticalAlignment="Top">
+            <StackPanel Grid.Column="1" Margin="{StaticResource ColumnMargin}">
                 <Label Content="Calendar" Style="{DynamicResource DescriptionHeaderStyle}" />
 
                 <CheckBox x:Name="IsTodayHighlightedCheckBox"
+                          Margin="{StaticResource ControlMargin}"
                           Content="IsTodayHighlighted"
                           IsChecked="True" />
-                <Calendar Margin="5"
+                <Calendar Margin="{StaticResource ControlMargin}"
                           DisplayDateStart="{x:Static system:DateTime.Now}"
                           IsTodayHighlighted="{Binding ElementName=IsTodayHighlightedCheckBox, Path=IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                           SelectionMode="MultipleRange" />
-                <Calendar Margin="5"
-                          HorizontalAlignment="Center"
-                          IsEnabled="False" />
+                <Calendar Margin="{StaticResource ControlMargin}" IsEnabled="False" />
             </StackPanel>
 
-            <StackPanel Grid.Row="0"
-                        Grid.Column="2"
-                        Margin="0 0 20 0"
-                        VerticalAlignment="Top"
-                        Orientation="Vertical">
+            <StackPanel Grid.Column="2" Margin="{StaticResource ColumnMargin}">
                 <Label Content="DateTime/Time picker" Style="{DynamicResource DescriptionHeaderStyle}" />
 
-                <Controls:DateTimePicker Margin="0 10 0 0">
+                <Controls:DateTimePicker Margin="{StaticResource ControlMargin}">
                     <i:Interaction.Behaviors>
                         <behaviors:DateTimeNowBehavior />
                     </i:Interaction.Behaviors>
                 </Controls:DateTimePicker>
 
-                <GroupBox Header="Try it yourself">
+                <GroupBox Margin="{StaticResource ControlMargin}" Header="Try it yourself">
                     <StackPanel>
                         <CheckBox Name="DateTimePickerIsEnabled"
+                                  Margin="{StaticResource ControlMargin}"
                                   Content="IsEnabled"
                                   IsChecked="True" />
-                        <CheckBox Name="DateTimePickerIsReadOnly" Content="IsReadOnly" />
+                        <CheckBox Name="DateTimePickerIsReadOnly"
+                                  Margin="{StaticResource ControlMargin}"
+                                  Content="IsReadOnly" />
                         <CheckBox Name="DateTimePickerIsClockVisible"
+                                  Margin="{StaticResource ControlMargin}"
                                   Content="IsClockVisible"
                                   IsChecked="True" />
                         <Grid>
@@ -125,12 +120,15 @@
                                 <ColumnDefinition />
                                 <ColumnDefinition />
                             </Grid.ColumnDefinitions>
+
                             <Label Grid.Row="0"
                                    Grid.Column="0"
+                                   Margin="{StaticResource ControlMargin}"
                                    Content="Orientation" />
                             <ComboBox Name="DateTimePickerOrientation"
                                       Grid.Row="0"
                                       Grid.Column="1"
+                                      Margin="{StaticResource ControlMargin}"
                                       SelectedItem="{x:Static Orientation.Horizontal}">
                                 <ComboBox.ItemsSource>
                                     <x:Array Type="Orientation">
@@ -139,12 +137,15 @@
                                     </x:Array>
                                 </ComboBox.ItemsSource>
                             </ComboBox>
+
                             <Label Grid.Row="1"
                                    Grid.Column="0"
+                                   Margin="{StaticResource ControlMargin}"
                                    Content="PickerVisibility" />
                             <ComboBox Name="DateTimePickerPickerVisibility"
                                       Grid.Row="1"
                                       Grid.Column="1"
+                                      Margin="{StaticResource ControlMargin}"
                                       SelectedItem="{x:Static Controls:TimePartVisibility.All}">
                                 <ComboBox.ItemsSource>
                                     <x:Array Type="Controls:TimePartVisibility">
@@ -156,12 +157,15 @@
                                     </x:Array>
                                 </ComboBox.ItemsSource>
                             </ComboBox>
+
                             <Label Grid.Row="2"
                                    Grid.Column="0"
+                                   Margin="{StaticResource ControlMargin}"
                                    Content="HandVisibility" />
                             <ComboBox Name="DateTimePickerHandVisibility"
                                       Grid.Row="2"
                                       Grid.Column="1"
+                                      Margin="{StaticResource ControlMargin}"
                                       SelectedItem="{x:Static Controls:TimePartVisibility.All}">
                                 <ComboBox.ItemsSource>
                                     <x:Array Type="Controls:TimePartVisibility">
@@ -173,12 +177,15 @@
                                     </x:Array>
                                 </ComboBox.ItemsSource>
                             </ComboBox>
+
                             <Label Grid.Row="3"
                                    Grid.Column="0"
+                                   Margin="{StaticResource ControlMargin}"
                                    Content="SelectedDateFormat" />
                             <ComboBox Name="DateTimePickerDateFormat"
                                       Grid.Row="3"
                                       Grid.Column="1"
+                                      Margin="{StaticResource ControlMargin}"
                                       SelectedItem="{x:Static DatePickerFormat.Short}">
                                 <ComboBox.ItemsSource>
                                     <x:Array Type="DatePickerFormat">
@@ -187,12 +194,15 @@
                                     </x:Array>
                                 </ComboBox.ItemsSource>
                             </ComboBox>
+
                             <Label Grid.Row="4"
                                    Grid.Column="0"
+                                   Margin="{StaticResource ControlMargin}"
                                    Content="SelectedTimeFormat" />
                             <ComboBox Name="DateTimePickerTimeFormat"
                                       Grid.Row="4"
                                       Grid.Column="1"
+                                      Margin="{StaticResource ControlMargin}"
                                       SelectedItem="{x:Static Controls:TimePickerFormat.Long}">
                                 <ComboBox.ItemsSource>
                                     <x:Array Type="Controls:TimePickerFormat">
@@ -201,13 +211,15 @@
                                     </x:Array>
                                 </ComboBox.ItemsSource>
                             </ComboBox>
+
                             <Label Grid.Row="5"
                                    Grid.Column="0"
+                                   Margin="{StaticResource ControlMargin}"
                                    Content="CultureInfo" />
                             <ComboBox Name="DateTimePickerCulture"
                                       Grid.Row="5"
                                       Grid.Column="1"
-                                      VerticalAlignment="Center"
+                                      Margin="{StaticResource ControlMargin}"
                                       Controls:TextBoxHelper.ClearTextButton="True"
                                       ItemsSource="{Binding CultureInfos, Mode=OneWay}"
                                       SelectedItem="{Binding CurrentCulture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
@@ -227,7 +239,9 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                         </Grid>
-                        <Controls:DateTimePicker Controls:TextBoxHelper.UseFloatingWatermark="True"
+
+                        <Controls:DateTimePicker Margin="{StaticResource ControlMargin}"
+                                                 Controls:TextBoxHelper.UseFloatingWatermark="True"
                                                  Culture="{Binding CurrentCulture, Mode=OneWay}"
                                                  HandVisibility="{Binding Path=SelectedItem, ElementName=DateTimePickerHandVisibility, Mode=TwoWay}"
                                                  IsClockVisible="{Binding Path=IsChecked, ElementName=DateTimePickerIsClockVisible, Mode=TwoWay}"
@@ -237,43 +251,45 @@
                                                  PickerVisibility="{Binding Path=SelectedItem, ElementName=DateTimePickerPickerVisibility, Mode=TwoWay}"
                                                  SelectedDateFormat="{Binding Path=SelectedItem, ElementName=DateTimePickerDateFormat}"
                                                  SelectedTimeFormat="{Binding Path=SelectedItem, ElementName=DateTimePickerTimeFormat}" />
-                        <GroupBox Header="Current time">
-                            <AdornerDecorator>
-                                <StackPanel>
-                                    <Controls:DateTimePicker x:Name="DateTimePicker"
-                                                             Margin="2"
-                                                             Culture="{Binding CurrentCulture, Mode=OneWay}"
-                                                             HandVisibility="{Binding Path=SelectedItem, ElementName=DateTimePickerHandVisibility, Mode=TwoWay}"
-                                                             IsClockVisible="{Binding Path=IsChecked, ElementName=DateTimePickerIsClockVisible, Mode=TwoWay}"
-                                                             IsEnabled="{Binding Path=IsChecked, ElementName=DateTimePickerIsEnabled, Mode=TwoWay}"
-                                                             IsReadOnly="{Binding Path=IsChecked, ElementName=DateTimePickerIsReadOnly, Mode=TwoWay}"
-                                                             Orientation="{Binding Path=SelectedItem, ElementName=DateTimePickerOrientation, Mode=TwoWay}"
-                                                             PickerVisibility="{Binding Path=SelectedItem, ElementName=DateTimePickerPickerVisibility, Mode=TwoWay}"
-                                                             SelectedDateFormat="{Binding Path=SelectedItem, ElementName=DateTimePickerDateFormat}"
-                                                             SelectedTimeFormat="{Binding Path=SelectedItem, ElementName=DateTimePickerTimeFormat}">
-                                        <i:Interaction.Behaviors>
-                                            <behaviors:DateTimeNowBehavior />
-                                        </i:Interaction.Behaviors>
-                                    </Controls:DateTimePicker>
 
-                                    <Controls:TimePicker Margin="2"
-                                                         Culture="{Binding CurrentCulture, Mode=OneWay}"
-                                                         HandVisibility="{Binding Path=SelectedItem, ElementName=DateTimePickerHandVisibility, Mode=TwoWay}"
-                                                         IsEnabled="{Binding Path=IsChecked, ElementName=DateTimePickerIsEnabled, Mode=TwoWay}"
-                                                         IsReadOnly="{Binding Path=IsChecked, ElementName=DateTimePickerIsReadOnly, Mode=TwoWay}"
-                                                         PickerVisibility="{Binding Path=SelectedItem, ElementName=DateTimePickerPickerVisibility, Mode=TwoWay}"
-                                                         SelectedDateTime="{Binding Path=SelectedDateTime, ElementName=DateTimePicker}"
-                                                         SelectedTimeFormat="{Binding Path=SelectedItem, ElementName=DateTimePickerTimeFormat}" />
-
-                                    <Controls:TimePicker Margin="2"
-                                                         Controls:TextBoxHelper.AutoWatermark="True"
-                                                         PickerVisibility="HourMinute"
-                                                         SelectedDateTime="{Binding TimePickerDate, Mode=TwoWay, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}"
-                                                         SelectedTimeFormat="Short" />
-                                </StackPanel>
-                            </AdornerDecorator>
-                        </GroupBox>
                     </StackPanel>
+                </GroupBox>
+
+                <GroupBox Margin="{StaticResource ControlMargin}" Header="Current time">
+                    <AdornerDecorator>
+                        <StackPanel>
+                            <Controls:DateTimePicker x:Name="DateTimePicker"
+                                                     Margin="{StaticResource ControlMargin}"
+                                                     Culture="{Binding CurrentCulture, Mode=OneWay}"
+                                                     HandVisibility="{Binding Path=SelectedItem, ElementName=DateTimePickerHandVisibility, Mode=TwoWay}"
+                                                     IsClockVisible="{Binding Path=IsChecked, ElementName=DateTimePickerIsClockVisible, Mode=TwoWay}"
+                                                     IsEnabled="{Binding Path=IsChecked, ElementName=DateTimePickerIsEnabled, Mode=TwoWay}"
+                                                     IsReadOnly="{Binding Path=IsChecked, ElementName=DateTimePickerIsReadOnly, Mode=TwoWay}"
+                                                     Orientation="{Binding Path=SelectedItem, ElementName=DateTimePickerOrientation, Mode=TwoWay}"
+                                                     PickerVisibility="{Binding Path=SelectedItem, ElementName=DateTimePickerPickerVisibility, Mode=TwoWay}"
+                                                     SelectedDateFormat="{Binding Path=SelectedItem, ElementName=DateTimePickerDateFormat}"
+                                                     SelectedTimeFormat="{Binding Path=SelectedItem, ElementName=DateTimePickerTimeFormat}">
+                                <i:Interaction.Behaviors>
+                                    <behaviors:DateTimeNowBehavior />
+                                </i:Interaction.Behaviors>
+                            </Controls:DateTimePicker>
+
+                            <Controls:TimePicker Margin="{StaticResource ControlMargin}"
+                                                 Culture="{Binding CurrentCulture, Mode=OneWay}"
+                                                 HandVisibility="{Binding Path=SelectedItem, ElementName=DateTimePickerHandVisibility, Mode=TwoWay}"
+                                                 IsEnabled="{Binding Path=IsChecked, ElementName=DateTimePickerIsEnabled, Mode=TwoWay}"
+                                                 IsReadOnly="{Binding Path=IsChecked, ElementName=DateTimePickerIsReadOnly, Mode=TwoWay}"
+                                                 PickerVisibility="{Binding Path=SelectedItem, ElementName=DateTimePickerPickerVisibility, Mode=TwoWay}"
+                                                 SelectedDateTime="{Binding Path=SelectedDateTime, ElementName=DateTimePicker}"
+                                                 SelectedTimeFormat="{Binding Path=SelectedItem, ElementName=DateTimePickerTimeFormat}" />
+
+                            <Controls:TimePicker Margin="{StaticResource ControlMargin}"
+                                                 Controls:TextBoxHelper.AutoWatermark="True"
+                                                 PickerVisibility="HourMinute"
+                                                 SelectedDateTime="{Binding TimePickerDate, Mode=TwoWay, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}"
+                                                 SelectedTimeFormat="Short" />
+                        </StackPanel>
+                    </AdornerDecorator>
                 </GroupBox>
             </StackPanel>
         </Grid>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SelectionExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SelectionExamples.xaml
@@ -10,6 +10,10 @@
              d:DesignWidth="800"
              mc:Ignorable="d">
 
+    <UserControl.Resources>
+        <Thickness x:Key="ControlMargin">0 5 0 0</Thickness>
+    </UserControl.Resources>
+
     <TabControl Margin="10" TabStripPlacement="Left">
         <TabItem Header="ListBox">
             <ScrollViewer Margin="2"
@@ -188,7 +192,6 @@
                           VerticalScrollBarVisibility="Auto">
                 <StackPanel HorizontalAlignment="Left" Orientation="Vertical">
                     <ComboBox Width="200"
-                              Margin="0 10 0 0"
                               Controls:TextBoxHelper.ClearTextButton="True"
                               Controls:TextBoxHelper.Watermark="Please select an item..."
                               BorderThickness="4"
@@ -203,8 +206,9 @@
                         <ComboBoxItem Content="Very long Item 3 for MahApps.Metro" />
                         <ComboBoxItem Content="Item 4" />
                     </ComboBox>
+
                     <ComboBox Width="200"
-                              Margin="0 10 0 0"
+                              Margin="{StaticResource ControlMargin}"
                               Controls:TextBoxHelper.ClearTextButton="True"
                               Controls:TextBoxHelper.Watermark="Please select an item..."
                               SelectedIndex="0">
@@ -218,8 +222,23 @@
                         <ComboBoxItem Content="Very long Item 3 for MahApps.Metro" />
                         <ComboBoxItem Content="Item 4" />
                     </ComboBox>
+
                     <ComboBox Width="200"
-                              Margin="0 10 0 0"
+                              Margin="{StaticResource ControlMargin}"
+                              SelectedIndex="0">
+                        <ComboBox.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="Test" />
+                            </ContextMenu>
+                        </ComboBox.ContextMenu>
+                        <ComboBoxItem Content="Item 1" />
+                        <ComboBoxItem Content="Item 2" />
+                        <ComboBoxItem Content="Very long Item 3 for MahApps.Metro" />
+                        <ComboBoxItem Content="Item 4" />
+                    </ComboBox>
+
+                    <ComboBox Width="200"
+                              Margin="{StaticResource ControlMargin}"
                               Controls:TextBoxHelper.ClearTextButton="True"
                               Controls:TextBoxHelper.UseFloatingWatermark="True"
                               Controls:TextBoxHelper.Watermark="Please select an item..."
@@ -234,8 +253,9 @@
                         <ComboBoxItem Content="Very long Item 3 for MahApps.Metro" />
                         <ComboBoxItem Content="Item 4" />
                     </ComboBox>
+
                     <ComboBox Width="200"
-                              Margin="0 10 0 0"
+                              Margin="{StaticResource ControlMargin}"
                               Controls:TextBoxHelper.ClearTextButton="True"
                               Controls:TextBoxHelper.UseFloatingWatermark="True"
                               Controls:TextBoxHelper.Watermark="Editable..."
@@ -249,8 +269,14 @@
                         <ComboBoxItem Content="Very long Item 3 for MahApps.Metro" />
                         <ComboBoxItem Content="Item 4" />
                     </ComboBox>
+
+                    <TextBox Margin="{StaticResource ControlMargin}"
+                             Controls:TextBoxHelper.ClearTextButton="True"
+                             Controls:TextBoxHelper.UseFloatingWatermark="True"
+                             Controls:TextBoxHelper.Watermark="Editable TextBox..." />
+
                     <ComboBox Width="200"
-                              Margin="0 10 0 0"
+                              Margin="{StaticResource ControlMargin}"
                               Controls:TextBoxHelper.UseFloatingWatermark="True"
                               Controls:TextBoxHelper.Watermark="Autocompletion"
                               DisplayMemberPath="Title"
@@ -259,9 +285,10 @@
                               MaxDropDownHeight="125"
                               Style="{DynamicResource MahApps.Styles.ComboBox.Virtualized}"
                               Text="{Binding Path=Title}" />
+
                     <ComboBox x:Name="groupingComboBox"
                               Width="200"
-                              Margin="0 10 0 0"
+                              Margin="{StaticResource ControlMargin}"
                               Controls:TextBoxHelper.Watermark="Autocompletion with grouping"
                               DisplayMemberPath="Title"
                               IsEditable="True"
@@ -279,8 +306,9 @@
                             </GroupStyle>
                         </ComboBox.GroupStyle>
                     </ComboBox>
+
                     <ComboBox Width="200"
-                              Margin="0 10 0 0"
+                              Margin="{StaticResource ControlMargin}"
                               IsEnabled="False"
                               SelectedIndex="0">
                         <ComboBoxItem Content="Item 1" />

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -11,6 +11,8 @@
     <Thickness x:Key="ComboBoxPopupBorderThemeThickness">1</Thickness>
     <Thickness x:Key="ComboBoxPopupBorderThemePadding">1</Thickness>
 
+    <Geometry x:Key="ComboBoxDownArrowGeometry">M 0 0 L 3.5 4 L 7 0 Z</Geometry>
+
     <Style x:Key="MahApps.Styles.TextBox.Editable"
            BasedOn="{StaticResource MahApps.Styles.TextBox}"
            TargetType="{x:Type TextBox}">
@@ -45,7 +47,7 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid Background="{TemplateBinding Background}">
-                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding Padding}">
+                        <Grid x:Name="PART_InnerGrid">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="TextColumn" Width="*" />
                                 <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
@@ -59,14 +61,17 @@
                                           Grid.Row="1"
                                           Grid.Column="0"
                                           Margin="0"
+                                          Padding="{TemplateBinding Padding}"
                                           VerticalAlignment="Stretch"
                                           Background="{x:Null}"
                                           BorderThickness="0"
-                                          IsTabStop="False" />
+                                          IsTabStop="False"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
                                        Grid.Column="0"
-                                       Margin="3 0"
+                                       Margin="4 0"
                                        Padding="{TemplateBinding Padding}"
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -76,9 +81,11 @@
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
+
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
+                                            Margin="4 0"
                                             Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{Converters:MathMultiplyConverter}">
@@ -114,6 +121,7 @@
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
                             </ContentControl>
+
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"
                                     Grid.RowSpan="2"
@@ -225,15 +233,16 @@
                                 IsTabStop="False"
                                 Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
                                 Visibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(Controls:TextBoxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" />
+
                         <Grid x:Name="BtnArrowBackground"
                               Grid.Column="2"
                               Width="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
                               Background="Transparent">
-                            <Path x:Name="BtnArrow"
+                            <Path x:Name="Arrow"
                                   Width="8"
                                   Height="4"
                                   HorizontalAlignment="Center"
-                                  Data="F1 M 301.14,-189.041L 311.57,-189.041L 306.355,-182.942L 301.14,-189.041 Z "
+                                  Data="{DynamicResource ComboBoxDownArrowGeometry}"
                                   Fill="{DynamicResource MahApps.Brushes.Gray1}"
                                   IsHitTestVisible="false"
                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
@@ -270,13 +279,13 @@
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.ComboBox.MouseOverInnerBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
         <Setter Property="Controls:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Sizes.Font.ClearTextButton}" />
-        <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="24" />
+        <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="MinHeight" Value="26" />
-        <Setter Property="Padding" Value="2" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
         <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
@@ -314,7 +323,6 @@
                     </ControlTemplate.Resources>
                     <Grid>
                         <Border x:Name="Border"
-                                Grid.ColumnSpan="3"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
@@ -336,7 +344,6 @@
                                           Grid.RowSpan="2"
                                           Grid.ColumnSpan="3"
                                           Margin="0"
-                                          Padding="{TemplateBinding Padding}"
                                           VerticalAlignment="Stretch"
                                           Controls:ControlsHelper.CornerRadius="{TemplateBinding Controls:ControlsHelper.CornerRadius}"
                                           Controls:TextBoxHelper.ButtonContent="{TemplateBinding Controls:TextBoxHelper.ButtonContent}"
@@ -352,6 +359,21 @@
                                           KeyboardNavigation.IsTabStop="False"
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                           Style="{DynamicResource MahApps.Styles.ToggleButton.ComboBoxDropDown}" />
+
+                            <Grid x:Name="ContentSite"
+                                  Grid.Row="1"
+                                  Grid.Column="0"
+                                  Margin="1 0">
+                                <ContentPresenter Margin="{TemplateBinding Padding}"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Content="{TemplateBinding SelectionBoxItem}"
+                                                  ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                                                  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                  ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                                  IsHitTestVisible="False"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
 
                             <TextBox x:Name="PART_EditableTextBox"
                                      Grid.Row="1"
@@ -387,7 +409,7 @@
                             <TextBlock x:Name="PART_WatermarkMessage"
                                        Grid.Row="1"
                                        Grid.Column="0"
-                                       Margin="5 0"
+                                       Margin="4 0"
                                        Padding="{TemplateBinding Padding}"
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -397,9 +419,11 @@
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
+
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
+                                            Margin="4 0"
                                             Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{Converters:MathMultiplyConverter}">
@@ -412,7 +436,6 @@
                                     </MultiBinding>
                                 </ContentControl.Height>
                                 <TextBlock x:Name="PART_FloatingMessage"
-                                           Margin="2 2 0 0"
                                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                            Foreground="{TemplateBinding Foreground}"
@@ -436,21 +459,6 @@
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
                             </ContentControl>
-
-                            <Grid x:Name="ContentSite"
-                                  Grid.Row="1"
-                                  Grid.Column="0"
-                                  Margin="4 0">
-                                <ContentPresenter Margin="{TemplateBinding Padding}"
-                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  Content="{TemplateBinding SelectionBoxItem}"
-                                                  ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
-                                                  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
-                                                  ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                                  IsHitTestVisible="False"
-                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                            </Grid>
                         </Grid>
 
                         <Border x:Name="DisabledVisualElement"
@@ -568,7 +576,7 @@
                         </DataTrigger>
                         <Trigger Property="IsEditable" Value="True">
                             <Setter Property="IsTabStop" Value="false" />
-                            <Setter TargetName="ContentSite" Property="Visibility" Value="Hidden" />
+                            <Setter TargetName="ContentSite" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="PART_DropDownToggle" Property="Background" Value="{x:Null}" />
                             <Setter TargetName="PART_DropDownToggle" Property="Focusable" Value="False" />
                             <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />

--- a/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -35,7 +35,6 @@
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="Margin" Value="0" />
         <Setter Property="MinHeight" Value="22" />
-        <Setter Property="Padding" Value="-2 0" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Style.Triggers>
             <MultiTrigger>
@@ -55,7 +54,6 @@
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="Margin" Value="0" />
         <Setter Property="MinHeight" Value="0" />
-        <Setter Property="Padding" Value="-2 0" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
     </Style>
 
@@ -66,7 +64,6 @@
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="HideUpDownButtons" Value="True" />
         <Setter Property="MinHeight" Value="0" />
-        <Setter Property="Padding" Value="0" />
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>

--- a/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -17,6 +17,7 @@
         <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonContent" Value="M34,52H31V38.5C29.66,39.9 28.16,40.78 26.34,41.45V37.76C27.3,37.45 28.34,36.86 29.46,36C30.59,35.15 31.36,34.15 31.78,33H34V52M45,52V48H37V45L45,33H48V45H50V48H48V52H45M45,45V38.26L40.26,45H45M18,57V23H23V20A2,2 0 0,1 25,18H29C30.11,18 31,18.9 31,20V23H45V20A2,2 0 0,1 47,18H51C52.11,18 53,18.9 53,20V23H58V57H18M21,54H55V31H21V54M48.5,20A1.5,1.5 0 0,0 47,21.5V24.5A1.5,1.5 0 0,0 48.5,26H49.5C50.34,26 51,25.33 51,24.5V21.5A1.5,1.5 0 0,0 49.5,20H48.5M26.5,20A1.5,1.5 0 0,0 25,21.5V24.5A1.5,1.5 0 0,0 26.5,26H27.5A1.5,1.5 0 0,0 29,24.5V21.5A1.5,1.5 0 0,0 27.5,20H26.5Z" />
         <Setter Property="Controls:TextBoxHelper.ButtonContentTemplate">
             <Setter.Value>
                 <DataTemplate>
@@ -27,7 +28,7 @@
                                     Padding="3"
                                     HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
-                                    Content="M34,52H31V38.5C29.66,39.9 28.16,40.78 26.34,41.45V37.76C27.3,37.45 28.34,36.86 29.46,36C30.59,35.15 31.36,34.15 31.78,33H34V52M45,52V48H37V45L45,33H48V45H50V48H48V52H45M45,45V38.26L40.26,45H45M18,57V23H23V20A2,2 0 0,1 25,18H29C30.11,18 31,18.9 31,20V23H45V20A2,2 0 0,1 47,18H51C52.11,18 53,18.9 53,20V23H58V57H18M21,54H55V31H21V54M48.5,20A1.5,1.5 0 0,0 47,21.5V24.5A1.5,1.5 0 0,0 48.5,26H49.5C50.34,26 51,25.33 51,24.5V21.5A1.5,1.5 0 0,0 49.5,20H48.5M26.5,20A1.5,1.5 0 0,0 25,21.5V24.5A1.5,1.5 0 0,0 26.5,26H27.5A1.5,1.5 0 0,0 29,24.5V21.5A1.5,1.5 0 0,0 27.5,20H26.5Z"
+                                    Content="{Binding Mode=OneWay}"
                                     Style="{DynamicResource MahApps.Styles.ContentControl.PathIcon}" />
                 </DataTemplate>
             </Setter.Value>

--- a/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -17,6 +17,22 @@
         <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <!--  Modern - Calendar14  -->
+                    <ContentControl x:Name="PART_PackIcon"
+                                    Width="{Binding RelativeSource={RelativeSource AncestorType=DatePicker}, Path=(Controls:TextBoxHelper.ButtonWidth), Mode=OneWay}"
+                                    Height="{Binding RelativeSource={RelativeSource AncestorType=DatePicker}, Path=(Controls:TextBoxHelper.ButtonWidth), Mode=OneWay}"
+                                    Padding="3"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Content="M34,52H31V38.5C29.66,39.9 28.16,40.78 26.34,41.45V37.76C27.3,37.45 28.34,36.86 29.46,36C30.59,35.15 31.36,34.15 31.78,33H34V52M45,52V48H37V45L45,33H48V45H50V48H48V52H45M45,45V38.26L40.26,45H45M18,57V23H23V20A2,2 0 0,1 25,18H29C30.11,18 31,18.9 31,20V23H45V20A2,2 0 0,1 47,18H51C52.11,18 53,18.9 53,20V23H58V57H18M21,54H55V31H21V54M48.5,20A1.5,1.5 0 0,0 47,21.5V24.5A1.5,1.5 0 0,0 48.5,26H49.5C50.34,26 51,25.33 51,24.5V21.5A1.5,1.5 0 0,0 49.5,20H48.5M26.5,20A1.5,1.5 0 0,0 25,21.5V24.5A1.5,1.5 0 0,0 26.5,26H27.5A1.5,1.5 0 0,0 29,24.5V21.5A1.5,1.5 0 0,0 27.5,20H26.5Z"
+                                    Style="{DynamicResource MahApps.Styles.ContentControl.PathIcon}" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Controls:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
@@ -24,7 +40,7 @@
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="IsTodayHighlighted" Value="True" />
         <Setter Property="MinHeight" Value="26" />
-        <Setter Property="Padding" Value="2" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="SelectedDateFormat" Value="Short" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
@@ -37,9 +53,10 @@
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding Controls:ControlsHelper.CornerRadius}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding Padding}">
+
+                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding BorderThickness}">
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition x:Name="TextColumn" Width="*" />
                                 <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
@@ -47,23 +64,11 @@
                                 <RowDefinition x:Name="ButtonRow" Height="*" />
                             </Grid.RowDefinitions>
 
-                            <Button x:Name="PART_Button"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="1"
-                                    Foreground="{TemplateBinding Foreground}"
-                                    IsTabStop="False"
-                                    Style="{DynamicResource MahApps.Styles.Button.Chromeless}">
-                                <!--  PackIconModern - Calendar14  -->
-                                <ContentControl Width="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
-                                                Height="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
-                                                Padding="2"
-                                                Content="M34,52H31V38.5C29.66,39.9 28.16,40.78 26.34,41.45V37.76C27.3,37.45 28.34,36.86 29.46,36C30.59,35.15 31.36,34.15 31.78,33H34V52M45,52V48H37V45L45,33H48V45H50V48H48V52H45M45,45V38.26L40.26,45H45M18,57V23H23V20A2,2 0 0,1 25,18H29C30.11,18 31,18.9 31,20V23H45V20A2,2 0 0,1 47,18H51C52.11,18 53,18.9 53,20V23H58V57H18M21,54H55V31H21V54M48.5,20A1.5,1.5 0 0,0 47,21.5V24.5A1.5,1.5 0 0,0 48.5,26H49.5C50.34,26 51,25.33 51,24.5V21.5A1.5,1.5 0 0,0 49.5,20H48.5M26.5,20A1.5,1.5 0 0,0 25,21.5V24.5A1.5,1.5 0 0,0 26.5,26H27.5A1.5,1.5 0 0,0 29,24.5V21.5A1.5,1.5 0 0,0 27.5,20H26.5Z"
-                                                Style="{DynamicResource MahApps.Styles.ContentControl.PathIcon}" />
-                            </Button>
-
                             <DatePickerTextBox x:Name="PART_TextBox"
                                                Grid.Row="1"
                                                Grid.Column="0"
+                                               Margin="0"
+                                               Padding="{TemplateBinding Padding}"
                                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                                Controls:TextBoxHelper.Watermark="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.Watermark), Mode=OneWay}"
@@ -83,6 +88,7 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
+                                            Margin="4 0"
                                             Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{Converters:MathMultiplyConverter}">
@@ -119,14 +125,31 @@
                                 </TextBlock>
                             </ContentControl>
 
+                            <Button x:Name="PART_Button"
+                                    Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="1"
+                                    Width="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
+                                    Content="{TemplateBinding Controls:TextBoxHelper.ButtonContent}"
+                                    ContentTemplate="{TemplateBinding Controls:TextBoxHelper.ButtonContentTemplate}"
+                                    Focusable="False"
+                                    FontFamily="{TemplateBinding Controls:TextBoxHelper.ButtonFontFamily}"
+                                    FontSize="{TemplateBinding Controls:TextBoxHelper.ButtonFontSize}"
+                                    Foreground="{TemplateBinding Foreground}"
+                                    IsTabStop="False"
+                                    Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
+                                    Template="{TemplateBinding Controls:TextBoxHelper.ButtonTemplate}" />
+
                             <Popup x:Name="PART_Popup"
                                    Grid.Row="1"
                                    Grid.Column="0"
                                    AllowsTransparency="True"
                                    Placement="Bottom"
                                    PlacementTarget="{Binding ElementName=PART_Root}"
+                                   PopupAnimation="Fade"
                                    StaysOpen="False" />
                         </Grid>
+
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource MahApps.Brushes.Controls.Disabled}"
                                 BorderBrush="{DynamicResource MahApps.Brushes.Controls.Disabled}"
@@ -192,6 +215,7 @@
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="Template">
@@ -238,44 +262,56 @@
                                              Duration="0:0:0.2" />
                         </Storyboard>
                     </ControlTemplate.Resources>
-                    <Grid x:Name="PART_InnerGrid" Margin="2">
+                    <Grid x:Name="PART_InnerGrid">
 
                         <ScrollViewer x:Name="PART_ContentHost"
+                                      Margin="0"
+                                      Padding="{TemplateBinding Padding}"
                                       VerticalAlignment="Stretch"
                                       Background="{x:Null}"
                                       BorderThickness="0"
                                       FocusVisualStyle="{x:Null}"
-                                      IsTabStop="False" />
+                                      IsTabStop="False"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+
                         <ContentControl x:Name="PART_Watermark"
-                                        Margin="4 0 0 0"
+                                        Margin="4 0"
+                                        Padding="{TemplateBinding Padding}"
                                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                         Controls:TextBoxHelper.WatermarkAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                         Controls:TextBoxHelper.WatermarkTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
+                                        Controls:TextBoxHelper.WatermarkWrapping="{TemplateBinding Controls:TextBoxHelper.WatermarkWrapping}"
                                         Focusable="False"
                                         Foreground="{TemplateBinding Foreground}"
                                         IsHitTestVisible="False"
-                                        Opacity="0.6"
                                         Visibility="Hidden">
                             <ContentControl.Template>
                                 <ControlTemplate TargetType="{x:Type ContentControl}">
-                                    <TextBlock HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    <TextBlock Margin="0"
+                                               Padding="{TemplateBinding Padding}"
+                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                               Style="{DynamicResource MahApps.Styles.TextBlock.Watermark}"
                                                Text="{TemplateBinding Content}"
                                                TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
-                                               TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
+                                               TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
+                                               TextWrapping="{TemplateBinding Controls:TextBoxHelper.WatermarkWrapping}" />
                                 </ControlTemplate>
                             </ContentControl.Template>
                         </ContentControl>
+
                         <TextBlock x:Name="PART_Message"
-                                   Margin="4 0 0 0"
+                                   Margin="4 0"
+                                   Padding="{TemplateBinding Padding}"
                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                    Foreground="{TemplateBinding Foreground}"
                                    Style="{DynamicResource MahApps.Styles.TextBlock.Watermark}"
                                    Text="{TemplateBinding Controls:TextBoxHelper.Watermark}"
                                    TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
-                                   TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}" />
+                                   TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
+                                   TextWrapping="{TemplateBinding Controls:TextBoxHelper.WatermarkWrapping}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <MultiTrigger>

--- a/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -93,7 +93,7 @@
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />
-        <Setter Property="Padding" Value="0" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="SelectionBrush" Value="{DynamicResource MahApps.Brushes.Highlight}" />
         <!--  change SnapsToDevicePixels to true to view a better border and validation error  -->
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -136,13 +136,15 @@
                                     Effect="{DynamicResource MahApps.DropShadowEffect.WaitingForData}"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </AdornerDecorator>
+
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding Controls:ControlsHelper.CornerRadius}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <Grid Margin="2">
+
+                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding BorderThickness}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="TextColumn" Width="*" />
                                 <ColumnDefinition x:Name="CapsLockColumn" Width="Auto" />
@@ -156,15 +158,17 @@
                             <ScrollViewer x:Name="PART_ContentHost"
                                           Grid.Row="1"
                                           Grid.Column="0"
-                                          Margin="2"
+                                          Margin="0"
+                                          Padding="{TemplateBinding Padding}"
                                           VerticalAlignment="Stretch"
                                           Background="{x:Null}"
                                           BorderThickness="0"
                                           IsTabStop="False" />
+
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
                                        Grid.Column="0"
-                                       Margin="6 2 6 2"
+                                       Margin="4 0"
                                        Padding="{TemplateBinding Padding}"
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -174,9 +178,11 @@
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
+
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
+                                            Margin="4 0"
                                             Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{Converters:MathMultiplyConverter}">
@@ -212,6 +218,7 @@
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
                             </ContentControl>
+
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"
                                               Grid.RowSpan="2"
@@ -223,6 +230,7 @@
                                               TextBlock.Foreground="{DynamicResource MahApps.Brushes.Controls.Validation}"
                                               ToolTip="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:PasswordBoxHelper.CapsLockWarningToolTip), Mode=OneWay}"
                                               Visibility="Collapsed" />
+
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"
                                     Grid.RowSpan="2"
@@ -239,6 +247,7 @@
                                     Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
                                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
+
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource MahApps.Brushes.Controls.Disabled}"
                                 BorderBrush="{DynamicResource MahApps.Brushes.Controls.Disabled}"
@@ -385,13 +394,15 @@
                                     Effect="{DynamicResource MahApps.DropShadowEffect.WaitingForData}"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </AdornerDecorator>
+
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding Controls:ControlsHelper.CornerRadius}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <Grid x:Name="PART_InnerGrid" Margin="2">
+
+                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding BorderThickness}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="TextColumn" Width="*" />
                                 <ColumnDefinition x:Name="CapsLockColumn" Width="Auto" />
@@ -405,15 +416,17 @@
                             <ScrollViewer x:Name="PART_ContentHost"
                                           Grid.Row="1"
                                           Grid.Column="0"
-                                          Margin="2"
+                                          Margin="0"
+                                          Padding="{TemplateBinding Padding}"
                                           VerticalAlignment="Stretch"
                                           Background="{x:Null}"
                                           BorderThickness="0"
                                           IsTabStop="False" />
+
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
                                        Grid.Column="0"
-                                       Margin="6 2 6 2"
+                                       Margin="4 0"
                                        Padding="{TemplateBinding Padding}"
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -423,9 +436,11 @@
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
+
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
+                                            Margin="4 0"
                                             Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{Converters:MathMultiplyConverter}">
@@ -461,6 +476,7 @@
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
                             </ContentControl>
+
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"
                                               Grid.RowSpan="2"
@@ -472,6 +488,7 @@
                                               TextBlock.Foreground="{DynamicResource MahApps.Brushes.Controls.Validation}"
                                               ToolTip="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:PasswordBoxHelper.CapsLockWarningToolTip), Mode=OneWay}"
                                               Visibility="Collapsed" />
+
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"
                                     Grid.RowSpan="2"
@@ -489,6 +506,7 @@
                                     Template="{TemplateBinding Controls:TextBoxHelper.ButtonTemplate}"
                                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.TextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
+
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource MahApps.Brushes.Controls.Disabled}"
                                 BorderBrush="{DynamicResource MahApps.Brushes.Controls.Disabled}"
@@ -594,10 +612,12 @@
                 <ControlTemplate TargetType="{x:Type TextBox}">
                     <Grid Background="{TemplateBinding Background}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                         <ScrollViewer x:Name="PART_ContentHost"
-                                      Margin="{TemplateBinding Padding}"
+                                      Margin="0"
+                                      Padding="{TemplateBinding Padding}"
                                       Background="{x:Null}"
                                       BorderThickness="0"
-                                      IsTabStop="False" />
+                                      IsTabStop="False"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
@@ -649,13 +669,15 @@
                                     Effect="{DynamicResource MahApps.DropShadowEffect.WaitingForData}"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </AdornerDecorator>
+
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding Controls:ControlsHelper.CornerRadius}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <Grid x:Name="PART_InnerGrid" Margin="2">
+
+                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding BorderThickness}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="TextColumn" Width="*" />
                                 <ColumnDefinition x:Name="CapsLockColumn" Width="Auto" />
@@ -670,15 +692,17 @@
                             <ScrollViewer x:Name="PART_ContentHost"
                                           Grid.Row="1"
                                           Grid.Column="0"
-                                          Margin="2"
+                                          Margin="0"
+                                          Padding="{TemplateBinding Padding}"
                                           VerticalAlignment="Stretch"
                                           Background="{x:Null}"
                                           BorderThickness="0"
                                           IsTabStop="False" />
+
                             <TextBox x:Name="RevealedPassword"
                                      Grid.Row="1"
                                      Grid.Column="0"
-                                     Margin="2"
+                                     Margin="0"
                                      Padding="{TemplateBinding Padding}"
                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -694,10 +718,11 @@
                                      Style="{DynamicResource MahApps.Styles.TextBox.Revealed}"
                                      Text="{TemplateBinding Behaviors:PasswordBoxBindingBehavior.Password}"
                                      Visibility="Hidden" />
+
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
                                        Grid.Column="0"
-                                       Margin="6 2 6 2"
+                                       Margin="4 0"
                                        Padding="{TemplateBinding Padding}"
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -707,9 +732,11 @@
                                        TextAlignment="{TemplateBinding Controls:TextBoxHelper.WatermarkAlignment}"
                                        TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        Visibility="Collapsed" />
+
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
+                                            Margin="4 0"
                                             Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{Converters:MathMultiplyConverter}">
@@ -745,6 +772,7 @@
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
                             </ContentControl>
+
                             <ContentPresenter x:Name="PART_CapsLockIndicator"
                                               Grid.Row="0"
                                               Grid.RowSpan="2"
@@ -756,6 +784,7 @@
                                               TextBlock.Foreground="{DynamicResource MahApps.Brushes.Controls.Validation}"
                                               ToolTip="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:PasswordBoxHelper.CapsLockWarningToolTip), Mode=OneWay}"
                                               Visibility="Collapsed" />
+
                             <Button x:Name="PART_RevealButton"
                                     Grid.Row="0"
                                     Grid.RowSpan="2"
@@ -768,6 +797,7 @@
                                     IsTabStop="False"
                                     Style="{DynamicResource MahApps.Styles.Button.Reveal}"
                                     Visibility="{Binding ElementName=RevealedPassword, Path=Text, Converter={StaticResource StringToVisibilityConverter}}" />
+
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"
                                     Grid.RowSpan="2"
@@ -785,6 +815,7 @@
                                     Template="{TemplateBinding Controls:TextBoxHelper.ButtonTemplate}"
                                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
+
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource MahApps.Brushes.Controls.Disabled}"
                                 BorderBrush="{DynamicResource MahApps.Brushes.Controls.Disabled}"

--- a/src/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -27,7 +27,7 @@
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />
-        <Setter Property="Padding" Value="0" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="SelectionBrush" Value="{DynamicResource MahApps.Brushes.Highlight}" />
         <!--  change SnapsToDevicePixels to True to view a better border and validation error  -->
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -70,13 +70,15 @@
                                     Effect="{DynamicResource MahApps.DropShadowEffect.WaitingForData}"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </AdornerDecorator>
+
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding Controls:ControlsHelper.CornerRadius}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <Grid x:Name="PART_InnerGrid" Margin="2">
+
+                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding BorderThickness}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="TextColumn" Width="*" />
                                 <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
@@ -89,15 +91,18 @@
                             <ScrollViewer x:Name="PART_ContentHost"
                                           Grid.Row="1"
                                           Grid.Column="0"
-                                          Margin="2"
+                                          Margin="0"
+                                          Padding="{TemplateBinding Padding}"
                                           VerticalAlignment="Stretch"
                                           Background="{x:Null}"
                                           BorderThickness="0"
-                                          IsTabStop="False" />
+                                          IsTabStop="False"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
                                        Grid.Column="0"
-                                       Margin="6 2 6 2"
+                                       Margin="4 0"
                                        Padding="{TemplateBinding Padding}"
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -108,9 +113,11 @@
                                        TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        TextWrapping="{TemplateBinding Controls:TextBoxHelper.WatermarkWrapping}"
                                        Visibility="Collapsed" />
+
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
+                                            Margin="4 0"
                                             Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{Converters:MathMultiplyConverter}">
@@ -146,6 +153,7 @@
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
                             </ContentControl>
+
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"
                                     Grid.RowSpan="2"
@@ -162,6 +170,7 @@
                                     Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
                                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
+
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource MahApps.Brushes.Controls.Disabled}"
                                 BorderBrush="{DynamicResource MahApps.Brushes.Controls.Disabled}"
@@ -318,13 +327,15 @@
                                     Effect="{DynamicResource MahApps.DropShadowEffect.WaitingForData}"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </AdornerDecorator>
+
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding Controls:ControlsHelper.CornerRadius}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <Grid x:Name="PART_InnerGrid" Margin="2">
+
+                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding BorderThickness}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="TextColumn" Width="*" />
                                 <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
@@ -337,15 +348,17 @@
                             <ScrollViewer x:Name="PART_ContentHost"
                                           Grid.Row="1"
                                           Grid.Column="0"
-                                          Margin="2"
+                                          Margin="0"
+                                          Padding="{TemplateBinding Padding}"
                                           VerticalAlignment="Stretch"
                                           Background="{x:Null}"
                                           BorderThickness="0"
                                           IsTabStop="False" />
+
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
                                        Grid.Column="0"
-                                       Margin="6 2 6 2"
+                                       Margin="4 0"
                                        Padding="{TemplateBinding Padding}"
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -356,9 +369,11 @@
                                        TextTrimming="{TemplateBinding Controls:TextBoxHelper.WatermarkTrimming}"
                                        TextWrapping="{TemplateBinding Controls:TextBoxHelper.WatermarkWrapping}"
                                        Visibility="Collapsed" />
+
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
+                                            Margin="4 0"
                                             Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{Converters:MathMultiplyConverter}">
@@ -394,6 +409,7 @@
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
                             </ContentControl>
+
                             <Button x:Name="PART_ClearText"
                                     Grid.Row="0"
                                     Grid.RowSpan="2"
@@ -411,6 +427,7 @@
                                     Template="{TemplateBinding Controls:TextBoxHelper.ButtonTemplate}"
                                     Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.TextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
+
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource MahApps.Brushes.Controls.Disabled}"
                                 BorderBrush="{DynamicResource MahApps.Brushes.Controls.Disabled}"
@@ -594,7 +611,7 @@
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />
         <Setter Property="MinWidth" Value="10" />
-        <Setter Property="Padding" Value="2" />
+        <Setter Property="Padding" Value="2 4" />
         <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
@@ -636,7 +653,7 @@
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
                                        Grid.Column="0"
-                                       Margin="6 0"
+                                       Margin="4 0"
                                        Padding="{TemplateBinding Padding}"
                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -651,7 +668,7 @@
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
-                                            Margin="6 0"
+                                            Margin="4 0"
                                             Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{Converters:MathMultiplyConverter}">

--- a/src/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -115,6 +115,23 @@
         <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="Controls:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.FocusBorder}" />
         <Setter Property="Controls:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.MouseOverBorder}" />
+        <Setter Property="Controls:TextBoxHelper.ButtonContent" Value="M34,52H31V38.5C29.66,39.9 28.16,40.78 26.34,41.45V37.76C27.3,37.45 28.34,36.86 29.46,36C30.59,35.15 31.36,34.15 31.78,33H34V52M45,52V48H37V45L45,33H48V45H50V48H48V52H45M45,45V38.26L40.26,45H45M18,57V23H23V20A2,2 0 0,1 25,18H29C30.11,18 31,18.9 31,20V23H45V20A2,2 0 0,1 47,18H51C52.11,18 53,18.9 53,20V23H58V57H18M21,54H55V31H21V54M48.5,20A1.5,1.5 0 0,0 47,21.5V24.5A1.5,1.5 0 0,0 48.5,26H49.5C50.34,26 51,25.33 51,24.5V21.5A1.5,1.5 0 0,0 49.5,20H48.5M26.5,20A1.5,1.5 0 0,0 25,21.5V24.5A1.5,1.5 0 0,0 26.5,26H27.5A1.5,1.5 0 0,0 29,24.5V21.5A1.5,1.5 0 0,0 27.5,20H26.5Z" />
+        <Setter Property="Controls:TextBoxHelper.ButtonContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <!--  Modern - Calendar14  -->
+                    <ContentControl x:Name="PART_PackIcon"
+                                    Width="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:TimePickerBase}}, Path=(Controls:TextBoxHelper.ButtonWidth), Mode=OneWay}"
+                                    Height="{Binding RelativeSource={RelativeSource AncestorType={x:Type Controls:TimePickerBase}}, Path=(Controls:TextBoxHelper.ButtonWidth), Mode=OneWay}"
+                                    Padding="3"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Content="{Binding Mode=OneWay}"
+                                    Style="{DynamicResource MahApps.Styles.ContentControl.PathIcon}" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Controls:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="Controls:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="Controls:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Content}" />
@@ -122,7 +139,7 @@
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="HandVisibility" Value="HourMinute" />
         <Setter Property="MinHeight" Value="26" />
-        <Setter Property="Padding" Value="2" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="PickerVisibility" Value="HourMinute" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
@@ -135,7 +152,8 @@
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding Controls:ControlsHelper.CornerRadius}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding Padding}">
+
+                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding BorderThickness}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition />
                                 <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
@@ -144,9 +162,12 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition x:Name="ButtonRow" Height="*" />
                             </Grid.RowDefinitions>
+
                             <DatePickerTextBox x:Name="PART_TextBox"
                                                Grid.Row="1"
                                                Grid.Column="0"
+                                               Margin="0"
+                                               Padding="{TemplateBinding Padding}"
                                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                                Controls:TextBoxHelper.Watermark="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:TextBoxHelper.Watermark), Mode=OneWay}"
@@ -164,9 +185,11 @@
                                     <Behaviors:DatePickerTextBoxBehavior />
                                 </i:Interaction.Behaviors>
                             </DatePickerTextBox>
+
                             <ContentControl x:Name="PART_FloatingMessageContainer"
                                             Grid.Row="0"
                                             Grid.Column="0"
+                                            Margin="4 0"
                                             Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
                                 <ContentControl.Height>
                                     <MultiBinding Converter="{Converters:MathMultiplyConverter}">
@@ -202,20 +225,22 @@
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
                             </ContentControl>
+
                             <Button x:Name="PART_Button"
                                     Grid.Row="0"
                                     Grid.RowSpan="2"
                                     Grid.Column="1"
+                                    Width="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
+                                    Content="{TemplateBinding Controls:TextBoxHelper.ButtonContent}"
+                                    ContentTemplate="{TemplateBinding Controls:TextBoxHelper.ButtonContentTemplate}"
+                                    Focusable="False"
+                                    FontFamily="{TemplateBinding Controls:TextBoxHelper.ButtonFontFamily}"
+                                    FontSize="{TemplateBinding Controls:TextBoxHelper.ButtonFontSize}"
+                                    Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
-                                    Style="{DynamicResource MahApps.Styles.Button.Chromeless}">
-                                <!--  PackIconModern - Calendar14  -->
-                                <ContentControl x:Name="PART_ButtonIcon"
-                                                Width="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
-                                                Height="{TemplateBinding Controls:TextBoxHelper.ButtonWidth}"
-                                                Padding="2"
-                                                Content="M34,52H31V38.5C29.66,39.9 28.16,40.78 26.34,41.45V37.76C27.3,37.45 28.34,36.86 29.46,36C30.59,35.15 31.36,34.15 31.78,33H34V52M45,52V48H37V45L45,33H48V45H50V48H48V52H45M45,45V38.26L40.26,45H45M18,57V23H23V20A2,2 0 0,1 25,18H29C30.11,18 31,18.9 31,20V23H45V20A2,2 0 0,1 47,18H51C52.11,18 53,18.9 53,20V23H58V57H18M21,54H55V31H21V54M48.5,20A1.5,1.5 0 0,0 47,21.5V24.5A1.5,1.5 0 0,0 48.5,26H49.5C50.34,26 51,25.33 51,24.5V21.5A1.5,1.5 0 0,0 49.5,20H48.5M26.5,20A1.5,1.5 0 0,0 25,21.5V24.5A1.5,1.5 0 0,0 26.5,26H27.5A1.5,1.5 0 0,0 29,24.5V21.5A1.5,1.5 0 0,0 27.5,20H26.5Z"
-                                                Style="{DynamicResource MahApps.Styles.ContentControl.PathIcon}" />
-                            </Button>
+                                    Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
+                                    Template="{TemplateBinding Controls:TextBoxHelper.ButtonTemplate}" />
+
                             <Border x:Name="DisabledVisualElement"
                                     Grid.Row="0"
                                     Grid.RowSpan="2"
@@ -227,6 +252,7 @@
                                     IsHitTestVisible="False"
                                     Opacity="0"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+
                             <Popup x:Name="PART_Popup"
                                    Grid.Row="1"
                                    Grid.Column="0"
@@ -407,10 +433,6 @@
                             <Setter TargetName="StackPanel" Property="Orientation" Value="{Binding Path=Orientation, RelativeSource={RelativeSource TemplatedParent}}" />
                             <!--<Setter TargetName="PART_TextBox" Property="Text" Value="{Binding Path=SelectedDate, RelativeSource={RelativeSource TemplatedParent}}" />-->
                         </Trigger>
-                        <Trigger Property="IsDatePickerVisible" Value="False">
-                            <!--  PackIconMaterial - Clock  -->
-                            <Setter TargetName="PART_ButtonIcon" Property="Content" Value="M12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22C6.47,22 2,17.5 2,12A10,10 0 0,1 12,2M12.5,7V12.25L17,14.92L16.25,16.15L11,13V7H12.5Z" />
-                        </Trigger>
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding Path=IsVisible, RelativeSource={RelativeSource Self}}" Value="True" />
@@ -438,6 +460,7 @@
     </Style>
 
     <Style BasedOn="{StaticResource MahApps.Styles.TimePickerBase}" TargetType="{x:Type Controls:TimePicker}">
+        <Setter Property="Controls:TextBoxHelper.ButtonContent" Value="M12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22C6.47,22 2,17.5 2,12A10,10 0 0,1 12,2M12.5,7V12.25L17,14.92L16.25,16.15L11,13V7H12.5Z" />
         <Setter Property="Controls:TextBoxHelper.Watermark" Value="Select a time" />
     </Style>
 </ResourceDictionary>

--- a/src/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/src/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -16,7 +16,7 @@
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Sizes.Font.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="MinHeight" Value="26" />
-        <Setter Property="Padding" Value="0" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
         <Setter Property="SnapsToDevicePixels" Value="True" />
@@ -25,6 +25,7 @@
                 <ControlTemplate TargetType="{x:Type Controls:HotKeyBox}">
                     <TextBox x:Name="PART_TextBox"
                              MinHeight="{TemplateBinding MinHeight}"
+                             Margin="0"
                              Padding="{TemplateBinding Padding}"
                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -7,8 +7,6 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Shared.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Converters:ThicknessBindingConverter x:Key="ThicknessBindingConverter" />
-
     <Style TargetType="{x:Type Controls:NumericUpDown}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}" />
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border}" />
@@ -26,7 +24,7 @@
         <Setter Property="HorizontalContentAlignment" Value="Right" />
         <Setter Property="MinHeight" Value="26" />
         <Setter Property="MinWidth" Value="62" />
-        <Setter Property="Padding" Value="1" />
+        <Setter Property="Padding" Value="4" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
         <Setter Property="SnapsToDevicePixels" Value="true" />
@@ -50,8 +48,8 @@
                                      Grid.Column="0"
                                      MinWidth="20"
                                      MinHeight="0"
-                                     Margin="0 0 -2 0"
-                                     Padding="0"
+                                     Margin="0"
+                                     Padding="{TemplateBinding Padding}"
                                      HorizontalAlignment="Stretch"
                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -86,7 +84,7 @@
                             <RepeatButton x:Name="PART_NumericUp"
                                           Grid.Column="1"
                                           Width="{TemplateBinding UpDownButtonsWidth}"
-                                          Margin="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}"
+                                          Margin="0"
                                           Delay="{TemplateBinding Delay}"
                                           Focusable="{TemplateBinding UpDownButtonsFocusable}"
                                           Foreground="{TemplateBinding Foreground}"
@@ -102,7 +100,7 @@
                             <RepeatButton x:Name="PART_NumericDown"
                                           Grid.Column="2"
                                           Width="{TemplateBinding UpDownButtonsWidth}"
-                                          Margin="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}"
+                                          Margin="0"
                                           VerticalContentAlignment="Center"
                                           Delay="{TemplateBinding Delay}"
                                           Focusable="{TemplateBinding UpDownButtonsFocusable}"
@@ -136,29 +134,9 @@
                             <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_MiddleColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
                             <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_NumericUp" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}" />
                             <Setter TargetName="PART_RightColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="2" />
-                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
-                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="ButtonsAlignment" Value="Opposite" />
-                                <Condition Property="SwitchUpDownButtons" Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
-                            <Setter TargetName="PART_MiddleColumn" Property="Width" Value="*" />
-                            <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="2" />
-                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}" />
-                            <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_NumericUp" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
-                            <Setter TargetName="PART_RightColumn" Property="Width" Value="Auto" />
-                            <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
-                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -168,13 +146,22 @@
                             <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_MiddleColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}" />
                             <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="PART_NumericUp" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
                             <Setter TargetName="PART_RightColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="2" />
-                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
-                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
+                        </MultiTrigger>
+
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="ButtonsAlignment" Value="Opposite" />
+                                <Condition Property="SwitchUpDownButtons" Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_MiddleColumn" Property="Width" Value="*" />
+                            <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="2" />
+                            <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_RightColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="1" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -184,14 +171,11 @@
                             <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_MiddleColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
                             <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="2" />
-                            <Setter TargetName="PART_NumericUp" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}" />
                             <Setter TargetName="PART_RightColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
-                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
                         </MultiTrigger>
+
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="ButtonsAlignment" Value="Right" />
@@ -200,14 +184,11 @@
                             <Setter TargetName="PART_LeftColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_MiddleColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="PART_NumericDown" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Left}}" />
                             <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="2" />
-                            <Setter TargetName="PART_NumericUp" Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Right}}" />
                             <Setter TargetName="PART_RightColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
-                            <Setter TargetName="PART_TextBox" Property="Margin" Value="-2 0 0 0" />
                         </MultiTrigger>
+
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
                         </Trigger>


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

The padding for all input controls are hard coded in there styles, so it's not possible to override these settings in an easy way.

- [x] TextBox
- [x] RichTextBox
- [x] PasswordBox
- [x] DatePicker
- [x] NumericUpDown
- [x] ComboBox
- [x] HotKeyBox
- [x] DateTimePicker
- [x] TimePicker
