### PR TITLE
Adding proper version range for ControlzEx dependency

### DIFF
--- a/src/MahApps.Metro/MahApps.Metro.csproj
+++ b/src/MahApps.Metro/MahApps.Metro.csproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="ControlzEx" version="5.*" />
+        <PackageReference Include="ControlzEx" version="[5.*, 6)" />
         <PackageReference Include="XamlColorSchemeGenerator" version="4.0.0-rc0155" PrivateAssets="all" IncludeAssets="build" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.*">
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
We have to constrain the version range for our dependency on ControlzEx. Otherwise people might end in a situation where nuget automatically chooses an incompatible higher version.