### PR TITLE
Added FallbackValue in XAML for Calendar control styles:

### DIFF
--- a/src/MahApps.Metro/Styles/Controls.Calendar.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Calendar.xaml
@@ -1,9 +1,10 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
 
     <Style x:Key="MahApps.Styles.CalendarDayButton" TargetType="{x:Type CalendarDayButton}">
-        <Setter Property="FontFamily" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontFamily, Mode=OneWay}" />
-        <Setter Property="FontSize" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontSize, Mode=OneWay}" />
+        <Setter Property="FontFamily" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontFamily, Mode=OneWay, FallbackValue={x:Static SystemFonts.MessageFontFamily}}" />
+        <Setter Property="FontSize" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontSize, Mode=OneWay, FallbackValue={x:Static SystemFonts.MessageFontSize}}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="MinHeight" Value="5" />
         <Setter Property="MinWidth" Value="5" />
@@ -102,9 +103,9 @@
                         <!--  IsToday, IsTodayHighlighted and IsSelected  -->
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=IsTodayHighlighted}" Value="True" />
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsToday}" Value="True" />
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=IsTodayHighlighted, FallbackValue=False}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsToday, FallbackValue=False}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected, FallbackValue=False}" Value="True" />
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="DayButtonFocusVisual" Property="Stroke" Value="{DynamicResource MahApps.Brushes.Gray1}" />
                             <Setter TargetName="DayButtonFocusVisual" Property="Visibility" Value="Visible" />
@@ -114,8 +115,8 @@
                         <!--  IsToday and IsTodayHighlighted  -->
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=IsTodayHighlighted}" Value="True" />
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsToday}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=IsTodayHighlighted, FallbackValue=False}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsToday, FallbackValue=False}" Value="True" />
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="NormalText" Property="TextElement.Foreground" Value="{DynamicResource MahApps.Brushes.Selected.Foreground}" />
                             <Setter TargetName="TodayBackground" Property="Opacity" Value="1" />
@@ -291,7 +292,7 @@
                                        FontWeight="Bold"
                                        Foreground="{DynamicResource MahApps.Brushes.ThemeForeground}"
                                        Opacity="0.8"
-                                       Text="{Binding}" />
+                                       Text="{Binding FallbackValue={x:Static system:String.Empty}}" />
                         </DataTemplate>
                     </ControlTemplate.Resources>
                     <Grid x:Name="PART_Root">
@@ -394,11 +395,11 @@
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="PART_DisabledVisual" Property="Visibility" Value="Visible" />
                         </Trigger>
-                        <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}}" Value="Year">
+                        <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, FallbackValue={x:Static Visibility.Hidden}}" Value="Year">
                             <Setter TargetName="PART_MonthView" Property="Visibility" Value="Hidden" />
                             <Setter TargetName="PART_YearView" Property="Visibility" Value="Visible" />
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}}" Value="Decade">
+                        <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, FallbackValue={x:Static Visibility.Hidden}}" Value="Decade">
                             <Setter TargetName="PART_MonthView" Property="Visibility" Value="Hidden" />
                             <Setter TargetName="PART_YearView" Property="Visibility" Value="Visible" />
                         </DataTrigger>
@@ -411,8 +412,8 @@
     <!--  Style for Month and Year buttons  -->
     <Style x:Key="MahApps.Styles.CalendarButton" TargetType="{x:Type CalendarButton}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Accent4}" />
-        <Setter Property="FontFamily" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontFamily, Mode=OneWay}" />
-        <Setter Property="FontSize" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontSize, Mode=OneWay}" />
+        <Setter Property="FontFamily" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontFamily, Mode=OneWay, FallbackValue={x:Static SystemFonts.MessageFontFamily}}" />
+        <Setter Property="FontSize" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=FontSize, Mode=OneWay, FallbackValue={x:Static SystemFonts.MessageFontSize}}" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="MinHeight" Value="42" />
         <Setter Property="MinWidth" Value="40" />

--- a/src/MahApps.Metro/Styles/Controls.Calendar.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Calendar.xaml
@@ -103,7 +103,7 @@
                         <!--  IsToday, IsTodayHighlighted and IsSelected  -->
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=IsTodayHighlighted, FallbackValue=False}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=IsTodayHighlighted, FallbackValue=True}" Value="True" />
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsToday, FallbackValue=False}" Value="True" />
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected, FallbackValue=False}" Value="True" />
                             </MultiDataTrigger.Conditions>
