### PR TITLE
Drop .NET Framework 4.5.2 and 4.6

### DIFF
--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -20,10 +20,6 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <PropertyGroup>
-        <DefineConstants Condition="'$(TargetFramework)' == 'net5.0-windows'">$(DefineConstants);NET5_0_OR_GREATER</DefineConstants>
-    </PropertyGroup>
-
     <!-- Add the references for all projects and targets -->
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2021.*" PrivateAssets="All" IncludeAssets="build;compile" />

--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -6,7 +6,7 @@
 
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFrameworks>net452;net46;net47;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+        <TargetFrameworks>net5.0-windows;netcoreapp3.1;net47;net462</TargetFrameworks>
         <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AutoGenerateBindingRedirects Condition=" $(TargetFramework.StartsWith('net4')) ">true</AutoGenerateBindingRedirects>

--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -6,7 +6,7 @@
 
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFrameworks>net5.0-windows;netcoreapp3.1;net47;net462</TargetFrameworks>
+        <TargetFrameworks>net462;net47;netcoreapp3.1;net5.0-windows</TargetFrameworks>
         <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AutoGenerateBindingRedirects Condition=" $(TargetFramework.StartsWith('net4')) ">true</AutoGenerateBindingRedirects>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/App.net452.config
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/App.net452.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<configuration>
-    <startup>
-        <supportedRuntime version="v4.0"
-                          sku=".NETFramework,Version=v4.5.2" />
-    </startup>
-</configuration>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/App.net46.config
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/App.net46.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<configuration>
-    <startup>
-        <supportedRuntime version="v4.0"
-                          sku=".NETFramework,Version=v4.6" />
-    </startup>
-</configuration>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/App.net47.config
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/App.net47.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<configuration>
-    <startup>
-        <supportedRuntime version="v4.0"
-                          sku=".NETFramework,Version=v4.7" />
-    </startup>
-</configuration>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/App.netcoreapp3.0.config
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/App.netcoreapp3.0.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<configuration>
-</configuration>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/App.netcoreapp3.1.config
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/App.netcoreapp3.1.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<configuration>
-</configuration>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/AppBootstrapper.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/AppBootstrapper.cs
@@ -20,7 +20,7 @@ namespace Caliburn.Metro.Demo
 
         public AppBootstrapper()
         {
-            Initialize();
+            this.Initialize();
         }
 
         protected override void BuildUp(object instance)
@@ -49,34 +49,33 @@ namespace Caliburn.Metro.Demo
             this.container.Compose(batch);
         }
 
-        protected override IEnumerable<object>? GetAllInstances(Type serviceType)
+        protected override IEnumerable<object> GetAllInstances(Type serviceType)
         {
-            return this.container?.GetExportedValues<object>(AttributedModelServices.GetContractName(serviceType));
+            return this.container?.GetExportedValues<object>(AttributedModelServices.GetContractName(serviceType)) ?? Enumerable.Empty<object>();
         }
 
         protected override object GetInstance(Type serviceType, string key)
         {
             var contract = string.IsNullOrEmpty(key) ? AttributedModelServices.GetContractName(serviceType) : key;
-            var exports = this.container?.GetExportedValues<object>(contract);
+            var export = this.container?.GetExportedValues<object>(contract).FirstOrDefault();
 
-            if (exports?.Any() == true)
+            if (export is not null)
             {
-                return exports.First();
+                return export;
             }
 
-            throw new Exception(string.Format("Could not locate any instances of contract {0}.", contract));
+            throw new Exception($"Could not locate any instances of contract {contract}.");
         }
 
         protected override void OnStartup(object sender, StartupEventArgs e)
         {
-            var startupTasks =
-                GetAllInstances(typeof(StartupTask))
-                    .Cast<ExportedDelegate>()
-                    .Select(exportedDelegate => (StartupTask)exportedDelegate.CreateDelegate(typeof(StartupTask)));
+            var startupTasks = this.GetAllInstances(typeof(StartupTask))
+                                   .OfType<ExportedDelegate>()
+                                   .Select(exportedDelegate => (StartupTask)exportedDelegate.CreateDelegate(typeof(StartupTask))!);
 
             startupTasks.Apply(s => s());
 
-            DisplayRootViewFor<IShell>();
+            this.DisplayRootViewFor<IShell>();
         }
     }
 }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/Controls/StartupTasks.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/Controls/StartupTasks.cs
@@ -56,10 +56,16 @@ namespace Caliburn.Metro.Demo.Controls
         public void ApplyViewLocatorOverride()
         {
             var themeManager = this.serviceLocator.GetInstance<IThemeManager>();
-            Application.Current.Resources.MergedDictionaries.Add(themeManager.GetThemeResources());
+            if (themeManager is not null)
+            {
+                Application.Current.Resources.MergedDictionaries.Add(themeManager.GetThemeResources());
+            }
 
             var viewLocator = this.serviceLocator.GetInstance<IViewLocator>();
-            Micro.ViewLocator.GetOrCreateViewType = viewLocator.GetOrCreateViewType;
+            if (viewLocator is not null)
+            {
+                Micro.ViewLocator.GetOrCreateViewType = viewLocator.GetOrCreateViewType;
+            }
         }
     }
 }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/Controls/ViewLocator.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/Controls/ViewLocator.cs
