### PR TITLE
Implement `DefaultValue` to the `NumericUpDown`-Control

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -64,7 +64,7 @@
 
         <GroupBox Grid.Row="0"
                   Grid.Column="0"
-                  Margin="4 2"
+                  Margin="4,2"
                   Header="TextBox">
             <AdornerDecorator>
                 <StackPanel>
@@ -73,7 +73,7 @@
                             <DataTemplate>
                                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                                     <iconPacks:PackIconMaterial VerticalAlignment="Center" Kind="FaceProfile" />
-                                    <TextBlock Margin="2 0 0 0"
+                                    <TextBlock Margin="2,0,0,0"
                                                VerticalAlignment="Center"
                                                Text="{Binding}" />
                                 </StackPanel>
@@ -188,7 +188,7 @@
 
         <GroupBox Grid.Row="0"
                   Grid.Column="1"
-                  Margin="4 2"
+                  Margin="4,2"
                   Header="RichTextBox">
             <StackPanel>
                 <RichTextBox Margin="{StaticResource ControlMargin}"
@@ -265,7 +265,7 @@
 
         <GroupBox Grid.Row="0"
                   Grid.Column="2"
-                  Margin="4 2"
+                  Margin="4,2"
                   Header="PasswordBox">
             <StackPanel>
                 <PasswordBox Margin="{StaticResource ControlMargin}"
@@ -323,324 +323,215 @@
 
         <GroupBox Grid.Row="0"
                   Grid.Column="3"
