### PR TITLE
Implement ColorToSolidColorBrushConverter

### DIFF
--- a/src/MahApps.Metro/Converters/ColorToSolidColorBrushConverter.cs
+++ b/src/MahApps.Metro/Converters/ColorToSolidColorBrushConverter.cs
@@ -1,33 +1,37 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Data;
 using System.Windows.Media;
+using JetBrains.Annotations;
 
 namespace MahApps.Metro.Converters
 {
     /// <summary>
     /// Converts a given <see cref="Color"/> into a <see cref="SolidColorBrush"/>.
     /// </summary>
-    [ValueConversion (typeof(Color), typeof(SolidColorBrush)) ]
-    public class ColorToSolidColorBrushConverter : MarkupConverter
+    [ValueConversion(typeof(Color), typeof(SolidColorBrush))]
+    public class ColorToSolidColorBrushConverter : IValueConverter
     {
-        static ColorToSolidColorBrushConverter _DefaultInstance;
+        private static ColorToSolidColorBrushConverter defaultInstance;
 
         /// <summary>
-        /// returns a static instance if needed.
+        /// Gets a static instance of the converter if needed.
         /// </summary>
-        public static ColorToSolidColorBrushConverter DefaultInstance => _DefaultInstance ??= new ColorToSolidColorBrushConverter();
+        public static ColorToSolidColorBrushConverter DefaultInstance => defaultInstance ??= new ColorToSolidColorBrushConverter();
 
         /// <summary>
-        /// Gets or Sets the FallbackBrush which should be used if the conversion fails. 
+        /// Gets or Sets the brush which will be used if the conversion fails.
         /// </summary>
+        [CanBeNull]
         public SolidColorBrush FallbackBrush { get; set; }
 
-        protected override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        /// <summary>
+        /// Gets or Sets the color which will be used if the conversion fails.
+        /// </summary>
+        [CanBeNull]
+        public Color? FallbackColor { get; set; }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (value is Color color)
             {
@@ -35,22 +39,13 @@ namespace MahApps.Metro.Converters
                 brush.Freeze();
                 return brush;
             }
-            else
-            {
-                return FallbackBrush;
-            }
+
+            return this.FallbackBrush;
         }
 
-        protected override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is SolidColorBrush brush)
-            {
-                return brush.Color;
-            }
-            else
-            {
-                return null;
-            }
+            return value is SolidColorBrush brush ? brush.Color : this.FallbackColor;
         }
     }
 }

