### PR TITLE
Changing the binding for ValidationError.ErrorContent to mode=OneTime…

### DIFF
--- a/src/MahApps.Metro/Styles/Controls.ValidationError.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ValidationError.xaml
@@ -112,7 +112,7 @@
                                     <TextBlock MaxWidth="250"
                                                Margin="8 4 8 4"
                                                Foreground="{DynamicResource MahApps.Brushes.Text.Validation}"
-                                               Text="{Binding ErrorContent}"
+                                               Text="{Binding ErrorContent, Mode=OneTime}"
                                                TextWrapping="Wrap"
                                                UseLayoutRounding="False" />
                                 </DataTemplate>


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Updated the binding for the default validation error template (MahApps.Templates.ValidationError): the binding mode is set to OneTime, as the underlying object (System.Windows.Controls.ValidationError) does not implement `INotifyPropertyChanged `(avoid memory leak for CLR property binding)

## Closed Issues

Closes #3969