-                  Margin="4 2"
+                  Margin="4,2"
+                  Grid.IsSharedSizeScope="True"
                   Header="NumericUpDown">
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="21*" MinWidth="100" />
-                    <ColumnDefinition Width="4*" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+            <GroupBox.Resources>
+                <Style BasedOn="{StaticResource MahApps.Styles.MetroHeader.Horizontal}" TargetType="mah:MetroHeader" />
+                <Style BasedOn="{StaticResource MahApps.Styles.ToggleSwitch}" TargetType="mah:ToggleSwitch">
+                    <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
+                    <Setter Property="MinHeight" Value="1" />
+                </Style>
+                <GridLength x:Key="ToggleSwitchPreContentMargin">2</GridLength>
+                <GridLength x:Key="ToggleSwitchPostContentMargin">2</GridLength>
+            </GroupBox.Resources>
+            <StackPanel>
+                <mah:MetroHeader Header="IsReadOnly">
+                    <mah:ToggleSwitch Margin="{StaticResource ControlMargin}" IsOn="{Binding ElementName=NUD, Path=IsReadOnly, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="0"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="IsReadOnly" />
-                <CheckBox Grid.Row="0"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          Content="{Binding RelativeSource={RelativeSource Mode=Self}, Path=IsChecked}"
-                          IsChecked="{Binding ElementName=NUD, Path=IsReadOnly, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="InterceptArrowKeys">
+                    <mah:ToggleSwitch Margin="{StaticResource ControlMargin}" IsOn="{Binding ElementName=NUD, Path=InterceptArrowKeys, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="1"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="InterceptArrowKeys" />
-                <CheckBox Grid.Row="1"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          Content="{Binding RelativeSource={RelativeSource Mode=Self}, Path=IsChecked}"
-                          IsChecked="{Binding ElementName=NUD, Path=InterceptArrowKeys, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="InterceptMouseWheel">
+                    <mah:ToggleSwitch Margin="{StaticResource ControlMargin}" IsOn="{Binding ElementName=NUD, Path=InterceptMouseWheel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="2"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="InterceptMouseWheel" />
-                <CheckBox Grid.Row="2"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          Content="{Binding RelativeSource={RelativeSource Mode=Self}, Path=IsChecked}"
-                          IsChecked="{Binding ElementName=NUD, Path=InterceptMouseWheel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="InterceptManualEnter">
+                    <mah:ToggleSwitch Margin="{StaticResource ControlMargin}" IsOn="{Binding ElementName=NUD, Path=InterceptManualEnter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="3"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="InterceptManualEnter" />
-                <CheckBox Grid.Row="3"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          Content="{Binding RelativeSource={RelativeSource Mode=Self}, Path=IsChecked}"
-                          IsChecked="{Binding ElementName=NUD, Path=InterceptManualEnter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="HideUpDownButtons">
+                    <mah:ToggleSwitch Margin="{StaticResource ControlMargin}" IsOn="{Binding ElementName=NUD, Path=HideUpDownButtons, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="4"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="HideUpDownButtons" />
-                <CheckBox Grid.Row="4"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          Content="{Binding RelativeSource={RelativeSource Mode=Self}, Path=IsChecked}"
-                          IsChecked="{Binding ElementName=NUD, Path=HideUpDownButtons, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="SwitchUpDownButtons">
+                    <mah:ToggleSwitch Margin="{StaticResource ControlMargin}" IsOn="{Binding ElementName=NUD, Path=SwitchUpDownButtons, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="5"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="SwitchUpDownButtons" />
-                <CheckBox Grid.Row="5"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          Content="{Binding RelativeSource={RelativeSource Mode=Self}, Path=IsChecked}"
-                          IsChecked="{Binding ElementName=NUD, Path=SwitchUpDownButtons, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="ClearTextButton">
+                    <mah:ToggleSwitch Margin="{StaticResource ControlMargin}" IsOn="{Binding ElementName=NUD, Path=(mah:TextBoxHelper.ClearTextButton), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="6"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="ClearTextButton" />
-                <CheckBox Grid.Row="6"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          Content="{Binding RelativeSource={RelativeSource Mode=Self}, Path=IsChecked}"
-                          IsChecked="{Binding ElementName=NUD, Path=(mah:TextBoxHelper.ClearTextButton), Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="Min">
+                    <mah:NumericUpDown Margin="{StaticResource ControlMargin}"
+                                       mah:TextBoxHelper.ClearTextButton="True"
+                                       Maximum="{Binding ElementName=NUD, Path=Maximum, Mode=OneWay}"
+                                       Value="{Binding ElementName=NUD, Path=Minimum, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="7"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="Min" />
-                <mah:NumericUpDown Grid.Row="7"
-                                   Grid.Column="1"
-                                   Grid.ColumnSpan="2"
-                                   Margin="{StaticResource ControlMargin}"
-                                   mah:TextBoxHelper.ClearTextButton="True"
-                                   Maximum="{Binding ElementName=NUD, Path=Maximum, Mode=OneWay}"
-                                   Value="{Binding ElementName=NUD, Path=Minimum, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                <Label Grid.Row="8"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="Max" />
-                <mah:NumericUpDown Grid.Row="8"
-                                   Grid.Column="1"
-                                   Grid.ColumnSpan="2"
-                                   Margin="{StaticResource ControlMargin}"
-                                   mah:TextBoxHelper.ClearTextButton="True"
-                                   Minimum="{Binding ElementName=NUD, Path=Minimum, Mode=OneWay}"
-                                   Value="{Binding ElementName=NUD, Path=Maximum, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="Max">
+                    <mah:NumericUpDown Margin="{StaticResource ControlMargin}"
+                                       mah:TextBoxHelper.ClearTextButton="True"
+                                       Minimum="{Binding ElementName=NUD, Path=Minimum, Mode=OneWay}"
+                                       Value="{Binding ElementName=NUD, Path=Maximum, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="9"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="Interval" />
-                <mah:NumericUpDown Grid.Row="9"
-                                   Grid.Column="1"
-                                   Grid.ColumnSpan="2"
-                                   Margin="{StaticResource ControlMargin}"
-                                   mah:TextBoxHelper.ClearTextButton="True"
-                                   Value="{Binding ElementName=NUD, Path=Interval, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="Interval">
+                    <mah:NumericUpDown Margin="{StaticResource ControlMargin}"
+                                       mah:TextBoxHelper.ClearTextButton="True"
+                                       Value="{Binding ElementName=NUD, Path=Interval, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="10"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="SnapToMultipleOfInterval" />
-                <CheckBox Grid.Row="10"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          Content="{Binding RelativeSource={RelativeSource Mode=Self}, Path=IsChecked}"
-                          IsChecked="{Binding ElementName=NUD, Path=SnapToMultipleOfInterval, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="DefaultValue">
+                    <mah:NumericUpDown Margin="{StaticResource ControlMargin}"
+                                       mah:TextBoxHelper.ClearTextButton="True"
+                                       Value="{Binding ElementName=NUD, Path=DefaultValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="11"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="SpeedUp" />
-                <CheckBox Grid.Row="11"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          Content="{Binding RelativeSource={RelativeSource Mode=Self}, Path=IsChecked}"
-                          IsChecked="{Binding ElementName=NUD, Path=Speedup, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="SnapToMultipleOfInterval">
+                    <mah:ToggleSwitch Margin="{StaticResource ControlMargin}" IsOn="{Binding ElementName=NUD, Path=SnapToMultipleOfInterval, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="12"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="NumericInputMode" />
-                <ComboBox Grid.Row="12"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          ItemsSource="{Binding Source={StaticResource NumericInputValues}}"
-                          SelectedItem="{Binding ElementName=NUD, Path=NumericInputMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="SpeedUp">
+                    <mah:ToggleSwitch Margin="{StaticResource ControlMargin}" IsOn="{Binding ElementName=NUD, Path=Speedup, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="13"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="StringFormat" />
-                <ComboBox Grid.Row="13"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          mah:TextBoxHelper.ClearTextButton="True"
-                          IsEditable="True"
-                          ItemsSource="{x:Static exampleViews:TextExamples.NUD_StringFormats}"
-                          SelectedItem="{Binding ElementName=NUD, Path=StringFormat, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="NumericInputMode">
+                    <ComboBox Margin="{StaticResource ControlMargin}"
+                              ItemsSource="{Binding Source={StaticResource NumericInputValues}}"
+                              SelectedItem="{Binding ElementName=NUD, Path=NumericInputMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="14"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="CultureInfo" />
-                <ComboBox x:Name="NUD_CultureInfo"
-                          Grid.Row="14"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          HorizontalAlignment="Stretch"
-                          mah:TextBoxHelper.ClearTextButton="True"
-                          ItemsSource="{Binding CultureInfos, Mode=OneWay}"
-                          SelectedItem="{Binding ElementName=NUD, Path=Culture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}">
-                    <ComboBox.ItemTemplate>
-                        <DataTemplate DataType="{x:Type globalization:CultureInfo}">
-                            <TextBlock VerticalAlignment="Center">
-                                <TextBlock.Text>
-                                    <MultiBinding StringFormat="{}{0} ({1})">
-                                        <Binding Mode="OneWay" Path="DisplayName" />
-                                        <Binding Mode="OneWay" Path="IetfLanguageTag" />
-                                    </MultiBinding>
-                                </TextBlock.Text>
-                            </TextBlock>
-                        </DataTemplate>
-                    </ComboBox.ItemTemplate>
-                </ComboBox>
+                <mah:MetroHeader Header="StringFormat">
+                    <ComboBox Margin="{StaticResource ControlMargin}"
+                              mah:TextBoxHelper.ClearTextButton="True"
+                              IsEditable="True"
+                              ItemsSource="{x:Static exampleViews:TextExamples.NUD_StringFormats}"
+                              SelectedItem="{Binding ElementName=NUD, Path=StringFormat, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="15"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="NumberDecimalSeparator" />
-                <TextBox Grid.Row="15"
-                         Grid.Column="1"
-                         Grid.ColumnSpan="2"
-                         Margin="{StaticResource ControlMargin}"
-                         IsReadOnly="True"
-                         Text="{Binding ElementName=NUD_CultureInfo, Path=SelectedItem.NumberFormat.NumberDecimalSeparator}" />
+                <mah:MetroHeader Header="CultureInfo">
+                    <ComboBox x:Name="NUD_CultureInfo"
+                              Margin="{StaticResource ControlMargin}"
+                              HorizontalAlignment="Stretch"
+                              mah:TextBoxHelper.ClearTextButton="True"
+                              ItemsSource="{Binding CultureInfos, Mode=OneWay}"
+                              SelectedItem="{Binding ElementName=NUD, Path=Culture, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate DataType="{x:Type globalization:CultureInfo}">
+                                <TextBlock VerticalAlignment="Center">
+                                    <TextBlock.Text>
+                                        <MultiBinding StringFormat="{}{0} ({1})">
+                                            <Binding Mode="OneWay" Path="DisplayName" />
+                                            <Binding Mode="OneWay" Path="IetfLanguageTag" />
+                                        </MultiBinding>
+                                    </TextBlock.Text>
+                                </TextBlock>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </mah:MetroHeader>
 