--- a/src/MahApps.Metro/Converters/ColorToSolidColorBrushConverter.cs
+++ b/src/MahApps.Metro/Converters/ColorToSolidColorBrushConverter.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace MahApps.Metro.Converters
+{
+    /// <summary>
+    /// Converts a given <see cref="Color"/> into a <see cref="SolidColorBrush"/>.
+    /// </summary>
+    [ValueConversion (typeof(Color), typeof(SolidColorBrush)) ]
+    public class ColorToSolidColorBrushConverter : MarkupConverter
+    {
+        static ColorToSolidColorBrushConverter _DefaultInstance;
+
+        /// <summary>
+        /// returns a static instance if needed.
+        /// </summary>
+        public static ColorToSolidColorBrushConverter DefaultInstance => _DefaultInstance ??= new ColorToSolidColorBrushConverter();
+
+        /// <summary>
+        /// Gets or Sets the FallbackBrush which should be used if the conversion fails. 
+        /// </summary>
+        public SolidColorBrush FallbackBrush { get; set; }
+
+        protected override object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Color color)
+            {
+                var brush = new SolidColorBrush(color);
+                brush.Freeze();
+                return brush;
+            }
+            else
+            {
+                return FallbackBrush;
+            }
+        }
+
+        protected override object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is SolidColorBrush brush)
+            {
+                return brush.Color;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/MahApps.Metro/Themes/ColorPicker/ColorCanvas.xaml
+++ b/src/MahApps.Metro/Themes/ColorPicker/ColorCanvas.xaml
@@ -187,7 +187,7 @@
                                         Background="{DynamicResource MahApps.Brushes.Tile}"
                                         BorderBrush="{DynamicResource MahApps.Brushes.ThemeForeground}"
                                         BorderThickness="1">
-                                    <Rectangle Fill="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SelectedColor, Converter={x:Static converters:ColorToSolidColorBrushConverter.DefaultInstance}}" />
+                                    <Rectangle Fill="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedColor, Converter={x:Static converters:ColorToSolidColorBrushConverter.DefaultInstance}}" />
                                 </Border>
 
                                 <ContentControl x:Name="PART_NoColorPreview"

--- a/src/MahApps.Metro/Themes/ColorPicker/ColorCanvas.xaml
+++ b/src/MahApps.Metro/Themes/ColorPicker/ColorCanvas.xaml
@@ -187,11 +187,7 @@
                                         Background="{DynamicResource MahApps.Brushes.Tile}"
                                         BorderBrush="{DynamicResource MahApps.Brushes.ThemeForeground}"
                                         BorderThickness="1">
-                                    <Rectangle>
-                                        <Rectangle.Fill>
-                                            <SolidColorBrush Color="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SelectedColor, TargetNullValue=Transparent}" />
-                                        </Rectangle.Fill>
-                                    </Rectangle>
+                                    <Rectangle Fill="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=SelectedColor, Converter={x:Static converters:ColorToSolidColorBrushConverter.DefaultInstance}}" />
                                 </Border>
 
                                 <ContentControl x:Name="PART_NoColorPreview"

--- a/src/MahApps.Metro/Themes/ColorPicker/ColorPalette.xaml
+++ b/src/MahApps.Metro/Themes/ColorPicker/ColorPalette.xaml
@@ -111,11 +111,7 @@
                     <Binding Path="ColorNamesDictionary" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=mah:ColorPalette}" />
                 </MultiBinding>
             </Border.ToolTip>
-            <Grid>
-                <Grid.Background>
-                    <SolidColorBrush Color="{Binding}" />
-                </Grid.Background>
-            </Grid>
+            <Grid Background="{Binding Converter={x:Static converters:ColorToSolidColorBrushConverter.DefaultInstance}}" />
         </Border>
     </DataTemplate>
 

--- a/src/MahApps.Metro/Themes/ColorPicker/ColorPicker.xaml
+++ b/src/MahApps.Metro/Themes/ColorPicker/ColorPicker.xaml
@@ -22,11 +22,7 @@
                     Background="{DynamicResource MahApps.Brushes.Tile.Small}"
                     BorderBrush="{DynamicResource MahApps.Brushes.Control.Border}"
                     BorderThickness="1">
-                <Rectangle>
-                    <Rectangle.Fill>
-                        <SolidColorBrush Color="{Binding TargetNullValue=Transparent}" />
-                    </Rectangle.Fill>
-                </Rectangle>
+                <Rectangle Fill="{Binding Converter={x:Static converters:ColorToSolidColorBrushConverter.DefaultInstance}}" />
             </Border>
 
             <TextBlock Grid.Column="1"
@@ -49,11 +45,7 @@
                 Background="{DynamicResource MahApps.Brushes.Tile.Small}"
                 BorderBrush="{DynamicResource MahApps.Brushes.Control.Border}"
                 BorderThickness="1">
-            <Rectangle>
-                <Rectangle.Fill>
-                    <SolidColorBrush Color="{Binding}" />
-                </Rectangle.Fill>
-            </Rectangle>
+            <Rectangle Fill="{Binding Converter={x:Static converters:ColorToSolidColorBrushConverter.DefaultInstance}}" />
         </Border>
         <DataTemplate.Triggers>
             <DataTrigger Binding="{Binding}" Value="{x:Null}">


### PR DESCRIPTION
## Describe the changes you have made to improve this project
Implement a `ColorToSolidColorBrushConverter` because if we bind direct to a `Color` we might get binding issues.

## Unit test
none

## Additional context
This is an issue for some users but not for all. 

@nzain can you clone my branch, attach your tracing-tool and give me a feedback if it works now for you as well? Thank you. 

@seba30 if you enter a wrong color name I want to raise an error so the user gets notified that the value was wrong. So in this case the binding issue is wanted. 

## Closed Issues
Closes #4019 
