### PR TITLE
Adding x:Shared="False" to MahApps.TextBox.ContextMenu

### DIFF
--- a/src/MahApps.Metro/Styles/Controls.ContextMenu.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ContextMenu.xaml
@@ -55,7 +55,7 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 
-    <ContextMenu x:Key="MahApps.TextBox.ContextMenu" Style="{StaticResource MahApps.Styles.ContextMenu}">
+    <ContextMenu x:Key="MahApps.TextBox.ContextMenu" Style="{StaticResource MahApps.Styles.ContextMenu}" x:Shared="False">
         <MenuItem Command="ApplicationCommands.Cut" Style="{DynamicResource MahApps.Styles.MenuItem}" />
         <MenuItem Command="ApplicationCommands.Copy" Style="{DynamicResource MahApps.Styles.MenuItem}" />
         <MenuItem Command="ApplicationCommands.Paste" Style="{DynamicResource MahApps.Styles.MenuItem}" />

--- a/src/MahApps.Metro/Styles/VS/ContextMenu.xaml
+++ b/src/MahApps.Metro/Styles/VS/ContextMenu.xaml
@@ -55,7 +55,7 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 
-    <ContextMenu x:Key="MahApps.TextBox.ContextMenu" Style="{StaticResource MahApps.Styles.ContextMenu.VisualStudio}">
+    <ContextMenu x:Key="MahApps.TextBox.ContextMenu" Style="{StaticResource MahApps.Styles.ContextMenu.VisualStudio}" x:Shared="False">
         <MenuItem Command="ApplicationCommands.Cut" Style="{DynamicResource MahApps.Styles.MenuItem.VisualStudio}" />
         <MenuItem Command="ApplicationCommands.Copy" Style="{DynamicResource MahApps.Styles.MenuItem.VisualStudio}" />
         <MenuItem Command="ApplicationCommands.Paste" Style="{DynamicResource MahApps.Styles.MenuItem.VisualStudio}" />


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Added `x:Shared="False"` to the context menu (cut/copy/paste), used for all text-box controls.

## Unit test
none

## Additional context

There seems to be a lot of confusion about the sharing of context menus on the internet:

- Look at what Linda is replying to Bill Gates II [here](https://social.msdn.microsoft.com/Forums/vstudio/en-US/05dc431e-731e-415d-88ac-daa028f0a03e/using-a-contextmenu-resource-more-than-once?forum=wpf)
- [Here](https://www.c-sharpcorner.com/Resources/651/how-to-share-a-contextmenu-in-wpf.aspx) they explicitly show x:Shared="true" 

My guess is that it probably has to do with something in the style- as it the leak doesn't grow up in instances, it's one per control type (I think). 
Either that or it's the shared RoutedCommands (can there be a problem with those being shared!?)

If anyone understands the root cause here, I'd be curious to know..

## Closed Issues
Closes #3989 
