### PR TITLE
Fix wrong translation for color names

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ColorPickerExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/ColorPickerExample.xaml
@@ -7,33 +7,154 @@
              d:DesignHeight="450"
              d:DesignWidth="800"
              mc:Ignorable="d">
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel>
-            <GroupBox Margin="5 5 5 0" Header="Eye Dropper">
-                <mah:ColorEyeDropper Height="Auto"
-                                     HorizontalContentAlignment="Center"
-                                     mah:ControlsHelper.CornerRadius="3"
-                                     SelectedColor="{Binding ElementName=ColorCanvasExample, Path=SelectedColor, Mode=TwoWay}">
-                    <TextBlock TextAlignment="Center" TextWrapping="Wrap">
-                        <Run Text="You selected this color: " />
-                        <Run FontWeight="Bold" Text="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mah:ColorEyeDropper}, Path=SelectedColor}" />
-                        <LineBreak />
-                        <Run Text="Press and hold to select a different color from screen." />
-                    </TextBlock>
-                </mah:ColorEyeDropper>
-            </GroupBox>
+    <UserControl.Resources>
+        <Style BasedOn="{StaticResource MahApps.Styles.MetroHeader.Horizontal}" TargetType="mah:MetroHeader" />
+        <Style BasedOn="{StaticResource MahApps.Styles.GroupBox}" TargetType="GroupBox">
+            <Setter Property="Margin" Value="5,5,5,0" />
+        </Style>
+    </UserControl.Resources>
 
-            <GroupBox Margin="5 5 5 0" Header="Color Canvas">
-                <mah:ColorCanvas x:Name="ColorCanvasExample" DefaultColor="{DynamicResource MahApps.Colors.AccentBase}" />
-            </GroupBox>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*" MinWidth="250" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="3*" MinWidth="50" />
+        </Grid.ColumnDefinitions>
 
