### PR TITLE
(GH-3817) Fix coercing of OpenPaneLength at HamburgerMenu

### DIFF
--- a/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.Properties.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenu.Properties.cs
@@ -52,7 +52,7 @@ namespace MahApps.Metro.Controls
             }
             else
             {
-                return OpenPaneLengthProperty.DefaultMetadata.DefaultValue;
+                return inputValue;
             }
         }
 


### PR DESCRIPTION
## Describe the changes you have made to improve this project

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

Fix coercing of OpenPaneLength at HamburgerMenu.

The current behavior gives us a wrong value and a wrong UI.

![83740022-9d057400-a656-11ea-927b-09334abfa66c](https://user-images.githubusercontent.com/658431/83747662-3c2f6900-a661-11ea-9692-66edb98a273b.png)

## Closed Issues

<!-- Closes #xxxx -->

Closes #3817 