-                <Label Grid.Row="16"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="NumberGroupSeparator" />
-                <TextBox Grid.Row="16"
-                         Grid.Column="1"
-                         Grid.ColumnSpan="2"
-                         Margin="{StaticResource ControlMargin}"
-                         IsReadOnly="True"
-                         Text="{Binding ElementName=NUD_CultureInfo, Path=SelectedItem.NumberFormat.NumberGroupSeparator}" />
+                <mah:MetroHeader Header="NumberDecimalSeparator">
+                    <TextBox Margin="{StaticResource ControlMargin}"
+                             IsReadOnly="True"
+                             Text="{Binding ElementName=NUD_CultureInfo, Path=SelectedItem.NumberFormat.NumberDecimalSeparator}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="17"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="DecimalPointCorrection" />
-                <ComboBox Grid.Row="17"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          ItemsSource="{Binding Source={StaticResource DecimalPointCorrectionValues}}"
-                          SelectedItem="{Binding ElementName=NUD, Path=DecimalPointCorrection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="NumberGroupSeparator">
+                    <TextBox Margin="{StaticResource ControlMargin}"
+                             IsReadOnly="True"
+                             Text="{Binding ElementName=NUD_CultureInfo, Path=SelectedItem.NumberFormat.NumberGroupSeparator}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="18"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="TextAlignment" />
-                <ComboBox Grid.Row="18"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          ItemsSource="{Binding Source={StaticResource TextAlignmentValues}}"
-                          SelectedItem="{Binding ElementName=NUD, Path=TextAlignment, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="DecimalPointCorrection">
+                    <ComboBox Margin="{StaticResource ControlMargin}"
+                              ItemsSource="{Binding Source={StaticResource DecimalPointCorrectionValues}}"
+                              SelectedItem="{Binding ElementName=NUD, Path=DecimalPointCorrection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="19"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="ButtonsAlignment" />
-                <ComboBox Grid.Row="19"
-                          Grid.Column="1"
-                          Grid.ColumnSpan="2"
-                          Margin="{StaticResource ControlMargin}"
-                          ItemsSource="{Binding Source={StaticResource ButtonsAlignmentValues}}"
-                          SelectedItem="{Binding ElementName=NUD, Path=ButtonsAlignment, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="TextAlignment">
+                    <ComboBox Margin="{StaticResource ControlMargin}"
+                              ItemsSource="{Binding Source={StaticResource TextAlignmentValues}}"
+                              SelectedItem="{Binding ElementName=NUD, Path=TextAlignment, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="20"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="Watermark" />
-                <TextBox x:Name="NUD_Watermark"
-                         Grid.Row="20"
-                         Grid.Column="1"
-                         Grid.ColumnSpan="2"
-                         Margin="{StaticResource ControlMargin}"
-                         mah:TextBoxHelper.ClearTextButton="True"
-                         Text="Type a number" />
+                <mah:MetroHeader Header="ButtonsAlignment">
+                    <ComboBox Margin="{StaticResource ControlMargin}"
+                              ItemsSource="{Binding Source={StaticResource ButtonsAlignmentValues}}"
+                              SelectedItem="{Binding ElementName=NUD, Path=ButtonsAlignment, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="21"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="NumericUpDown"
-                       FontWeight="Bold" />
-                <mah:NumericUpDown x:Name="NUD"
-                                   Grid.Row="21"
-                                   Grid.Column="1"
-                                   Grid.ColumnSpan="2"
-                                   Margin="{StaticResource ControlMargin}"
-                                   mah:TextBoxHelper.Watermark="{Binding ElementName=NUD_Watermark, Path=Text, Mode=OneWay}"
-                                   Maximum="10"
-                                   Minimum="0"
-                                   DefaultValue="-1"
-                                   Value="{Binding NumericUpDownValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <mah:MetroHeader Header="Watermark">
+                    <TextBox x:Name="NUD_Watermark"
+                             Margin="{StaticResource ControlMargin}"
+                             mah:TextBoxHelper.ClearTextButton="True"
+                             Text="Type a number" />
+                </mah:MetroHeader>
 
