### PR TITLE
Added a way to use DataTemplate in BadgedControl

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
@@ -43,11 +43,13 @@
                 <Button Content="Print" />
             </Controls:Badged>
             <Controls:Badged x:Name="CountingBadge"
+                             BadgeFontSize="12"
+                             BadgeMargin="4 0"
                              Width="100"
                              Margin="{StaticResource ControlMargin}">
                 <Controls:Badged.BadgeTemplate>
                     <DataTemplate>
-                        <TextBlock Text="{Binding StringFormat='{}click-count: {0:00}'}" FontSize="12" />
+                        <TextBlock Text="{Binding StringFormat='{}Click-count: {0:00}'}" />
                     </DataTemplate>
                 </Controls:Badged.BadgeTemplate>
                 <Button Click="CountingButton_OnClick" Content="Click Me" />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ButtonsExample.xaml
@@ -45,6 +45,11 @@
             <Controls:Badged x:Name="CountingBadge"
                              Width="100"
                              Margin="{StaticResource ControlMargin}">
+                <Controls:Badged.BadgeTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding StringFormat='{}click-count: {0:00}'}" FontSize="12" />
+                    </DataTemplate>
+                </Controls:Badged.BadgeTemplate>
                 <Button Click="CountingButton_OnClick" Content="Click Me" />
             </Controls:Badged>
             <Button Width="100"

--- a/src/MahApps.Metro/Controls/Badged.cs
+++ b/src/MahApps.Metro/Controls/Badged.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media.Animation;
 using ControlzEx;
 
@@ -14,6 +15,21 @@ namespace MahApps.Metro.Controls
                                           typeof(Storyboard),
                                           typeof(Badged),
                                           new PropertyMetadata(default(Storyboard)));
+
+        /// <summary>Identifies the <see cref="BadgeTemplate"/> dependency property.</summary>
+        public static readonly DependencyProperty BadgeTemplateProperty 
+            = DependencyProperty.Register(nameof(BadgeTemplate), 
+                                          typeof(DataTemplate), 
+                                          typeof(Badged), 
+                                          new PropertyMetadata(null));
+
+        /// <summary>Identifies the <see cref="BadgeTemplateSelector"/> dependency property.</summary>
+        public static readonly DependencyProperty BadgeTemplateSelectorProperty 
+            = DependencyProperty.Register(nameof(BadgeTemplateSelector), 
+                                          typeof(DataTemplateSelector), 
+                                          typeof(Badged),
+                                          new PropertyMetadata(null));
+
 
         public Storyboard BadgeChangedStoryboard
         {
@@ -50,5 +66,30 @@ namespace MahApps.Metro.Controls
                 }
             }
         }
+
+
+
+        /// <summary>
+        /// Gets or Sets the <see cref="DataTemplate"/> for the Badge
+        /// </summary>
+        public DataTemplate BadgeTemplate
+        {
+            get { return (DataTemplate)GetValue(BadgeTemplateProperty); }
+            set { SetValue(BadgeTemplateProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or Sets the <see cref="DataTemplateSelector"/> for the Badge
+        /// </summary>
+        public DataTemplateSelector BadgeTemplateSelector
+        {
+            get { return (DataTemplateSelector)GetValue(BadgeTemplateSelectorProperty); }
+            set { SetValue(BadgeTemplateSelectorProperty, value); }
+        }
+
+        
+
+
+
     }
 }

--- a/src/MahApps.Metro/Controls/Badged.cs
+++ b/src/MahApps.Metro/Controls/Badged.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Media.Animation;
 using ControlzEx;
 
@@ -15,21 +14,6 @@ namespace MahApps.Metro.Controls
                                           typeof(Storyboard),
                                           typeof(Badged),
                                           new PropertyMetadata(default(Storyboard)));
