### PR TITLE
Fixed #3812: Expander reserves needed space before expanding.

### DIFF
--- a/src/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -463,6 +463,7 @@
                         </Trigger>
                         <Trigger Property="IsExpanded" Value="false">
                             <Setter TargetName="HeaderSite" Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.CornerRadius)}" />
+                            <Setter TargetName="ExpandSite" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
                             <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />


### PR DESCRIPTION
**The changes made in this pull request**

This pull request fixes a minor error in v2.0 where an expander reserves the space for the internal elements before it will be expanded.

**Closed Issues**
#3812 