-                <Label Grid.Row="22"
-                       Grid.Column="0"
-                       Margin="{StaticResource ControlMargin}"
-                       Content="Stored Value" />
-                <TextBox Grid.Row="22"
-                         Grid.Column="1"
-                         Grid.ColumnSpan="2"
-                         Margin="{StaticResource ControlMargin}"
-                         IsReadOnly="True"
-                         Text="{Binding ElementName=NUD, Path=Value, Mode=OneWay}" />
-            </Grid>
+                <mah:MetroHeader Header="Stored Value (non-nullable)">
+                    <TextBox Margin="{StaticResource ControlMargin}"
+                             IsReadOnly="True"
+                             Text="{Binding ElementName=NUD, Path=Value, Mode=OneWay}" />
+                </mah:MetroHeader>
+
+                <mah:MetroHeader Header="Stored Value (nullable)">
+                    <TextBox Margin="{StaticResource ControlMargin}"
+                             IsReadOnly="True"
+                             Text="{Binding ElementName=NUD_Nullable, Path=Value, Mode=OneWay}" />
+                </mah:MetroHeader>
+
+
+                <Separator Margin="0,5" />
+
+
+                <mah:MetroHeader Grid.Row="1"
+                                 mah:HeaderedControlHelper.HeaderFontWeight="Bold"
+                                 mah:HeaderedControlHelper.HeaderForeground="{DynamicResource MahApps.Brushes.Accent}"
+                                 Header="Non-Nullable">
+                    <mah:NumericUpDown x:Name="NUD"
+                                       Margin="{StaticResource ControlMargin}"
+                                       mah:TextBoxHelper.Watermark="{Binding ElementName=NUD_Watermark, Path=Text, Mode=OneWay}"
+                                       Maximum="10"
+                                       Minimum="0"
+                                       Value="{Binding NumericUpDownValue}" />
+                </mah:MetroHeader>
+
+                <mah:MetroHeader Grid.Row="1"
+                                 mah:HeaderedControlHelper.HeaderFontWeight="Bold"
+                                 mah:HeaderedControlHelper.HeaderForeground="{DynamicResource MahApps.Brushes.Accent}"
+                                 Header="Nullable">
+                    <mah:NumericUpDown x:Name="NUD_Nullable" 
+                                       Margin="{StaticResource ControlMargin}"
+                                       mah:TextBoxHelper.ClearTextButton="{Binding ElementName=NUD, Path=(mah:TextBoxHelper.ClearTextButton)}"
+                                       mah:TextBoxHelper.Watermark="{Binding ElementName=NUD, Path=(mah:TextBoxHelper.Watermark)}"
+                                       ButtonsAlignment="{Binding ElementName=NUD, Path=ButtonsAlignment}"
+                                       Culture="{Binding ElementName=NUD, Path=Culture}"
+                                       DecimalPointCorrection="{Binding ElementName=NUD, Path=DecimalPointCorrection}"
+                                       DefaultValue="{Binding ElementName=NUD, Path=DefaultValue}"
+                                       HideUpDownButtons="{Binding ElementName=NUD, Path=HideUpDownButtons}"
+                                       InterceptArrowKeys="{Binding ElementName=NUD, Path=InterceptArrowKeys}"
+                                       InterceptManualEnter="{Binding ElementName=NUD, Path=InterceptManualEnter}"
+                                       InterceptMouseWheel="{Binding ElementName=NUD, Path=InterceptMouseWheel}"
+                                       Interval="{Binding ElementName=NUD, Path=Interval}"
+                                       IsReadOnly="{Binding ElementName=NUD, Path=IsReadOnly}"
+                                       Maximum="{Binding ElementName=NUD, Path=Maximum}"
+                                       Minimum="{Binding ElementName=NUD, Path=Minimum}"
+                                       NumericInputMode="{Binding ElementName=NUD, Path=NumericInputMode}"
+                                       SnapToMultipleOfInterval="{Binding ElementName=NUD, Path=SnapToMultipleOfInterval}"
+                                       Speedup="{Binding ElementName=NUD, Path=Speedup}"
+                                       StringFormat="{Binding ElementName=NUD, Path=StringFormat}"
+                                       TextAlignment="{Binding ElementName=NUD, Path=TextAlignment}"
+                                       Value="{Binding NullableNumericUpDownValue}" />
+                </mah:MetroHeader>
+            </StackPanel>
         </GroupBox>
 
         <GroupBox Grid.Row="1"
                   Grid.Column="0"
