### PR TITLE
(GH-3821) Fix Fill and Stroke brush for RadioButton's outer ellipse

### DIFF
--- a/src/MahApps.Metro/Styles/Controls.RadioButton.xaml
+++ b/src/MahApps.Metro/Styles/Controls.RadioButton.xaml
@@ -34,19 +34,20 @@
                             <Grid x:Name="Radio"
                                   HorizontalAlignment="Center"
                                   VerticalAlignment="Center">
+                                <!--  Todo We need to use a different brush or an attached property to set the Fill and Stroke properties  -->
                                 <Ellipse x:Name="OuterEllipse"
                                          Width="18"
                                          Height="18"
-                                         Fill="{TemplateBinding Background}"
-                                         Stroke="{TemplateBinding BorderBrush}"
+                                         Fill="{DynamicResource MahApps.Brushes.ThemeBackground}"
+                                         Stroke="{DynamicResource MahApps.Brushes.CheckBox}"
                                          StrokeThickness="{TemplateBinding Controls:RadioButtonHelper.RadioStrokeThickness}"
                                          UseLayoutRounding="False" />
                                 <Ellipse x:Name="CheckOuterEllipse"
                                          Width="18"
                                          Height="18"
-                                         Fill="{TemplateBinding Background}"
+                                         Fill="{DynamicResource MahApps.Brushes.ThemeBackground}"
                                          Opacity="0"
-                                         Stroke="{TemplateBinding BorderBrush}"
+                                         Stroke="{DynamicResource MahApps.Brushes.CheckBox}"
                                          StrokeThickness="{TemplateBinding Controls:RadioButtonHelper.RadioStrokeThickness}"
                                          UseLayoutRounding="False" />
                                 <Ellipse x:Name="CheckGlyph"


### PR DESCRIPTION
## Describe the changes you have made to improve this project

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

We need to use a different brush or an attached property to set the Fill and Stroke properties.

For now we use the MahApps.Brushes.ThemeBackground and MahApps.Brushes.CheckBox.

## Closed Issues

<!-- Closes #xxxx -->

Closes #3821 
