### PR TITLE
Use WindowAutomationPeer to prevent nasty Win32Exception

### DIFF
--- a/src/MahApps.Metro/Automation/Peers/MetroWindowAutomationPeer.cs
+++ b/src/MahApps.Metro/Automation/Peers/MetroWindowAutomationPeer.cs
@@ -5,11 +5,10 @@
 using System.Windows;
 using System.Windows.Automation.Peers;
 using JetBrains.Annotations;
-using MahApps.Metro.Controls;
 
 namespace MahApps.Metro.Automation.Peers
 {
-    public class MetroWindowAutomationPeer : FrameworkElementAutomationPeer
+    public class MetroWindowAutomationPeer : WindowAutomationPeer
     {
         public MetroWindowAutomationPeer([NotNull] Window owner)
             : base(owner)
@@ -19,38 +18,6 @@ namespace MahApps.Metro.Automation.Peers
         protected override string GetClassNameCore()
         {
             return "MetroWindow";
-        }
-
-        protected override string GetNameCore()
-        {
-            string name = base.GetNameCore();
-
-            if (name == string.Empty)
-            {
-                MetroWindow window = (MetroWindow)this.Owner;
-
-                name = window.GetWindowText();
-                if (name == null)
-                {
-                    name = string.Empty;
-                }
-            }
-
-            return name;
-        }
-
-        protected override AutomationControlType GetAutomationControlTypeCore()
-        {
-            return AutomationControlType.Window;
-        }
-
-        protected override Rect GetBoundingRectangleCore()
-        {
-            MetroWindow window = (MetroWindow)this.Owner;
-
-            Rect bounds = window.GetWindowBoundingRectangle();
-
-            return bounds;
         }
     }
 }

--- a/src/MahApps.Metro/Controls/WinApiHelper.cs
+++ b/src/MahApps.Metro/Controls/WinApiHelper.cs
@@ -53,31 +53,8 @@ namespace MahApps.Metro.Controls
                 && source.RootVisual is null == false
                 && source.Handle != IntPtr.Zero)
             {
-                int size = NativeMethods.GetWindowTextLength(source.Handle);
-                if (size == 0)
-                {
-                    var lastError = Win32Error.GetLastError();
-                    if (lastError != Win32Error.ERROR_SUCCESS)
-                    {
-                        throw new Win32Exception(lastError.Error);
-                    }
-
-                    return string.Empty;
-                }
-
-                var builder = new StringBuilder(size + 1);
-                var finalLength = NativeMethods.GetWindowText(source.Handle, builder, builder.Capacity);
-                if (finalLength == 0)
-                {
-                    var lastError = Win32Error.GetLastError();
-                    if (lastError != Win32Error.ERROR_SUCCESS)
-                    {
-                        throw new Win32Exception(lastError.Error);
-                    }
-
-                    return string.Empty;
-                }
-
+                var builder = new StringBuilder(512);
+                NativeMethods.GetWindowText(source.Handle, builder, builder.Capacity);
                 return builder.ToString();
             }
 


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Use WindowAutomationPeer to prevent nasty Win32Exception. Since last release we got several issues with Win32Exception like

```
System.ComponentModel.Win32Exception: Too many posts were made to a semaphore
   Source: MahApps.Metro
   TargetAssembly: MahApps.Metro, Version=2.0.0.0, Culture=neutral, PublicKeyToken=51482d6f650b2b3f
   TargetModule: MahApps.Metro.dll
   TargetSite: System.String GetWindowText(System.Windows.Window)
   at MahApps.Metro.Controls.WinApiHelper.GetWindowText(Window window)
   at MahApps.Metro.Automation.Peers.MetroWindowAutomationPeer.GetNameCore()
   at System.Windows.Automation.Peers.AutomationPeer.UpdateSubtree()
   at System.Windows.ContextLayoutManager.fireAutomationEvents()
   at System.Windows.ContextLayoutManager.UpdateLayout()
   at System.Windows.ContextLayoutManager.UpdateLayoutCallback(Object arg)
   at System.Windows.Media.MediaContext.FireInvokeOnRenderCallbacks()
   at System.Windows.Media.MediaContext.RenderMessageHandlerCore(Object resizedCompositionTarget)
   at System.Windows.Media.MediaContext.RenderMessageHandler(Object resizedCompositionTarget)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.DispatcherOperation.InvokeImpl()
   at MS.Internal.CulturePreservingExecutionContext.CallbackWrapper(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
   at MS.Internal.CulturePreservingExecutionContext.Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Windows.Threading.DispatcherOperation.Invoke()
   at System.Windows.Threading.Dispatcher.ProcessQueue()
   at System.Windows.Threading.Dispatcher.WndProcHook(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
   at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
   at MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
   at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
   at System.Windows.Application.RunDispatcher(Object ignore)
   at System.Windows.Application.RunInternal(Window window)
   at FancyZonesEditor.App.Main()
```

or

```
Description: The process was terminated due to an unhandled exception.
Exception Info: System.ComponentModel.Win32Exception
at MahApps.Metro.Controls.WinApiHelper.GetWindowText(System.Windows.Window)
at MahApps.Metro.Automation.Peers.MetroWindowAutomationPeer.GetNameCore()
at System.Windows.Automation.Peers.AutomationPeer.UpdateSubtree()
at System.Windows.ContextLayoutManager.fireAutomationEvents()
at System.Windows.ContextLayoutManager.UpdateLayout()
at System.Windows.UIElement.UpdateLayout()
at System.Windows.Interop.HwndSource.Process_WM_SIZE(System.Windows.UIElement, IntPtr, MS.Internal.Interop.WindowMessage, IntPtr, IntPtr)
at System.Windows.Interop.HwndSource.LayoutFilterMessage(IntPtr, Int32, IntPtr, IntPtr, Boolean ByRef)
at MS.Win32.HwndWrapper.WndProc(IntPtr, Int32, IntPtr, IntPtr, Boolean ByRef)
at MS.Win32.HwndSubclass.DispatcherCallbackOperation(System.Object)
at System.Windows.Threading.ExceptionWrapper.InternalRealCall(System.Delegate, System.Object, Int32)
at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(System.Object, System.Delegate, System.Object, Int32, System.Delegate)
at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(System.Windows.Threading.DispatcherPriority, System.TimeSpan, System.Delegate, System.Object, Int32)
at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr, Int32, IntPtr, IntPtr)
```


<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Closed Issues

<!-- Closes #xxxx -->

Closes #3922 
Closes #3929 

