### PR TITLE
(GH-3859) Allow own ViewModel collection for HamburgerMenu ItemsSource

### DIFF
--- a/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenuListBox.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/HamburgerMenuListBox.cs
@@ -1,0 +1,58 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace MahApps.Metro.Controls
+{
+    public class HamburgerMenuListBox : ListBox
+    {
+        private readonly BooleanToVisibilityConverter booleanToVisibilityConverter = new BooleanToVisibilityConverter();
+
+        static HamburgerMenuListBox()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(HamburgerMenuListBox), new FrameworkPropertyMetadata(typeof(HamburgerMenuListBox)));
+        }
+
+        protected override void PrepareContainerForItemOverride(DependencyObject element, object item)
+        {
+            base.PrepareContainerForItemOverride(element, item);
+
+            if (element is ListBoxItem listBoxItem)
+            {
+                if (item is IHamburgerMenuItemBase baseMenuItem)
+                {
+                    listBoxItem.SetBinding(VisibilityProperty,
+                                           new Binding
+                                           {
+                                               Source = baseMenuItem,
+                                               Path = new PropertyPath(nameof(IHamburgerMenuItemBase.IsVisible)),
+                                               Converter = this.booleanToVisibilityConverter,
+                                               FallbackValue = Visibility.Visible
+                                           });
+                }
+
+                if (item is IHamburgerMenuItem hamburgerMenuItem)
+                {
+                    listBoxItem.SetBinding(IsEnabledProperty,
+                                           new Binding
+                                           {
+                                               Source = hamburgerMenuItem,
+                                               Path = new PropertyPath(nameof(IHamburgerMenuItem.IsEnabled)),
+                                               FallbackValue = true
+                                           });
+                }
+            }
+        }
+
+        protected override void ClearContainerForItemOverride(DependencyObject element, object item)
+        {
+            base.ClearContainerForItemOverride(element, item);
+
+            if (element is ListBoxItem listBoxItem)
+            {
+                BindingOperations.ClearBinding(listBoxItem, VisibilityProperty);
+                BindingOperations.ClearBinding(listBoxItem, IsEnabledProperty);
+            }
+        }
+    }
+}

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemBase.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/HamburgerMenuItemBase.cs
@@ -2,7 +2,7 @@
 
 namespace MahApps.Metro.Controls
 {
-    public class HamburgerMenuItemBase : Freezable
+    public class HamburgerMenuItemBase : Freezable, IHamburgerMenuItemBase
     {
         /// <summary>
         /// Identifies the <see cref="Tag"/> dependency property.

--- a/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/IHamburgerMenuItemBase.cs
+++ b/src/MahApps.Metro/Controls/HamburgerMenu/MenuItems/IHamburgerMenuItemBase.cs
@@ -1,0 +1,13 @@
+﻿namespace MahApps.Metro.Controls
+{
+    public interface IHamburgerMenuItemBase
+    {
+        /// <summary>
+        /// Gets or sets the value indicating whether this element is visible in the user interface (UI). This is a dependency property.
+        /// </summary>
+        /// <returns>
+        /// true if the item is visible, otherwise false. The default value is true.
+        /// </returns>
+        bool IsVisible { get; set; }
+    }
+}

--- a/src/MahApps.Metro/Themes/Generic.xaml
+++ b/src/MahApps.Metro/Themes/Generic.xaml
@@ -51,6 +51,7 @@
     <Style BasedOn="{StaticResource MahApps.Styles.WindowCommandsItem}" TargetType="{x:Type Controls:WindowCommandsItem}" />
     <Style BasedOn="{StaticResource MahApps.Styles.WindowCommands}" TargetType="{x:Type Controls:WindowCommands}" />
     <Style BasedOn="{StaticResource MahApps.Styles.WindowButtonCommands.Win10}" TargetType="{x:Type Controls:WindowButtonCommands}" />
+    <Style BasedOn="{StaticResource MahApps.Styles.HamburgerMenuListBox}" TargetType="{x:Type Controls:HamburgerMenuListBox}" />
     <Style BasedOn="{StaticResource MahApps.Styles.HamburgerMenu}" TargetType="{x:Type Controls:HamburgerMenu}" />
     <Style BasedOn="{StaticResource MahApps.Styles.MetroHeader}" TargetType="{x:Type Controls:MetroHeader}" />
     <Style BasedOn="{StaticResource MahApps.Styles.BaseMetroDialog}" TargetType="{x:Type Dialogs:BaseMetroDialog}" />

--- a/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
@@ -192,7 +192,6 @@
         <Setter Property="MinHeight" Value="0" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
-        <Setter Property="Visibility" Value="{Binding IsVisible, Mode=OneWay, FallbackValue=True, Converter={StaticResource BooleanToVisibilityConverter}}" />
     </Style>
 
     <Style x:Key="MahApps.Styles.ListBoxItem.HamburgerMenuItem"
@@ -200,7 +199,6 @@
            TargetType="{x:Type ListBoxItem}">
         <Setter Property="Controls:ItemHelper.SelectedBackgroundBrush" Value="{DynamicResource MahApps.Brushes.Accent}" />
         <Setter Property="FocusVisualStyle" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:HamburgerMenu}}, Path=ItemFocusVisualStyle, Mode=OneWay, FallbackValue={x:Null}}" />
-        <Setter Property="IsEnabled" Value="{Binding IsEnabled, Mode=OneWay, FallbackValue=true}" />
         <Setter Property="IsTabStop" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Controls:HamburgerMenu}}, Path=IsTabStop, Mode=OneWay, FallbackValue=True}" />
         <Setter Property="Template">
             <Setter.Value>
@@ -392,6 +390,10 @@
         <Setter Property="VirtualizingStackPanel.IsVirtualizing" Value="False" />
     </Style>
 
