### PR TITLE
Make NumericUpDown more stylable

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -65,7 +65,8 @@
         <GroupBox Grid.Row="0"
                   Grid.Column="0"
                   Margin="4 2"
-                  Header="TextBox">
+                  Header="TextBox"
+                  UseLayoutRounding="True">
             <AdornerDecorator>
                 <StackPanel>
                     <mah:MetroHeader Margin="{StaticResource ControlMargin}" Header="TextBox Header">
@@ -191,7 +192,8 @@
         <GroupBox Grid.Row="0"
                   Grid.Column="1"
                   Margin="4 2"
-                  Header="RichTextBox">
+                  Header="RichTextBox"
+                  UseLayoutRounding="True">
             <StackPanel>
                 <RichTextBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.ClearTextButton="True"
@@ -268,7 +270,8 @@
         <GroupBox Grid.Row="0"
                   Grid.Column="2"
                   Margin="4 2"
-                  Header="PasswordBox">
+                  Header="PasswordBox"
+                  UseLayoutRounding="True">
             <StackPanel>
                 <PasswordBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.Watermark="Password"
@@ -327,7 +330,8 @@
                   Grid.Column="3"
                   Margin="4 2"
                   Grid.IsSharedSizeScope="True"
-                  Header="NumericUpDown">
+                  Header="NumericUpDown"
+                  UseLayoutRounding="True">
             <GroupBox.Resources>
                 <Style BasedOn="{StaticResource MahApps.Styles.MetroHeader.Horizontal}" TargetType="mah:MetroHeader" />
                 <Style BasedOn="{StaticResource MahApps.Styles.ToggleSwitch}" TargetType="mah:ToggleSwitch">
@@ -532,7 +536,8 @@
         <GroupBox Grid.Row="1"
                   Grid.Column="0"
                   Margin="4 2"
-                  Header="HotKeyBox">
+                  Header="HotKeyBox"
+                  UseLayoutRounding="True">
             <StackPanel>
                 <CheckBox x:Name="ModifierKeysRequired"
                           Margin="{StaticResource ControlMargin}"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -150,9 +150,9 @@
                     <!--  Entypo MagnifyingGlass  -->
                     <TextBox Name="test2"
                              Margin="{StaticResource ControlMargin}"
-                             mah:TextBoxHelper.ButtonContent="M17.545,15.467l-3.779-3.779c0.57-0.935,0.898-2.035,0.898-3.21c0-3.417-2.961-6.377-6.378-6.377  C4.869,2.1,2.1,4.87,2.1,8.287c0,3.416,2.961,6.377,6.377,6.377c1.137,0,2.2-0.309,3.115-0.844l3.799,3.801  c0.372,0.371,0.975,0.371,1.346,0l0.943-0.943C18.051,16.307,17.916,15.838,17.545,15.467z M4.004,8.287  c0-2.366,1.917-4.283,4.282-4.283c2.366,0,4.474,2.107,4.474,4.474c0,2.365-1.918,4.283-4.283,4.283  C6.111,12.76,4.004,10.652,4.004,8.287z"
                              mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmdWithParameter, Mode=OneWay}"
                              mah:TextBoxHelper.ButtonCommandParameter="{Binding ElementName=test2, Path=Text}"
+                             mah:TextBoxHelper.ButtonContent="M17.545,15.467l-3.779-3.779c0.57-0.935,0.898-2.035,0.898-3.21c0-3.417-2.961-6.377-6.378-6.377  C4.869,2.1,2.1,4.87,2.1,8.287c0,3.416,2.961,6.377,6.377,6.377c1.137,0,2.2-0.309,3.115-0.844l3.799,3.801  c0.372,0.371,0.975,0.371,1.346,0l0.943-0.943C18.051,16.307,17.916,15.838,17.545,15.467z M4.004,8.287  c0-2.366,1.917-4.283,4.282-4.283c2.366,0,4.474,2.107,4.474,4.474c0,2.365-1.918,4.283-4.283,4.283  C6.111,12.76,4.004,10.652,4.004,8.287z"
                              mah:TextBoxHelper.Watermark="Enter parameter"
                              Style="{DynamicResource MahApps.Styles.TextBox.Search}" />
                     <TextBox Margin="{StaticResource ControlMargin}"
