### PR TITLE
Fix bug #4083

### DIFF
--- a/src/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -441,7 +441,6 @@
 
                         <Trigger Property="IsClockVisible" Value="False">
                             <Setter TargetName="PART_Clock" Property="Visibility" Value="Collapsed" />
-                            <Setter TargetName="PART_ClockPartSelectorsHolder" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                         <Trigger Property="IsDatePickerVisible" Value="True">
                             <Setter TargetName="PART_Calendar" Property="Visibility" Value="Visible" />


### PR DESCRIPTION
Setting IsClockVisible=false on the TimePicker should not hide the HoursMinutesSeconds picker. Only the clock should be hidden

Closes #4083 
