### PR TITLE
Handle DataGridColumn visibility in VisibilityHelper

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/DataGridExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/DataGridExamples.xaml
@@ -134,6 +134,8 @@
 
             <vc:AlbumPriceIsTooMuchConverter x:Key="AlbumPriceIsTooMuchConverter" />
 
+            <models:BindingProxy x:Key="proxy" Data="{Binding }"/>
+
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -148,12 +150,20 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Label Grid.Row="0"
-               Grid.Column="0"
-               Grid.ColumnSpan="2"
-               HorizontalAlignment="Left"
-               Content="Metro Style"
-               Style="{DynamicResource DescriptionHeaderStyle}" />
+        <StackPanel Grid.Row="0"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    HorizontalAlignment="Left"
+                    Orientation="Horizontal">
+
+            <Label Content="Metro Style"
+                   Style="{DynamicResource DescriptionHeaderStyle}" />
+
+            <mah:ToggleSwitch Margin="2"
+                              IsOn="{Binding ShowTitleColumn}"
+                              OnContent="Title visible" 
+                              OffContent="No Title"/>
+        </StackPanel>
 
         <ContentControl Grid.Row="1"
                         Grid.Column="0"
@@ -199,7 +209,7 @@
                                         EditingElementStyle="{DynamicResource MahApps.Styles.CheckBox.DataGrid.Win10}"
                                         ElementStyle="{DynamicResource MahApps.Styles.CheckBox.DataGrid.Win10}"
                                         Header="Album Selected" />
-                <DataGridTextColumn Binding="{Binding Title}" Header="Title" />
+                <DataGridTextColumn Binding="{Binding Title}" Header="Title" mah:VisibilityHelper.IsVisible="{Binding Data.ShowTitleColumn, Source={StaticResource proxy}}"/>
                 <DataGridTextColumn Binding="{Binding Artist.Name}" Header="Artist" />
                 <DataGridComboBoxColumn DisplayMemberPath="Name"
                                         Header="Artist"
@@ -260,7 +270,7 @@
                   RowHeaderWidth="0"
                   Style="{DynamicResource MahApps.Styles.DataGrid.Azure}">
             <DataGrid.Columns>
-                <DataGridTextColumn Binding="{Binding Title}" Header="Title" />
+                <DataGridTextColumn Binding="{Binding Title}" Header="Title" mah:VisibilityHelper.IsVisible="{Binding Data.ShowTitleColumn, Source={StaticResource proxy}}"/>
                 <DataGridTextColumn Binding="{Binding Artist.Name}" Header="Artist" />
                 <DataGridTextColumn Binding="{Binding Genre.Name}" Header="Genre" />
                 <DataGridTemplateColumn Header="Price">

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
@@ -254,6 +254,13 @@ namespace MetroDemo
             HotkeyManager.Current.Remove("demo");
         }
 
+        private bool showTitleColumn = true;
+        public bool ShowTitleColumn
+        {
+            get => showTitleColumn;
+            set => Set(ref showTitleColumn, value);
+        }
+
         public string Title { get; set; }
 
         public int SelectedIndex { get; set; }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/BindingProxy.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/BindingProxy.cs
@@ -1,0 +1,20 @@
+﻿using System.Windows;
+
+namespace MetroDemo.Models
+{
+    public class BindingProxy : Freezable
+    {
+        protected override Freezable CreateInstanceCore()
+        {
+            return new BindingProxy();
+        }
+
+        public object? Data
+        {
+            get => GetValue(DataProperty);
+            set => SetValue(DataProperty, value);
+        }
+
+        public static readonly DependencyProperty DataProperty = DependencyProperty.Register(nameof(Data), typeof(object), typeof(BindingProxy));
+    }
+}

--- a/src/MahApps.Metro/Controls/Helper/VisibilityHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/VisibilityHelper.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace MahApps.Metro.Controls
 {
@@ -23,6 +24,12 @@ namespace MahApps.Metro.Controls
             if (d is FrameworkElement fe)
             {
                 fe.Visibility = (bool?)e.NewValue == true
+                    ? Visibility.Visible
+                    : Visibility.Collapsed;
+            }
+            else if (d is DataGridColumn dataGridColumn)
+            {
+                dataGridColumn.Visibility = (bool?)e.NewValue == true
                     ? Visibility.Visible
                     : Visibility.Collapsed;
             }
@@ -56,6 +63,12 @@ namespace MahApps.Metro.Controls
                     ? Visibility.Collapsed
                     : Visibility.Visible;
             }
+            else if (d is DataGridColumn dataGridColumn)
+            {
+                dataGridColumn.Visibility = (bool?)e.NewValue == true
+                    ? Visibility.Collapsed
+                    : Visibility.Visible;
+            }
         }
 
         public static void SetIsCollapsed(DependencyObject element, bool? value)
@@ -83,6 +96,12 @@ namespace MahApps.Metro.Controls
             if (d is FrameworkElement fe)
             {
                 fe.Visibility = (bool?)e.NewValue == true
+                    ? Visibility.Hidden
+                    : Visibility.Visible;
+            }
+            else if (d is DataGridColumn dataGridColumn)
+            {
+                dataGridColumn.Visibility = (bool?)e.NewValue == true
                     ? Visibility.Hidden
                     : Visibility.Visible;
             }


### PR DESCRIPTION
## Describe the changes you have made to improve this project

The VisibilityHelper cannot change the visibility of a DataGridColumn, this type does not inherits from FrameworkElement.
I've update the VisibilityHelper to allow this case.

I also updated the sample project to show this feature in use, in the DataGrid view.