@@ -526,6 +526,7 @@
                                        SnapToMultipleOfInterval="{Binding ElementName=NUD, Path=SnapToMultipleOfInterval}"
                                        Speedup="{Binding ElementName=NUD, Path=Speedup}"
                                        StringFormat="{Binding ElementName=NUD, Path=StringFormat}"
+                                       Style="{DynamicResource MahApps.Styles.NumericUpDown.Fluent}"
                                        SwitchUpDownButtons="{Binding ElementName=NUD, Path=SwitchUpDownButtons}"
                                        TextAlignment="{Binding ElementName=NUD, Path=TextAlignment}"
                                        Value="{Binding NullableNumericUpDownValue}" />

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -25,6 +25,7 @@ namespace MahApps.Metro.Controls
     [TemplatePart(Name = PART_NumericUp, Type = typeof(RepeatButton))]
     [TemplatePart(Name = PART_NumericDown, Type = typeof(RepeatButton))]
     [TemplatePart(Name = PART_TextBox, Type = typeof(TextBox))]
+    [StyleTypedProperty(Property = nameof(SpinButtonStyle), StyleTargetType = typeof(ButtonBase))]
     public class NumericUpDown : Control
     {
         private const string PART_NumericDown = "PART_NumericDown";
@@ -584,6 +585,22 @@ namespace MahApps.Metro.Controls
             set => this.SetValue(TrackMouseWheelWhenMouseOverProperty, BooleanBoxes.Box(value));
         }
 