-                  Margin="4 2"
+                  Margin="4,2"
                   Header="HotKeyBox">
             <StackPanel>
                 <CheckBox x:Name="ModifierKeysRequired"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -355,6 +355,7 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <Label Grid.Row="0"
@@ -621,6 +622,7 @@
                                    mah:TextBoxHelper.Watermark="{Binding ElementName=NUD_Watermark, Path=Text, Mode=OneWay}"
                                    Maximum="10"
                                    Minimum="0"
+                                   DefaultValue="-1"
                                    Value="{Binding NumericUpDownValue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
                 <Label Grid.Row="22"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -64,7 +64,7 @@
 
         <GroupBox Grid.Row="0"
                   Grid.Column="0"
-                  Margin="4,2"
+                  Margin="4 2"
                   Header="TextBox">
             <AdornerDecorator>
                 <StackPanel>
@@ -73,7 +73,7 @@
                             <DataTemplate>
                                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                                     <iconPacks:PackIconMaterial VerticalAlignment="Center" Kind="FaceProfile" />
-                                    <TextBlock Margin="2,0,0,0"
+                                    <TextBlock Margin="2 0 0 0"
                                                VerticalAlignment="Center"
                                                Text="{Binding}" />
                                 </StackPanel>
@@ -188,7 +188,7 @@
 
         <GroupBox Grid.Row="0"
                   Grid.Column="1"