@@ -34,10 +34,10 @@ namespace Caliburn.Metro.Demo.Controls
 
             if (viewType.IsInterface || viewType.IsAbstract || !typeof(UIElement).IsAssignableFrom(viewType))
             {
-                return new TextBlock { Text = string.Format("Cannot create {0}.", viewType.FullName) };
+                return new TextBlock { Text = $"Cannot create {viewType.FullName}." };
             }
 
-            var newInstance = (UIElement)Activator.CreateInstance(viewType);
+            var newInstance = (UIElement)Activator.CreateInstance(viewType)!;
 
             Micro.ViewLocator.InitializeComponent(newInstance);
 

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/MahApps.Metro.Caliburn.Demo.csproj
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/MahApps.Metro.Caliburn.Demo.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFrameworks>net452;net46;net47</TargetFrameworks>
+        <TargetFrameworks>net47;net462</TargetFrameworks>
         <AssemblyName>MahApps.Metro.Caliburn.Demo</AssemblyName>
         <RootNamespace>Caliburn.Metro.Demo</RootNamespace>
         <DisableFody Condition=" '$(Configuration)' == 'Debug' ">true</DisableFody>
@@ -33,14 +33,6 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Costura.Fody" Version="4.*" PrivateAssets="All" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Include="app.manifest" />
-        <None Remove="App.config" />
-        <AppConfigWithTargetPath Include="App.$(TargetFramework).config">
-            <TargetPath>$(AssemblyName).exe.config</TargetPath>
-        </AppConfigWithTargetPath>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/MahApps.Metro.Caliburn.Demo.csproj
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/MahApps.Metro.Caliburn.Demo.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFrameworks>net47;net462</TargetFrameworks>
         <AssemblyName>MahApps.Metro.Caliburn.Demo</AssemblyName>
         <RootNamespace>Caliburn.Metro.Demo</RootNamespace>
         <DisableFody Condition=" '$(Configuration)' == 'Debug' ">true</DisableFody>
@@ -27,7 +26,7 @@
 
     <ItemGroup>
         <PackageReference Include="MahApps.Metro.IconPacks" Version="4.*" />
-        <PackageReference Include="Caliburn.Micro" Version="3.*" />
+        <PackageReference Include="Caliburn.Micro" Version="4.0.173" />
         <PackageReference Include="Fody" Version="6.*">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/Services/IServiceLocator.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/Services/IServiceLocator.cs
@@ -6,7 +6,7 @@ namespace Caliburn.Metro.Demo.Services
 {
     public interface IServiceLocator
     {
-        T GetInstance<T>()
+        T? GetInstance<T>()
             where T : class;
     }
 }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/Services/MefServiceLocator.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/Services/MefServiceLocator.cs
@@ -20,7 +20,7 @@ namespace Caliburn.Metro.Demo.Services
             this.compositionContainer = compositionContainer;
         }
 
-        public T GetInstance<T>()
+        public T? GetInstance<T>()
             where T : class
         {
             try

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/ViewModels/ShellViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/ViewModels/ShellViewModel.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
 using Caliburn.Metro.Demo.ViewModels.Flyouts;
 using Caliburn.Micro;
 
@@ -15,12 +17,12 @@ namespace Caliburn.Metro.Demo.ViewModels
 
         public ShellViewModel()
         {
-            FlyoutViewModels = new BindableCollection<FlyoutBaseViewModel>();
+            this.FlyoutViewModels = new BindableCollection<FlyoutBaseViewModel>();
         }
 
-        public void Close()
+        public async Task Close()
         {
-            this.TryClose();
+            await this.TryCloseAsync();
         }
 
         public void ToggleFlyout(int index)
@@ -29,9 +31,8 @@ namespace Caliburn.Metro.Demo.ViewModels
             flyout.IsOpen = !flyout.IsOpen;
         }
 
-        protected override void OnInitialize()
+        protected override Task OnInitializeAsync(CancellationToken cancellationToken)
         {
-            base.OnInitialize();
             this.DisplayName = "Caliburn Metro Demo";
             this.FlyoutViewModels.Add(new Flyout1ViewModel());
             this.FlyoutViewModels.Add(new Flyout2ViewModel());
@@ -40,6 +41,8 @@ namespace Caliburn.Metro.Demo.ViewModels
             this.FlyoutViewModels.Add(new FlyoutLeftViewModel());
             this.FlyoutViewModels.Add(new FlyoutTopViewModel());
             this.FlyoutViewModels.Add(new FlyoutBottomViewModel());
+
+            return Task.FromResult(true);
         }
     }
 }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/Views/ShellView.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/Views/ShellView.xaml
@@ -53,6 +53,7 @@
             <Button x:Name="CloseButton"
                     MinWidth="90"
                     Margin="2"
