### PR TITLE
Use DateTime.TryParse instead of TimeSpan.TryParse

### DIFF
--- a/src/MahApps.Metro/Controls/TimePicker/TimePicker.cs
+++ b/src/MahApps.Metro/Controls/TimePicker/TimePicker.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Threading;
 
@@ -51,10 +52,15 @@ namespace MahApps.Metro.Controls
                 return;
             }
 
-            if (TimeSpan.TryParse(this.textBox.Text, this.SpecificCultureInfo, out var timeSpan))
+            const DateTimeStyles dateTimeParseStyle = DateTimeStyles.AllowWhiteSpaces
+                                                      & DateTimeStyles.AssumeLocal
+                                                      & DateTimeStyles.NoCurrentDateDefault;
+
+            if (DateTime.TryParse(this.textBox.Text, this.SpecificCultureInfo, dateTimeParseStyle, out var timeSpan))
             {
-                this.SetCurrentValue(SelectedDateTimeProperty, this.SelectedDateTime.GetValueOrDefault().Date + timeSpan);
+                this.SetCurrentValue(SelectedDateTimeProperty, this.SelectedDateTime.GetValueOrDefault().Date + timeSpan.TimeOfDay);
             }
+
             else
             {
                 this.SetCurrentValue(SelectedDateTimeProperty, null);


### PR DESCRIPTION
## Describe the changes you have made to improve this project
In `TimePicker` `DateTimeTryParse` instead of `TimeSpan.TryParse` because `TimeSpan.TryParse` does not parse time if it has AM or PM notation

## Unit test
`DateTimePickerTests.cs` (not changed)

## Additional context
Solution taken from here: https://stackoverflow.com/questions/17553738/am-pm-to-timespan 

## Closed Issues
Closes #3931 
