### PR TITLE
Allow changing the ListView grid header reorder indicator brush

### DIFF
--- a/src/MahApps.Metro/Controls/GridViewHeaderRowPresenterEx.cs
+++ b/src/MahApps.Metro/Controls/GridViewHeaderRowPresenterEx.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using ControlzEx;
+
+namespace MahApps.Metro.Controls
+{
+    public class GridViewHeaderRowPresenterEx : GridViewHeaderRowPresenter
+    {
+        private PropertyChangeNotifier? visibilityPropertyChangeNotifier;
+
+        protected override void OnVisualChildrenChanged(DependencyObject visualAdded, DependencyObject visualRemoved)
+        {
+            base.OnVisualChildrenChanged(visualAdded, visualRemoved);
+
+            if (visualAdded is Separator addedIndicator)
+            {
+                this.visibilityPropertyChangeNotifier = new PropertyChangeNotifier(addedIndicator, Separator.IsVisibleProperty);
+                this.visibilityPropertyChangeNotifier.ValueChanged += (o, e) =>
+                    {
+                        if (o is Separator { IsVisible: true } indicator)
+                        {
+                            var border = indicator.FindChild<Border>();
+                            if (border is not null)
+                            {
+                                var itemsControl = FindItemsControlThroughTemplatedParent(this);
+                                if (itemsControl is not null)
+                                {
+                                    var brush = ItemHelper.GetGridViewHeaderIndicatorBrush(itemsControl) ?? Brushes.Navy;
+                                    border.SetValue(Border.BackgroundProperty, brush);
+                                }
+                            }
+                        }
+                    };
+            }
+        }
+
+        private static ItemsControl? FindItemsControlThroughTemplatedParent(GridViewHeaderRowPresenter presenter)
+        {
+            FrameworkElement? fe = presenter.TemplatedParent as FrameworkElement;
+            ItemsControl? itemsControl = null;
+
+            while (fe != null)
+            {
+                itemsControl = fe as ItemsControl;
+                if (itemsControl != null)
+                {
+                    break;
+                }
+
+                fe = fe.TemplatedParent as FrameworkElement;
+            }
+
+            return itemsControl;
+        }
+    }
+}

--- a/src/MahApps.Metro/Controls/Helper/ItemHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ItemHelper.cs
@@ -684,5 +684,34 @@ namespace MahApps.Metro.Controls
         {
             element.SetValue(MouseRightButtonPressedForegroundBrushProperty, value);
         }
+
+        /// <summary>
+        /// Gets or sets the brush which will be used when the indicator of the <see cref="GridViewHeaderRowPresenter"/> become visible. 
+        /// </summary>
+        public static readonly DependencyProperty GridViewHeaderIndicatorBrushProperty
+            = DependencyProperty.RegisterAttached(
+                "GridViewHeaderIndicatorBrush",
+                typeof(Brush),
+                typeof(ItemHelper),
+                new FrameworkPropertyMetadata(null));
+
+        /// <summary>Helper for getting <see cref="GridViewHeaderIndicatorBrushProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="UIElement"/> to read <see cref="GridViewHeaderIndicatorBrushProperty"/> from.</param>
+        /// <returns>The brush which will be used when the indicator of the <see cref="GridViewHeaderRowPresenter"/> become visible.</returns>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(ListView))]
+        public static Brush? GetGridViewHeaderIndicatorBrush(UIElement element)
+        {
+            return (Brush?)element.GetValue(GridViewHeaderIndicatorBrushProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="GridViewHeaderIndicatorBrushProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="UIElement"/> to set <see cref="GridViewHeaderIndicatorBrushProperty"/> on.</param>
+        /// <param name="value">The brush which will be used when the indicator of the <see cref="GridViewHeaderRowPresenter"/> become visible.</param>
+        [AttachedPropertyBrowsableForType(typeof(ListView))]
+        public static void SetGridViewHeaderIndicatorBrush(UIElement element, Brush? value)
+        {
+            element.SetValue(GridViewHeaderIndicatorBrushProperty, value);
+        }
     }
 }

--- a/src/MahApps.Metro/Styles/Controls.ListView.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ListView.xaml
@@ -25,17 +25,17 @@
                                           HorizontalScrollBarVisibility="Hidden"
                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                           VerticalScrollBarVisibility="Hidden">