-                  Margin="4,2"
+                  Margin="4 2"
                   Header="RichTextBox">
             <StackPanel>
                 <RichTextBox Margin="{StaticResource ControlMargin}"
@@ -265,7 +265,7 @@
 
         <GroupBox Grid.Row="0"
                   Grid.Column="2"
-                  Margin="4,2"
+                  Margin="4 2"
                   Header="PasswordBox">
             <StackPanel>
                 <PasswordBox Margin="{StaticResource ControlMargin}"
@@ -323,7 +323,7 @@
 
         <GroupBox Grid.Row="0"
                   Grid.Column="3"
-                  Margin="4,2"
+                  Margin="4 2"
                   Grid.IsSharedSizeScope="True"
                   Header="NumericUpDown">
             <GroupBox.Resources>
@@ -484,11 +484,9 @@
                 </mah:MetroHeader>
 
 
-                <Separator Margin="0,5" />
+                <Separator Margin="0 5" />
 
-
-                <mah:MetroHeader Grid.Row="1"
-                                 mah:HeaderedControlHelper.HeaderFontWeight="Bold"
+                <mah:MetroHeader mah:HeaderedControlHelper.HeaderFontWeight="Bold"
                                  mah:HeaderedControlHelper.HeaderForeground="{DynamicResource MahApps.Brushes.Accent}"
                                  Header="Non-Nullable">
                     <mah:NumericUpDown x:Name="NUD"
@@ -499,11 +497,10 @@
                                        Value="{Binding NumericUpDownValue}" />
                 </mah:MetroHeader>
 
-                <mah:MetroHeader Grid.Row="1"
-                                 mah:HeaderedControlHelper.HeaderFontWeight="Bold"
+                <mah:MetroHeader mah:HeaderedControlHelper.HeaderFontWeight="Bold"
                                  mah:HeaderedControlHelper.HeaderForeground="{DynamicResource MahApps.Brushes.Accent}"
                                  Header="Nullable">
-                    <mah:NumericUpDown x:Name="NUD_Nullable" 
+                    <mah:NumericUpDown x:Name="NUD_Nullable"
                                        Margin="{StaticResource ControlMargin}"
                                        mah:TextBoxHelper.ClearTextButton="{Binding ElementName=NUD, Path=(mah:TextBoxHelper.ClearTextButton)}"
                                        mah:TextBoxHelper.Watermark="{Binding ElementName=NUD, Path=(mah:TextBoxHelper.Watermark)}"
@@ -523,6 +520,7 @@
                                        SnapToMultipleOfInterval="{Binding ElementName=NUD, Path=SnapToMultipleOfInterval}"
                                        Speedup="{Binding ElementName=NUD, Path=Speedup}"
                                        StringFormat="{Binding ElementName=NUD, Path=StringFormat}"
+                                       SwitchUpDownButtons="{Binding ElementName=NUD, Path=SwitchUpDownButtons}"
                                        TextAlignment="{Binding ElementName=NUD, Path=TextAlignment}"
                                        Value="{Binding NullableNumericUpDownValue}" />
                 </mah:MetroHeader>
@@ -531,7 +529,7 @@
 
         <GroupBox Grid.Row="1"
                   Grid.Column="0"
-                  Margin="4,2"
+                  Margin="4 2"
                   Header="HotKeyBox">
             <StackPanel>
                 <CheckBox x:Name="ModifierKeysRequired"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
@@ -276,13 +276,22 @@ namespace MetroDemo
             set => this.Set(ref this.currentCulture, value);
         }
 
-        private double? numericUpDownValue = null;
+        private double numericUpDownValue = default;
 