-            <GroupBox Margin="5" Header="Color Picker">
-                <mah:ColorPicker mah:TextBoxHelper.AutoWatermark="True"
-                                 mah:TextBoxHelper.ClearTextButton="True"
-                                 mah:TextBoxHelper.UseFloatingWatermark="True"
-                                 mah:TextBoxHelper.Watermark="Select a color"
-                                 SelectedColor="{Binding ElementName=ColorCanvasExample, Path=SelectedColor}" />
-            </GroupBox>
-        </StackPanel>
-    </ScrollViewer>
+        <ScrollViewer Grid.Column="0" Grid.IsSharedSizeScope="True">
+            <StackPanel>
+                <GroupBox Header="ARGB-Color">
+                    <StackPanel>
+                        <mah:MetroHeader Header="Alpha">
+                            <mah:NumericUpDown Maximum="255"
+                                               Minimum="0"
+                                               Value="{Binding ElementName=ColorCanvasExample, Path=A}" />
+                        </mah:MetroHeader>
+                        <mah:MetroHeader Header="Red">
+                            <mah:NumericUpDown Maximum="255"
+                                               Minimum="0"
+                                               Value="{Binding ElementName=ColorCanvasExample, Path=R}" />
+                        </mah:MetroHeader>
+                        <mah:MetroHeader Header="Green">
+                            <mah:NumericUpDown Maximum="255"
+                                               Minimum="0"
+                                               Value="{Binding ElementName=ColorCanvasExample, Path=G}" />
+                        </mah:MetroHeader>
+                        <mah:MetroHeader Header="Blue">
+                            <mah:NumericUpDown Maximum="255"
+                                               Minimum="0"
+                                               Value="{Binding ElementName=ColorCanvasExample, Path=B}" />
+                        </mah:MetroHeader>
+                    </StackPanel>
+                </GroupBox>
+
+                <GroupBox Header="HSV-Color">
+                    <StackPanel>
+                        <mah:MetroHeader Header="Hue">
+                            <mah:NumericUpDown Maximum="360"
+                                               Minimum="0"
+                                               StringFormat="N1"
+                                               Value="{Binding ElementName=ColorCanvasExample, Path=Hue}" />
+                        </mah:MetroHeader>
+                        <mah:MetroHeader Header="Saturation">
+                            <mah:NumericUpDown Maximum="100"
+                                               Minimum="0"
+                                               StringFormat="p0"
+                                               Value="{Binding ElementName=ColorCanvasExample, Path=Saturation}" />
+                        </mah:MetroHeader>
+                        <mah:MetroHeader Header="Value">
+                            <mah:NumericUpDown Maximum="100"
+                                               Minimum="0"
+                                               StringFormat="p0"
+                                               Value="{Binding ElementName=ColorCanvasExample, Path=Value}" />
+                        </mah:MetroHeader>
+                    </StackPanel>
+                </GroupBox>
+
+                <GroupBox Header="Localization">
+                    <StackPanel>
+                        <mah:MetroHeader Header="Color names">
+                            <ComboBox x:Name="cmbColorHelper" SelectedIndex="0">
+                                <ComboBoxItem Tag="{x:Static mah:ColorHelper.DefaultInstance}">Localized</ComboBoxItem>
+                                <ComboBoxItem Tag="{x:Static mah:ColorHelper.DefaultInstanceInvariant}">Invariant</ComboBoxItem>
+                            </ComboBox>
+                        </mah:MetroHeader>
+                        <mah:MetroHeader Header="Palettes Tab Header">
+                            <TextBox Text="{Binding ElementName=colorPickerExample, Path=ColorPalettesTabHeader}" />
+                        </mah:MetroHeader>
+                        <mah:MetroHeader Header="Advanced Tab Header">
+                            <TextBox Text="{Binding ElementName=colorPickerExample, Path=AdvancedTabHeader}" />
+                        </mah:MetroHeader>
+                        <mah:MetroHeader Header="Standard Palette Header">
+                            <TextBox Text="{Binding ElementName=colorPickerExample, Path=StandardColorPaletteHeader}" />
+                        </mah:MetroHeader>
+                        <mah:MetroHeader Header="Available Palette Header">
+                            <TextBox Text="{Binding ElementName=colorPickerExample, Path=AvailableColorPaletteHeader}" />
+                        </mah:MetroHeader>
+                        <mah:MetroHeader Header="Recent Palette Header">
+                            <TextBox Text="{Binding ElementName=colorPickerExample, Path=RecentColorPaletteHeader}" />
+                        </mah:MetroHeader>
+
+                        
+                    </StackPanel>
+                </GroupBox>
+
+                <GroupBox Header="Behavior" >
+                    <StackPanel>
+                        <mah:MetroHeader Header="AddToRecentColorTrigger">
+                            <ComboBox x:Name="cmbAddToRecentTrigger" SelectedIndex="0">
+                                <ComboBoxItem Tag="{x:Static mah:AddToRecentColorsTrigger.ColorPickerClosed}">ColorPickerClosed</ComboBoxItem>
+                                <ComboBoxItem Tag="{x:Static mah:AddToRecentColorsTrigger.SelectedColorChanged}">SelectedColorChanged</ComboBoxItem>
+                                <ComboBoxItem Tag="{x:Static mah:AddToRecentColorsTrigger.Never}">Never</ComboBoxItem>
+                            </ComboBox>
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="CloseOnSelectedColorChanged">
+                            <mah:ToggleSwitch IsOn="{Binding ElementName=colorPickerExample, Path=CloseOnSelectedColorChanged}" />
+                        </mah:MetroHeader>
+                    </StackPanel>
+                </GroupBox>
+                
+            </StackPanel>
+        </ScrollViewer>
+
+        <GridSplitter Grid.Column="1"
+                      Width="3"
+                      VerticalAlignment="Stretch" />
+
+        <ScrollViewer Grid.Column="2" VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+                <GroupBox Margin="5,5,5,0" Header="Eye Dropper">
+                    <mah:ColorEyeDropper Height="Auto"
+                                         HorizontalContentAlignment="Center"
+                                         mah:ControlsHelper.CornerRadius="3"
+                                         SelectedColor="{Binding ElementName=ColorCanvasExample, Path=SelectedColor, Mode=TwoWay}">
+                        <TextBlock TextAlignment="Center" TextWrapping="Wrap">
+                            <Run Text="You selected this color: " />
+                            <Run FontWeight="Bold" Text="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mah:ColorEyeDropper}, Path=SelectedColor}" />
+                            <LineBreak />
+                            <Run Text="Press and hold to select a different color from screen." />
+                        </TextBlock>
+                    </mah:ColorEyeDropper>
+                </GroupBox>
+
+                <GroupBox Margin="5,5,5,0" Header="Color Canvas">
+                    <mah:ColorCanvas x:Name="ColorCanvasExample"
+                                     ColorHelper="{Binding ElementName=cmbColorHelper, Path=SelectedItem.Tag}"
+                                     DefaultColor="{DynamicResource MahApps.Colors.AccentBase}" />
+                </GroupBox>
+
+                <GroupBox Margin="5" Header="Color Picker">
+                    <mah:ColorPicker x:Name="colorPickerExample"
+                                     mah:TextBoxHelper.AutoWatermark="True"
+                                     mah:TextBoxHelper.ClearTextButton="True"
+                                     mah:TextBoxHelper.UseFloatingWatermark="True"
+                                     mah:TextBoxHelper.Watermark="Select a color"
+                                     AddToRecentColorsTrigger="{Binding ElementName=cmbAddToRecentTrigger, Path=SelectedItem.Tag}"
+                                     ColorHelper="{Binding ElementName=cmbColorHelper, Path=SelectedItem.Tag}"
+                                     SelectedColor="{Binding ElementName=ColorCanvasExample, Path=SelectedColor}" />
+                </GroupBox>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
 </UserControl>

