### PR TITLE
Add new HamburgerMenuHeaderItem

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HamburgerMenuCreatorsUpdate.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HamburgerMenuCreatorsUpdate.xaml
@@ -179,12 +179,13 @@
                                     ItemInvoked="HamburgerMenuControl_OnItemInvoked"
                                     ItemTemplate="{StaticResource HamburgerMenuItem}"
                                     OptionsItemTemplate="{StaticResource HamburgerOptionsMenuItem}"
-                                    SelectedIndex="0"
+                                    SelectedIndex="1"
                                     Style="{StaticResource HamburgerMenuCreatorsStyle}"
                                     VerticalScrollBarOnLeftSide="False">
                 <!--  Items  -->
                 <Controls:HamburgerMenu.ItemsSource>
                     <Controls:HamburgerMenuItemCollection>
+                        <Controls:HamburgerMenuHeaderItem Label="Pictures" />
                         <Controls:HamburgerMenuGlyphItem Glyph="/Assets/Photos/BigFourSummerHeat.png" Label="Big four summer heat" />
                         <Controls:HamburgerMenuGlyphItem Glyph="/Assets/Photos/BisonBadlandsChillin.png" Label="Bison badlands Chillin" />
                         <Controls:HamburgerMenuSeparatorItem />

--- a/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.Events.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.Events.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 
 namespace MahApps.Metro.Controls
@@ -68,6 +67,11 @@ namespace MahApps.Metro.Controls
         {
             var selectedItem = _buttonsListView.SelectedItem;
 
+            if (!CanRaiseItemEvents(selectedItem))
+            {
+                return false;
+            }
+
             (selectedItem as HamburgerMenuItem)?.RaiseCommand();
             RaiseItemCommand();
 
@@ -78,6 +82,26 @@ namespace MahApps.Metro.Controls
             }
 
             return raiseItemEvents;
+        }
+
+        private bool CanRaiseItemEvents(object selectedItem)
+        {
+            if (selectedItem is null)
+            {
+                return false;
+            }
+
+            if (selectedItem is IHamburgerMenuHeaderItem || selectedItem is IHamburgerMenuSeparatorItem)
+            {
+                if (this._buttonsListView != null)
+                {
+                    this._buttonsListView.SelectedIndex = -1;
+                }
+
+                return false;
+            }
+
+            return true;
         }
 
         private bool RaiseItemEvents(object selectedItem)
@@ -100,6 +124,11 @@ namespace MahApps.Metro.Controls
         {
             var selectedItem = _optionsListView.SelectedItem;
 
+            if (!CanRaiseOptionsItemEvents(selectedItem))
+            {
+                return false;
+            }
+
             (selectedItem as HamburgerMenuItem)?.RaiseCommand();
             RaiseOptionsItemCommand();
 
@@ -112,9 +141,34 @@ namespace MahApps.Metro.Controls
             return raiseOptionsItemEvents;
         }
 
