### PR TITLE
Add a good "FullScreen : bool" property

### DIFF
--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -168,19 +168,19 @@ namespace MahApps.Metro.Controls
 
         #region Full Screen Region
 
-        public readonly static DependencyProperty RealRestoreBoundsProperty = DependencyProperty.RegisterAttached(
+        public readonly static DependencyProperty RealRestoreBoundsProperty = DependencyProperty.Register(
             "RealRestoreBounds",
             typeof(Rect),
             typeof(MetroWindow),
             new PropertyMetadata(null));
 
-        public readonly static DependencyProperty PreWindowsStateProperty = DependencyProperty.RegisterAttached(
+        public readonly static DependencyProperty PreWindowsStateProperty = DependencyProperty.Register(
             "PreWindowsState",
             typeof(WindowState),
             typeof(MetroWindow),
             new PropertyMetadata(null));
 
-        public readonly static DependencyProperty FullScreenProperty = DependencyProperty.RegisterAttached(
+        public readonly static DependencyProperty FullScreenProperty = DependencyProperty.Register(
             "FullScreen",
             typeof(bool),
             typeof(MetroWindow),

--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -196,6 +196,11 @@ namespace MahApps.Metro.Controls
 
                 static IntPtr LockHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
                 {
+                    //just to avoid unused argument
+                    if(hwnd == IntPtr.Zero)
+                    {
+                        return IntPtr.Zero;
+                    }
                     if (msg == 0x46)
                     {
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -194,13 +194,9 @@ namespace MahApps.Metro.Controls
                 System.Windows.Interop.HwndSource hwndSource =
                     System.Windows.Interop.HwndSource.FromHwnd(windowInteropHelper.EnsureHandle());
 
-                static IntPtr LockHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+                System.Windows.Interop.HwndSourceHook LockHook = new System.Windows.Interop.HwndSourceHook(
+                (IntPtr _, int msg, IntPtr wParam, IntPtr lParam, ref bool handled) =>
                 {
-                    //just to avoid unused argument
-                    if(hwnd == IntPtr.Zero)
-                    {
-                        return hwnd;
-                    }
                     if (msg == 0x46)
                     {
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -210,7 +206,7 @@ namespace MahApps.Metro.Controls
                         System.Runtime.InteropServices.Marshal.StructureToPtr(wp, lParam, false);
                     }
                     return IntPtr.Zero;
-                }
+                });
 
                 if ((bool)args.NewValue)
                 {

--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -199,7 +199,7 @@ namespace MahApps.Metro.Controls
                     //just to avoid unused argument
                     if(hwnd == IntPtr.Zero)
                     {
-                        return IntPtr.Zero;
+                        return hwnd;
                     }
                     if (msg == 0x46)
                     {


### PR DESCRIPTION
## Add A FullScreen property with `bool` type (with extra good behaviors).

current way of fullscreen has few problems:
1- when window is max it change to restore state then full screen (I know why it is needed and I put a middle step so it look like no change happend)
2- current fullscreen can be ruined by window menu (Alt + Space). I set a hook lock on window so it can't be changed.

I used it as an attached property maybe the pattern is not that good.

## Unit test

<!-- If it's possible then make a unit test for your changes. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
![image](https://user-images.githubusercontent.com/35791547/109409731-06968280-794a-11eb-9ed0-d2486b73f074.png)
the 'move' option is active but actually not works and windows can't be moved.

## Closed Issues

<!-- Closes #xxxx -->
