### PR TITLE
(GH-3812) Fix wrong space for Expander before expanded

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/VSDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/VSDemo.xaml
@@ -91,6 +91,8 @@
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <GroupBox Grid.Row="0"
@@ -170,13 +172,18 @@
                                   Header="Hidden Stuff">
                             <StackPanel Orientation="Vertical">
                                 <TextBlock Text="...42..." />
-                                <Expander ExpandDirection="Down" Header="Second Hidden Stuff">
+                                <Expander ExpandDirection="Down"
+                                          Header="Second Hidden Stuff"
+                                          IsExpanded="True">
                                     <StackPanel Orientation="Vertical">
                                         <TextBlock Text="...is the Answer to the Ultimate Question of Life, The Universe, and Everything" />
                                     </StackPanel>
                                 </Expander>
                             </StackPanel>
                         </Expander>
+                        <Button Grid.Row="2"
+                                Margin="20"
+                                Content="Beam me up..." />
                     </Grid>
                 </TabItem>
                 <TabItem Header="Demo">

--- a/src/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
@@ -121,6 +121,7 @@ namespace MahApps.Metro.Controls
                             }
 
                             expandSite.SetCurrentValue(UIElement.OpacityProperty, 1d);
+                            expandSite.SetCurrentValue(UIElement.VisibilityProperty, Visibility.Visible);
                         }
                     });
 
@@ -214,6 +215,7 @@ namespace MahApps.Metro.Controls
                             }
 
                             expandSite.SetCurrentValue(UIElement.OpacityProperty, 0d);
+                            expandSite.SetCurrentValue(UIElement.VisibilityProperty, Visibility.Collapsed);
                         }
                     });
 

--- a/src/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -322,6 +322,7 @@
                          To="0"
                          Duration="0:0:0.25" />
         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ExpandSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+            <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}" />
             <DiscreteObjectKeyFrame KeyTime="0:0:0.25" Value="{x:Static Visibility.Collapsed}" />
         </ObjectAnimationUsingKeyFrames>
     </Storyboard>
@@ -393,8 +394,10 @@
                                     CornerRadius="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(Controls:ControlsHelper.CornerRadius), Converter={StaticResource CornerRadiusBindingConverter}, ConverterParameter={x:Static Converters:RadiusType.Top}}"
                                     DockPanel.Dock="Bottom"
                                     Focusable="false"
+                                    Opacity="0"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                    UseLayoutRounding="True">
+                                    UseLayoutRounding="True"
+                                    Visibility="Collapsed">
                                 <ContentPresenter Margin="{TemplateBinding Padding}"
                                                   Content="{TemplateBinding Content}"
                                                   ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/src/MahApps.Metro/Styles/VS/Expander.xaml
+++ b/src/MahApps.Metro/Styles/VS/Expander.xaml
@@ -321,6 +321,7 @@
                          To="0"
                          Duration="0:0:0.1" />
         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ExpandSite" Storyboard.TargetProperty="(UIElement.Visibility)">
+            <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}" />
             <DiscreteObjectKeyFrame KeyTime="0:0:0.1" Value="{x:Static Visibility.Collapsed}" />
         </ObjectAnimationUsingKeyFrames>
     </Storyboard>
@@ -375,8 +376,10 @@
                                     BorderThickness="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static Converters:ThicknessSideType.Top}}"
                                     DockPanel.Dock="Bottom"
                                     Focusable="False"
+                                    Opacity="0"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                    UseLayoutRounding="True">
+                                    UseLayoutRounding="True"
+                                    Visibility="Collapsed">
                                 <ContentPresenter Margin="{TemplateBinding Padding}"
                                                   Content="{TemplateBinding Content}"
                                                   ContentTemplate="{TemplateBinding ContentTemplate}"


### PR DESCRIPTION
**Describe the changes you have made to improve this project**

The Expander reserves internal needed space before expanding. This PR fixes this.

Additionally the collapse storyboard needs to set a keyframe to visible, because it collapse the expander directly if the storyboard is executed for the first time (strange behavior).

**Closed Issues**

Closes #3812 