### PR TITLE
Remove flyout accent theme

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/ViewModels/Flyouts/FlyoutLeftViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/ViewModels/Flyouts/FlyoutLeftViewModel.cs
@@ -12,7 +12,7 @@ namespace Caliburn.Metro.Demo.ViewModels.Flyouts
         {
             this.Header = "left";
             this.Position = Position.Left;
-            this.Theme = FlyoutTheme.Accent;
+            this.Theme = FlyoutTheme.Dark;
         }
     }
 }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/ViewModels/Flyouts/FlyoutTopViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Caliburn.Demo/ViewModels/Flyouts/FlyoutTopViewModel.cs
@@ -12,7 +12,7 @@ namespace Caliburn.Metro.Demo.ViewModels.Flyouts
         {
             this.Header = "Top";
             this.Position = Position.Top;
-            this.Theme = FlyoutTheme.Accent;
+            this.Theme = FlyoutTheme.Inverse;
         }
     }
 }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml
@@ -167,20 +167,6 @@
 
             <exampleWindows:ShowcaseFlyout DataContext="{Binding}" />
 
-            <mah:Flyout Header="Accented"
-                        Position="Right"
-                        Theme="Accent">
-                <Grid Width="400" Margin="10">
-                    <StackPanel>
-                        <TextBlock Text="This flyout adapts its theme to the current accent" />
-                        <GroupBox Height="250"
-                                  Margin="10"
-                                  Header="Flyout Group Box" />
-                        <Button Margin="10" Content="Button" />
-                        <ToggleButton Margin="10" Content="Toggle Button" />
-                    </StackPanel>
-                </Grid>
-            </mah:Flyout>
             <mah:Flyout Header="Inverse"
                         Position="Right"
                         Theme="Inverse">
@@ -402,9 +388,6 @@
             <Button Margin="2"
                     Click="ShowThird"
                     Content="Show 3" />
-            <Button Margin="2"
-                    Click="ShowAccent"
-                    Content="Accent" />
             <Button Margin="2"
                     Click="ShowInverse"
                     Content="Inverse" />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/FlyoutDemo.xaml.cs
@@ -77,54 +77,49 @@ namespace MetroDemo.ExampleWindows
             this.ToggleFlyout(2);
         }
 
-        private void ShowAccent(object sender, RoutedEventArgs e)
+        private void ShowInverse(object sender, RoutedEventArgs e)
         {
             this.ToggleFlyout(3);
         }
 
-        private void ShowInverse(object sender, RoutedEventArgs e)
+        private void ShowAdapt(object sender, RoutedEventArgs e)
         {
             this.ToggleFlyout(4);
         }
 
-        private void ShowAdapt(object sender, RoutedEventArgs e)
+        private void ShowSettings(object sender, RoutedEventArgs e)
         {
             this.ToggleFlyout(5);
         }
 
-        private void ShowSettings(object sender, RoutedEventArgs e)
+        private void ShowLeft(object sender, RoutedEventArgs e)
         {
             this.ToggleFlyout(6);
         }
 
-        private void ShowLeft(object sender, RoutedEventArgs e)
+        private void ShowCustomTop(object sender, RoutedEventArgs e)
         {
             this.ToggleFlyout(7);
         }
 
-        private void ShowCustomTop(object sender, RoutedEventArgs e)
+        private void ShowTop(object sender, RoutedEventArgs e)
         {
             this.ToggleFlyout(8);
         }
 
-        private void ShowTop(object sender, RoutedEventArgs e)
+        private void ShowBottom(object sender, RoutedEventArgs e)
         {
             this.ToggleFlyout(9);
         }
 
-        private void ShowBottom(object sender, RoutedEventArgs e)
+        private void ShowModal(object sender, RoutedEventArgs e)
         {
             this.ToggleFlyout(10);
         }
 
-        private void ShowModal(object sender, RoutedEventArgs e)
-        {
-            this.ToggleFlyout(11);
-        }
-
         private void ShowAppBar(object sender, RoutedEventArgs e)
         {
-            this.ToggleFlyout(12);
+            this.ToggleFlyout(11);
         }
 
         private void CloseMe(object sender, RoutedEventArgs e)

