### PR TITLE
Add ShowValidationErrorOnKeyboardFocus property to validation popup

### DIFF
--- a/src/MahApps.Metro/Controls/CustomValidationPopup.cs
+++ b/src/MahApps.Metro/Controls/CustomValidationPopup.cs
@@ -61,6 +61,22 @@ namespace MahApps.Metro.Controls
             set => this.SetValue(ShowValidationErrorOnMouseOverProperty, BooleanBoxes.Box(value));
         }
 
+        /// <summary>Identifies the <see cref="ShowValidationErrorOnKeyboardFocus"/> dependency property.</summary>
+        public static readonly DependencyProperty ShowValidationErrorOnKeyboardFocusProperty
+            = DependencyProperty.Register(nameof(ShowValidationErrorOnKeyboardFocus),
+                                          typeof(bool),
+                                          typeof(CustomValidationPopup),
+                                          new PropertyMetadata(BooleanBoxes.TrueBox));
+
+        /// <summary>
+        /// Gets or sets whether the validation error text will be shown when the element has the keyboard focus.
+        /// </summary>
+        public bool ShowValidationErrorOnKeyboardFocus
+        {
+            get => (bool)this.GetValue(ShowValidationErrorOnKeyboardFocusProperty);
+            set => this.SetValue(ShowValidationErrorOnKeyboardFocusProperty, BooleanBoxes.Box(value));
+        }
+
         /// <summary>Identifies the <see cref="AdornedElement"/> dependency property.</summary>
         public static readonly DependencyProperty AdornedElementProperty
             = DependencyProperty.Register(nameof(AdornedElement),
@@ -218,13 +234,22 @@ namespace MahApps.Metro.Controls
             this.Unloaded += this.CustomValidationPopup_Unloaded;
         }
 
+        private bool ShouldPopupOpen()
+        {
+            var adornedElement = this.AdornedElement;
+            var isOpen = adornedElement is not null
+                         && Validation.GetHasError(adornedElement)
+                         && adornedElement.IsKeyboardFocusWithin
+                         && this.ShowValidationErrorOnKeyboardFocus
+                         && ValidationHelper.GetShowValidationErrorOnKeyboardFocus(adornedElement);
+            return isOpen;
+        }
+
         private void Flyout_OpeningFinished(object? sender, RoutedEventArgs e)
         {
             this.RefreshPosition();
 
-            var adornedElement = this.AdornedElement;
-            var isOpen = Validation.GetHasError(adornedElement!) && adornedElement!.IsKeyboardFocusWithin;
-            this.SetCurrentValue(IsOpenProperty, BooleanBoxes.Box(isOpen));
+            this.SetCurrentValue(IsOpenProperty, BooleanBoxes.Box(this.ShouldPopupOpen()));
 
             this.SetValue(CanShowPropertyKey, BooleanBoxes.TrueBox);
         }
@@ -251,9 +276,7 @@ namespace MahApps.Metro.Controls
         {
             this.RefreshPosition();
 
-            var adornedElement = this.AdornedElement;
-            var isOpen = Validation.GetHasError(adornedElement!) && adornedElement!.IsKeyboardFocusWithin;
-            this.SetCurrentValue(IsOpenProperty, BooleanBoxes.Box(isOpen));
+            this.SetCurrentValue(IsOpenProperty, BooleanBoxes.Box(this.ShouldPopupOpen()));
 
             this.SetValue(CanShowPropertyKey, BooleanBoxes.TrueBox);
         }
@@ -266,9 +289,7 @@ namespace MahApps.Metro.Controls
 
                 if (IsElementVisible(this.AdornedElement as FrameworkElement, this.scrollViewer))
                 {
-                    var adornedElement = this.AdornedElement;
-                    var isOpen = Validation.GetHasError(adornedElement!) && adornedElement!.IsKeyboardFocusWithin;
-                    this.SetCurrentValue(IsOpenProperty, BooleanBoxes.Box(isOpen));
+                    this.SetCurrentValue(IsOpenProperty, BooleanBoxes.Box(this.ShouldPopupOpen()));
                 }
                 else
                 {

--- a/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
@@ -69,5 +69,35 @@ namespace MahApps.Metro.Controls
         {
             element.SetValue(ShowValidationErrorOnMouseOverProperty, BooleanBoxes.Box(value));
         }
+
+        /// <summary>
+        /// Identifies the ShowValidationErrorOnKeyboardFocus attached property.
+        /// </summary>
+        public static readonly DependencyProperty ShowValidationErrorOnKeyboardFocusProperty
+            = DependencyProperty.RegisterAttached(
+                "ShowValidationErrorOnKeyboardFocus",
+                typeof(bool),
+                typeof(ValidationHelper),
+                new PropertyMetadata(BooleanBoxes.TrueBox));
+
+        /// <summary>
+        /// Gets whether the validation error text will be shown when the element has the keyboard focus.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static bool GetShowValidationErrorOnKeyboardFocus(UIElement element)
+        {
+            return (bool)element.GetValue(ShowValidationErrorOnKeyboardFocusProperty);
+        }
+
+        /// <summary>
+        /// Sets whether the validation error text will be shown when the element has the keyboard focus.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetShowValidationErrorOnKeyboardFocus(UIElement element, bool value)
+        {
+            element.SetValue(ShowValidationErrorOnKeyboardFocusProperty, BooleanBoxes.Box(value));
+        }
     }
 }

--- a/src/MahApps.Metro/Styles/Controls.ValidationError.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ValidationError.xaml
@@ -128,14 +128,18 @@
             <DataTrigger Binding="{Binding ElementName=placeholder, Path=AdornedElement.BorderThickness, FallbackValue=0, TargetNullValue=0}" Value="0">
                 <Setter TargetName="ValidationErrorElement" Property="BorderThickness" Value="1" />
             </DataTrigger>
+
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding ElementName=ValidationPopup, Path=CanShow, Mode=OneWay}" Value="True" />
                     <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay}" Value="True" />
                     <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.HasError), Mode=OneWay}" Value="True" />
+                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(mah:ValidationHelper.ShowValidationErrorOnKeyboardFocus), Mode=OneWay}" Value="True" />
+                    <Condition Binding="{Binding ElementName=ValidationPopup, Path=ShowValidationErrorOnKeyboardFocus, Mode=OneWay}" Value="True" />
                 </MultiDataTrigger.Conditions>
                 <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
             </MultiDataTrigger>
+            
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding ElementName=RedTriangle, Path=IsMouseOver, Mode=OneWay}" Value="True" />


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Add new dependency property ShowValidationErrorOnKeyboardFocus to the validation popup. Also add an attached property to the ValidationHelper.

With this new properties it's possible to hide the popup globally or for a specific control. The validation can then be shown with the `ShowValidationErrorOnMouseOver` property.

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Closed Issues

Closes #4086 

<!-- Closes #xxxx -->