+                    caliburn:Message.Attach="[Event Click] = [Action Close]"
                     Content="Close" />
         </StackPanel>
 

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.net452.config
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.net452.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<configuration>
-    <startup>
-        <supportedRuntime version="v4.0"
-                          sku=".NETFramework,Version=v4.5.2" />
-    </startup>
-</configuration>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.net46.config
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.net46.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<configuration>
-    <startup>
-        <supportedRuntime version="v4.0"
-                          sku=".NETFramework,Version=v4.6" />
-    </startup>
-</configuration>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.net47.config
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.net47.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<configuration>
-    <startup>
-        <supportedRuntime version="v4.0"
-                          sku=".NETFramework,Version=v4.7" />
-    </startup>
-</configuration>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.netcoreapp3.1.config
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.netcoreapp3.1.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<configuration>
-</configuration>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.csproj
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MahApps.Metro.Demo.csproj
@@ -46,14 +46,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="app.manifest" />
-        <None Remove="App.config" />
-        <AppConfigWithTargetPath Include="App.$(TargetFramework).config" Condition="$(DefineConstants.Contains(NETCOREAPP)) == false">
-            <TargetPath>$(AssemblyName).exe.config</TargetPath>
-        </AppConfigWithTargetPath>
-    </ItemGroup>
-
-    <ItemGroup>
         <Compile DependentUpon="%(Filename)" SubType="Code" Update="**\obj\**\*.g$(DefaultLanguageSourceExtension)" />
         <Compile DependentUpon="%(Filename)" SubType="Designer" Update="**\*.xaml$(DefaultLanguageSourceExtension)" />
     </ItemGroup>

--- a/src/MahApps.Metro/Accessibility/AccessibilitySwitches.cs
+++ b/src/MahApps.Metro/Accessibility/AccessibilitySwitches.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if !NET452
 using System;
 using System.Runtime.CompilerServices;
-#endif
 
 namespace MahApps.Metro.Accessibility
 {
@@ -22,12 +20,8 @@ namespace MahApps.Metro.Accessibility
         /// </summary>
         public static bool UseNetFx472CompatibleAccessibilityFeatures
         {
-#if NET452
-            get => false;
-#else
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => AppContext.TryGetSwitch(UseLegacyAccessibilityFeatures3SwitchName, out bool flag) && flag == true;
-#endif
         }
 
         #endregion

--- a/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -452,11 +452,7 @@ namespace MahApps.Metro.Controls.Dialogs
 
             if (this.IsLoaded)
             {
-#if NET452
-                return Task.FromResult<object>(default!);
-#else
                 return Task.CompletedTask;
-#endif
             }
 
             var tcs = new TaskCompletionSource<object>();

--- a/src/MahApps.Metro/Controls/WindowSettings.cs
+++ b/src/MahApps.Metro/Controls/WindowSettings.cs
@@ -51,14 +51,22 @@ namespace MahApps.Metro.Controls
         {
             get
             {
-                if (this["Placement"] != null)
+                try
                 {
-                    return ((WINDOWPLACEMENT?)this["Placement"]);
+                    return this[nameof(Placement)] as WINDOWPLACEMENT;
                 }
+                catch (ConfigurationErrorsException? ex)
+                {
+                    string? filename = null;
+                    while (ex != null && (filename = ex.Filename) == null)
+                    {
+                        ex = ex.InnerException as ConfigurationErrorsException;
+                    }
 
-                return null;
+                    throw new MahAppsException($"The settings file '{filename ?? "<unknown>"}' seems to be corrupted", ex);
+                }
             }
-            set => this["Placement"] = value;
+            set => this[nameof(Placement)] = value;
         }
 #pragma warning restore 618
 
@@ -72,10 +80,7 @@ namespace MahApps.Metro.Controls
             {
                 try
                 {
-                    if (this["UpgradeSettings"] != null)
-                    {
-                        return (bool)this["UpgradeSettings"];
-                    }
+                    return (this[nameof(UpgradeSettings)] as bool?).GetValueOrDefault(true);
                 }
                 catch (ConfigurationErrorsException? ex)
                 {
@@ -87,10 +92,8 @@ namespace MahApps.Metro.Controls
 
                     throw new MahAppsException($"The settings file '{filename ?? "<unknown>"}' seems to be corrupted", ex);
                 }
-
-                return true;
             }
-            set => this["UpgradeSettings"] = value;
+            set => this[nameof(UpgradeSettings)] = value;
         }
     }
 }

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownFixture.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownFixture.cs
@@ -73,11 +73,7 @@ namespace MahApps.Metro.Tests.Tests
             this.NumDown = null;
             this.Window = null;
 
-#if NET452
-            return Task.Delay(0);
-#else
             return Task.CompletedTask;
-#endif
         }
     }
 }


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Drop .NET Framework 4.5.2 and 4.6 which will reach End of Support on April 26, 2022.

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Additional context

Use latest Caliburn.Micro v4.0.173 in demo.

<!-- Add any other context or screenshots about the feature request here. -->

## Closed Issues

Closes #4214 

<!-- Closes #xxxx -->