-                                <GridViewHeaderRowPresenter x:Name="PART_HeaderRowPresenter"
-                                                            Margin="2 0 2 0"
-                                                            AllowsColumnReorder="{Binding TemplatedParent.View.AllowsColumnReorder, RelativeSource={RelativeSource TemplatedParent}}"
-                                                            ColumnHeaderContainerStyle="{Binding TemplatedParent.View.ColumnHeaderContainerStyle, RelativeSource={RelativeSource TemplatedParent}}"
-                                                            ColumnHeaderContextMenu="{Binding TemplatedParent.View.ColumnHeaderContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
-                                                            ColumnHeaderStringFormat="{Binding TemplatedParent.View.ColumnHeaderStringFormat, RelativeSource={RelativeSource TemplatedParent}}"
-                                                            ColumnHeaderTemplate="{Binding TemplatedParent.View.ColumnHeaderTemplate, RelativeSource={RelativeSource TemplatedParent}}"
-                                                            ColumnHeaderTemplateSelector="{Binding TemplatedParent.View.ColumnHeaderTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}"
-                                                            ColumnHeaderToolTip="{Binding TemplatedParent.View.ColumnHeaderToolTip, RelativeSource={RelativeSource TemplatedParent}}"
-                                                            Columns="{Binding TemplatedParent.View.Columns, RelativeSource={RelativeSource TemplatedParent}}"
-                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                <mah:GridViewHeaderRowPresenterEx x:Name="PART_HeaderRowPresenter"
+                                                                  Margin="2 0 2 0"
+                                                                  AllowsColumnReorder="{Binding TemplatedParent.View.AllowsColumnReorder, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                  ColumnHeaderContainerStyle="{Binding TemplatedParent.View.ColumnHeaderContainerStyle, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                  ColumnHeaderContextMenu="{Binding TemplatedParent.View.ColumnHeaderContextMenu, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                  ColumnHeaderStringFormat="{Binding TemplatedParent.View.ColumnHeaderStringFormat, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                  ColumnHeaderTemplate="{Binding TemplatedParent.View.ColumnHeaderTemplate, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                  ColumnHeaderTemplateSelector="{Binding TemplatedParent.View.ColumnHeaderTemplateSelector, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                  ColumnHeaderToolTip="{Binding TemplatedParent.View.ColumnHeaderToolTip, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                  Columns="{Binding TemplatedParent.View.Columns, RelativeSource={RelativeSource TemplatedParent}}"
+                                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </ScrollViewer>
                             <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
                                                     CanContentScroll="{TemplateBinding CanContentScroll}"
@@ -91,7 +91,7 @@
     <!--
         Do not set CanContentScroll=True below. This breaks the scrolling for groups with more items that will fit on screen.
         It also (setting True) has the ugly side effect of scrolling the entire group and not the items. The downside is we lose
-        virtualisation http://serialseb.blogspot.com/2007/09/wpf-tips-7-smooth-scrolling.html
+        virtualization http://serialseb.blogspot.com/2007/09/wpf-tips-7-smooth-scrolling.html
     -->
     <Style x:Key="MahApps.Styles.ListView" TargetType="{x:Type ListView}">
         <Setter Property="AlternationCount" Value="2" />
@@ -138,13 +138,14 @@
             </Setter.Value>
         </Setter>
         <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="mah:ItemHelper.GridViewHeaderIndicatorBrush" Value="{DynamicResource MahApps.Brushes.AccentBase}" />
     </Style>
 
     <Style x:Key="MahApps.Styles.ListView.Virtualized"
            BasedOn="{StaticResource MahApps.Styles.ListView}"
            TargetType="{x:Type ListView}">
         <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
-        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="True" />
+        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
         <Setter Property="VirtualizingStackPanel.IsVirtualizing" Value="True" />
         <Setter Property="VirtualizingStackPanel.IsVirtualizingWhenGrouping" Value="True" />
         <Setter Property="VirtualizingStackPanel.VirtualizationMode" Value="Recycling" />


### PR DESCRIPTION
## Describe the changes you have made to improve this project

The column reorder indicator of the `GridViewHeaderRowPresenter` is hard coded and can not easily change by the user. Especially the brush of the inner border can not be changed.

So we added a new attached property to the `ItemHelper` called `GridViewHeaderIndicatorBrush`.

![2022-02-17_11h08_07](https://user-images.githubusercontent.com/658431/154453973-02d657b3-3635-4c76-a819-4438a29d4660.png)

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Additional context

The default value for `ItemHelper.GridViewHeaderIndicatorBrush` is `MahApps.Brushes.AccentBase`.

![2022-02-17_11h09_41](https://user-images.githubusercontent.com/658431/154454148-cf735450-f270-4e94-846f-671ddd36c90e.png)

<!-- Add any other context or screenshots about the feature request here. -->
