### PR TITLE
ColorPicker: fix wrong xml comment

### DIFF
--- a/src/MahApps.Metro/Controls/ColorPicker/ColorPicker.cs
+++ b/src/MahApps.Metro/Controls/ColorPicker/ColorPicker.cs
@@ -694,7 +694,7 @@ namespace MahApps.Metro.Controls
                                         new PropertyMetadata(BooleanBoxes.FalseBox));
 
         /// <summary>
-        /// Gets or sets the visibility of the standard <see cref="ColorPalette"/>.
+        /// Gets or sets whether the DropDown should close after a color was selected from a <see cref="ColorPalette"/>. The default is <see langword="false" />
         /// </summary>
         public bool CloseOnSelectedColorChanged
         {


### PR DESCRIPTION
## Describe the changes you have made to improve this project

This PR fixes a wrong xml comment of the property `CloseOnSelectedColorChanged`.
Sorry for the inconvenience.

## Unit test

<!-- If it's possible then make a unit test for your changes. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->

## Closed Issues

<!-- Closes #xxxx -->