--- a/src/MahApps.Metro/Controls/Flyout.cs
+++ b/src/MahApps.Metro/Controls/Flyout.cs
@@ -681,14 +681,8 @@ namespace MahApps.Metro.Controls
 
             switch (this.Theme)
             {
-                case FlyoutTheme.Accent:
-                    ThemeManager.Current.ApplyThemeResourcesFromTheme(this.Resources, windowTheme);
-                    this.OverrideFlyoutResources(this.Resources, true);
-                    break;
-
                 case FlyoutTheme.Adapt:
                     ThemeManager.Current.ApplyThemeResourcesFromTheme(this.Resources, windowTheme);
-                    this.OverrideFlyoutResources(this.Resources);
                     break;
 
                 case FlyoutTheme.Inverse:
@@ -700,7 +694,6 @@ namespace MahApps.Metro.Controls
                     }
 
                     ThemeManager.Current.ApplyThemeResourcesFromTheme(this.Resources, inverseTheme);
-                    this.OverrideFlyoutResources(this.Resources);
                     break;
 
                 case FlyoutTheme.Dark:
@@ -712,7 +705,6 @@ namespace MahApps.Metro.Controls
                     }
 
                     ThemeManager.Current.ApplyThemeResourcesFromTheme(this.Resources, darkTheme);
-                    this.OverrideFlyoutResources(this.Resources);
                     break;
 
                 case FlyoutTheme.Light:
@@ -724,54 +716,8 @@ namespace MahApps.Metro.Controls
                     }
 
                     ThemeManager.Current.ApplyThemeResourcesFromTheme(this.Resources, lightTheme);
-                    this.OverrideFlyoutResources(this.Resources);
                     break;
             }
-        }
-
-        protected virtual void OverrideFlyoutResources(ResourceDictionary resources, bool accent = false)
-        {
-            var fromColorKey = accent ? "MahApps.Colors.Highlight" : "MahApps.Colors.Flyout";
-
-            resources.BeginInit();
-
-            var fromColor = (Color)resources[fromColorKey];
-            resources["MahApps.Colors.ThemeBackground"] = fromColor;
-            resources["MahApps.Colors.Flyout"] = fromColor;
-
-            var newBrush = new SolidColorBrush(fromColor);
-            newBrush.Freeze();
-            resources["MahApps.Brushes.Flyout.Background"] = newBrush;
-            resources["MahApps.Brushes.Control.Background"] = newBrush;
-            resources["MahApps.Brushes.ThemeBackground"] = newBrush;
-            resources["MahApps.Brushes.Window.Background"] = newBrush;
-            resources[SystemColors.WindowBrushKey] = newBrush;
-
-            if (accent)
-            {
-                fromColor = (Color)resources["MahApps.Colors.IdealForeground"];
-                newBrush = new SolidColorBrush(fromColor);
-                newBrush.Freeze();
-                resources["MahApps.Brushes.Flyout.Foreground"] = newBrush;
-                resources["MahApps.Brushes.Text"] = newBrush;
-
-                if (resources.Contains("MahApps.Colors.AccentBase"))
-                {
-                    fromColor = (Color)resources["MahApps.Colors.AccentBase"];
-                }
-                else
-                {
-                    var accentColor = (Color)resources["MahApps.Colors.Accent"];
-                    fromColor = Color.FromArgb(255, accentColor.R, accentColor.G, accentColor.B);
-                }
-
-                newBrush = new SolidColorBrush(fromColor);
-                newBrush.Freeze();
-                resources["MahApps.Colors.Highlight"] = fromColor;
-                resources["MahApps.Brushes.Highlight"] = newBrush;
-            }
-
-            resources.EndInit();
         }
 
         private void UpdateOpacityChange()

--- a/src/MahApps.Metro/Controls/FlyoutTheme.cs
+++ b/src/MahApps.Metro/Controls/FlyoutTheme.cs
@@ -30,11 +30,6 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Use the light theme for the <see cref="Flyout"/>.
         /// </summary>
-        Light,
-
-        /// <summary>
-        /// The <see cref="Flyout"/> theme will match the host window's accent color.
-        /// </summary>
-        Accent
+        Light
     }
 }


### PR DESCRIPTION
## Describe the changes you have made to improve this project

BREAKING CHANGE: Remove Flyout accent theme

An accent theme background is really complicated to manage. If it's really necessary to use such background then the user can create a special resource theme with the ThemeManager and use it for the Flyout.

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Closed Issues

<!-- Closes #xxxx -->

Closes #4253 
