### PR TITLE
Add option to close ColorPicker on selected color changed

### DIFF
--- a/src/MahApps.Metro/Controls/ColorPicker/ColorPicker.cs
+++ b/src/MahApps.Metro/Controls/ColorPicker/ColorPicker.cs
@@ -686,6 +686,22 @@ namespace MahApps.Metro.Controls
             set => this.SetValue(IsAdvancedTabVisibleProperty, BooleanBoxes.Box(value));
         }
 
+        /// <summary>Identifies the <see cref="CloseOnSelectedColorChanged"/> dependency property.</summary>
+        public static readonly DependencyProperty CloseOnSelectedColorChangedProperty =
+            DependencyProperty.Register(nameof(CloseOnSelectedColorChanged),
+                                        typeof(bool),
+                                        typeof(ColorPicker),
+                                        new PropertyMetadata(BooleanBoxes.FalseBox));
+
+        /// <summary>
+        /// Gets or sets the visibility of the standard <see cref="ColorPalette"/>.
+        /// </summary>
+        public bool CloseOnSelectedColorChanged
+        {
+            get => (bool)this.GetValue(CloseOnSelectedColorChangedProperty);
+            set => this.SetValue(CloseOnSelectedColorChangedProperty, BooleanBoxes.Box(value));
+        }
+
         public override void OnApplyTemplate()
         {
             if (this.PART_ColorPaletteStandard != null)
@@ -776,6 +792,11 @@ namespace MahApps.Metro.Controls
             if (sender is ColorPalette colorPalette && !this.ColorIsUpdating)
             {
                 this.SetCurrentValue(SelectedColorProperty, colorPalette.SelectedItem as Color?);
+
+                if (CloseOnSelectedColorChanged)
+                {
+                    Close();
+                }
             }
         }
 


### PR DESCRIPTION
## Describe the changes you have made to improve this project

This PR adds a property `CloseOnSelectedColorChanged` to the `ColorPicker` control which allows the user to specify if the DropDown should be closed after a color is selected from a palette.
Further info can be found in #4128.

## Unit test

None, because I don't know how to to that for this control.

## Additional context

The default value is `false` to not break existing behavior.

![colorpicker_autoclose](https://user-images.githubusercontent.com/6222752/122570335-f36c0780-d04b-11eb-8847-caff55971bb2.gif)

## Closed Issues

Closes #4128
