### PR TITLE
Fix Accessibility Insights issues with WindowCommands

### DIFF
--- a/src/MahApps.Metro/Automation/Peers/WindowCommandsAutomationPeer.cs
+++ b/src/MahApps.Metro/Automation/Peers/WindowCommandsAutomationPeer.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows;
+using System.Windows.Automation.Peers;
+using JetBrains.Annotations;
+using MahApps.Metro.Controls;
+
+namespace MahApps.Metro.Automation.Peers
+{
+    public class WindowCommandsAutomationPeer : FrameworkElementAutomationPeer
+    {
+        public WindowCommandsAutomationPeer([NotNull] WindowCommands owner)
+            : base(owner)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override string GetClassNameCore()
+        {
+            return "WindowCommands";
+        }
+
+        /// <inheritdoc />
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.ToolBar;
+        }
+
+        /// <inheritdoc />
+        protected override string GetNameCore()
+        {
+            string nameCore = base.GetNameCore();
+
+            if (string.IsNullOrEmpty(nameCore))
+            {
+                nameCore = ((WindowCommands)this.Owner).Name;
+            }
+
+            if (string.IsNullOrEmpty(nameCore))
+            {
+                nameCore = this.GetClassNameCore();
+            }
+
+            return nameCore;
+        }
+
+        /// <inheritdoc />
+        protected override bool IsOffscreenCore()
+        {
+            return !((WindowCommands)this.Owner).HasItems || base.IsOffscreenCore();
+        }
+
+        protected override Point GetClickablePointCore()
+        {
+            if (!((WindowCommands)this.Owner).HasItems)
+            {
+                return new Point(double.NaN, double.NaN);
+            }
+
+            return base.GetClickablePointCore();
+        }
+    }
+}

--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Windows;
+using System.Windows.Automation;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -129,8 +130,30 @@ namespace MahApps.Metro.Controls
         public static readonly DependencyProperty IconTemplateProperty = DependencyProperty.Register(nameof(IconTemplate), typeof(DataTemplate), typeof(MetroWindow), new PropertyMetadata(null));
         public static readonly DependencyProperty TitleTemplateProperty = DependencyProperty.Register(nameof(TitleTemplate), typeof(DataTemplate), typeof(MetroWindow), new PropertyMetadata(null));
 
-        public static readonly DependencyProperty LeftWindowCommandsProperty = DependencyProperty.Register(nameof(LeftWindowCommands), typeof(WindowCommands), typeof(MetroWindow), new PropertyMetadata(null, UpdateLogicalChilds));
-        public static readonly DependencyProperty RightWindowCommandsProperty = DependencyProperty.Register(nameof(RightWindowCommands), typeof(WindowCommands), typeof(MetroWindow), new PropertyMetadata(null, UpdateLogicalChilds));
+        public static readonly DependencyProperty LeftWindowCommandsProperty = DependencyProperty.Register(nameof(LeftWindowCommands), typeof(WindowCommands), typeof(MetroWindow), new PropertyMetadata(null, OnLeftWindowCommandsPropertyChanged));
+
+        private static void OnLeftWindowCommandsPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is WindowCommands windowCommands)
+            {
+                AutomationProperties.SetName(windowCommands, nameof(LeftWindowCommands));
+            }
+
+            UpdateLogicalChilds(d, e);
+        }
+
+        public static readonly DependencyProperty RightWindowCommandsProperty = DependencyProperty.Register(nameof(RightWindowCommands), typeof(WindowCommands), typeof(MetroWindow), new PropertyMetadata(null, OnRightWindowCommandsPropertyChanged));
+
+        private static void OnRightWindowCommandsPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is WindowCommands windowCommands)
+            {
+                AutomationProperties.SetName(windowCommands, nameof(RightWindowCommands));
+            }
+
+            UpdateLogicalChilds(d, e);
+        }
+
         public static readonly DependencyProperty WindowButtonCommandsProperty = DependencyProperty.Register(nameof(WindowButtonCommands), typeof(WindowButtonCommands), typeof(MetroWindow), new PropertyMetadata(null, UpdateLogicalChilds));
 
         public static readonly DependencyProperty LeftWindowCommandsOverlayBehaviorProperty = DependencyProperty.Register(nameof(LeftWindowCommandsOverlayBehavior), typeof(WindowCommandsOverlayBehavior), typeof(MetroWindow), new PropertyMetadata(WindowCommandsOverlayBehavior.Never, OnShowTitleBarPropertyChangedCallback));

--- a/src/MahApps.Metro/Controls/WindowCommands.cs
+++ b/src/MahApps.Metro/Controls/WindowCommands.cs
@@ -8,10 +8,12 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Data;
 using ControlzEx;
 using ControlzEx.Theming;
+using MahApps.Metro.Automation.Peers;
 using MahApps.Metro.ValueBoxes;
 
 namespace MahApps.Metro.Controls
@@ -357,6 +359,14 @@ namespace MahApps.Metro.Controls
                 var window = this.TryFindParent<Window>();
                 this.SetValue(ParentWindowPropertyKey, window);
             }
+        }
+
+        /// <summary>
+        /// Creates AutomationPeer (<see cref="UIElement.OnCreateAutomationPeer"/>)
+        /// </summary>
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new WindowCommandsAutomationPeer(this);
         }
     }
 }

--- a/src/MahApps.Metro/Themes/WindowCommands.xaml
+++ b/src/MahApps.Metro/Themes/WindowCommands.xaml
@@ -185,6 +185,7 @@
     <ControlTemplate x:Key="MahApps.Templates.WindowCommands" TargetType="Controls:WindowCommands">
         <DockPanel>
             <ToggleButton x:Name="PART_ToggleButton"
+                          AutomationProperties.Name="OverflowToggleButton"
                           ClickMode="Press"
                           DockPanel.Dock="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(DockPanel.Dock), Mode=OneWay}"
                           Foreground="{TemplateBinding Foreground}"


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Fix Accessibility Insights issues with WindowCommands.

- Add `WindowCommandsAutomationPeer` class
- Set AutomationProperties name to `LeftWindowCommands` or `RightWindowCommands`
- Set AutomationProperties name for overflow button to `OverflowToggleButton`

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Closed Issues

<!-- Closes #xxxx -->

Closes #3894 
