### PR TITLE
Add Custom Controls to the Visual Studio Toolbox

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.csproj
+++ b/src/MahApps.Metro/MahApps.Metro.csproj
@@ -29,6 +29,10 @@
         <EmbeddedResource Include="**\GeneratorParameters.json" />
     </ItemGroup>
 
+    <ItemGroup>
+        <None Include="VisualStudioToolsManifest.xml" Pack="true" PackagePath="tools" />
+    </ItemGroup>
+
     <Target Name="GenerateXamlFiles" BeforeTargets="DispatchToInnerBuilds">
         <PropertyGroup>
             <XamlCombinePath>$(MSBuildProjectDirectory)/Themes/XamlCombine.exe</XamlCombinePath>

--- a/src/MahApps.Metro/VisualStudioToolsManifest.xml
+++ b/src/MahApps.Metro/VisualStudioToolsManifest.xml
@@ -1,0 +1,7 @@
+﻿<FileList>
+    <File Reference="MahApps.Metro.dll">
+        <ToolboxItems VSCategory="MahApps.Metro" BlendCategory="MahApps.Metro">
+            <Item Type="MahApps.Metro.Controls.Badged" />
+        </ToolboxItems>
+    </File>
+</FileList>

--- a/src/MahApps.Metro/VisualStudioToolsManifest.xml
+++ b/src/MahApps.Metro/VisualStudioToolsManifest.xml
@@ -2,6 +2,37 @@
     <File Reference="MahApps.Metro.dll">
         <ToolboxItems VSCategory="MahApps.Metro" BlendCategory="MahApps.Metro">
             <Item Type="MahApps.Metro.Controls.Badged" />
+            <Item Type="MahApps.Metro.Controls.ClipBorder" />
+            <Item Type="MahApps.Metro.Controls.ContentControlEx" />
+            <Item Type="MahApps.Metro.Controls.DateTimePicker" />
+            <Item Type="MahApps.Metro.Controls.DropDownButton" />
+            <Item Type="MahApps.Metro.Controls.FlipView" />
+            <Item Type="MahApps.Metro.Controls.FlyoutsControl" />
+            <Item Type="MahApps.Metro.Controls.FontIcon" />
+            <Item Type="MahApps.Metro.Controls.HamburgerMenu" />
+            <Item Type="MahApps.Metro.Controls.HotKeyBox" />
+            <Item Type="MahApps.Metro.Controls.MetroAnimatedSingleRowTabControl" />
+            <Item Type="MahApps.Metro.Controls.MetroAnimatedTabControl" />
+            <Item Type="MahApps.Metro.Controls.MetroContentControl" />
+            <Item Type="MahApps.Metro.Controls.MetroHeader" />
+            <Item Type="MahApps.Metro.Controls.MetroProgressBar" />
+            <Item Type="MahApps.Metro.Controls.MetroTabControl" />
+            <Item Type="MahApps.Metro.Controls.MetroThumbContentControl" />
+            <Item Type="MahApps.Metro.Controls.MultiFrameImage" />
+            <Item Type="MahApps.Metro.Controls.NumericUpDown" />
+            <Item Type="MahApps.Metro.Controls.Pivot" />
+            <Item Type="MahApps.Metro.Controls.Planerator" />
+            <Item Type="MahApps.Metro.Controls.ProgressRing" />
+            <Item Type="MahApps.Metro.Controls.RangeSlider" />
+            <Item Type="MahApps.Metro.Controls.RevealImage" />
+            <Item Type="MahApps.Metro.Controls.SplitButton" />
+            <Item Type="MahApps.Metro.Controls.SplitView" />
+            <Item Type="MahApps.Metro.Controls.Tile" />
+            <Item Type="MahApps.Metro.Controls.TimePicker" />
+            <Item Type="MahApps.Metro.Controls.ToggleSwitch" />
+            <Item Type="MahApps.Metro.Controls.TransitioningContentControl" />
+            <Item Type="MahApps.Metro.Controls.WindowButtonCommands" />
+            <Item Type="MahApps.Metro.Controls.WindowCommands" />
         </ToolboxItems>
     </File>
 </FileList>


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Add all possible MahApps controls to the `VisualStudioToolsManifest.xml` file so that all custom control will be populated in the Visual Studio toolbox.

Refer to this [link](https://docs.microsoft.com/en-us/nuget/guides/create-ui-controls#add-toolboxassets-pane-support-for-xaml-controls) for more information about the structure of the VisualStudioToolsManifest file.

[Blog post](https://www.syncfusion.com/blogs/post/add-net-core-3-0-custom-control-to-your-visual-studio-toolbox.aspx)

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->
