### PR TITLE
Introduce new attached property ControlsHelper.RecognizesAccessKey

### DIFF
--- a/src/MahApps.Metro/Controls/ContentControlEx.cs
+++ b/src/MahApps.Metro/Controls/ContentControlEx.cs
@@ -5,44 +5,39 @@ namespace MahApps.Metro.Controls
 {
     public class ContentControlEx : ContentControl
     {
-        /// <summary>
-        /// The DependencyProperty for the CharacterCasing property.
-        /// Controls whether or not content is converted to upper or lower case
-        /// Default Value: CharacterCasing.Normal
-        /// </summary>
-        public static readonly DependencyProperty ContentCharacterCasingProperty =
-            DependencyProperty.Register("ContentCharacterCasing",
-                                        typeof(CharacterCasing),
-                                        typeof(ContentControlEx),
-                                        new FrameworkPropertyMetadata(CharacterCasing.Normal, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure),
-                                        value => CharacterCasing.Normal <= (CharacterCasing)value && (CharacterCasing)value <= CharacterCasing.Upper);
+        /// <summary>Identifies the <see cref="ContentCharacterCasing"/> dependency property.</summary>
+        public static readonly DependencyProperty ContentCharacterCasingProperty
+            = DependencyProperty.Register(
+                nameof(ContentCharacterCasing),
+                typeof(CharacterCasing),
+                typeof(ContentControlEx),
+                new FrameworkPropertyMetadata(CharacterCasing.Normal, FrameworkPropertyMetadataOptions.Inherits | FrameworkPropertyMetadataOptions.AffectsMeasure),
+                value => CharacterCasing.Normal <= (CharacterCasing)value && (CharacterCasing)value <= CharacterCasing.Upper);
 
         /// <summary> 
-        /// Character casing of the Content
+        /// Gets or sets the character casing of the Content.
         /// </summary> 
         public CharacterCasing ContentCharacterCasing
         {
-            get { return (CharacterCasing)GetValue(ContentCharacterCasingProperty); }
-            set { SetValue(ContentCharacterCasingProperty, value); }
+            get { return (CharacterCasing)this.GetValue(ContentCharacterCasingProperty); }
+            set { this.SetValue(ContentCharacterCasingProperty, value); }
         }
 
-        /// <summary>
-        /// The DependencyProperty for the RecognizesAccessKey property. 
-        /// Default Value: false 
-        /// </summary> 
-        public static readonly DependencyProperty RecognizesAccessKeyProperty =
-            DependencyProperty.Register("RecognizesAccessKey",
-                                        typeof(bool),
-                                        typeof(ContentControlEx),
-                                        new FrameworkPropertyMetadata(false));
+        /// <summary>Identifies the <see cref="RecognizesAccessKey"/> dependency property.</summary>
+        public static readonly DependencyProperty RecognizesAccessKeyProperty
+            = DependencyProperty.Register(
+                nameof(RecognizesAccessKey),
+                typeof(bool),
+                typeof(ContentControlEx),
+                new FrameworkPropertyMetadata(false));
 
         /// <summary> 
         /// Determine if the inner ContentPresenter should use AccessText in its style
         /// </summary> 
         public bool RecognizesAccessKey
         {
-            get { return (bool)GetValue(RecognizesAccessKeyProperty); }
-            set { SetValue(RecognizesAccessKeyProperty, value); }
+            get { return (bool)this.GetValue(RecognizesAccessKeyProperty); }
+            set { this.SetValue(RecognizesAccessKeyProperty, value); }
         }
 
         static ContentControlEx()

--- a/src/MahApps.Metro/Controls/Helper/ControlsHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ControlsHelper.cs
@@ -66,7 +66,38 @@ namespace MahApps.Metro.Controls
             element.SetValue(ContentCharacterCasingProperty, value);
         }
 
+        public static readonly DependencyProperty RecognizesAccessKeyProperty
+            = DependencyProperty.RegisterAttached(
+                "RecognizesAccessKey",
+                typeof(bool),
+                typeof(ControlsHelper),
+                new FrameworkPropertyMetadata(true));
 
+        /// <summary> 
+        /// Gets the value if the inner ContentPresenter use AccessText in its style.
+        /// </summary> 
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(ButtonBase))]
+        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(DropDownButton))]
+        [AttachedPropertyBrowsableForType(typeof(SplitButton))]
+        public static bool GetRecognizesAccessKey(UIElement element)
+        {
+            return (bool)element.GetValue(RecognizesAccessKeyProperty);
+        }
+
+        /// <summary> 
+        /// Sets the value if the inner ContentPresenter should use AccessText in its style.
+        /// </summary> 
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(ButtonBase))]
+        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(DropDownButton))]
+        [AttachedPropertyBrowsableForType(typeof(SplitButton))]
+        public static void SetRecognizesAccessKey(UIElement element, bool value)
+        {
+            element.SetValue(RecognizesAccessKeyProperty, value);
+        }
 
         public static readonly DependencyProperty FocusBorderBrushProperty
             = DependencyProperty.RegisterAttached("FocusBorderBrush",

--- a/src/MahApps.Metro/Controls/Helper/ControlsHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ControlsHelper.cs
@@ -77,8 +77,7 @@ namespace MahApps.Metro.Controls
         /// Gets the value if the inner ContentPresenter use AccessText in its style.
         /// </summary> 
         [Category(AppName.MahApps)]
-        [AttachedPropertyBrowsableForType(typeof(ButtonBase))]
-        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(ContentControl))]
         [AttachedPropertyBrowsableForType(typeof(DropDownButton))]
         [AttachedPropertyBrowsableForType(typeof(SplitButton))]
         public static bool GetRecognizesAccessKey(UIElement element)
