### PR TITLE
Fix NullReferenceException in WindowsSettingBehavior

### DIFF
--- a/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
+++ b/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
@@ -47,7 +47,14 @@ namespace MahApps.Metro.Behaviors
             window.Closed += this.AssociatedObject_Closed;
 
             // This operation must be thread safe
-            Application.Current?.BeginInvoke(() => Application.Current.SessionEnding += this.CurrentApplicationSessionEnding); 
+            window.BeginInvoke(() =>
+                {
+                    var application = Application.Current;
+                    if (application != null)
+                    {
+                        application.SessionEnding += this.CurrentApplicationSessionEnding;
+                    }
+                }); 
         }
 
         private void AssociatedObject_Closing(object sender, System.ComponentModel.CancelEventArgs e)
@@ -93,7 +100,14 @@ namespace MahApps.Metro.Behaviors
             window.SourceInitialized -= this.AssociatedObject_SourceInitialized;
 
             // This operation must be thread safe
-            Application.Current?.BeginInvoke(() => Application.Current.SessionEnding -= this.CurrentApplicationSessionEnding);
+            window.BeginInvoke(() =>
+                {
+                    var application = Application.Current;
+                    if (application != null)
+                    {
+                        application.SessionEnding -= this.CurrentApplicationSessionEnding;
+                    }
+                });
         }
 
 #pragma warning disable 618


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Fix possible NullReferenceException in WindowsSettingBehavior while unregistering session ending event.

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Closed Issues

<!-- Closes #xxxx -->

Closes #4013 