-        public double? NumericUpDownValue
+        public double NumericUpDownValue
         {
             get => this.numericUpDownValue;
             set => this.Set(ref this.numericUpDownValue, value);
         }
+
+        private double? nullableNumericUpDownValue = null;
+
+        public double? NullableNumericUpDownValue
+        {
+            get => this.nullableNumericUpDownValue;
+            set => this.Set(ref this.nullableNumericUpDownValue, value);
+        }
+
 
         public ICommand EndOfScrollReachedCmdWithParameter { get; }
 

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -378,32 +378,32 @@ namespace MahApps.Metro.Controls
         }
 
         [MustUseReturnValue]
-        private static object? CoerceValue(DependencyObject d, object? value)
+        private static object? CoerceValue(DependencyObject d, object? baseValue)
         {
             var numericUpDown = (NumericUpDown)d;
-            if (value is null)
+            if (baseValue is null)
             {
                 return numericUpDown.DefaultValue;
             }
 
-            double val = ((double?)value).Value;
+            var value = ((double?)baseValue).Value;
 
             if (!numericUpDown.NumericInputMode.HasFlag(NumericInput.Decimal))
             {
-                val = Math.Truncate(val);
+                value = Math.Truncate(value);
             }
 
-            if (val < numericUpDown.Minimum)
+            if (value < numericUpDown.Minimum)
             {
                 return numericUpDown.Minimum;
             }
 
-            if (val > numericUpDown.Maximum)
+            if (value > numericUpDown.Maximum)
             {
                 return numericUpDown.Maximum;
             }
 
-            return val;
+            return value;
         }
 
         /// <summary>
@@ -418,25 +418,12 @@ namespace MahApps.Metro.Controls
             set => this.SetValue(ValueProperty, value);
         }
 
-
         /// <summary>Identifies the <see cref="DefaultValue"/> dependency property.</summary>
-        public static readonly DependencyProperty DefaultValueProperty 
-            = DependencyProperty.Register(nameof(DefaultValue), 
-                                          typeof(double?), 
-                                          typeof(NumericUpDown), 
+        public static readonly DependencyProperty DefaultValueProperty
+            = DependencyProperty.Register(nameof(DefaultValue),
+                                          typeof(double?),
+                                          typeof(NumericUpDown),
                                           new PropertyMetadata(null, OnDefaultValuePropertyChanged, CoerceDefaultValue));
-
-        /// <summary>
-        /// Gets or sets the default value of the NumericUpDown which will be used if the <see cref="Value"/> is <see langword="null"/>.
-        /// </summary>
-        [Bindable(true)]
-        [Category("Common")]
-        [DefaultValue(null)]
-        public double? DefaultValue
-        {
-            get { return (double?)GetValue(DefaultValueProperty); }
-            set { SetValue(DefaultValueProperty, value); }
-        }
 
         private static void OnDefaultValuePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
@@ -448,12 +435,13 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        private static object CoerceDefaultValue(DependencyObject d, object value)
+        [MustUseReturnValue]
+        private static object? CoerceDefaultValue(DependencyObject d, object? baseValue)
         {
-            if (value is double val)
+            if (baseValue is double val)
             {
-                double minimum = ((NumericUpDown)d).Minimum;
-                double maximum = ((NumericUpDown)d).Maximum;
+                var minimum = ((NumericUpDown)d).Minimum;
+                var maximum = ((NumericUpDown)d).Maximum;
 
                 if (val < minimum)
                 {
@@ -464,10 +452,21 @@ namespace MahApps.Metro.Controls
                     return maximum;
                 }
             }
-           
-            return value;
+
+            return baseValue;
         }
 
+        /// <summary>
+        /// Gets or sets the default value of the NumericUpDown which will be used if the <see cref="Value"/> is <see langword="null"/>.
+        /// </summary>
+        [Bindable(true)]
+        [Category("Common")]
+        [DefaultValue(null)]
+        public double? DefaultValue
+        {
+            get => (double?)this.GetValue(DefaultValueProperty);
+            set => this.SetValue(DefaultValueProperty, value);
+        }
 
         /// <summary>Identifies the <see cref="Minimum"/> dependency property.</summary>
         public static readonly DependencyProperty MinimumProperty
@@ -1487,7 +1486,7 @@ namespace MahApps.Metro.Controls
                 }
                 else if (this.DefaultValue.HasValue)
                 {
-                    this.SetValueTo(DefaultValue.Value);
+                    this.SetValueTo(this.DefaultValue.Value);
                 }
             }
 
