### PR TITLE
Add IsNotNullConverter value converter

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SelectionExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SelectionExamples.xaml
@@ -239,7 +239,7 @@
 
                     <ComboBox Width="200"
                               Margin="{StaticResource ControlMargin}"
-                              mah:TextBoxHelper.ClearTextButton="True"
+                              mah:TextBoxHelper.ClearTextButton="{Binding Path=SelectedItem, RelativeSource={RelativeSource Mode=Self}, Converter={x:Static mah:IsNotNullConverter.Instance}}"
                               mah:TextBoxHelper.Watermark="Please select an item..."
                               SelectedIndex="0">
                         <ComboBox.ContextMenu>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -277,6 +277,7 @@
                              mah:TextBoxHelper.Watermark="Password"
                              Password="Password" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"
+                             mah:TextBoxHelper.ClearTextButton="True"
                              mah:TextBoxHelper.UseFloatingWatermark="True"
                              mah:TextBoxHelper.Watermark="Win8"
                              Password="Win8"

--- a/src/MahApps.Metro/Converters/IsNotNullConverter.cs
+++ b/src/MahApps.Metro/Converters/IsNotNullConverter.cs
@@ -8,16 +8,16 @@ using System.Windows.Data;
 namespace MahApps.Metro.Converters
 {
     [ValueConversion(typeof(object), typeof(bool))]
-    public sealed class IsNullConverter : IValueConverter
+    public sealed class IsNotNullConverter : IValueConverter
     {
         /// <summary>
-        /// Gets a static default instance of <see cref="IsNullConverter"/>.
+        /// Gets a static default instance of <see cref="IsNotNullConverter"/>.
         /// </summary>
-        public static readonly IsNullConverter Instance = new();
+        public static readonly IsNotNullConverter Instance = new();
 
         public object? Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)
         {
-            return value is null;
+            return value is not null;
         }
 
         public object? ConvertBack(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture)


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Add a IsNotNullConverter value converter.

Sample:

```xaml
<ComboBox Width="200"
          Margin="{StaticResource ControlMargin}"
          mah:TextBoxHelper.ClearTextButton="{Binding Path=SelectedItem, RelativeSource={RelativeSource Mode=Self}, Converter={x:Static mah:IsNotNullConverter.Instance}}"
          mah:TextBoxHelper.Watermark="Please select an item..."
          SelectedIndex="0">
    <ComboBoxItem Content="Item 1" />
    <ComboBoxItem Content="Item 2" />
    <ComboBoxItem Content="Very long Item 3 for MahApps.Metro" />
    <ComboBoxItem Content="Item 4" />
</ComboBox>
```

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->
