### PR TITLE
Fix changing DefaultButtonFocus for MessageDialog

### DIFF
--- a/src/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
@@ -169,19 +169,7 @@ namespace MahApps.Metro.Controls.Dialogs
             this.SetCurrentValue(NegativeButtonTextProperty, this.DialogSettings.NegativeButtonText);
             this.SetCurrentValue(FirstAuxiliaryButtonTextProperty, this.DialogSettings.FirstAuxiliaryButtonText);
             this.SetCurrentValue(SecondAuxiliaryButtonTextProperty, this.DialogSettings.SecondAuxiliaryButtonText);
-
-            var defaultButtonFocus = this.DialogSettings.DefaultButtonFocus;
-
-            //Ensure it's a valid option
-            if (!this.IsApplicable(defaultButtonFocus))
-            {
-                defaultButtonFocus = this.ButtonStyle == MessageDialogStyle.Affirmative
-                    ? MessageDialogResult.Affirmative
-                    : MessageDialogResult.Negative;
-            }
-
-            this.SetCurrentValue(DefaultButtonFocusProperty, defaultButtonFocus);
-
+            
             this.ApplyDefaultButtonFocus();
         }
 
@@ -398,7 +386,7 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             return value switch
             {
-                MessageDialogResult.Affirmative => this.ButtonStyle == MessageDialogStyle.Affirmative,
+                MessageDialogResult.Affirmative => true,
                 MessageDialogResult.Negative => this.ButtonStyle != MessageDialogStyle.Affirmative,
                 MessageDialogResult.FirstAuxiliary => this.ButtonStyle is MessageDialogStyle.AffirmativeAndNegativeAndSingleAuxiliary or MessageDialogStyle.AffirmativeAndNegativeAndDoubleAuxiliary,
                 MessageDialogResult.SecondAuxiliary => this.ButtonStyle == MessageDialogStyle.AffirmativeAndNegativeAndDoubleAuxiliary,


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Fix DefaultButtonFocus error.

The DefaultButtonFocus is always Negative, can't change to the other, except MessageDialogStyle is Affirmative.

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->
