### PR TITLE
Fixes UnitTest failures by adjusting the XAML content before parsing

### DIFF
--- a/src/MahApps.Metro/Styles/Themes/Theme.Template.xaml
+++ b/src/MahApps.Metro/Styles/Themes/Theme.Template.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:markup="clr-namespace:MahApps.Metro.Markup"
+                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:system="clr-namespace:System;assembly=mscorlib"


### PR DESCRIPTION
This is just a rough fix.
The code is not optimized for performance.
As the whole ThemeHelper will be replaced with the RuntimeThemeGenerator from ControlzEx i will use better optimized code there.