-
-        /// <summary>Identifies the <see cref="BadgeTemplate"/> dependency property.</summary>
-        public static readonly DependencyProperty BadgeTemplateProperty 
-            = DependencyProperty.Register(nameof(BadgeTemplate), 
-                                          typeof(DataTemplate), 
-                                          typeof(Badged), 
-                                          new PropertyMetadata(null));
-
-        /// <summary>Identifies the <see cref="BadgeTemplateSelector"/> dependency property.</summary>
-        public static readonly DependencyProperty BadgeTemplateSelectorProperty 
-            = DependencyProperty.Register(nameof(BadgeTemplateSelector), 
-                                          typeof(DataTemplateSelector), 
-                                          typeof(Badged),
-                                          new PropertyMetadata(null));
-
 
         public Storyboard BadgeChangedStoryboard
         {
@@ -66,30 +50,5 @@ namespace MahApps.Metro.Controls
                 }
             }
         }
-
-
-
-        /// <summary>
-        /// Gets or Sets the <see cref="DataTemplate"/> for the Badge
-        /// </summary>
-        public DataTemplate BadgeTemplate
-        {
-            get { return (DataTemplate)GetValue(BadgeTemplateProperty); }
-            set { SetValue(BadgeTemplateProperty, value); }
-        }
-
-        /// <summary>
-        /// Gets or Sets the <see cref="DataTemplateSelector"/> for the Badge
-        /// </summary>
-        public DataTemplateSelector BadgeTemplateSelector
-        {
-            get { return (DataTemplateSelector)GetValue(BadgeTemplateSelectorProperty); }
-            set { SetValue(BadgeTemplateSelectorProperty, value); }
-        }
-
-        
-
-
-
     }
 }

--- a/src/MahApps.Metro/Converters/SizeToCornerRadiusConverter.cs
+++ b/src/MahApps.Metro/Converters/SizeToCornerRadiusConverter.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Markup;
@@ -13,21 +9,16 @@ namespace MahApps.Metro.Converters
     /// <summary>
     /// This Converter converts a given height or width of an control to a CornerRadius
     /// </summary>
-    public class SizeToCornerRadiusConverter : MarkupExtension, IValueConverter
+    [ValueConversion(typeof(double), typeof(CornerRadius))]
+    [MarkupExtensionReturnType(typeof(SizeToCornerRadiusConverter))]
+    public class SizeToCornerRadiusConverter : MarkupConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        protected override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is double val)
-            {
-                return new CornerRadius(val / 2);
-            }
-            else
-            {
-                throw new ArgumentException("The value is not a valid double.");
-            }
+            return value is double val ? new CornerRadius(val / 2) : new CornerRadius();
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        protected override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             return Binding.DoNothing;
         }

--- a/src/MahApps.Metro/Converters/SizeToCornerRadiusConverter.cs
+++ b/src/MahApps.Metro/Converters/SizeToCornerRadiusConverter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace MahApps.Metro.Converters
+{
+    /// <summary>
+    /// This Converter converts a given height or width of an control to a CornerRadius
+    /// </summary>
+    public class SizeToCornerRadiusConverter : MarkupExtension, IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is double val)
+            {
+                return new CornerRadius(val / 2);
+            }
+            else
+            {
+                throw new ArgumentException("The value is not a valid double.");
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return Binding.DoNothing;
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}

--- a/src/MahApps.Metro/Themes/Badged.xaml
+++ b/src/MahApps.Metro/Themes/Badged.xaml
@@ -23,7 +23,10 @@
     <Style TargetType="{x:Type controls:Badged}">
         <Setter Property="BadgeBackground" Value="{DynamicResource MahApps.Brushes.Badged.Background}" />
         <Setter Property="BadgeChangedStoryboard" Value="{StaticResource BadgeChangedStoryboard}" />
+        <Setter Property="BadgeFontSize" Value="11" />
+        <Setter Property="BadgeFontWeight" Value="DemiBold" />
         <Setter Property="BadgeForeground" Value="{DynamicResource MahApps.Brushes.Badged.Foreground}" />
+        <Setter Property="BadgeMargin" Value="1 0" />
         <Setter Property="BadgePlacementMode" Value="TopRight" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="IsTabStop" Value="False" />