@@ -90,8 +89,7 @@ namespace MahApps.Metro.Controls
         /// Sets the value if the inner ContentPresenter should use AccessText in its style.
         /// </summary> 
         [Category(AppName.MahApps)]
-        [AttachedPropertyBrowsableForType(typeof(ButtonBase))]
-        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(ContentControl))]
         [AttachedPropertyBrowsableForType(typeof(DropDownButton))]
         [AttachedPropertyBrowsableForType(typeof(SplitButton))]
         public static void SetRecognizesAccessKey(UIElement element, bool value)

--- a/src/MahApps.Metro/Styles/Clean/CleanGroupBox.xaml
+++ b/src/MahApps.Metro/Styles/Clean/CleanGroupBox.xaml
@@ -28,7 +28,7 @@
                                                        FontStretch="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontStretch}"
                                                        FontWeight="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontWeight}"
                                                        Foreground="{TemplateBinding Controls:HeaderedControlHelper.HeaderForeground}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
 

--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -47,7 +47,7 @@
                                                    ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
                                                    ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                   RecognizesAccessKey="True"
+                                                   RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                 </ControlTemplate>
@@ -95,7 +95,7 @@
                                                    ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
                                                    ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                   RecognizesAccessKey="True"
+                                                   RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                 </ControlTemplate>
@@ -288,7 +288,7 @@
                                                    ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
                                                    ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                   RecognizesAccessKey="True"
+                                                   RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                 </ControlTemplate>
@@ -424,7 +424,7 @@
                                                    ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
                                                    ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                   RecognizesAccessKey="True"
+                                                   RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -484,7 +484,7 @@
                                                    ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
                                                    ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                   RecognizesAccessKey="True"
+                                                   RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
@@ -564,7 +564,7 @@
                                                    ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
                                                    ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                   RecognizesAccessKey="True"
+                                                   RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
@@ -725,7 +725,7 @@
                                                    ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
                                                    ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                   RecognizesAccessKey="True"
+                                                   RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -808,7 +808,7 @@
                                                            ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                            ContentTemplate="{TemplateBinding ContentTemplate}"
                                                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                           RecognizesAccessKey="True"
+                                                           RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Grid>
                         </Border>
@@ -918,7 +918,7 @@
                                                            ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                            ContentTemplate="{TemplateBinding ContentTemplate}"
                                                            ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                           RecognizesAccessKey="True"
+                                                           RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Grid>
                         </Border>

--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -185,7 +185,7 @@
                                           Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          RecognizesAccessKey="True"
+                                          RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -243,7 +243,7 @@
                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                               Opacity="0.75"
-                              RecognizesAccessKey="True"
+                              RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
         </Grid>
         <ControlTemplate.Triggers>
@@ -631,7 +631,7 @@
                                           Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          RecognizesAccessKey="True"
+                                          RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -1015,7 +1015,7 @@
                                           Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          RecognizesAccessKey="True" />
+                                          RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}" />
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsKeyboardFocused" Value="True">

--- a/src/MahApps.Metro/Styles/Controls.CheckBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.CheckBox.xaml
@@ -65,7 +65,7 @@
                                           ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
                                           ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                          RecognizesAccessKey="True" />
