### PR TITLE
Improved external dialog to no longer extend onto other monitors

### DIFF
--- a/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -620,8 +620,10 @@ namespace MahApps.Metro.Controls.Dialogs
             win.Topmost = false; //It is not necessary here because the owner is setted
             win.WindowStartupLocation = WindowStartupLocation.CenterOwner; //WindowStartupLocation should be CenterOwner
 
+            var offset = SystemParameters.WindowNonClientFrameThickness.Left + SystemParameters.WindowResizeBorderThickness.Left +
+                    SystemParameters.WindowNonClientFrameThickness.Right + SystemParameters.WindowResizeBorderThickness.Right;
             //Set Width and Height maximum according Owner
-            win.Width = window.ActualWidth;
+            win.Width = window.WindowState != WindowState.Maximized ? window.ActualWidth : window.ActualWidth - offset;
             win.MaxHeight = window.ActualHeight;
             win.SizeToContent = SizeToContent.Height;
 

--- a/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -660,6 +660,17 @@ namespace MahApps.Metro.Controls.Dialogs
             }
             else
             {
+                // Remove the border on left and right side
+                win.BeginInvoke(x =>
+                                    {
+                                        x.SetCurrentValue(Control.BorderThicknessProperty, new Thickness(0, x.BorderThickness.Top, 0, x.BorderThickness.Bottom));
+                                        if (x is MetroWindow metroWindow)
+                                        {
+                                            metroWindow.SetCurrentValue(MetroWindow.ResizeBorderThicknessProperty, new Thickness(0, metroWindow.ResizeBorderThickness.Top, 0, metroWindow.ResizeBorderThickness.Bottom));
+                                        }
+                                    },
+                                DispatcherPriority.Loaded);
+
                 var offset = SystemParameters.WindowNonClientFrameThickness.Left + SystemParameters.WindowResizeBorderThickness.Left +
                              SystemParameters.WindowNonClientFrameThickness.Right + SystemParameters.WindowResizeBorderThickness.Right;
                 win.Width = window.ActualWidth - offset;

--- a/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -619,11 +619,19 @@ namespace MahApps.Metro.Controls.Dialogs
             win.Owner = window;
             win.Topmost = false; //It is not necessary here because the owner is setted
             win.WindowStartupLocation = WindowStartupLocation.CenterOwner; //WindowStartupLocation should be CenterOwner
-
-            var offset = SystemParameters.WindowNonClientFrameThickness.Left + SystemParameters.WindowResizeBorderThickness.Left +
-                    SystemParameters.WindowNonClientFrameThickness.Right + SystemParameters.WindowResizeBorderThickness.Right;
+            
             //Set Width and Height maximum according Owner
-            win.Width = window.WindowState != WindowState.Maximized ? window.ActualWidth : window.ActualWidth - offset;
+            if(window.WindowState != WindowState.Maximized)
+            {
+                win.Width = window.ActualWidth;
+            }
+            else
+            {
+                var offset = SystemParameters.WindowNonClientFrameThickness.Left + SystemParameters.WindowResizeBorderThickness.Left +
+                    SystemParameters.WindowNonClientFrameThickness.Right + SystemParameters.WindowResizeBorderThickness.Right;
+                win.Width = window.ActualWidth - offset;
+            }
+
             win.MaxHeight = window.ActualHeight;
             win.SizeToContent = SizeToContent.Height;
 

--- a/src/MahApps.Metro/Controls/Extensions.cs
+++ b/src/MahApps.Metro/Controls/Extensions.cs
@@ -66,6 +66,19 @@ namespace MahApps.Metro.Controls
             dispatcherObject.Dispatcher.BeginInvoke(priority, invokeAction);
         }
 
+        public static void BeginInvoke<T>([NotNull] this T dispatcherObject, [NotNull] Action<T> invokeAction, DispatcherPriority priority = DispatcherPriority.Background) where T: DispatcherObject
+        {
+            if (dispatcherObject == null)
+            {
+                throw new ArgumentNullException(nameof(dispatcherObject));
+            }
+            if (invokeAction == null)
+            {
+                throw new ArgumentNullException(nameof(invokeAction));
+            }
+            dispatcherObject.Dispatcher?.BeginInvoke(priority, new Action(() => invokeAction(dispatcherObject)));
+        }
+
         /// <summary> 
         ///   Executes the specified action if the element is loaded or at the loaded event if it's not loaded.
         /// </summary>

--- a/src/MahApps.Metro/Controls/WinApiHelper.cs
+++ b/src/MahApps.Metro/Controls/WinApiHelper.cs
@@ -1,11 +1,38 @@
-﻿#pragma warning disable 618
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+using ControlzEx.Standard;
+
 namespace MahApps.Metro.Controls
 {
-    using System;
-    using ControlzEx.Standard;
-
+    [SuppressMessage("ReSharper", "CS0618")]
     public static class WinApiHelper
     {
+        /// <summary>
+        /// Get the working area size of the monitor from where the visual stays.
+        /// </summary>
+        /// <param name="visual">The visual element to get the monitor information.</param>
+        /// <returns>The working area size of the monitor.</returns>
+        public static Size GetMonitorWorkSize(this Visual visual)
+        {
+            // Try to get the monitor from where the owner stays and use the working area for window size properties
+            if (visual != null && PresentationSource.FromVisual(visual) is HwndSource source)
+            {
+                var monitor = NativeMethods.MonitorFromWindow(source.Handle, MonitorOptions.MONITOR_DEFAULTTONEAREST);
+                if (monitor != IntPtr.Zero)
+                {
+                    MONITORINFO monitorInfo = NativeMethods.GetMonitorInfoW(monitor);
+                    var rcWorkArea = monitorInfo.rcWork;
+
+                    return new Size(rcWorkArea.Width, rcWorkArea.Height);
+                }
+            }
+
+            return default;
+        }
+
         /// <summary>
         /// Gets the relative mouse position to the given handle in client coordinates.
         /// </summary>
@@ -16,6 +43,7 @@ namespace MahApps.Metro.Controls
             {
                 return new System.Windows.Point();
             }
+
             var point = WinApiHelper.GetPhysicalCursorPos();
             NativeMethods.ScreenToClient(hWnd, ref point);
             return new System.Windows.Point(point.X, point.Y);
@@ -39,6 +67,7 @@ namespace MahApps.Metro.Controls
             {
                 point = new System.Windows.Point();
             }
+
             return returnValue;
         }
 


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

- Added a check for window state in `CreateModalExternalWindow`
- Added a border offset to take in account the overhang on both sides of the window when maximized causing a dialog to extend outside of the screen bounds.
- Fix `SetupExternalDialogWindow`
Use the monitor from where the owner stays and use the working area for the dialog size properties and remove also the left and right border.
- Simplify getting the working area from current monitor with new extension method `GetMonitorWorkSize`
Use this method in both variants SetupExternalDialogWindow and CreateModalExternalWindow which also fixes the main issue without calculating an offset by hand.

![external-dialog-fix](https://user-images.githubusercontent.com/43521957/69114658-e822b580-0a7d-11ea-8f1b-296825ca86a8.png)

**Closed Issues**

Closes #3538 