@@ -50,22 +53,28 @@
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Top"
                                 Background="{TemplateBinding BadgeBackground}"
+                                BorderBrush="{TemplateBinding BadgeBorderBrush}"
+                                BorderThickness="{TemplateBinding BadgeBorderThickness}"
                                 CornerRadius="{Binding RelativeSource={RelativeSource Mode=Self}, Path=ActualHeight, Converter={converters:SizeToCornerRadiusConverter}}"
                                 RenderTransformOrigin=".5,.5"
-                                TextElement.FontSize="11"
-                                TextElement.FontWeight="DemiBold"
                                 Visibility="{TemplateBinding IsBadgeSet, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <Border.RenderTransform>
                                 <ScaleTransform ScaleX="1" ScaleY="1" />
                             </Border.RenderTransform>
                             <ContentControl x:Name="PART_BadgeContent"
-                                            Margin="1 0 1 0"
+                                            Margin="{TemplateBinding BadgeMargin}"
                                             HorizontalAlignment="Center"
                                             VerticalAlignment="Center"
                                             Content="{TemplateBinding Badge}"
+                                            ContentStringFormat="{TemplateBinding BadgeStringFormat}"
                                             ContentTemplate="{TemplateBinding BadgeTemplate}"
                                             ContentTemplateSelector="{TemplateBinding BadgeTemplateSelector}"
                                             Focusable="False"
+                                            FontFamily="{TemplateBinding BadgeFontFamily}"
+                                            FontSize="{TemplateBinding BadgeFontSize}"
+                                            FontStretch="{TemplateBinding BadgeFontStretch}"
+                                            FontStyle="{TemplateBinding BadgeFontStyle}"
+                                            FontWeight="{TemplateBinding BadgeFontWeight}"
                                             Foreground="{TemplateBinding BadgeForeground}"
                                             IsTabStop="False" />
                         </Border>

--- a/src/MahApps.Metro/Themes/Badged.xaml
+++ b/src/MahApps.Metro/Themes/Badged.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:MahApps.Metro.Converters"
                     xmlns:controls="clr-namespace:MahApps.Metro.Controls">
 
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
@@ -43,13 +44,13 @@
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
                         <Border x:Name="PART_BadgeContainer"
-                                MinWidth="18"
+                                MinWidth="{Binding RelativeSource={RelativeSource Mode=Self}, Path=ActualHeight}"
                                 MinHeight="18"
                                 Padding="2"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Top"
                                 Background="{TemplateBinding BadgeBackground}"
-                                CornerRadius="9"
+                                CornerRadius="{Binding RelativeSource={RelativeSource Mode=Self}, Path=ActualHeight, Converter={converters:SizeToCornerRadiusConverter}}"
                                 RenderTransformOrigin=".5,.5"
                                 TextElement.FontSize="11"
                                 TextElement.FontWeight="DemiBold"
@@ -62,6 +63,8 @@
                                             HorizontalAlignment="Center"
                                             VerticalAlignment="Center"
                                             Content="{TemplateBinding Badge}"
+                                            ContentTemplate="{TemplateBinding BadgeTemplate}"
+                                            ContentTemplateSelector="{TemplateBinding BadgeTemplateSelector}"
                                             Focusable="False"
                                             Foreground="{TemplateBinding BadgeForeground}"
                                             IsTabStop="False" />


### PR DESCRIPTION
**Describe the changes you have made to improve this project**
- Added a `BadgeTemplate` and `BadgeTemplateSelector` to the `Badge` control
- Set the `MinWidth` to be `ActualHeight`. That way we make sure the Badge shape is correct
- Set the `Badge` `CornerRadius` to the half of `ActualHeight`. This lets the control look rounded as before, even with bigger content 

**Unit test**
None

**Additional context**
preview:
![image](https://user-images.githubusercontent.com/47110241/80968771-d27d2e80-8e18-11ea-8391-b153eb3303a4.png)


**Closed Issues**
#3789 