### PR TITLE
Fix not showing GlowBrush if ResizeMode is set to NoResize

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
@@ -438,7 +438,14 @@ namespace MetroDemo
                 testWindow.Close();
             }
 
-            testWindow = new MetroWindow() { Owner = this, WindowStartupLocation = WindowStartupLocation.CenterOwner, Title = "Another Test...", Width = 500, Height = 300 };
+            testWindow = new MetroWindow()
+                         {
+                             Owner = this,
+                             WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                             Title = "Another Test...",
+                             Width = 500,
+                             Height = 300
+                         };
             testWindow.Closed += (o, args) => testWindow = null;
             return testWindow;
         }

--- a/src/MahApps.Metro/Behaviors/BorderlessWindowBehavior.cs
+++ b/src/MahApps.Metro/Behaviors/BorderlessWindowBehavior.cs
@@ -40,10 +40,10 @@ namespace MahApps.Metro.Behaviors
         {
             if (sender is MetroWindow window)
             {
+                window.SetIsHitTestVisibleInChromeProperty<UIElement>("PART_Icon");
+
                 if (window.ResizeMode != ResizeMode.NoResize)
                 {
-                    //window.SetIsHitTestVisibleInChromeProperty<Border>("PART_Border");
-                    window.SetIsHitTestVisibleInChromeProperty<UIElement>("PART_Icon");
                     window.SetWindowChromeResizeGripDirection("WindowResizeGrip", ResizeGripDirection.BottomRight);
                 }
             }

--- a/src/MahApps.Metro/Controls/ContentControlEx.cs
+++ b/src/MahApps.Metro/Controls/ContentControlEx.cs
@@ -4,6 +4,8 @@
 
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
+using ControlzEx.Windows.Shell;
 using MahApps.Metro.ValueBoxes;
 
 namespace MahApps.Metro.Controls
@@ -46,6 +48,21 @@ namespace MahApps.Metro.Controls
         static ContentControlEx()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(ContentControlEx), new FrameworkPropertyMetadata(typeof(ContentControlEx)));
+        }
+
+        protected override void OnContentChanged(object oldContent, object newContent)
+        {
+            if (oldContent is IInputElement && oldContent is DependencyObject oldInputElement)
+            {
+                BindingOperations.ClearBinding(oldInputElement, WindowChrome.IsHitTestVisibleInChromeProperty);
+            }
+
+            base.OnContentChanged(oldContent, newContent);
+
+            if (newContent is IInputElement && newContent is DependencyObject newInputElement)
+            {
+                BindingOperations.SetBinding(newInputElement, WindowChrome.IsHitTestVisibleInChromeProperty, new Binding { Path = new PropertyPath(WindowChrome.IsHitTestVisibleInChromeProperty), Source = this });
+            }
         }
     }
 }

--- a/src/MahApps.Metro/Controls/ContentPresenterEx.cs
+++ b/src/MahApps.Metro/Controls/ContentPresenterEx.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using ControlzEx.Windows.Shell;
+
+namespace MahApps.Metro.Controls
+{
+    public class ContentPresenterEx : ContentPresenter
+    {
+        static ContentPresenterEx()
+        {
+            ContentProperty.OverrideMetadata(typeof(ContentPresenterEx), new FrameworkPropertyMetadata(OnContentPropertyChanged));
+        }
+
+        private static void OnContentPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.OldValue is IInputElement && e.OldValue is DependencyObject oldInputElement)
+            {
+                BindingOperations.ClearBinding(oldInputElement, WindowChrome.IsHitTestVisibleInChromeProperty);
+            }
+
+            if (e.NewValue is IInputElement && e.NewValue is DependencyObject newInputElement)
+            {
+                BindingOperations.SetBinding(newInputElement, WindowChrome.IsHitTestVisibleInChromeProperty, new Binding { Path = new PropertyPath(WindowChrome.IsHitTestVisibleInChromeProperty), Source = d });
+            }
+        }
+    }
+}

--- a/src/MahApps.Metro/Themes/ContentControlEx.xaml
+++ b/src/MahApps.Metro/Themes/ContentControlEx.xaml
@@ -12,7 +12,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type controls:ContentControlEx}">
-                    <Grid Background="Transparent">
+                    <Grid Background="{TemplateBinding Background}">
                         <ContentPresenter x:Name="PART_ContentPresenter"
                                           Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:behaviors="clr-namespace:MahApps.Metro.Behaviors"
                     xmlns:controlzEx="urn:controlzex"
                     xmlns:converters="clr-namespace:MahApps.Metro.Converters"
                     xmlns:mah="clr-namespace:MahApps.Metro.Controls">
