### PR TITLE
Fix not displaying validation error on Flyout

### DIFF
--- a/src/MahApps.Metro/Controls/CustomValidationPopup.cs
+++ b/src/MahApps.Metro/Controls/CustomValidationPopup.cs
@@ -186,7 +186,7 @@ namespace MahApps.Metro.Controls
             this.flyout = adornedElement.TryFindParent<Flyout>();
             if (this.flyout != null)
             {
-                canShow = canShow && !this.flyout.AreAnimationsEnabled;
+                canShow = canShow && (!this.flyout.AreAnimationsEnabled || this.flyout.IsShown);
                 this.flyout.OpeningFinished += this.Flyout_OpeningFinished;
                 this.flyout.IsOpenChanged += this.Flyout_IsOpenChanged;
                 this.flyout.ClosingFinished += this.Flyout_ClosingFinished;

--- a/src/MahApps.Metro/Controls/Flyout.cs
+++ b/src/MahApps.Metro/Controls/Flyout.cs
@@ -69,7 +69,28 @@ namespace MahApps.Metro.Controls
 
         public static readonly DependencyProperty PositionProperty = DependencyProperty.Register(nameof(Position), typeof(Position), typeof(Flyout), new PropertyMetadata(Position.Left, PositionChanged));
         public static readonly DependencyProperty IsPinnedProperty = DependencyProperty.Register(nameof(IsPinned), typeof(bool), typeof(Flyout), new PropertyMetadata(BooleanBoxes.TrueBox));
+
         public static readonly DependencyProperty IsOpenProperty = DependencyProperty.Register(nameof(IsOpen), typeof(bool), typeof(Flyout), new FrameworkPropertyMetadata(BooleanBoxes.FalseBox, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, IsOpenedChanged));
+
+        /// <summary>Identifies the <see cref="IsShown"/> dependency property.</summary>
+        private static readonly DependencyPropertyKey IsShownPropertyKey
+            = DependencyProperty.RegisterReadOnly(nameof(IsShown),
+                                                  typeof(bool),
+                                                  typeof(Flyout),
+                                                  new PropertyMetadata(BooleanBoxes.FalseBox));
+
+        /// <summary>Identifies the <see cref="IsShown"/> dependency property.</summary>
+        public static readonly DependencyProperty IsShownProperty = IsShownPropertyKey.DependencyProperty;
+
+        /// <summary>
+        /// Gets whether the Flyout is completely shown (after IsOpen was set to true).
+        /// </summary>
+        public bool IsShown
+        {
+            get => (bool)this.GetValue(IsShownProperty);
+            protected set => this.SetValue(IsShownPropertyKey, BooleanBoxes.Box(value));
+        }
+
         public static readonly DependencyProperty AnimateOnPositionChangeProperty = DependencyProperty.Register(nameof(AnimateOnPositionChange), typeof(bool), typeof(Flyout), new PropertyMetadata(BooleanBoxes.TrueBox));
         public static readonly DependencyProperty AnimateOpacityProperty = DependencyProperty.Register(nameof(AnimateOpacity), typeof(bool), typeof(Flyout), new FrameworkPropertyMetadata(BooleanBoxes.FalseBox, OnAnimateOpacityPropertyChanged));
         public static readonly DependencyProperty IsModalProperty = DependencyProperty.Register(nameof(IsModal), typeof(bool), typeof(Flyout), new PropertyMetadata(BooleanBoxes.FalseBox));
@@ -482,6 +503,7 @@ namespace MahApps.Metro.Controls
                                 }
 
                                 flyout.StopAutoCloseTimer();
+                                flyout.SetValue(IsShownPropertyKey, BooleanBoxes.FalseBox);
                                 if (flyout.hideStoryboard != null)
                                 {
                                     flyout.hideStoryboard.Completed += flyout.HideStoryboardCompleted;
@@ -509,6 +531,7 @@ namespace MahApps.Metro.Controls
                             else
                             {
                                 flyout.StopAutoCloseTimer();
+                                flyout.SetValue(IsShownPropertyKey, BooleanBoxes.FalseBox);
                                 flyout.Hide();
                             }
 
@@ -616,6 +639,7 @@ namespace MahApps.Metro.Controls
 
         private void Shown()
         {
+            this.SetValue(IsShownPropertyKey, BooleanBoxes.TrueBox);
             this.RaiseEvent(new RoutedEventArgs(OpeningFinishedEvent));
         }
 


### PR DESCRIPTION
## Describe the changes you have made to improve this project

The validation error was not shown on Flyout after the Flyout is shown.

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Additional context

Introduce a new Flyout property `IsShown` to indicate that the Flyout is completely shown after `IsOpen` property was set to true.

<!-- Add any other context or screenshots about the feature request here. -->

## Closed Issues

<!-- Closes #xxxx -->

Closes #3943 
