### PR TITLE
Update Binding before executing the command of "TextBoxHelper.ButtonCommand"

### DIFF
--- a/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
@@ -900,14 +900,9 @@ namespace MahApps.Metro.Controls
                 {
                     passwordBox.GetBindingExpression(PasswordBoxBindingBehavior.PasswordProperty)?.UpdateSource();
                 }
-                else if (parent is ComboBox comboBox)
+                else if (parent is ComboBox comboBox && comboBox.IsEditable)
                 {
-                    if (comboBox.IsEditable)
-                    {
-                        comboBox.GetBindingExpression(ComboBox.TextProperty)?.UpdateSource();
-                    }
-
-                    comboBox.GetBindingExpression(ComboBox.SelectedItemProperty)?.UpdateSource();
+                    comboBox.GetBindingExpression(ComboBox.TextProperty)?.UpdateSource();
                 }
 
                 command.Execute(commandParameter);

--- a/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
@@ -892,6 +892,24 @@ namespace MahApps.Metro.Controls
             var commandParameter = GetButtonCommandParameter(parent) ?? parent;
             if (command != null && command.CanExecute(commandParameter))
             {
+                if (parent is TextBox textBox)
+                {
+                    textBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
+                }
+                else if (parent is PasswordBox passwordBox)
+                {
+                    passwordBox.GetBindingExpression(PasswordBoxBindingBehavior.PasswordProperty)?.UpdateSource();
+                }
+                else if (parent is ComboBox comboBox)
+                {
+                    if (comboBox.IsEditable)
+                    {
+                        comboBox.GetBindingExpression(ComboBox.TextProperty)?.UpdateSource();
+                    }
+
+                    comboBox.GetBindingExpression(ComboBox.SelectedItemProperty)?.UpdateSource();
+                }
+
                 command.Execute(commandParameter);
             }
 

--- a/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
@@ -896,14 +896,6 @@ namespace MahApps.Metro.Controls
                 {
                     textBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
                 }
-                else if (parent is PasswordBox passwordBox)
-                {
-                    passwordBox.GetBindingExpression(PasswordBoxBindingBehavior.PasswordProperty)?.UpdateSource();
-                }
-                else if (parent is ComboBox comboBox && comboBox.IsEditable)
-                {
-                    comboBox.GetBindingExpression(ComboBox.TextProperty)?.UpdateSource();
-                }
 
                 command.Execute(commandParameter);
             }


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Now an update of the binding is done before executing the command of "TextBoxHelper.ButtonCommand".

## Unit test

guess not

## Additional context

See #3924 

## Closed Issues

#3924 