+                                          RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}" />
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />

--- a/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -257,7 +257,7 @@
                                 </Grid.ColumnDefinitions>
                                 <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  RecognizesAccessKey="True"
+                                                  RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                 <Control Grid.Column="1"
                                          Focusable="False"

--- a/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -168,6 +168,7 @@
                                 BorderThickness="{TemplateBinding BorderThickness}" />
 
                         <Controls:ContentControlEx x:Name="HeaderContent"
+                                                   Grid.Column="0"
                                                    Margin="{TemplateBinding BorderThickness}"
                                                    Padding="{TemplateBinding Padding}"
                                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -177,7 +178,7 @@
                                                    ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
                                                    ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                   RecognizesAccessKey="True"
+                                                   RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
                         <Path x:Name="SortArrow"

--- a/src/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -71,7 +71,7 @@
                                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                     </Border>
@@ -145,7 +145,7 @@
                                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                     </Border>
@@ -218,7 +218,7 @@
                                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                     </Border>
@@ -281,7 +281,7 @@
                                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                     </Border>

--- a/src/MahApps.Metro/Styles/Controls.GroupBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.GroupBox.xaml
@@ -45,7 +45,7 @@
                                                        FontSize="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontSize}"
                                                        FontStretch="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontStretch}"
                                                        FontWeight="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontWeight}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                        UseLayoutRounding="False">
                                 <TextElement.Foreground>

--- a/src/MahApps.Metro/Styles/Controls.Label.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Label.xaml
@@ -18,7 +18,7 @@
                         <ContentPresenter x:Name="PART_ContentPresenter"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          RecognizesAccessKey="True"
+                                          RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Border>
                     <ControlTemplate.Triggers>

--- a/src/MahApps.Metro/Styles/Controls.ListView.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ListView.xaml
@@ -325,7 +325,7 @@
                                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
                         <Thumb x:Name="PART_HeaderGripper"

--- a/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -25,7 +25,7 @@
                                           Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          RecognizesAccessKey="True"
+                                          RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                     <ControlTemplate.Triggers>

--- a/src/MahApps.Metro/Styles/Controls.RadioButton.xaml
+++ b/src/MahApps.Metro/Styles/Controls.RadioButton.xaml
@@ -55,7 +55,7 @@
                                           ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
                                           ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                          RecognizesAccessKey="True" />
+                                          RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}" />
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="CommonStates">
                                 <VisualState x:Name="Normal" />

--- a/src/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -156,7 +156,7 @@
                                                        FontStyle="{TemplateBinding FontStyle}"
                                                        FontWeight="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontWeight}"
                                                        Foreground="{TemplateBinding Foreground}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                        UseLayoutRounding="False" />
                             <Controls:Underline x:Name="Underline"

--- a/src/MahApps.Metro/Styles/Controls.Toolbar.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Toolbar.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:MahApps.Metro.Controls">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TextBox.xaml" />
@@ -30,7 +31,7 @@
                         <ContentPresenter Margin="2"
                                           HorizontalAlignment="Center"
                                           VerticalAlignment="Center"
-                                          RecognizesAccessKey="True" />
+                                          RecognizesAccessKey="{TemplateBinding controls:ControlsHelper.RecognizesAccessKey}" />
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsKeyboardFocused" Value="true">

--- a/src/MahApps.Metro/Styles/VS/Expander.xaml
+++ b/src/MahApps.Metro/Styles/VS/Expander.xaml
@@ -73,7 +73,7 @@
                                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                     </Border>
@@ -122,7 +122,7 @@
                                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             <Grid x:Name="ArrowGrid"
                                   Grid.Column="1"
@@ -219,7 +219,7 @@
                                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                     </Border>
@@ -266,7 +266,7 @@
                                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             <Grid x:Name="ArrowGrid"
                                   Grid.Column="1"

--- a/src/MahApps.Metro/Styles/VS/GroupBox.xaml
+++ b/src/MahApps.Metro/Styles/VS/GroupBox.xaml
@@ -37,7 +37,7 @@
                                                        FontStretch="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontStretch}"
                                                        FontWeight="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontWeight}"
                                                        Foreground="{TemplateBinding Controls:HeaderedControlHelper.HeaderForeground}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                         <Border Grid.Row="1"

