### PR TITLE
(GH-3783) Add OnCommand and OffCommand to ToggleSwitch

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
@@ -281,11 +281,15 @@
                     UseLayoutRounding="True">
             <Label Content="ToggleSwitch" Style="{DynamicResource DescriptionHeaderStyle}" />
 
-            <Controls:ToggleSwitch x:Name="TestToggleSwitch"
+            <Controls:ToggleSwitch IsOn="{Binding CanUseToggleSwitch, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                    Margin="{StaticResource ControlMargin}"
                                    Header="Header" />
-            <Controls:ToggleSwitch Margin="{StaticResource ControlMargin}" IsEnabled="{Binding ElementName=TestToggleSwitch, Path=IsOn, Mode=OneWay}" />
             <Controls:ToggleSwitch Margin="{StaticResource ControlMargin}"
+                                   CommandParameter="{Binding}"
+                                   OnCommand="{Binding ToggleSwitchOnCommand}"
+                                   OffCommand="{Binding ToggleSwitchOffCommand}" />
+            <Controls:ToggleSwitch Margin="{StaticResource ControlMargin}"
+                                   Command="{Binding ToggleSwitchCommand}"
                                    IsOn="True"
                                    OffContent="Disabled"
                                    OnContent="Enabled" />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
@@ -10,7 +10,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Media;
-using MahApps.Metro;
 using MetroDemo.Models;
 using System.Windows.Input;
 using MahApps.Metro.Controls;
@@ -182,6 +181,9 @@ namespace MetroDemo
                 );
 
             this.ShowHamburgerAboutCommand = ShowAboutCommand.Command;
+
+            this.ToggleSwitchCommand = new SimpleCommand(execute: async x => { await ((MetroWindow)Application.Current.MainWindow).ShowMessageAsync("ToggleSwitch", $"The ToggleSwitch is now {((ToggleSwitch)x).IsOn}."); },
+                                                         canExecute: x => this.CanUseToggleSwitch);
         }
 
         public ICommand ArtistsDropDownCommand { get; }
@@ -201,6 +203,22 @@ namespace MetroDemo
             });
 
         public ICommand SyncThemeNowCommand { get; } = new SimpleCommand(execute: x => ThemeManager.Current.SyncTheme());
+
+        public ICommand ToggleSwitchCommand { get; }
+
+        private bool canUseToggleSwitch = true;
+
+        public bool CanUseToggleSwitch
+        {
+            get => this.canUseToggleSwitch;
+            set => this.Set(ref this.canUseToggleSwitch, value);
+        }
+
+        public ICommand ToggleSwitchOnCommand { get; } = new SimpleCommand(execute: async x => { await ((MetroWindow)Application.Current.MainWindow).ShowMessageAsync("ToggleSwitch", "The ToggleSwitch is now On."); },
+                                                                           canExecute: x => x is MainWindowViewModel viewModel && viewModel.CanUseToggleSwitch);
+
+        public ICommand ToggleSwitchOffCommand { get; } = new SimpleCommand(execute: async x => { await ((MetroWindow)Application.Current.MainWindow).ShowMessageAsync("ToggleSwitch", "The ToggleSwitch is now Off."); },
+                                                                            canExecute: x => x is MainWindowViewModel viewModel && viewModel.CanUseToggleSwitch);
 
         public void Dispose()
         {

--- a/src/MahApps.Metro/Controls/CommandHelpers.cs
+++ b/src/MahApps.Metro/Controls/CommandHelpers.cs
@@ -57,5 +57,57 @@ namespace MahApps.Metro.Controls
                 }
             }
         }