+        /// <summary>Identifies the <see cref="SpinButtonStyle"/> dependency property.</summary>
+        public static readonly DependencyProperty SpinButtonStyleProperty
+            = DependencyProperty.Register(nameof(SpinButtonStyle),
+                                          typeof(Style),
+                                          typeof(NumericUpDown),
+                                          new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets the <see cref="FrameworkElement.Style"/> for the spin buttons.
+        /// </summary>
+        public Style? SpinButtonStyle
+        {
+            get => (Style?)this.GetValue(SpinButtonStyleProperty);
+            set => this.SetValue(SpinButtonStyleProperty, value);
+        }
+
         /// <summary>Identifies the <see cref="ButtonsAlignment"/> dependency property.</summary>
         public static readonly DependencyProperty ButtonsAlignmentProperty
             = DependencyProperty.Register(nameof(ButtonsAlignment),
@@ -690,6 +707,114 @@ namespace MahApps.Metro.Controls
         {
             get => (bool)this.GetValue(SwitchUpDownButtonsProperty);
             set => this.SetValue(SwitchUpDownButtonsProperty, BooleanBoxes.Box(value));
+        }
+
+        /// <summary>Identifies the <see cref="ButtonUpContent"/> dependency property.</summary>
+        public static readonly DependencyProperty ButtonUpContentProperty
+            = DependencyProperty.Register(nameof(ButtonUpContent),
+                                          typeof(object),
+                                          typeof(NumericUpDown),
+                                          new FrameworkPropertyMetadata(null));
+
+        /// <summary>
+        /// Provides the object content that should be displayed on the Up Button.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        public object? ButtonUpContent
+        {
+            get => (object?)this.GetValue(ButtonUpContentProperty);
+            set => this.SetValue(ButtonUpContentProperty, value);
+        }
+
+        /// <summary>Identifies the <see cref="ButtonUpContentTemplate"/> dependency property.</summary>
+        public static readonly DependencyProperty ButtonUpContentTemplateProperty
+            = DependencyProperty.Register(nameof(ButtonUpContentTemplate),
+                                          typeof(DataTemplate),
+                                          typeof(NumericUpDown));
+
+        /// <summary>
+        /// Gets or sets the DataTemplate used to display the Up button's content.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        public DataTemplate? ButtonUpContentTemplate
+        {
+            get => (DataTemplate?)this.GetValue(ButtonUpContentTemplateProperty);
+            set => this.SetValue(ButtonUpContentTemplateProperty, value);
+        }
+
+        /// <summary>Identifies the <see cref="ButtonUpContentStringFormat"/> dependency property.</summary>
+        public static readonly DependencyProperty ButtonUpContentStringFormatProperty
+            = DependencyProperty.Register(nameof(ButtonUpContentStringFormat),
+                                          typeof(string),
+                                          typeof(NumericUpDown),
+                                          new FrameworkPropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets a composite string that specifies how to format the ButtonUpContent property if it is displayed as a string.
+        /// </summary>
+        /// <remarks> 
+        /// This property is ignored if <seealso cref="ButtonUpContentTemplate"/> is set.
+        /// </remarks>
+        [Bindable(true)]
+        [Category(AppName.MahApps)]
+        public string? ButtonUpContentStringFormat
+        {
+            get => (string?)this.GetValue(ButtonUpContentStringFormatProperty);
+            set => this.SetValue(ButtonUpContentStringFormatProperty, value);
+        }
+
+        /// <summary>Identifies the <see cref="ButtonDownContent"/> dependency property.</summary>
+        public static readonly DependencyProperty ButtonDownContentProperty
+            = DependencyProperty.Register(nameof(ButtonDownContent),
+                                          typeof(object),
+                                          typeof(NumericUpDown),
+                                          new FrameworkPropertyMetadata(null));
+
+        /// <summary>
+        /// Provides the object content that should be displayed on the Down Button.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        public object? ButtonDownContent
+        {
+            get => (object?)this.GetValue(ButtonDownContentProperty);
+            set => this.SetValue(ButtonDownContentProperty, value);
+        }
+
+        /// <summary>Identifies the <see cref="ButtonDownContentTemplate"/> dependency property.</summary>
+        public static readonly DependencyProperty ButtonDownContentTemplateProperty
+            = DependencyProperty.Register(nameof(ButtonDownContentTemplate),
+                                          typeof(DataTemplate),
+                                          typeof(NumericUpDown));
+
+        /// <summary>
+        /// Gets or sets the DataTemplate used to display the Down button's content.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        public DataTemplate? ButtonDownContentTemplate
+        {
+            get => (DataTemplate?)this.GetValue(ButtonDownContentTemplateProperty);
+            set => this.SetValue(ButtonDownContentTemplateProperty, value);
+        }
+
+        /// <summary>Identifies the <see cref="ButtonDownContentStringFormat"/> dependency property.</summary>
+        public static readonly DependencyProperty ButtonDownContentStringFormatProperty
+            = DependencyProperty.Register(nameof(ButtonDownContentStringFormat),
+                                          typeof(string),
+                                          typeof(NumericUpDown),
+                                          new FrameworkPropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets a composite string that specifies how to format the ButtonDownContent property if it is displayed as a string.
+        /// </summary>
+        /// <remarks> 
+        /// This property is ignored if <seealso cref="ButtonDownContentTemplate"/> is set.
+        /// </remarks>
+        [Bindable(true)]
+        [Category(AppName.MahApps)]
+        public string? ButtonDownContentStringFormat
+        {
+            get => (string?)this.GetValue(ButtonDownContentStringFormatProperty);
+            set => this.SetValue(ButtonDownContentStringFormatProperty, value);
         }
 
         /// <summary>Identifies the <see cref="ChangeValueOnTextChanged"/> dependency property.</summary>

--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -242,7 +242,6 @@
                               Margin="{TemplateBinding Padding}"
                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                              Opacity="0.75"
                               RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
         </Grid>
@@ -251,7 +250,7 @@
                 <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="1" />
             </Trigger>
             <Trigger Property="IsMouseOver" Value="False">
-                <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value=".5" />
+                <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="0.5" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Foreground" Value="#ADADAD" />
@@ -261,7 +260,7 @@
 
     <Style x:Key="MahApps.Styles.Button.Chromeless" TargetType="{x:Type ButtonBase}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Transparent}" />
-        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="Padding" Value="0" />
         <Setter Property="Template" Value="{StaticResource MahApps.Templates.Button.Chromeless}" />

--- a/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -33,7 +33,7 @@
                             <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="1" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
-                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value=".5" />
+                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="0.5" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/Styles/Controls.xaml
+++ b/src/MahApps.Metro/Styles/Controls.xaml
@@ -38,6 +38,7 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.ContentControl.xaml" />
 
         <!--  Theme styles with keys  -->
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/NumericUpDown.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/Flyout.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/MetroHeader.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Themes/WindowCommands.xaml" />

--- a/src/MahApps.Metro/Themes/Generic.xaml
+++ b/src/MahApps.Metro/Themes/Generic.xaml
@@ -50,6 +50,7 @@
 
     <!--  set up default styles for our custom controls  -->
 
+    <Style BasedOn="{StaticResource MahApps.Styles.NumericUpDown}" TargetType="{x:Type mah:NumericUpDown}" />
     <Style BasedOn="{StaticResource MahApps.Styles.Flyout}" TargetType="{x:Type mah:Flyout}" />
     <Style BasedOn="{StaticResource MahApps.Styles.ToggleSwitch}" TargetType="{x:Type mah:ToggleSwitch}" />
     <Style BasedOn="{StaticResource MahApps.Styles.ContentControlEx}" TargetType="{x:Type mah:ContentControlEx}" />

--- a/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
@@ -39,7 +39,6 @@
                                           Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          Opacity="0.75"
                                           RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
@@ -50,7 +49,7 @@
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="False">
                             <Setter TargetName="PART_Background" Property="Opacity" Value="0" />
-                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="0.75" />
+                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="0.5" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Foreground" Value="#ADADAD" />

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -9,11 +9,12 @@
 
     <Thickness x:Key="NumericUpDownBorderThickness">1,1,1,1</Thickness>
     <Thickness x:Key="NumericUpDownSelectedBorderThickness">1,1,1,1</Thickness>
-    <Thickness x:Key="NumericUpDownSpinButtonBorderThickness">0,0,0,0</Thickness>
+    <Thickness x:Key="NumericUpDownSpinButtonRightBorderThickness">0,0,0,0</Thickness>
+    <Thickness x:Key="NumericUpDownSpinButtonLeftBorderThickness">0,0,0,0</Thickness>
 
     <Style x:Key="MahApps.Styles.Button.NumericUpDown.Spin" TargetType="{x:Type ButtonBase}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Transparent}" />
-        <Setter Property="BorderThickness" Value="{DynamicResource NumericUpDownSpinButtonBorderThickness}" />
+        <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="IsTabStop" Value="False" />
@@ -164,6 +165,7 @@
                                           Width="{TemplateBinding UpDownButtonsWidth}"
                                           Margin="0"
                                           mah:ControlsHelper.CornerRadius="0"
+                                          BorderThickness="{DynamicResource NumericUpDownSpinButtonRightBorderThickness}"
                                           Content="{TemplateBinding ButtonUpContent}"
                                           ContentStringFormat="{TemplateBinding ButtonUpContentStringFormat}"
                                           ContentTemplate="{TemplateBinding ButtonUpContentTemplate}"
@@ -175,6 +177,7 @@
                                           Width="{TemplateBinding UpDownButtonsWidth}"
                                           Margin="0"
                                           mah:ControlsHelper.CornerRadius="0"
+                                          BorderThickness="{DynamicResource NumericUpDownSpinButtonRightBorderThickness}"
                                           Content="{TemplateBinding ButtonDownContent}"
                                           ContentStringFormat="{TemplateBinding ButtonDownContentStringFormat}"
                                           ContentTemplate="{TemplateBinding ButtonDownContentTemplate}"
@@ -206,7 +209,9 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_MiddleColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericDown" Property="BorderThickness" Value="{DynamicResource NumericUpDownSpinButtonLeftBorderThickness}" />
                             <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_NumericUp" Property="BorderThickness" Value="{DynamicResource NumericUpDownSpinButtonLeftBorderThickness}" />
                             <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="0" />
                             <Setter TargetName="PART_RightColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="2" />
@@ -218,7 +223,9 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_MiddleColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="PART_NumericDown" Property="BorderThickness" Value="{DynamicResource NumericUpDownSpinButtonLeftBorderThickness}" />
                             <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_NumericUp" Property="BorderThickness" Value="{DynamicResource NumericUpDownSpinButtonLeftBorderThickness}" />
                             <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="1" />
                             <Setter TargetName="PART_RightColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="2" />
@@ -231,7 +238,9 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_MiddleColumn" Property="Width" Value="*" />
+                            <Setter TargetName="PART_NumericDown" Property="BorderThickness" Value="{DynamicResource NumericUpDownSpinButtonRightBorderThickness}" />
                             <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="2" />
+                            <Setter TargetName="PART_NumericUp" Property="BorderThickness" Value="{DynamicResource NumericUpDownSpinButtonLeftBorderThickness}" />
                             <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="0" />
                             <Setter TargetName="PART_RightColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="1" />
@@ -243,7 +252,9 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="PART_LeftColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_MiddleColumn" Property="Width" Value="*" />
+                            <Setter TargetName="PART_NumericDown" Property="BorderThickness" Value="{DynamicResource NumericUpDownSpinButtonLeftBorderThickness}" />
                             <Setter TargetName="PART_NumericDown" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="PART_NumericUp" Property="BorderThickness" Value="{DynamicResource NumericUpDownSpinButtonRightBorderThickness}" />
                             <Setter TargetName="PART_NumericUp" Property="Grid.Column" Value="2" />
                             <Setter TargetName="PART_RightColumn" Property="Width" Value="Auto" />
                             <Setter TargetName="PART_TextBox" Property="Grid.Column" Value="1" />
@@ -309,7 +320,8 @@
            TargetType="{x:Type mah:NumericUpDown}">
         <Style.Resources>
             <Thickness x:Key="NumericUpDownSelectedBorderThickness">2,2,2,2</Thickness>
-            <Thickness x:Key="NumericUpDownSpinButtonBorderThickness">1,0,0,0</Thickness>
+            <Thickness x:Key="NumericUpDownSpinButtonRightBorderThickness">1,0,0,0</Thickness>
+            <Thickness x:Key="NumericUpDownSpinButtonLeftBorderThickness">0,0,1,0</Thickness>
         </Style.Resources>
         <Setter Property="ButtonDownContentTemplate">
             <Setter.Value>
@@ -335,7 +347,7 @@
         </Setter>
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Default}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-        <Setter Property="Padding" Value="10 5 5 5" />
+        <Setter Property="Padding" Value="10 5" />
         <Setter Property="SpinButtonStyle">
             <Setter.Value>
                 <Style BasedOn="{StaticResource MahApps.Styles.Button.NumericUpDown.Spin}" TargetType="{x:Type ButtonBase}">

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -11,15 +11,13 @@
     <Thickness x:Key="NumericUpDownSelectedBorderThickness">1,1,1,1</Thickness>
     <Thickness x:Key="NumericUpDownSpinButtonBorderThickness">0,0,0,0</Thickness>
 
-    <Style x:Key="MahApps.Styles.Button.NumericUpDown.Spin"
-           TargetType="{x:Type ButtonBase}">
-        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
-        <Setter Property="IsTabStop" Value="False" />
+    <Style x:Key="MahApps.Styles.Button.NumericUpDown.Spin" TargetType="{x:Type ButtonBase}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Transparent}" />
-        <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="BorderThickness" Value="{DynamicResource NumericUpDownSpinButtonBorderThickness}" />
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Padding" Value="0" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
@@ -56,6 +54,7 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
@@ -303,5 +302,74 @@
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
+    </Style>
+
+    <Style x:Key="MahApps.Styles.NumericUpDown.Fluent"
+           BasedOn="{StaticResource MahApps.Styles.NumericUpDown}"
+           TargetType="{x:Type mah:NumericUpDown}">
+        <Style.Resources>
+            <Thickness x:Key="NumericUpDownSelectedBorderThickness">2,2,2,2</Thickness>
+            <Thickness x:Key="NumericUpDownSpinButtonBorderThickness">1,0,0,0</Thickness>
+        </Style.Resources>
+        <Setter Property="ButtonDownContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <mah:PathIcon Width="14"
+                                  Height="14"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Data="M 18.935547 4.560547 L 19.814453 5.439453 L 10 15.253906 L 0.185547 5.439453 L 1.064453 4.560547 L 10 13.496094 Z" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="ButtonUpContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <mah:PathIcon Width="14"
+                                  Height="14"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Data="M 19.091797 14.970703 L 10 5.888672 L 0.908203 14.970703 L 0.029297 14.091797 L 10 4.111328 L 19.970703 14.091797 Z" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Default}" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Padding" Value="10 5 5 5" />
+        <Setter Property="SpinButtonStyle">
+            <Setter.Value>
+                <Style BasedOn="{StaticResource MahApps.Styles.Button.NumericUpDown.Spin}" TargetType="{x:Type ButtonBase}">
+                    <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border}" />
+                    <Style.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
+                            <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray2}" />
+                            <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="TextAlignment" Value="Left" />
+        <Setter Property="UpDownButtonsFocusable" Value="False" />
+        <Setter Property="UpDownButtonsWidth" Value="34" />
+        <Setter Property="mah:ControlsHelper.CornerRadius" Value="2" />
+        <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.AccentBase}" />
+        <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.MouseOver}" />
+        <Setter Property="mah:TextBoxHelper.ButtonContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <mah:PathIcon Width="12"
+                                  Height="12"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Data="F1 M 11.416016 10 L 20 18.583984 L 18.583984 20 L 10 11.416016 L 1.416016 20 L 0 18.583984 L 8.583984 10 L 0 1.416016 L 1.416016 0 L 10 8.583984 L 18.583984 0 L 20 1.416016 Z" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="34" />
     </Style>
 </ResourceDictionary>

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -4,12 +4,96 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Shared.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Buttons.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style TargetType="{x:Type mah:NumericUpDown}">
+    <Thickness x:Key="NumericUpDownBorderThickness">1,1,1,1</Thickness>
+    <Thickness x:Key="NumericUpDownSelectedBorderThickness">1,1,1,1</Thickness>
+    <Thickness x:Key="NumericUpDownSpinButtonBorderThickness">0,0,0,0</Thickness>
+
+    <Style x:Key="MahApps.Styles.Button.NumericUpDown.Spin"
+           TargetType="{x:Type ButtonBase}">
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Transparent}" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="BorderThickness" Value="{DynamicResource NumericUpDownSpinButtonBorderThickness}" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ButtonBase}">
+                    <mah:ClipBorder x:Name="Border"
+                                    Margin="0"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <mah:ContentControlEx x:Name="PART_ContentPresenter"
+                                              Padding="{TemplateBinding Padding}"
+                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              Content="{TemplateBinding Content}"
+                                              ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                              ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                              ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                              RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                    </mah:ClipBorder>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="1" />
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="False">
+                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="0.5" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.SystemControlForegroundChromeDisabledLow}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
+                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
+                <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="MahApps.Styles.NumericUpDown" TargetType="{x:Type mah:NumericUpDown}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}" />
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border}" />
-        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="BorderThickness" Value="{DynamicResource NumericUpDownBorderThickness}" />
+        <Setter Property="ButtonDownContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <mah:PathIcon Width="14"
+                                  Height="14"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Data="M19,13H5V11H19V13Z" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="ButtonUpContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <mah:PathIcon Width="14"
+                                  Height="14"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Data="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
         <Setter Property="ContextMenu" Value="{DynamicResource MahApps.TextBox.ContextMenu}" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