+    <Style x:Key="MahApps.Styles.HamburgerMenuListBox"
+           BasedOn="{StaticResource MahApps.Styles.ListBox.HamburgerMenu}"
+           TargetType="{x:Type Controls:HamburgerMenuListBox}" />
+
     <ControlTemplate x:Key="MahApps.Templates.HamburgerMenu" TargetType="{x:Type Controls:HamburgerMenu}">
         <Grid>
             <Controls:SplitView x:Name="MainSplitView"
@@ -434,41 +436,39 @@
                                             ContentTemplate="{TemplateBinding HamburgerMenuHeaderTemplate}"
                                             IsTabStop="False" />
                         </DockPanel>
-                        <ListBox Name="ButtonsListView"
-                                 Grid.Row="1"
-                                 Width="{TemplateBinding OpenPaneLength}"
-                                 Controls:ScrollViewerHelper.VerticalScrollBarOnLeftSide="{TemplateBinding VerticalScrollBarOnLeftSide}"
-                                 AutomationProperties.Name="Menu items"
-                                 Foreground="{TemplateBinding PaneForeground}"
-                                 IsTextSearchEnabled="False"
-                                 ItemContainerStyleSelector="{StaticResource HamburgerMenuItemStyleSelector}"
-                                 ItemTemplate="{TemplateBinding ItemTemplate}"
-                                 ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                 ItemsSource="{TemplateBinding ItemsSource}"
-                                 ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                 SelectedIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedIndex, Mode=TwoWay}"
-                                 SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedItem, Mode=TwoWay}"
-                                 SelectionMode="Single"
-                                 Style="{StaticResource MahApps.Styles.ListBox.HamburgerMenu}"
-                                 TabIndex="1" />
-                        <ListBox Name="OptionsListView"
-                                 Grid.Row="2"
-                                 Width="{TemplateBinding OpenPaneLength}"
-                                 Margin="0 20 0 0"
-                                 VerticalAlignment="Bottom"
-                                 AutomationProperties.Name="Option items"
-                                 Foreground="{TemplateBinding PaneForeground}"
-                                 IsTextSearchEnabled="False"
-                                 ItemContainerStyleSelector="{StaticResource HamburgerMenuItemOptionsStyleSelector}"
-                                 ItemTemplate="{TemplateBinding OptionsItemTemplate}"
-                                 ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
-                                 ItemsSource="{TemplateBinding OptionsItemsSource}"
-                                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                                 SelectedIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedOptionsIndex, Mode=TwoWay}"
-                                 SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedOptionsItem, Mode=TwoWay}"
-                                 SelectionMode="Single"
-                                 Style="{StaticResource MahApps.Styles.ListBox.HamburgerMenu}"
-                                 TabIndex="2" />
+                        <Controls:HamburgerMenuListBox x:Name="ButtonsListView"
+                                                       Grid.Row="1"
+                                                       Width="{TemplateBinding OpenPaneLength}"
+                                                       Controls:ScrollViewerHelper.VerticalScrollBarOnLeftSide="{TemplateBinding VerticalScrollBarOnLeftSide}"
+                                                       AutomationProperties.Name="Menu items"
+                                                       Foreground="{TemplateBinding PaneForeground}"
+                                                       IsTextSearchEnabled="False"
+                                                       ItemContainerStyleSelector="{StaticResource HamburgerMenuItemStyleSelector}"
+                                                       ItemTemplate="{TemplateBinding ItemTemplate}"
+                                                       ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                                       ItemsSource="{TemplateBinding ItemsSource}"
+                                                       ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                                       SelectedIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedIndex, Mode=TwoWay}"
+                                                       SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedItem, Mode=TwoWay}"
+                                                       SelectionMode="Single"
+                                                       TabIndex="1" />
+                        <Controls:HamburgerMenuListBox x:Name="OptionsListView"
+                                                       Grid.Row="2"
+                                                       Width="{TemplateBinding OpenPaneLength}"
+                                                       Margin="0 20 0 0"
+                                                       VerticalAlignment="Bottom"
+                                                       AutomationProperties.Name="Option items"
+                                                       Foreground="{TemplateBinding PaneForeground}"
+                                                       IsTextSearchEnabled="False"
+                                                       ItemContainerStyleSelector="{StaticResource HamburgerMenuItemOptionsStyleSelector}"
+                                                       ItemTemplate="{TemplateBinding OptionsItemTemplate}"
+                                                       ItemTemplateSelector="{TemplateBinding OptionsItemTemplateSelector}"
+                                                       ItemsSource="{TemplateBinding OptionsItemsSource}"
+                                                       ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                                       SelectedIndex="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedOptionsIndex, Mode=TwoWay}"
+                                                       SelectedItem="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedOptionsItem, Mode=TwoWay}"
+                                                       SelectionMode="Single"
+                                                       TabIndex="2" />
                     </Grid>
                 </Controls:SplitView.Pane>
                 <Controls:TransitioningContentControl x:Name="ContentPart"


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Introduce HamburgerMenuListBox class which handles the IsVisible (IHamburgerMenuItemBase) and IsEnabled (IHamburgerMenuItem) properties and bind them to the properties of the ListBoxItem.

This makes it easier to use own ViewModel collections which are mostly not implement these properties. But now it can be done with the interfaces.

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Additional context

[Here is an example](https://github.com/punker76/code-samples/tree/main/MahAppsMetroHamburgerMenu) for this scenario:

![mahapps_hamburger_binding](https://user-images.githubusercontent.com/658431/84917080-28ebb700-b0bf-11ea-8b31-1c6a6885e4bf.gif)

<!-- Add any other context or screenshots about the feature request here. -->

## Closed Issues

<!-- Closes #xxxx -->
Closes #3859 