+
+        internal static bool CanExecuteCommandSource(ICommandSource commandSource, ICommand theCommand)
+        {
+            var command = theCommand;
+            if (command == null)
+            {
+                return false;
+            }
+
+            var commandParameter = commandSource.CommandParameter ?? commandSource;
+            if (command is RoutedCommand routedCommand)
+            {
+                var target = commandSource.CommandTarget ?? commandSource as IInputElement;
+                return routedCommand.CanExecute(commandParameter, target);
+            }
+
+            return command.CanExecute(commandParameter);
+        }
+
+        [SecurityCritical]
+        [SecuritySafeCritical]
+        internal static void ExecuteCommandSource(ICommandSource commandSource, ICommand theCommand)
+        {
+            CriticalExecuteCommandSource(commandSource, theCommand);
+        }
+
+        [SecurityCritical]
+        internal static void CriticalExecuteCommandSource(ICommandSource commandSource, ICommand theCommand)
+        {
+            var command = theCommand;
+            if (command == null)
+            {
+                return;
+            }
+
+            var commandParameter = commandSource.CommandParameter ?? commandSource;
+            if (command is RoutedCommand routedCommand)
+            {
+                var target = commandSource.CommandTarget ?? commandSource as IInputElement;
+                if (routedCommand.CanExecute(commandParameter, target))
+                {
+                    routedCommand.Execute(commandParameter, target);
+                }
+            }
+            else
+            {
+                if (command.CanExecute(commandParameter))
+                {
+                    command.Execute(commandParameter);
+                }
+            }
+        }
     }
 }

--- a/src/MahApps.Metro/Controls/ToggleSwitch.cs
+++ b/src/MahApps.Metro/Controls/ToggleSwitch.cs
@@ -332,10 +332,45 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Gets or sets a command which will be executed when the <see cref="IsOnProperty"/> changes.
         /// </summary>
+        [Category(AppName.MahApps)]
         public ICommand Command
         {
             get => (ICommand)this.GetValue(CommandProperty);
             set => this.SetValue(CommandProperty, value);
+        }
+
+        /// <summary>Identifies the <see cref="OnCommand"/> dependency property.</summary>
+        public static readonly DependencyProperty OnCommandProperty
+            = DependencyProperty.Register(nameof(OnCommand),
+                                          typeof(ICommand),
+                                          typeof(ToggleSwitch),
+                                          new PropertyMetadata(null, OnCommandChanged));
+
+        /// <summary>
+        /// Gets or sets a command which will be executed when the <see cref="IsOnProperty"/> changes.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        public ICommand OnCommand
+        {
+            get => (ICommand)this.GetValue(OnCommandProperty);
+            set => this.SetValue(OnCommandProperty, value);
+        }
+
+        /// <summary>Identifies the <see cref="OffCommand"/> dependency property.</summary>
+        public static readonly DependencyProperty OffCommandProperty
+            = DependencyProperty.Register(nameof(OffCommand),
+                                          typeof(ICommand),
+                                          typeof(ToggleSwitch),
+                                          new PropertyMetadata(null, OnCommandChanged));
+
+        /// <summary>
+        /// Gets or sets a command which will be executed when the <see cref="IsOnProperty"/> changes.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        public ICommand OffCommand
+        {
+            get => (ICommand)this.GetValue(OffCommandProperty);
+            set => this.SetValue(OffCommandProperty, value);
         }
 
         /// <summary>Identifies the <see cref="CommandParameter"/> dependency property.</summary>
@@ -597,9 +632,11 @@ namespace MahApps.Metro.Controls
 
         private void Toggle()
         {
-            this.SetCurrentValue(IsOnProperty, !this.IsOn);
+            var newValue = !this.IsOn;
+            this.SetCurrentValue(IsOnProperty, newValue);
 
             CommandHelpers.ExecuteCommandSource(this);
+            CommandHelpers.ExecuteCommandSource(this, newValue ? this.OnCommand : this.OffCommand);
         }
 
         private static void OnCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

Add OnCommand and OffCommand properties to the ToggleSwitch. The previous ToggleSwitch had similar commands which allowed simple logic for this 2 states.

The command parameter for both commands will be the value of the CommandParameter or the ToggleSwitch if the property is null.

If the commands are not executable then the ToggleSwitch is still enabled, it will only disable the execuation.

e.g.

```xaml
<Controls:ToggleSwitch CommandParameter="{Binding}"
                       OnCommand="{Binding ToggleSwitchOnCommand}"
                       OffCommand="{Binding ToggleSwitchOffCommand}" />
```

**Closed Issues**

Closes #3783 