@@ -22,6 +106,7 @@
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
         <Setter Property="SnapsToDevicePixels" Value="true" />
+        <Setter Property="SpinButtonStyle" Value="{DynamicResource MahApps.Styles.Button.NumericUpDown.Spin}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type mah:NumericUpDown}">
@@ -79,36 +164,31 @@
                                           Grid.Column="1"
                                           Width="{TemplateBinding UpDownButtonsWidth}"
                                           Margin="0"
+                                          mah:ControlsHelper.CornerRadius="0"
+                                          Content="{TemplateBinding ButtonUpContent}"
+                                          ContentStringFormat="{TemplateBinding ButtonUpContentStringFormat}"
+                                          ContentTemplate="{TemplateBinding ButtonUpContentTemplate}"
                                           Delay="{TemplateBinding Delay}"
                                           Focusable="{TemplateBinding UpDownButtonsFocusable}"
-                                          Foreground="{TemplateBinding Foreground}"
-                                          IsTabStop="False"
-                                          Style="{DynamicResource MahApps.Styles.Button.Chromeless}">
-                                <Path x:Name="PolygonUp"
-                                      Width="14"
-                                      Height="14"
-                                      Data="F1 M 35,19L 41,19L 41,35L 57,35L 57,41L 41,41L 41,57L 35,57L 35,41L 19,41L 19,35L 35,35L 35,19 Z "
-                                      Fill="{DynamicResource MahApps.Brushes.Gray1}"
-                                      Stretch="Fill" />
-                            </RepeatButton>
+                                          Style="{TemplateBinding SpinButtonStyle}" />
                             <RepeatButton x:Name="PART_NumericDown"
                                           Grid.Column="2"
                                           Width="{TemplateBinding UpDownButtonsWidth}"
                                           Margin="0"