@@ -71,19 +72,21 @@
                                VerticalAlignment="Top"
                                Focusable="False">
                         <!--  the left window commands  -->
-                        <ContentPresenter x:Name="PART_LeftWindowCommands"
-                                          Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                          VerticalAlignment="Top"
-                                          Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                          DockPanel.Dock="Left"
-                                          Focusable="False" />
+                        <mah:ContentPresenterEx x:Name="PART_LeftWindowCommands"
+                                                Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                VerticalAlignment="Top"
+                                                controlzEx:WindowChrome.IsHitTestVisibleInChrome="True"
+                                                Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                DockPanel.Dock="Left"
+                                                Focusable="False" />
                         <!--  the right window commands  -->
-                        <ContentPresenter x:Name="PART_RightWindowCommands"
-                                          Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                          VerticalAlignment="Top"
-                                          Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                          DockPanel.Dock="Right"
-                                          Focusable="False" />
+                        <mah:ContentPresenterEx x:Name="PART_RightWindowCommands"
+                                                Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                VerticalAlignment="Top"
+                                                controlzEx:WindowChrome.IsHitTestVisibleInChrome="True"
+                                                Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                DockPanel.Dock="Right"
+                                                Focusable="False" />
                         <!--  the title bar  -->
                         <mah:MetroThumbContentControl x:Name="PART_TitleBar"
                                                       Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
@@ -108,15 +111,16 @@
                     </DockPanel>
 
                     <!--  the window button commands  -->
-                    <ContentPresenter x:Name="PART_WindowButtonCommands"
-                                      Grid.Row="1"
-                                      Grid.RowSpan="2"
-                                      Grid.Column="3"
-                                      Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      VerticalAlignment="Top"
-                                      Panel.ZIndex="1"
-                                      Content="{Binding WindowButtonCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      Focusable="False" />
+                    <mah:ContentPresenterEx x:Name="PART_WindowButtonCommands"
+                                            Grid.Row="1"
+                                            Grid.RowSpan="2"
+                                            Grid.Column="3"
+                                            Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                            VerticalAlignment="Top"
+                                            Panel.ZIndex="1"
+                                            controlzEx:WindowChrome.IsHitTestVisibleInChrome="True"
+                                            Content="{Binding WindowButtonCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                            Focusable="False" />
 
                     <!--  the main window content  -->
                     <mah:MetroContentControl x:Name="PART_Content"
@@ -128,7 +132,10 @@
                                              OnlyLoadTransition="True"
                                              TransitionsEnabled="{TemplateBinding WindowTransitionsEnabled}"
                                              UseLayoutRounding="True">
-                        <ContentPresenter Margin="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static converters:ThicknessSideType.Top}}" UseLayoutRounding="False" />
+                        <mah:ContentPresenterEx x:Name="PART_ContentPresenter"
+                                                Margin="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static converters:ThicknessSideType.Top}}"
+                                                controlzEx:WindowChrome.IsHitTestVisibleInChrome="True"
+                                                UseLayoutRounding="False" />
                     </mah:MetroContentControl>
 
                     <!--  disables the main content when a modal flyout is shown  -->
@@ -244,11 +251,19 @@
             </MultiTrigger>
             <!--  HitTest visibility  -->
             <Trigger Property="GlowBrush" Value="{x:Null}">
-                <Setter TargetName="PART_Border" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_Border" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
+                <Setter TargetName="PART_ContentPresenter" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
+                <Setter TargetName="PART_LeftWindowCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
+                <Setter TargetName="PART_RightWindowCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
+                <Setter TargetName="PART_WindowButtonCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
             </Trigger>
             <Trigger Property="ResizeMode" Value="NoResize">
-                <Setter Property="ResizeBorderThickness" Value="0" />
-                <Setter TargetName="PART_Border" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
+                <Setter TargetName="PART_Border" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_ContentPresenter" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_LeftWindowCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_RightWindowCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_TitleBar" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_WindowButtonCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
             </Trigger>
             <!--  no icon and no icon content template -> collapse the icon content control  -->
             <MultiTrigger>
@@ -354,33 +369,36 @@
                                Panel.ZIndex="1"
                                Focusable="False">
                         <!--  the left window commands  -->
