### PR TITLE
Show read only state in DataGridColumnHeader

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/DataGridExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/DataGridExamples.xaml
@@ -192,7 +192,9 @@
                 </GroupStyle>
             </DataGrid.GroupStyle>
             <DataGrid.Columns>
-                <DataGridCheckBoxColumn Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsSelected, Mode=OneWay}" Header="Row Selected" />
+                <DataGridCheckBoxColumn Binding="{Binding RelativeSource={RelativeSource AncestorType=DataGridRow}, Path=IsSelected, Mode=OneWay}"
+                                        Header="Row Selected"
+                                        IsReadOnly="True" />
                 <DataGridCheckBoxColumn Binding="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                         EditingElementStyle="{DynamicResource MahApps.Styles.CheckBox.DataGrid.Win10}"
                                         ElementStyle="{DynamicResource MahApps.Styles.CheckBox.DataGrid.Win10}"

--- a/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -233,12 +233,12 @@
     </Style>
 
     <Style x:Key="MahApps.Styles.DataGridColumnHeader" TargetType="{x:Type DataGridColumnHeader}">
-        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Gray5}" />
+        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.DataGridColumnHeader.Background}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.DataGridColumnHeader.BorderBrush}" />
         <Setter Property="BorderThickness" Value="0 0 0 3" />
         <Setter Property="Cursor" Value="Hand" />
         <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.DataGridColumnHeader.Foreground}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="Margin" Value="0" />
         <Setter Property="MinHeight" Value="25" />
@@ -279,12 +279,13 @@
                               Height="10"
                               Margin="0 0 8 2"
                               VerticalAlignment="Center"
-                              Fill="{DynamicResource MahApps.Brushes.Gray2}"
+                              Fill="{DynamicResource MahApps.Brushes.DataGridColumnHeader.SortArrowFill}"
                               RenderTransformOrigin="0.5,0.5"
                               Stretch="Fill"
                               Visibility="Collapsed" />
 
                         <Thumb x:Name="PART_LeftHeaderGripper"
+                               Grid.Column="0"
                                HorizontalAlignment="Left"
                                Background="Transparent"
                                Style="{StaticResource MahApps.Styles.Thumb.ColumnHeaderGripper}" />
@@ -314,12 +315,15 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{DynamicResource MahApps.CharacterCasing.DataGridColumnHeader}" />
         <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=Column.IsReadOnly, RelativeSource={RelativeSource Self}, Mode=OneWay, FallbackValue=False, TargetNullValue=False}" Value="True">
+                <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.DataGridColumnHeader.Background.ReadOnly}" />
+            </DataTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
                     <Condition Property="IsMouseOver" Value="True" />
                     <Condition Property="SortDirection" Value="{x:Null}" />
                 </MultiTrigger.Conditions>
-                <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
+                <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.DataGridColumnHeader.Background.MouseOver}" />
             </MultiTrigger>
             <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />

--- a/src/MahApps.Metro/Styles/Themes/Theme.Template.xaml
+++ b/src/MahApps.Metro/Styles/Themes/Theme.Template.xaml
@@ -231,6 +231,13 @@
     <SolidColorBrush x:Key="MahApps.Brushes.DataGrid.Selection.Text.Inactive" Color="{StaticResource MahApps.Colors.ThemeForeground}" options:Freeze="True" />
     <SolidColorBrush x:Key="MahApps.Brushes.DataGrid.Selection.Text.MouseOver" Color="{StaticResource MahApps.Colors.IdealForeground}" options:Freeze="True" />
 
+    <SolidColorBrush x:Key="MahApps.Brushes.DataGridColumnHeader.Background" Color="{StaticResource MahApps.Colors.ThemeBackground}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.DataGridColumnHeader.Background.MouseOver" Color="{StaticResource MahApps.Colors.Gray8}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.DataGridColumnHeader.Background.ReadOnly" Color="{StaticResource MahApps.Colors.Gray6}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.DataGridColumnHeader.Foreground" Color="{StaticResource MahApps.Colors.ThemeForeground}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.DataGridColumnHeader.BorderBrush" Color="{StaticResource MahApps.Colors.Gray5}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.DataGridColumnHeader.SortArrowFill" Color="{StaticResource MahApps.Colors.Gray2}" options:Freeze="True" />
+
     <SolidColorBrush x:Key="MahApps.Brushes.Badged.Background" Color="{StaticResource MahApps.Colors.AccentBase}" options:Freeze="True" />
     <SolidColorBrush x:Key="MahApps.Brushes.Badged.Background.Disabled" Color="{{MahApps.Colors.Badged.Background.Disabled}}" options:Freeze="True" />
     <SolidColorBrush x:Key="MahApps.Brushes.Badged.Foreground" Color="{StaticResource MahApps.Colors.IdealForeground}" options:Freeze="True" />


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Show the IsReadOnly property state of the column as background. Introduce new brush keys for the DataGridColumnHeader.

- `MahApps.Brushes.DataGridColumnHeader.Background`
- `MahApps.Brushes.DataGridColumnHeader.Background.MouseOver`
- `MahApps.Brushes.DataGridColumnHeader.Background.ReadOnly`
- `MahApps.Brushes.DataGridColumnHeader.Foreground`
- `MahApps.Brushes.DataGridColumnHeader.BorderBrush`
- `MahApps.Brushes.DataGridColumnHeader.SortArrowFill`

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Closed Issues

Closes #3243 

<!-- Closes #xxxx -->