-                                          VerticalContentAlignment="Center"
+                                          mah:ControlsHelper.CornerRadius="0"
+                                          Content="{TemplateBinding ButtonDownContent}"
+                                          ContentStringFormat="{TemplateBinding ButtonDownContentStringFormat}"
+                                          ContentTemplate="{TemplateBinding ButtonDownContentTemplate}"
                                           Delay="{TemplateBinding Delay}"
                                           Focusable="{TemplateBinding UpDownButtonsFocusable}"
-                                          Foreground="{TemplateBinding Foreground}"
-                                          IsTabStop="False"
-                                          Style="{DynamicResource MahApps.Styles.Button.Chromeless}">
-                                <Path x:Name="PolygonDown"
-                                      Width="14"
-                                      Height="3"
-                                      Data="F1 M 19,38L 57,38L 57,44L 19,44L 19,38 Z "
-                                      Fill="{DynamicResource MahApps.Brushes.Gray1}"
-                                      Stretch="Fill" />
-                            </RepeatButton>
+                                          Style="{TemplateBinding SpinButtonStyle}" />
                         </Grid>
+                        <Border x:Name="FocusBorder"
+                                Background="{x:Null}"
+                                BorderBrush="{x:Null}"
+                                BorderThickness="0"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
                                 BorderBrush="{DynamicResource MahApps.Brushes.Control.Disabled}"
