### PR TITLE
Fix incorrect sdk version in `global.json`

### DIFF
--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
-    "sdk": {
-        "version": "5",
-        "rollForward": "latestFeature"
-    }
+  "sdk": {
+    "version": "5.0.301",
+    "rollForward": "latestFeature"
+  }
 }


### PR DESCRIPTION
## Describe the changes you have made to improve this project

This PR fixes an incorrect sdk version inside of `global.json`.

## Unit test

<!-- If it's possible then make a unit test for your changes. -->

## Additional context

The version needs to be specified in a correct format to take effect. See second line of output from `dotnet --info`.
According to [this issue](https://github.com/dotnet/sdk/issues/13799) and the [corresponding documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x#matching-rules) you need to specify an existing version.

Maybe you want to specify `latestMinor` instead of `latestFeature`. ([see documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json?tabs=netcore3x#rollforward))

#### output of current `global.json`

![global_json_wrong](https://user-images.githubusercontent.com/6222752/123958288-277cec00-d9ad-11eb-8c80-5c2a147b134f.png)

#### output of this PR

![global_json_correct](https://user-images.githubusercontent.com/6222752/123958315-31065400-d9ad-11eb-9635-8c80ab4db904.png)

#### output of an old version

![global_json_example](https://user-images.githubusercontent.com/6222752/123958330-36639e80-d9ad-11eb-8130-d18a022c5611.png)

## Closed Issues

<!-- Closes #xxxx -->