+        private bool CanRaiseOptionsItemEvents(object selectedItem)
+        {
+            if (selectedItem is null)
+            {
+                return false;
+            }
+
+            if (selectedItem is IHamburgerMenuHeaderItem || selectedItem is IHamburgerMenuSeparatorItem)
+            {
+                if (this._optionsListView != null)
+                {
+                    this._optionsListView.SelectedIndex = -1;
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
         private bool RaiseOptionsItemEvents(object selectedItem)
         {
             if (selectedItem is null)
+            {
+                return false;
+            }
+
+            if (selectedItem is IHamburgerMenuHeaderItem || selectedItem is IHamburgerMenuSeparatorItem)
             {
                 return false;
             }

--- a/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.Properties.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.Properties.cs
@@ -93,6 +93,11 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty ItemContainerStyleProperty = DependencyProperty.Register(nameof(ItemContainerStyle), typeof(Style), typeof(HamburgerMenu), new PropertyMetadata(null));
 
         /// <summary>
+        /// Identifies the <see cref="HeaderItemContainerStyle"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty HeaderItemContainerStyleProperty = DependencyProperty.Register(nameof(HeaderItemContainerStyle), typeof(Style), typeof(HamburgerMenu), new PropertyMetadata(null));
+
+        /// <summary>
         /// Identifies the <see cref="SeparatorItemContainerStyle"/> dependency property.
         /// </summary>
         public static readonly DependencyProperty SeparatorItemContainerStyleProperty = DependencyProperty.Register(nameof(SeparatorItemContainerStyle), typeof(Style), typeof(HamburgerMenu), new PropertyMetadata(null));
@@ -248,7 +253,16 @@ namespace MahApps.Metro.Controls
             set { SetValue(ItemContainerStyleProperty, value); }
         }
 
-        /// <summary>
+        /// <summary>   
+        /// Gets or sets the Style used for each header item.
+        /// </summary>
+        public Style HeaderItemContainerStyle
+        {
+            get { return (Style)GetValue(HeaderItemContainerStyleProperty); }
+            set { SetValue(HeaderItemContainerStyleProperty, value); }
+        }
+
+        /// <summary>   
         /// Gets or sets the Style used for each separator item.
         /// </summary>
         public Style SeparatorItemContainerStyle

--- a/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.cs
@@ -77,20 +77,27 @@ namespace MahApps.Metro.Controls
                 return;
             }
 
-            if (RaiseItemEvents(_buttonsListView?.SelectedItem))
+            var item = this._buttonsListView?.SelectedItem;
+            var canRaiseItemEvents = this.CanRaiseItemEvents(item);
+            if (canRaiseItemEvents && RaiseItemEvents(item))
             {
                 return;
             }
 
-            if (RaiseOptionsItemEvents(_optionsListView?.SelectedItem))
+            var optionItem = this._optionsListView?.SelectedItem;
+            var canRaiseOptionsItemEvents = this.CanRaiseOptionsItemEvents(optionItem);
+            if (canRaiseOptionsItemEvents && RaiseOptionsItemEvents(optionItem))
             {
                 return;
             }
 
-            var selectedItem = _buttonsListView?.SelectedItem ?? _optionsListView?.SelectedItem;
-            if (selectedItem != null)
+            if (canRaiseItemEvents || canRaiseOptionsItemEvents)
             {
-                SetCurrentValue(ContentProperty, selectedItem);
+                var selectedItem = item ?? optionItem;
+                if (selectedItem != null)
+                {
+                    SetCurrentValue(ContentProperty, selectedItem);
+                }
             }
         }
     }

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuHeaderItem.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuHeaderItem.cs
@@ -1,0 +1,33 @@
+﻿using System.Windows;
+
+namespace MahApps.Metro.Controls
+{
+    public class HamburgerMenuHeaderItem : HamburgerMenuItemBase, IHamburgerMenuHeaderItem
+    {
+        /// <summary>
+        /// Identifies the <see cref="Label"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty LabelProperty = DependencyProperty.Register(nameof(Label), typeof(string), typeof(HamburgerMenuHeaderItem), new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets a value that specifies label to display.
+        /// </summary>
+        public string Label
+        {
+            get
+            {
+                return (string)GetValue(LabelProperty);
+            }
+
+            set
+            {
+                SetValue(LabelProperty, value);
+            }
+        }
+
+        protected override Freezable CreateInstanceCore()
+        {
+            return new HamburgerMenuHeaderItem();
+        }
+    }
+}

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemStyleSelector.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemStyleSelector.cs
@@ -19,7 +19,14 @@ namespace MahApps.Metro.Controls
                 var hamburgerMenu = listBox?.TryFindParent<HamburgerMenu>();
                 if (hamburgerMenu != null)
                 {
-                    if (item is IHamburgerMenuSeparatorItem)
+                    if (item is IHamburgerMenuHeaderItem)
+                    {
+                        if (hamburgerMenu.HeaderItemContainerStyle != null)
+                        {
+                            return hamburgerMenu.HeaderItemContainerStyle;
+                        }
+                    }
+                    else if (item is IHamburgerMenuSeparatorItem)
                     {
                         if (hamburgerMenu.SeparatorItemContainerStyle != null)
                         {

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/IHamburgerMenuHeaderItem.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/IHamburgerMenuHeaderItem.cs
@@ -1,0 +1,10 @@
+﻿namespace MahApps.Metro.Controls
+{
+    public interface IHamburgerMenuHeaderItem
+    {
+        /// <summary>
+        /// Gets or sets a value that specifies label to display.
+        /// </summary>
+        string Label { get; set; }
+    }
+}

--- a/src/MahApps.Metro/Themes/HamburgerMenu.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenu.xaml
@@ -21,6 +21,7 @@
                 </DataTemplate>
             </Setter.Value>
         </Setter>
+        <Setter Property="HeaderItemContainerStyle" Value="{StaticResource MahApps.Styles.ListBoxItem.HamburgerMenuHeader}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="ItemContainerStyle" Value="{StaticResource MahApps.Styles.ListBoxItem.HamburgerMenuItem}" />
         <Setter Property="KeyboardNavigation.ControlTabNavigation" Value="Local" />

--- a/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
@@ -10,6 +10,7 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Buttons.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.ListBox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Scrollbars.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TextBlock.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <system:Double x:Key="HamburgerMenuSelectionIndicatorThemeWidth">6</system:Double>
@@ -267,6 +268,44 @@
                             <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:ItemHelper.DisabledSelectedForegroundBrush), Mode=OneWay}" />
                             <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource Self}, Path=(Controls:ItemHelper.DisabledSelectedBackgroundBrush), Mode=OneWay}" />
                         </MultiTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="MahApps.Styles.TextBlock.HamburgerMenuHeader"
+           BasedOn="{StaticResource MahApps.Styles.TextBlock}"
+           TargetType="{x:Type TextBlock}">
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="TextWrapping" Value="NoWrap" />
+    </Style>
+
+    <Style x:Key="MahApps.Styles.ListBoxItem.HamburgerMenuHeader"
+           BasedOn="{StaticResource MahApps.Styles.ListBoxItem.HamburgerBase}"
+           TargetType="{x:Type ListBoxItem}">
+        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="IsHitTestVisible" Value="False" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Padding" Value="8 8 0 8" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                    <Grid Background="{TemplateBinding Background}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <TextBlock x:Name="PART_HeaderText"
+                                   Margin="{TemplateBinding Padding}"
+                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                   Style="{DynamicResource MahApps.Styles.TextBlock.HamburgerMenuHeader}"
+                                   Text="{Binding Label}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <DataTrigger Binding="{Binding IsPaneOpen, RelativeSource={RelativeSource AncestorType=Controls:HamburgerMenu}}" Value="False">
+                            <Setter TargetName="PART_HeaderText" Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

- Add new `HamburgerMenuHeaderItem` (`IHamburgerMenuHeaderItem`)
An item which can be used to show a header above other HamburgerMenu items.
- Prevent selection for IHamburgerMenuHeaderItem and IHamburgerMenuSeparatorItem
- Use HamburgerMenuHeaderItem at creators style sample

![image](https://user-images.githubusercontent.com/658431/68936048-fa5cd500-0799-11ea-9e2d-b605c5daecda.png)