--- a/src/MahApps.Metro/Controls/ColorPicker/ColorHelper.cs
+++ b/src/MahApps.Metro/Controls/ColorPicker/ColorHelper.cs
@@ -30,11 +30,11 @@ namespace MahApps.Metro.Controls
         /// </summary>
         public static readonly ColorHelper DefaultInstanceInvariant = new(CultureInfo.InvariantCulture);
 
-        
         /// <summary>
         /// Creates a new Instance of the ColorHelper with the default translations.
         /// </summary>
-        public ColorHelper() : this(CultureInfo.CurrentUICulture, typeof(ColorNames))
+        public ColorHelper()
+            : this(CultureInfo.CurrentUICulture, typeof(ColorNames))
         {
             // Empty
         }
@@ -43,7 +43,8 @@ namespace MahApps.Metro.Controls
         /// Creates a new Instance of the ColorHelper
         /// </summary>
         /// <param name="culture">The <see cref="CultureInfo"/> used to get the local color names</param>
-        public ColorHelper(CultureInfo? culture) : this(culture, typeof(ColorNames))
+        public ColorHelper(CultureInfo? culture)
+            : this(culture, typeof(ColorNames))
         {
             // Empty
         }
@@ -53,25 +54,25 @@ namespace MahApps.Metro.Controls
         /// </summary>
         /// <param name="culture">The <see cref="CultureInfo"/> used to get the local color names</param>
         /// <param name="resourceDictionaryType">A type from which the <see cref="ResourceManager"/> derives all information for finding .resources files.</param>
