### PR TITLE
Fix wrong stored window placement (position) if Taskbar is on top or left

### DIFF
--- a/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
+++ b/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
@@ -185,6 +185,13 @@ namespace MahApps.Metro.Behaviors
                     RECT rect;
                     if (UnsafeNativeMethods.GetWindowRect(hwnd, out rect))
                     {
+                        var monitor = NativeMethods.MonitorFromWindow(hwnd, MonitorOptions.MONITOR_DEFAULTTONEAREST);
+                        if (monitor != IntPtr.Zero)
+                        {
+                            var monitorInfo = NativeMethods.GetMonitorInfo(monitor);
+                            rect.Offset(monitorInfo.rcMonitor.Left - monitorInfo.rcWork.Left, monitorInfo.rcMonitor.Top - monitorInfo.rcWork.Top);
+                        }
+
                         wp.normalPosition = rect;
                     }
                 }


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Fix wrong stored window placement (position) if Taskbar is on top or left. The GetWindowRect gets the rectangle inclusive the Taskbar height (width).

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Closed Issues

<!-- Closes #xxxx -->

Closes #4067 