@@ -1503,12 +1502,12 @@ namespace MahApps.Metro.Controls
 
             if (string.IsNullOrEmpty(((TextBox)sender).Text))
             {
-                if (DefaultValue.HasValue)
+                if (this.DefaultValue.HasValue)
                 {
-                    this.SetValueTo(DefaultValue.Value);
+                    this.SetValueTo(this.DefaultValue.Value);
                     if (!this.manualChange)
                     {
-                        this.InternalSetText(DefaultValue.Value);
+                        this.InternalSetText(this.DefaultValue.Value);
                     }
                 }
                 else

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -331,5 +331,49 @@ namespace MahApps.Metro.Tests.Tests
             theTextBox.RaiseEvent(textCompositionEventArgs);
             theTextBox.RaiseEvent(new RoutedEventArgs(UIElement.LostFocusEvent));
         }
+
+
+        [Fact]
+        public async Task ShouldSetDefaultValue()
+        {
+            // Prepare
+            await this.fixture.PrepareForTestAsync().ConfigureAwait(true);
+            await TestHost.SwitchToAppThread();
+
+            var nud = this.fixture.Window.TheNUD;
+            nud.Minimum = 0;
+            nud.Maximum = 10;
+
+            // 1. Test: The default value must be set here. Let's check this.
+
+            nud.DefaultValue = 1;
+            nud.Value = null;
+
+            Assert.Equal(nud.Value, nud.DefaultValue);
+
+
+            // 2. Test: There is no default value, so we should be able to set it to null
+
+            nud.DefaultValue = null;
+            nud.Value = null;
+
+            Assert.Equal(nud.Value, nud.DefaultValue);
+
+
+            // 3. Test: We set the Default Value greater than the Maximum. It should be corrected by the control
+            nud.DefaultValue = 100;
+            nud.Value = null;
+
+            Assert.Equal(nud.Maximum, nud.DefaultValue);
+            Assert.Equal(nud.Maximum, nud.Value);
+
+
+            // 4. Test: We set the Default Value lower than the Minimum. It should be corrected by the control
+            nud.DefaultValue = -100;
+            nud.Value = null;
+
+            Assert.Equal(nud.Minimum, nud.DefaultValue);
+            Assert.Equal(nud.Minimum, nud.Value);
+        }
     }
 }

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -332,7 +332,6 @@ namespace MahApps.Metro.Tests.Tests
             theTextBox.RaiseEvent(new RoutedEventArgs(UIElement.LostFocusEvent));
         }
 
-
         [Fact]
         public async Task ShouldSetDefaultValue()
         {
@@ -351,7 +350,6 @@ namespace MahApps.Metro.Tests.Tests
 
             Assert.Equal(nud.Value, nud.DefaultValue);
 
-
             // 2. Test: There is no default value, so we should be able to set it to null
 
             nud.DefaultValue = null;
@@ -359,14 +357,12 @@ namespace MahApps.Metro.Tests.Tests
 
             Assert.Equal(nud.Value, nud.DefaultValue);
 
-
             // 3. Test: We set the Default Value greater than the Maximum. It should be corrected by the control
             nud.DefaultValue = 100;
             nud.Value = null;
 
             Assert.Equal(nud.Maximum, nud.DefaultValue);
             Assert.Equal(nud.Maximum, nud.Value);
-
 
             // 4. Test: We set the Default Value lower than the Minimum. It should be corrected by the control
             nud.DefaultValue = -100;


### PR DESCRIPTION
## Describe the changes you have made to improve this project
Implemented a new Property `DefaultValue` which will be used if the `Value` is `null`. This will also prevent errors for non-nullable values if set.

## Unit test
Implemented some basic tests which worked fine so far. 
Test-Overview: 
```c# 
MahApps.Metro.Tests.NumericUpDownTestsNumericUpDownTests.ShouldSetDefaultValue
// 1. Test: The default value must be set here. Let's check this.
// 2. Test: There is no default value, so we should be able to set it to null
// 3. Test: We set the Default Value greater than the Maximum. It should be corrected by the control
// 4. Test: We set the Default Value lower than the Minimum. It should be corrected by the control
```

## Additional context
See the demo for Testing

![image](https://user-images.githubusercontent.com/47110241/115905168-01dfdd80-a466-11eb-8dc0-d832c0f8e0b4.png)


## Closed Issues

Closes #3668 
Closes #3936 