-        public ColorHelper(CultureInfo? culture, Type resourceDictionaryType)
+        public ColorHelper(CultureInfo? culture, Type? resourceDictionaryType)
         {
-            ColorNamesDictionary = new Dictionary<Color, string>();
+            this.ColorNamesDictionary = new Dictionary<Color, string>();
 
-            if (culture is null)
+            if (culture is null || resourceDictionaryType is null)
             {
                 foreach (var propertyInfo in typeof(Colors).GetProperties(BindingFlags.Static | BindingFlags.Public))
                 {
-                    var color = (Color)(propertyInfo.GetValue(null) ?? default(Color));
                     try
                     {
-                        if (!ColorNamesDictionary.ContainsKey(color))
+                        var color = (Color)(propertyInfo.GetValue(null) ?? default(Color));
+                        if (!this.ColorNamesDictionary.ContainsKey(color))
                         {
-                            ColorNamesDictionary.Add(color, propertyInfo.Name);
+                            this.ColorNamesDictionary.Add(color, propertyInfo.Name);
                         }
                     }
                     catch (Exception)
                     {
-                        Trace.TraceError($"{color} could not be added to dictionary!");
+                        Trace.TraceError($"Color from {propertyInfo.Name} could not be added to dictionary!");
                     }
                 }
             }
@@ -80,7 +81,7 @@ namespace MahApps.Metro.Controls
                 var rm = new ResourceManager(resourceDictionaryType);
                 var resourceSet = rm.GetResourceSet(culture, true, true);
 
-                if (resourceSet != null)
+                if (resourceSet is not null)
                 {
                     foreach (var entry in resourceSet.OfType<DictionaryEntry>())
                     {
@@ -88,7 +89,7 @@ namespace MahApps.Metro.Controls
                         {
                             if (ColorConverter.ConvertFromString(entry.Key.ToString()) is Color color)
                             {
-                                ColorNamesDictionary.Add(color, entry.Value!.ToString()!);
+                                this.ColorNamesDictionary.Add(color, entry.Value!.ToString()!);
                             }
                         }
                         catch (Exception)
@@ -121,7 +122,7 @@ namespace MahApps.Metro.Controls
                     return null;
                 }
 
-                colorNamesDictionary ??= ColorNamesDictionary;
+                colorNamesDictionary ??= this.ColorNamesDictionary;
 
                 if (!colorName!.StartsWith("#"))
                 {
@@ -177,7 +178,7 @@ namespace MahApps.Metro.Controls
                 return null;
             }
 
-            colorNamesDictionary ??= ColorNamesDictionary;
+            colorNamesDictionary ??= this.ColorNamesDictionary;
 
             var colorHex = useAlphaChannel ? color.ToString() : $"#{color.Value.R:X2}{color.Value.G:X2}{color.Value.B:X2}";
 

--- a/src/MahApps.Metro/Themes/ColorPicker/ColorPicker.xaml
+++ b/src/MahApps.Metro/Themes/ColorPicker/ColorPicker.xaml
@@ -328,6 +328,7 @@
                                                                       Style="{TemplateBinding StandardColorPaletteStyle}"
                                                                       IsAlphaChannelVisible="{TemplateBinding IsAlphaChannelVisible}"
                                                                       ColorHelper="{TemplateBinding ColorHelper}"
+                                                                      ColorNamesDictionary="{TemplateBinding ColorNamesDictionary}"
                                                                       Visibility="{TemplateBinding IsStandardColorPaletteVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                                                     <mah:ColorPalette x:Name="PART_ColorPaletteAvailable"
@@ -337,6 +338,7 @@
                                                                       Style="{TemplateBinding AvailableColorPaletteStyle}"
                                                                       IsAlphaChannelVisible="{TemplateBinding IsAlphaChannelVisible}"
                                                                       ColorHelper="{TemplateBinding ColorHelper}"
+                                                                      ColorNamesDictionary="{TemplateBinding ColorNamesDictionary}"
                                                                       Visibility="{TemplateBinding IsAvailableColorPaletteVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                                                     <mah:ColorPalette x:Name="PART_ColorPaletteCustom01"
@@ -346,6 +348,7 @@
                                                                       Style="{TemplateBinding CustomColorPalette01Style}"
                                                                       IsAlphaChannelVisible="{TemplateBinding IsAlphaChannelVisible}"
                                                                       ColorHelper="{TemplateBinding ColorHelper}"
+                                                                      ColorNamesDictionary="{TemplateBinding ColorNamesDictionary}"
                                                                       Visibility="{TemplateBinding IsCustomColorPalette01Visible, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                                                     <mah:ColorPalette x:Name="PART_ColorPaletteCustom02"
@@ -355,6 +358,7 @@
                                                                       Style="{TemplateBinding CustomColorPalette02Style}"
                                                                       IsAlphaChannelVisible="{TemplateBinding IsAlphaChannelVisible}"
                                                                       ColorHelper="{TemplateBinding ColorHelper}"
+                                                                      ColorNamesDictionary="{TemplateBinding ColorNamesDictionary}"
                                                                       Visibility="{TemplateBinding IsCustomColorPalette02Visible, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                                                     <mah:ColorPalette x:Name="PART_ColorPaletteRecent"
@@ -364,6 +368,7 @@
                                                                       Style="{TemplateBinding RecentColorPaletteStyle}"
                                                                       IsAlphaChannelVisible="{TemplateBinding IsAlphaChannelVisible}"
                                                                       ColorHelper="{TemplateBinding ColorHelper}"
+                                                                      ColorNamesDictionary="{TemplateBinding ColorNamesDictionary}"
                                                                       Visibility="{TemplateBinding IsRecentColorPaletteVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                                 </VirtualizingStackPanel>
                                             </ScrollViewer>


### PR DESCRIPTION
## Describe the changes you have made to improve this project

- Fix missing TemplateBinding for `ColorPalettes`
- Make the `ColorNamesDictionary` an instance member 
- Create parameterless constructor with uses the default translations
- Create constructor which uses a given culture. If the the culture is `null` we use the actual color names from .NET
- Create a constructor which uses a given culture and a given resource to look up the names
- 
## Unit test
None

## Additional context

⚠ BREAKING CHANGE ⚠

This PR might be a breaking change if anyone used the static `ColorNamesHelper`.

## Closed Issues
Closes #4131 