-                        <ContentPresenter x:Name="PART_LeftWindowCommands"
-                                          Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                          VerticalAlignment="Top"
-                                          Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                          DockPanel.Dock="Left"
-                                          Focusable="False" />
+                        <mah:ContentPresenterEx x:Name="PART_LeftWindowCommands"
+                                                Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                VerticalAlignment="Top"
+                                                controlzEx:WindowChrome.IsHitTestVisibleInChrome="True"
+                                                Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                DockPanel.Dock="Left"
+                                                Focusable="False" />
                         <!--  the right window commands  -->
-                        <ContentPresenter x:Name="PART_RightWindowCommands"
-                                          Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                          VerticalAlignment="Top"
-                                          Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                          DockPanel.Dock="Right"
-                                          Focusable="False" />
+                        <mah:ContentPresenterEx x:Name="PART_RightWindowCommands"
+                                                Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                VerticalAlignment="Top"
+                                                controlzEx:WindowChrome.IsHitTestVisibleInChrome="True"
+                                                Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                DockPanel.Dock="Right"
+                                                Focusable="False" />
                         <!--  the fake title bar  -->
                         <Grid />
                     </DockPanel>
 
                     <!--  the window button commands  -->
-                    <ContentPresenter x:Name="PART_WindowButtonCommands"
-                                      Grid.Row="1"
-                                      Grid.RowSpan="2"
-                                      Grid.Column="3"
-                                      Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      VerticalAlignment="Top"
-                                      Panel.ZIndex="1"
-                                      Content="{Binding WindowButtonCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                      Focusable="False" />
+                    <mah:ContentPresenterEx x:Name="PART_WindowButtonCommands"
+                                            Grid.Row="1"
+                                            Grid.RowSpan="2"
+                                            Grid.Column="3"
+                                            Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                            VerticalAlignment="Top"
+                                            Panel.ZIndex="1"
+                                            controlzEx:WindowChrome.IsHitTestVisibleInChrome="True"
+                                            Content="{Binding WindowButtonCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                            Focusable="False" />
 
                     <!--  the main window content  -->
                     <mah:MetroContentControl x:Name="PART_Content"
@@ -392,7 +410,10 @@
                                              OnlyLoadTransition="True"
                                              TransitionsEnabled="{TemplateBinding WindowTransitionsEnabled}"
                                              UseLayoutRounding="True">
-                        <ContentPresenter Margin="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static converters:ThicknessSideType.Top}}" UseLayoutRounding="False" />
+                        <mah:ContentPresenterEx x:Name="PART_ContentPresenter"
+                                                Margin="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={StaticResource ThicknessBindingConverter}, ConverterParameter={x:Static converters:ThicknessSideType.Top}}"
+                                                controlzEx:WindowChrome.IsHitTestVisibleInChrome="True"
+                                                UseLayoutRounding="False" />
                     </mah:MetroContentControl>
 
                     <!--  disables the main content when a modal flyout is shown  -->
@@ -525,11 +546,19 @@
             </MultiTrigger>
             <!--  HitTest visibility  -->
             <Trigger Property="GlowBrush" Value="{x:Null}">
-                <Setter TargetName="PART_Border" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_Border" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
+                <Setter TargetName="PART_ContentPresenter" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
+                <Setter TargetName="PART_LeftWindowCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
+                <Setter TargetName="PART_RightWindowCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
+                <Setter TargetName="PART_WindowButtonCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
             </Trigger>
             <Trigger Property="ResizeMode" Value="NoResize">
-                <Setter Property="ResizeBorderThickness" Value="0" />
-                <Setter TargetName="PART_Border" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="False" />
+                <Setter TargetName="PART_Border" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_ContentPresenter" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_LeftWindowCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_RightWindowCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_TitleBar" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
+                <Setter TargetName="PART_WindowButtonCommands" Property="controlzEx:WindowChrome.IsHitTestVisibleInChrome" Value="True" />
             </Trigger>
             <!--  no icon and no icon content template -> collapse the icon content control  -->
             <MultiTrigger>


### PR DESCRIPTION
## Describe the changes you have made to improve this project

- Set Icon always hit test visible to chrome
- Fix template binding for inner grid background for ContentControlEx
- Bind the IsHitTestVisibleInChromeProperty to the content of the ContentControlEx
- Bind the IsHitTestVisibleInChromeProperty to the content of the new ContentPresenterEx

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Closed Issues

<!-- Closes #xxxx -->

Closes #3963 
