### PR TITLE
Add Flat slider resource keys for MinWidth and MinHeight

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -623,7 +623,7 @@
                                         Controls:TextBoxHelper.Watermark="{Binding ElementName=NUD_Watermark, Path=Text, Mode=OneWay}"
                                         Maximum="10"
                                         Minimum="0"
-                                        Value="{Binding NumericUpDownValue, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" />
+                                        Value="{Binding NumericUpDownValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                 <Label Grid.Row="22"
                        Grid.Column="0"

--- a/src/MahApps.Metro/Styles/Controls.FlatSlider.xaml
+++ b/src/MahApps.Metro/Styles/Controls.FlatSlider.xaml
@@ -1,6 +1,10 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controls="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <system:Double x:Key="MahApps.Sizes.Slider.Flat.Horizontal.MinHeight">12</system:Double>
+    <system:Double x:Key="MahApps.Sizes.Slider.Flat.Vertical.MinWidth">12</system:Double>
 
     <Style x:Key="MahApps.Styles.RepeatButton.SliderTrack.Flat" TargetType="{x:Type RepeatButton}">
         <Setter Property="Focusable" Value="False" />
@@ -74,9 +78,9 @@
                                   Style="{DynamicResource MahApps.Styles.RepeatButton.SliderTrack.Flat}" />
                 </Track.DecreaseRepeatButton>
                 <Track.Thumb>
-                    <controls:MetroThumb Width="{TemplateBinding Slider.MinHeight}"
-                                         Background="{TemplateBinding Slider.BorderBrush}"
-                                         Style="{DynamicResource MahApps.Styles.Thumb.Slider.Flat}" />
+                    <mah:MetroThumb Width="{TemplateBinding Slider.MinHeight}"
+                                    Background="{TemplateBinding Slider.BorderBrush}"
+                                    Style="{DynamicResource MahApps.Styles.Thumb.Slider.Flat}" />
                 </Track.Thumb>
                 <Track.IncreaseRepeatButton>
                     <RepeatButton Background="{TemplateBinding Slider.Background}"
@@ -121,9 +125,9 @@
                                   Style="{DynamicResource MahApps.Styles.RepeatButton.SliderTrack.Flat}" />
                 </Track.DecreaseRepeatButton>
                 <Track.Thumb>
-                    <controls:MetroThumb Height="{TemplateBinding Slider.MinWidth}"
-                                         Background="{TemplateBinding Slider.BorderBrush}"
-                                         Style="{DynamicResource MahApps.Styles.Thumb.Slider.Flat}" />
+                    <mah:MetroThumb Height="{TemplateBinding Slider.MinWidth}"
+                                    Background="{TemplateBinding Slider.BorderBrush}"
+                                    Style="{DynamicResource MahApps.Styles.Thumb.Slider.Flat}" />
                 </Track.Thumb>
                 <Track.IncreaseRepeatButton>
                     <RepeatButton Background="{TemplateBinding Slider.Background}"
@@ -169,13 +173,13 @@
                 <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent2}" />
             </Trigger>
             <Trigger Property="Orientation" Value="Horizontal">
-                <Setter Property="MinHeight" Value="12" />
+                <Setter Property="MinHeight" Value="{DynamicResource MahApps.Sizes.Slider.Flat.Horizontal.MinHeight}" />
                 <Setter Property="MinWidth" Value="0" />
                 <Setter Property="Template" Value="{DynamicResource MahApps.Templates.Slider.Horizontal.Flat}" />
             </Trigger>
             <Trigger Property="Orientation" Value="Vertical">
                 <Setter Property="MinHeight" Value="0" />
-                <Setter Property="MinWidth" Value="12" />
+                <Setter Property="MinWidth" Value="{DynamicResource MahApps.Sizes.Slider.Flat.Vertical.MinWidth}" />
                 <Setter Property="Template" Value="{DynamicResource MahApps.Templates.Slider.Vertical.Flat}" />
             </Trigger>
         </Style.Triggers>


### PR DESCRIPTION
## Describe the changes you have made to improve this project

The current MinWidth and MinHeight of the horizontal and vertical Flat slider was hard coded. So introduce 2 new resource keys to allow changing these values dynamically.

- MahApps.Sizes.Slider.Flat.Horizontal.MinHeight (default 12)
- MahApps.Sizes.Slider.Flat.Vertical.MinWidth (default 12)

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->