--- a/src/MahApps.Metro/Styles/VS/TabControl.xaml
+++ b/src/MahApps.Metro/Styles/VS/TabControl.xaml
@@ -171,7 +171,7 @@
                                                        FontStyle="{TemplateBinding FontStyle}"
                                                        FontWeight="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontWeight}"
                                                        Foreground="{TemplateBinding Foreground}"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             <Button x:Name="PART_CloseButton"
                                     VerticalAlignment="Center"

--- a/src/MahApps.Metro/Themes/DropDownButton.xaml
+++ b/src/MahApps.Metro/Themes/DropDownButton.xaml
@@ -100,7 +100,7 @@
                                                                    ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
                                                                    ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                                   RecognizesAccessKey="True"
+                                                                   RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                                    UseLayoutRounding="False" />
                                     </StackPanel>

--- a/src/MahApps.Metro/Themes/FlipView.xaml
+++ b/src/MahApps.Metro/Themes/FlipView.xaml
@@ -181,7 +181,7 @@
                                                   Margin="{TemplateBinding Padding}"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  RecognizesAccessKey="True"
+                                                  RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Border>
                             <ControlTemplate.Triggers>

--- a/src/MahApps.Metro/Themes/Flyout.xaml
+++ b/src/MahApps.Metro/Themes/Flyout.xaml
@@ -87,7 +87,6 @@
                                                        FontSize="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontSize}"
                                                        FontStretch="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontStretch}"
                                                        FontWeight="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontWeight}"
-                                                       RecognizesAccessKey="True"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     <ContentPresenter x:Name="PART_Content"
                                       ContentSource="Content"

--- a/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
@@ -39,7 +39,7 @@
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                           Opacity="0.75"
-                                          RecognizesAccessKey="True"
+                                          RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                     <ControlTemplate.Triggers>

--- a/src/MahApps.Metro/Themes/MetroHeader.xaml
+++ b/src/MahApps.Metro/Themes/MetroHeader.xaml
@@ -32,7 +32,7 @@
                                                        FontWeight="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontWeight}"
                                                        Foreground="{TemplateBinding Controls:HeaderedControlHelper.HeaderForeground}"
                                                        IsTabStop="False"
-                                                       RecognizesAccessKey="True"
+                                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
                         <Grid Grid.Row="1" Background="{TemplateBinding Background}">

--- a/src/MahApps.Metro/Themes/MetroTabItem.xaml
+++ b/src/MahApps.Metro/Themes/MetroTabItem.xaml
@@ -54,7 +54,7 @@
                                                            FontStyle="{TemplateBinding FontStyle}"
                                                            FontWeight="{TemplateBinding Controls:HeaderedControlHelper.HeaderFontWeight}"
                                                            Foreground="{TemplateBinding Foreground}"
-                                                           RecognizesAccessKey="True"
+                                                           RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                 <Button x:Name="PART_CloseButton"
                                         Grid.Column="1"

--- a/src/MahApps.Metro/Themes/SplitButton.xaml
+++ b/src/MahApps.Metro/Themes/SplitButton.xaml
@@ -57,7 +57,7 @@
                                                            ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
                                                            ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                                                            IsHitTestVisible="False"
-                                                           RecognizesAccessKey="True"
+                                                           RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                            UseLayoutRounding="False" />
                             </StackPanel>
@@ -185,7 +185,7 @@
                                                            ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
                                                            ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                                                            IsHitTestVisible="False"
-                                                           RecognizesAccessKey="True"
+                                                           RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                            UseLayoutRounding="False" />
                             </StackPanel>

--- a/src/MahApps.Metro/Themes/WindowCommands.xaml
+++ b/src/MahApps.Metro/Themes/WindowCommands.xaml
@@ -13,7 +13,7 @@
                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                       RecognizesAccessKey="True"
+                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
         </Grid>
     </ControlTemplate>
@@ -29,7 +29,7 @@
                                        ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                        ContentTemplate="{TemplateBinding ContentTemplate}"
                                        ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                       RecognizesAccessKey="True"
+                                       RecognizesAccessKey="{TemplateBinding Controls:ControlsHelper.RecognizesAccessKey}"
                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
         </Grid>
     </ControlTemplate>


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Introduce a new attached dependency property `ControlsHelper.RecognizesAccessKey` to allow set the `RecognizesAccessKey` of controls which has a `ContentControlEx` / `ContentPresenter` inside.

**Closed Issues**

Closes #3715 
