### PR TITLE
(GH-3829) Fix DateTimePicker BindingExpression errors

### DIFF
--- a/src/MahApps.Metro/Accessibility/AccessibilitySwitches.cs
+++ b/src/MahApps.Metro/Accessibility/AccessibilitySwitches.cs
@@ -1,0 +1,31 @@
+﻿#if !NET452
+using System;
+using System.Runtime.CompilerServices;
+#endif
+
+namespace MahApps.Metro.Accessibility
+{
+    public static class AccessibilitySwitches
+    {
+        #region UseNetFx472CompatibleAccessibilityFeatures
+
+        internal const string UseLegacyAccessibilityFeatures3SwitchName = "Switch.UseLegacyAccessibilityFeatures.3";
+
+        /// <summary>
+        /// Switch to force accessibility to only use features compatible with .NET 472
+        /// When true, all accessibility features are compatible with .NET 472
+        /// When false, accessibility features added in .NET versions greater than 472 can be enabled.
+        /// </summary>
+        public static bool UseNetFx472CompatibleAccessibilityFeatures
+        {
+#if NET452
+            get => false;
+#else
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => AppContext.TryGetSwitch(UseLegacyAccessibilityFeatures3SwitchName, out bool flag) && flag == true;
+#endif
+        }
+
+        #endregion
+    }
+}

--- a/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -3,7 +3,8 @@
                     xmlns:Controls="clr-namespace:MahApps.Metro.Controls"
                     xmlns:Converters="clr-namespace:MahApps.Metro.Converters"
                     xmlns:behaviors="clr-namespace:MahApps.Metro.Behaviors"
-                    xmlns:i="http://schemas.microsoft.com/xaml/behaviors">
+                    xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+                    xmlns:accessibility="clr-namespace:MahApps.Metro.Accessibility">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Shared.xaml" />
@@ -357,6 +358,16 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+    </Style>
+
+    <Style x:Key="MahApps.Styles.DatePickerTextBox.TimePickerBase" BasedOn="{StaticResource MahApps.Styles.DatePickerTextBox}" TargetType="{x:Type DatePickerTextBox}">
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=(accessibility:AccessibilitySwitches.UseNetFx472CompatibleAccessibilityFeatures)}" Value="false">
+                <Setter Property="AutomationProperties.Name" Value="{Binding Path=(AutomationProperties.Name), Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Controls:TimePickerBase}}}"/>
+                <Setter Property="AutomationProperties.LabeledBy" Value="{Binding Path=(AutomationProperties.LabeledBy), Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Controls:TimePickerBase}}}"/>
+                <Setter Property="AutomationProperties.HelpText" Value="{Binding Path=(AutomationProperties.HelpText), Mode=OneWay, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Controls:TimePickerBase}}}"/>
+            </DataTrigger>
+        </Style.Triggers>
     </Style>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -183,7 +183,8 @@
                                                FontSize="{TemplateBinding FontSize}"
                                                Foreground="{TemplateBinding Foreground}"
                                                IsReadOnly="{Binding Path=IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}"
-                                               SelectionBrush="{DynamicResource MahApps.Brushes.Highlight}">
+                                               SelectionBrush="{DynamicResource MahApps.Brushes.Highlight}"
+                                               Style="{DynamicResource MahApps.Styles.DatePickerTextBox.TimePickerBase}">
                                 <i:Interaction.Behaviors>
                                     <Behaviors:DatePickerTextBoxBehavior />
                                 </i:Interaction.Behaviors>


### PR DESCRIPTION
## Describe the changes you have made to improve this project

We use a DatePickerTextBox inside the TimePickerBase which causes these errors with TargetFramework 4.8 and higher.

The DatePickerTextBox style uses triggers for UseNetFx472CompatibleAccessibilityFeatures, but the Bindings are looking for a DatePicker, that's why we get these errors.

To fix this we added a new style for our DatePickerTextBox called `MahApps.Styles.DatePickerTextBox.TimePickerBase`.

## Closed Issues

Closes #3829 
