### PR TITLE
Fix for #4096

### DIFF
--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -17,7 +17,7 @@
 
     <!-- Add the references for all projects and targets -->
     <ItemGroup>
-        <PackageReference Include="JetBrains.Annotations" Version="2020.*" PrivateAssets="All" includeAssets="build;compile" />
+        <PackageReference Include="JetBrains.Annotations" Version="2020.*" PrivateAssets="All" IncludeAssets="build;compile" />
         <PackageReference Include="WpfAnalyzers" Version="3.5.*" PrivateAssets="All" />
     </ItemGroup>
 

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
@@ -26,10 +26,6 @@ namespace MetroDemo
             this.DataContext = this._viewModel;
 
             this.InitializeComponent();
-
-            this.flyoutDemo = new FlyoutDemo();
-            this.flyoutDemo.ApplyTemplate();
-            this.flyoutDemo.Closed += (o, e) => this.flyoutDemo = null;
         }
 
         public static readonly DependencyProperty ToggleFullScreenProperty =
@@ -105,7 +101,7 @@ namespace MetroDemo
 
         private void LaunchFlyoutDemo(object sender, RoutedEventArgs e)
         {
-            if (this.flyoutDemo == null)
+            if (this.flyoutDemo is null)
             {
                 this.flyoutDemo = new FlyoutDemo();
                 this.flyoutDemo.Closed += (o, args) => this.flyoutDemo = null;

--- a/src/MahApps.Metro/Behaviors/TiltBehavior.cs
+++ b/src/MahApps.Metro/Behaviors/TiltBehavior.cs
@@ -119,10 +119,10 @@ namespace MahApps.Metro.Behaviors
             this.RotatorParent.Child = this.attachedElement;
 
             CompositionTarget.Rendering += this.CompositionTargetRendering;
-            ThemeManager.Current.ThemeChanged += this.ThemeManagerIsThemeChanged;
+            ThemeManager.Current.ThemeChanged += this.HandleThemeManagerThemeChanged;
         }
 
-        private void ThemeManagerIsThemeChanged(object? sender, ThemeChangedEventArgs e)
+        private void HandleThemeManagerThemeChanged(object? sender, ThemeChangedEventArgs e)
         {
             this.Invoke(() => { this.RotatorParent?.Refresh(); });
         }
@@ -130,7 +130,7 @@ namespace MahApps.Metro.Behaviors
         protected override void OnDetaching()
         {
             CompositionTarget.Rendering -= this.CompositionTargetRendering;
-            ThemeManager.Current.ThemeChanged -= this.ThemeManagerIsThemeChanged;
+            ThemeManager.Current.ThemeChanged -= this.HandleThemeManagerThemeChanged;
 
             base.OnDetaching();
         }

--- a/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -277,17 +277,17 @@ namespace MahApps.Metro.Controls.Dialogs
 
         private void BaseMetroDialogLoaded(object? sender, RoutedEventArgs e)
         {
-            ThemeManager.Current.ThemeChanged -= this.ThemeManagerIsThemeChanged;
-            ThemeManager.Current.ThemeChanged += this.ThemeManagerIsThemeChanged;
+            ThemeManager.Current.ThemeChanged -= this.HandleThemeManagerThemeChanged;
+            ThemeManager.Current.ThemeChanged += this.HandleThemeManagerThemeChanged;
             this.OnLoaded();
         }
 
         private void BaseMetroDialogUnloaded(object? sender, RoutedEventArgs e)
         {
-            ThemeManager.Current.ThemeChanged -= this.ThemeManagerIsThemeChanged;
+            ThemeManager.Current.ThemeChanged -= this.HandleThemeManagerThemeChanged;
         }
 
-        private void ThemeManagerIsThemeChanged(object? sender, ThemeChangedEventArgs e)
+        private void HandleThemeManagerThemeChanged(object? sender, ThemeChangedEventArgs e)
         {
             this.Invoke(this.HandleThemeChange);
         }

--- a/src/MahApps.Metro/Controls/Flyout.cs
+++ b/src/MahApps.Metro/Controls/Flyout.cs
@@ -674,6 +674,11 @@ namespace MahApps.Metro.Controls
 
         internal void ChangeFlyoutTheme(ControlzEx.Theming.Theme windowTheme)
         {
+            if (windowTheme == ThemeManager.Current.DetectTheme(this.Resources))
+            {
+                return;
+            }
+
             switch (this.Theme)
             {
                 case FlyoutTheme.Accent:

--- a/src/MahApps.Metro/Controls/Flyout.cs
+++ b/src/MahApps.Metro/Controls/Flyout.cs
@@ -612,6 +612,11 @@ namespace MahApps.Metro.Controls
 
         private void UpdateFlyoutTheme()
         {
+            if (this.IsLoaded == false)
+            {
+                return;
+            }
+
             var flyoutsControl = this.Owner ?? this.TryFindParent<FlyoutsControl>();
 
             if (System.ComponentModel.DesignerProperties.GetIsInDesignMode(this))

--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -1263,8 +1263,8 @@ namespace MahApps.Metro.Controls
 
             this.ResetAllWindowCommandsBrush();
 
-            ThemeManager.Current.ThemeChanged += this.ThemeManagerOnIsThemeChanged;
-            this.Unloaded += (_, _) => ThemeManager.Current.ThemeChanged -= this.ThemeManagerOnIsThemeChanged;
+            ThemeManager.Current.ThemeChanged += this.HandleThemeManagerThemeChanged;
+            this.Unloaded += (_, _) => ThemeManager.Current.ThemeChanged -= this.HandleThemeManagerThemeChanged;
         }
 
         private void InitializeWindowChromeBehavior()
@@ -1367,7 +1367,7 @@ namespace MahApps.Metro.Controls
             }
         }
 
-        private void ThemeManagerOnIsThemeChanged(object? sender, ThemeChangedEventArgs e)
+        private void HandleThemeManagerThemeChanged(object? sender, ThemeChangedEventArgs e)
         {
             this.Invoke(() =>
                 {
@@ -1387,9 +1387,18 @@ namespace MahApps.Metro.Controls
                         return;
                     }
 
+                    var newTheme = ReferenceEquals(e.Target, this)
+                        ? e.NewTheme
+                        : ThemeManager.Current.DetectTheme(this);
+
+                    if (newTheme is null)
+                    {
+                        return;
+                    }
+
                     foreach (var flyout in flyouts)
                     {
-                        flyout.ChangeFlyoutTheme(e.NewTheme);
+                        flyout.ChangeFlyoutTheme(newTheme);
                     }
 
                     this.HandleWindowCommandsForFlyouts(flyouts);

--- a/src/MahApps.Metro/MahApps.Metro.csproj
+++ b/src/MahApps.Metro/MahApps.Metro.csproj
@@ -16,8 +16,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="ControlzEx" version="4.*" />
-        <PackageReference Include="XamlColorSchemeGenerator" version="4-*" PrivateAssets="All" IncludeAssets="build" />
+        <PackageReference Include="ControlzEx" Version="4.*" />
+        <PackageReference Include="XamlColorSchemeGenerator" Version="4-*" PrivateAssets="All" IncludeAssets="build" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.*">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
## Describe the changes you have made to improve this project

We have to use the correct theme when we receive a ThemeChanged event as it's a global event.
If the event targets the current window we use the theme from e.NewTheme, otherwise we have to detect the theme for `this` and use that as the new flyout theme.

## Closed Issues

#4096