@@ -115,7 +115,7 @@
                         <!--  IsToday and IsTodayHighlighted  -->
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=IsTodayHighlighted, FallbackValue=False}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, Path=IsTodayHighlighted, FallbackValue=True}" Value="True" />
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsToday, FallbackValue=False}" Value="True" />
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="NormalText" Property="TextElement.Foreground" Value="{DynamicResource MahApps.Brushes.Selected.Foreground}" />
@@ -395,11 +395,11 @@
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="PART_DisabledVisual" Property="Visibility" Value="Visible" />
                         </Trigger>
-                        <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, FallbackValue={x:Static Visibility.Hidden}}" Value="Year">
+                        <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, FallbackValue={x:Static CalendarMode.Month}}" Value="Year">
                             <Setter TargetName="PART_MonthView" Property="Visibility" Value="Hidden" />
                             <Setter TargetName="PART_YearView" Property="Visibility" Value="Visible" />
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, FallbackValue={x:Static Visibility.Hidden}}" Value="Decade">
+                        <DataTrigger Binding="{Binding DisplayMode, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Calendar}}, FallbackValue={x:Static CalendarMode.Month}}" Value="Decade">
                             <Setter TargetName="PART_MonthView" Property="Visibility" Value="Hidden" />
                             <Setter TargetName="PART_YearView" Property="Visibility" Value="Visible" />
                         </DataTrigger>

--- a/src/MahApps.Metro/Styles/Controls.Calendar.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Calendar.xaml
@@ -292,7 +292,7 @@
                                        FontWeight="Bold"
                                        Foreground="{DynamicResource MahApps.Brushes.ThemeForeground}"
                                        Opacity="0.8"
-                                       Text="{Binding FallbackValue={x:Static system:String.Empty}}" />
+                                       Text="{Binding}" />
                         </DataTemplate>
                     </ControlTemplate.Resources>
                     <Grid x:Name="PART_Root">


### PR DESCRIPTION
This is to address performance issues when templates & styles are loaded & unloaded from the visual tree - these warnings slow the UI from rendering and can cause animation to stutter - specifically the Calendar control in this case.

This only occur where a Template or Style (MahApps) uses a "{Binding}" without specifying a 'FallbackValue' value.

examples of the messages:

System.Windows.Data Information: 10 :
Cannot retrieve value using the binding and no valid fallback value exists; using default instead. BindingExpression:(no path); DataItem=null; target element is 'TextBlock' (Name=''); target property is 'Text' (type 'String')

System.Windows.Data Information: 10 :
Cannot retrieve value using the binding and no valid fallback value exists; using default instead. BindingExpression:Path=DisplayMode; DataItem=null; target element is 'CalendarItem' (Name='PART_CalendarItem'); target property is 'NoTarget' (type 'Object')

System.Windows.Data Information: 10 :
Cannot retrieve value using the binding and no valid fallback value exists; using default instead. BindingExpression:Path=DisplayMode; DataItem=null; target element is 'CalendarItem' (Name='PART_CalendarItem'); target property is 'NoTarget' (type 'Object')

System.Windows.Data Information: 10 :
Cannot retrieve value using the binding and no valid fallback value exists; using default instead. BindingExpression:Path=FontSize; DataItem=null; target element is 'CalendarDayButton' (Name=''); target property is 'FontSize' (type 'Double')

 System.Windows.Data Information: 10 :
Cannot retrieve value using the binding and no valid fallback value exists; using default instead. BindingExpression:Path=FontFamily; DataItem=null; target element is 'CalendarDayButton' (Name=''); target property is 'FontFamily' (type 'FontFamily')

 System.Windows.Data Information: 10 :
Cannot retrieve value using the binding and no valid fallback value exists; using default instead. BindingExpression:Path=IsTodayHighlighted; DataItem=null; target element is 'CalendarDayButton' (Name=''); target property is 'NoTarget' (type 'Object')

MahApps.Styles.CalendarButton
MahApps.Styles.CalendarDayButton
MahApps.Styles.CalendarItem

## Describe the changes you have made to improve this project

Added FallbackValue to any '{Binding}' in Calendar styles.

## Unit test

XAML changes only - so no unit tests.

## Additional context

Used Snoop with Debug Listener turned on at Information Level.

## Closed Issues