@@ -200,27 +280,12 @@
                             </MultiTrigger.Conditions>
                             <Setter TargetName="PART_TextBox" Property="IsReadOnly" Value="True" />
                         </MultiTrigger>
-                        <Trigger SourceName="PART_NumericUp" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_NumericUp" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-                            <Setter TargetName="PolygonUp" Property="Fill" Value="{DynamicResource MahApps.Brushes.Accent}" />
-                        </Trigger>
-                        <Trigger SourceName="PART_NumericUp" Property="IsPressed" Value="True">
-                            <Setter TargetName="PART_NumericUp" Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="PolygonUp" Property="Fill" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-                        </Trigger>
-                        <Trigger SourceName="PART_NumericDown" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_NumericDown" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-                            <Setter TargetName="PolygonDown" Property="Fill" Value="{DynamicResource MahApps.Brushes.Accent}" />
-                        </Trigger>
-                        <Trigger SourceName="PART_NumericDown" Property="IsPressed" Value="True">
-                            <Setter TargetName="PART_NumericDown" Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="PolygonDown" Property="Fill" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-                        </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
                             <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.MouseOverBorderBrush)}" />
                         </Trigger>
-                        <Trigger SourceName="PART_TextBox" Property="IsFocused" Value="true">
-                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderBrush)}" />
+                        <Trigger SourceName="PART_TextBox" Property="IsSelectionActive" Value="true">
+                            <Setter TargetName="FocusBorder" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderBrush)}" />
+                            <Setter TargetName="FocusBorder" Property="BorderThickness" Value="{DynamicResource NumericUpDownSelectedBorderThickness}" />
                         </Trigger>
                         <Trigger Property="HideUpDownButtons" Value="True">
                             <Setter TargetName="PART_NumericDown" Property="Visibility" Value="Collapsed" />


### PR DESCRIPTION
## Describe the changes you have made to improve this project

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

Add new properties to allow changing inner spin buttons

- SpinButtonStyle
- ButtonUpContent
- ButtonUpContentTemplate
- ButtonUpContentStringFormat
- ButtonDownContent
- ButtonDownContentTemplate
- ButtonDownContentStringFormat

Add new styles

- MahApps.Styles.NumericUpDown
- MahApps.Styles.Button.NumericUpDown.Spin
- MahApps.Styles.NumericUpDown.Fluent (experimental)

Add new const keys

- NumericUpDownBorderThickness
- NumericUpDownSelectedBorderThickness
- NumericUpDownSpinButtonRightBorderThickness
- NumericUpDownSpinButtonLeftBorderThickness

![2021-06-17_18h15_33](https://user-images.githubusercontent.com/658431/122435817-9bc09400-cf98-11eb-8571-d6d97398d590.png)

![2021-06-17_18h15_52](https://user-images.githubusercontent.com/658431/122435820-9d8a5780-cf98-11eb-918f-fd15b75e745e.png)
