### PR TITLE
Fix missing FallbackValue values in binding for MahApps styles

### DIFF
--- a/src/MahApps.Metro/Styles/Controls.MenuItem.xaml
+++ b/src/MahApps.Metro/Styles/Controls.MenuItem.xaml
@@ -37,12 +37,12 @@
     <Style x:Key="MahApps.Styles.MenuItem" TargetType="{x:Type MenuItem}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.MenuItem.Background}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}, FallbackValue={x:Static HorizontalAlignment.Stretch}}" />
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}, FallbackValue={x:Static HorizontalAlignment.Left}}" />
         <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
         <Setter Property="ScrollViewer.PanningMode" Value="Both" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=SubmenuItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}" />
-        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}, FallbackValue={x:Static VerticalAlignment.Stretch}}" />
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}, FallbackValue={x:Static VerticalAlignment.Top}}" />
         <Setter Property="mah:ControlsHelper.CornerRadius" Value="{Binding Path=(mah:ControlsHelper.CornerRadius), FallbackValue=0, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
         <Style.Triggers>
             <Trigger Property="Role" Value="TopLevelHeader">

--- a/src/MahApps.Metro/Styles/Controls.MenuItem.xaml
+++ b/src/MahApps.Metro/Styles/Controls.MenuItem.xaml
@@ -37,12 +37,12 @@
     <Style x:Key="MahApps.Styles.MenuItem" TargetType="{x:Type MenuItem}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.MenuItem.Background}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}, FallbackValue={x:Static HorizontalAlignment.Stretch}}" />
         <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
         <Setter Property="ScrollViewer.PanningMode" Value="Both" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="Template" Value="{DynamicResource {ComponentResourceKey ResourceId=SubmenuItemTemplateKey, TypeInTargetAssembly={x:Type MenuItem}}}" />
-        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
+        <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}, FallbackValue={x:Static VerticalAlignment.Stretch}}" />
         <Setter Property="mah:ControlsHelper.CornerRadius" Value="{Binding Path=(mah:ControlsHelper.CornerRadius), FallbackValue=0, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}" />
         <Style.Triggers>
             <Trigger Property="Role" Value="TopLevelHeader">


### PR DESCRIPTION
## Describe the changes you have made to improve this project

MenuItem causing 'System.Windows.Data.Inforamtion 10:...' messages being generated. This causes performance problems when the controls are unloaded from the view or when DataContext is set to null.

XAML binding performance bug - missing FallbackValue values causes WPF information messages to be generated.

## Unit test

No unit tests - changes to XAML only
