### PR TITLE
Fix scrolling and width of RichTextBox

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -195,6 +195,11 @@
                   Header="RichTextBox"
                   UseLayoutRounding="True">
             <StackPanel>
+                <RichTextBox Margin="{StaticResource ControlMargin}" ScrollViewer.HorizontalScrollBarVisibility="Auto">
+                    <FlowDocument PageWidth="NaN">
+                        <Paragraph>Hello</Paragraph>
+                    </FlowDocument>
+                </RichTextBox>
                 <RichTextBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.ClearTextButton="True"
                              mah:TextBoxHelper.Watermark="Type something in..."
@@ -215,52 +220,44 @@
                              Style="{StaticResource MahApps.Styles.RichTextBox.Button}" />
                 <RichTextBox Height="120"
                              Margin="{StaticResource ControlMargin}"
-                             Padding="5"
                              mah:TextBoxHelper.SelectAllOnFocus="True"
                              IsDocumentEnabled="True"
                              SpellCheck.IsEnabled="True">
-                    <!--
-                        Workaround for: RichTextBox behaves oddly inside a ScrollViewer
-                        
-                        The workaround would be to bind the Documents PageWidth to the RichTextBox's ActualWidth
-                    -->
-                    <FlowDocument PageWidth="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type RichTextBox}}, Path=ActualWidth}">
+                    <FlowDocument>
                         <Paragraph>
                             <Hyperlink NavigateUri="https://github.com/MahApps/MahApps.Metro">
                                 <Run Text="Normal" />
                             </Hyperlink>
                             <LineBreak />
-                            <Run>Bacon ipsum dolor sit amet venison drumstick meatball ham hock corned beef. Strip steak bacon andouille pig beef short ribs.</Run>
+                            <Run>Cupcake ipsum dolor sit amet dessert halvah dessert. Chocolate oat cake carrot cake sweet dragée gummi bears chocolate.</Run>
                         </Paragraph>
                     </FlowDocument>
                 </RichTextBox>
                 <RichTextBox Height="120"
                              Margin="{StaticResource ControlMargin}"
-                             Padding="5"
                              IsDocumentEnabled="True"
                              IsReadOnly="True">
-                    <FlowDocument PageWidth="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type RichTextBox}}, Path=ActualWidth}">
+                    <FlowDocument>
                         <Paragraph>
                             <Hyperlink NavigateUri="https://github.com/MahApps/MahApps.Metro">
                                 <Run Text="ReadOnly" />
                             </Hyperlink>
                             <LineBreak />
-                            <Run>Bacon ipsum dolor sit amet venison drumstick meatball ham hock corned beef. Strip steak bacon andouille pig beef short ribs.</Run>
+                            <Run>Cupcake ipsum dolor sit amet dessert halvah dessert. Chocolate oat cake carrot cake sweet dragée gummi bears chocolate.</Run>
                         </Paragraph>
                     </FlowDocument>
                 </RichTextBox>
                 <RichTextBox Height="120"
                              Margin="{StaticResource ControlMargin}"
-                             Padding="5"
                              IsDocumentEnabled="True"
                              IsEnabled="False">
-                    <FlowDocument PageWidth="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type RichTextBox}}, Path=ActualWidth}">
+                    <FlowDocument>
                         <Paragraph>
                             <Hyperlink NavigateUri="https://github.com/MahApps/MahApps.Metro">
                                 <Run Text="Disabled" />
                             </Hyperlink>
                             <LineBreak />
-                            <Run>Bacon ipsum dolor sit amet venison drumstick meatball ham hock corned beef. Strip steak bacon andouille pig beef short ribs.</Run>
+                            <Run>Cupcake ipsum dolor sit amet dessert halvah dessert. Chocolate oat cake carrot cake sweet dragée gummi bears chocolate.</Run>
                         </Paragraph>
                     </FlowDocument>
                 </RichTextBox>

--- a/src/MahApps.Metro/Controls/Helper/ScrollViewerHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ScrollViewerHelper.cs
@@ -14,12 +14,30 @@ namespace MahApps.Metro.Controls
 {
     public static class ScrollViewerHelper
     {
+        public static readonly DependencyProperty ScrollContentPresenterMarginProperty
+            = DependencyProperty.RegisterAttached(
+                "ScrollContentPresenterMargin",
+                typeof(Thickness),
+                typeof(ScrollViewerHelper));
+
+        [AttachedPropertyBrowsableForType(typeof(ScrollViewer))]
+        public static Thickness GetScrollContentPresenterMargin(ScrollViewer scrollViewer)
+        {
+            return (Thickness)scrollViewer.GetValue(ScrollContentPresenterMarginProperty);
+        }
+
+        [AttachedPropertyBrowsableForType(typeof(ScrollViewer))]
+        public static void SetScrollContentPresenterMargin(ScrollViewer scrollViewer, Thickness value)
+        {
+            scrollViewer.SetValue(ScrollContentPresenterMarginProperty, value);
+        }
+
         /// <summary>
         /// Identifies the VerticalScrollBarOnLeftSide attached property.
         /// This property can be used to set vertical scrollbar left side from the tabpanel (look at MetroAnimatedSingleRowTabControl)
         /// </summary>
-        public static readonly DependencyProperty VerticalScrollBarOnLeftSideProperty =
-            DependencyProperty.RegisterAttached(
+        public static readonly DependencyProperty VerticalScrollBarOnLeftSideProperty
+            = DependencyProperty.RegisterAttached(
                 "VerticalScrollBarOnLeftSide",
                 typeof(bool),
                 typeof(ScrollViewerHelper),
@@ -48,8 +66,8 @@ namespace MahApps.Metro.Controls
         /// <summary>
         /// Identifies the IsHorizontalScrollWheelEnabled attached property.
         /// </summary>
-        public static readonly DependencyProperty IsHorizontalScrollWheelEnabledProperty =
-            DependencyProperty.RegisterAttached(
+        public static readonly DependencyProperty IsHorizontalScrollWheelEnabledProperty
+            = DependencyProperty.RegisterAttached(
                 "IsHorizontalScrollWheelEnabled",
                 typeof(bool),
                 typeof(ScrollViewerHelper),

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -41,7 +41,8 @@
                                           Background="{x:Null}"
                                           BorderThickness="0"
                                           IsTabStop="False"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
 
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"

--- a/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -284,7 +284,8 @@
                                       BorderThickness="0"
                                       FocusVisualStyle="{x:Null}"
                                       IsTabStop="False"
-                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                      Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
 
                         <ContentControl x:Name="PART_Watermark"
                                         Margin="4 0"

--- a/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -121,7 +121,9 @@
                                           VerticalAlignment="Stretch"
                                           Background="{x:Null}"
                                           BorderThickness="0"
-                                          IsTabStop="False" />
+                                          IsTabStop="False"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
 
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
@@ -365,7 +367,9 @@
                                           VerticalAlignment="Stretch"
                                           Background="{x:Null}"
                                           BorderThickness="0"
-                                          IsTabStop="False" />
+                                          IsTabStop="False"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
 
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
@@ -565,7 +569,8 @@
                                       Background="{x:Null}"
                                       BorderThickness="0"
                                       IsTabStop="False"
-                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                      Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
@@ -617,7 +622,9 @@
                                           VerticalAlignment="Stretch"
                                           Background="{x:Null}"
                                           BorderThickness="0"
-                                          IsTabStop="False" />
+                                          IsTabStop="False"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
 
                             <TextBox x:Name="RevealedPassword"
                                      Grid.Row="1"

--- a/src/MahApps.Metro/Styles/Controls.Scrollbars.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Scrollbars.xaml
@@ -261,22 +261,24 @@
                         <ScrollBar x:Name="PART_VerticalScrollBar"
                                    Grid.Row="0"
                                    Grid.Column="1"
+                                   AutomationProperties.AutomationId="VerticalScrollBar"
                                    Cursor="Arrow"
                                    Maximum="{TemplateBinding ScrollableHeight}"
                                    Minimum="0"
                                    ViewportSize="{TemplateBinding ViewportHeight}"
                                    Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-                                   Value="{Binding VerticalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                                   Value="{TemplateBinding VerticalOffset}" />
                         <ScrollBar x:Name="PART_HorizontalScrollBar"
                                    Grid.Row="1"
                                    Grid.Column="0"
+                                   AutomationProperties.AutomationId="HorizontalScrollBar"
                                    Cursor="Arrow"
                                    Maximum="{TemplateBinding ScrollableWidth}"
                                    Minimum="0"
                                    Orientation="Horizontal"
                                    ViewportSize="{TemplateBinding ViewportWidth}"
                                    Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
-                                   Value="{Binding HorizontalOffset, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                                   Value="{TemplateBinding HorizontalOffset}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="mah:ScrollViewerHelper.VerticalScrollBarOnLeftSide" Value="True">
@@ -292,5 +294,69 @@
         </Setter>
         <Setter Property="mah:ScrollViewerHelper.VerticalScrollBarOnLeftSide" Value="False" />
     </Style>
+
+    <Style x:Key="MahApps.Styles.ScrollViewer.TextControlContentHost"
+           BasedOn="{StaticResource MahApps.Styles.ScrollViewer}"
+           TargetType="{x:Type ScrollViewer}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                    <Grid x:Name="Grid" Background="{TemplateBinding Background}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition x:Name="leftColumn" Width="*" />
+                            <ColumnDefinition x:Name="rightColumn" Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Border Grid.Row="0"
+                                Grid.Column="0"
+                                Padding="{TemplateBinding Padding}">
+                            <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
+                                                    Margin="{TemplateBinding mah:ScrollViewerHelper.ScrollContentPresenterMargin}"
+                                                    CanContentScroll="{TemplateBinding CanContentScroll}"
+                                                    CanHorizontallyScroll="False"
+                                                    CanVerticallyScroll="False"
+                                                    Content="{TemplateBinding Content}"
+                                                    ContentTemplate="{TemplateBinding ContentTemplate}" />
+                        </Border>
+                        <ScrollBar x:Name="PART_VerticalScrollBar"
+                                   Grid.Row="0"
+                                   Grid.Column="1"
+                                   AutomationProperties.AutomationId="VerticalScrollBar"
+                                   Cursor="Arrow"
+                                   Maximum="{TemplateBinding ScrollableHeight}"
+                                   Minimum="0"
+                                   ViewportSize="{TemplateBinding ViewportHeight}"
+                                   Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                                   Value="{TemplateBinding VerticalOffset}" />
+                        <ScrollBar x:Name="PART_HorizontalScrollBar"
+                                   Grid.Row="1"
+                                   Grid.Column="0"
+                                   AutomationProperties.AutomationId="HorizontalScrollBar"
+                                   Cursor="Arrow"
+                                   Maximum="{TemplateBinding ScrollableWidth}"
+                                   Minimum="0"
+                                   Orientation="Horizontal"
+                                   ViewportSize="{TemplateBinding ViewportWidth}"
+                                   Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
+                                   Value="{TemplateBinding HorizontalOffset}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="mah:ScrollViewerHelper.VerticalScrollBarOnLeftSide" Value="True">
+                            <Setter TargetName="PART_HorizontalScrollBar" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_ScrollContentPresenter" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_VerticalScrollBar" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="leftColumn" Property="Width" Value="Auto" />
+                            <Setter TargetName="rightColumn" Property="Width" Value="*" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="mah:ScrollViewerHelper.ScrollContentPresenterMargin" Value="-2 0" />
+    </Style>
+
 
 </ResourceDictionary>

--- a/src/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -64,7 +64,8 @@
                                           Background="{x:Null}"
                                           BorderThickness="0"
                                           IsTabStop="False"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
 
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
@@ -301,7 +302,9 @@
                                           VerticalAlignment="Stretch"
                                           Background="{x:Null}"
                                           BorderThickness="0"
-                                          IsTabStop="False" />
+                                          IsTabStop="False"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
 
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
@@ -537,7 +540,7 @@
                 <Setter Property="FontStyle" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type RichTextBox}}, Path=FontStyle}" />
                 <Setter Property="FontWeight" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type RichTextBox}}, Path=FontWeight}" />
                 <Setter Property="Language" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type RichTextBox}}, Path=Language}" />
-                <Setter Property="PageWidth" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type RichTextBox}}, Path=ActualWidth}" />
+                <Setter Property="OverridesDefaultStyle" Value="True" />
             </Style>
         </Style.Resources>
         <Setter Property="AllowDrop" Value="True" />
@@ -550,9 +553,12 @@
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="MinHeight" Value="26" />
         <Setter Property="MinWidth" Value="10" />
-        <Setter Property="Padding" Value="2 4" />
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Padding" Value="4" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
         <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
@@ -561,7 +567,7 @@
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="{x:Type TextBoxBase}">
+                <ControlTemplate TargetType="{x:Type RichTextBox}">
                     <Grid>
                         <Border x:Name="BorderElement"
                                 Background="{TemplateBinding Background}"
@@ -580,16 +586,24 @@
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
 
-                            <ScrollViewer x:Name="PART_ContentHost"
-                                          Grid.Row="1"
-                                          Grid.Column="0"
-                                          Margin="0"
-                                          Padding="{TemplateBinding Padding}"
-                                          VerticalAlignment="Stretch"
-                                          Background="{x:Null}"
-                                          BorderThickness="0"
-                                          IsTabStop="False"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <Grid x:Name="PART_GridContentHost"
+                                  Grid.Row="1"
+                                  Grid.Column="0">
+                                <ScrollViewer x:Name="PART_ContentHost"
+                                              Width="{Binding ElementName=PART_GridContentHost, Path=ActualWidth}"
+                                              Margin="0"
+                                              Padding="{TemplateBinding Padding}"
+                                              VerticalAlignment="Stretch"
+                                              mah:ScrollViewerHelper.ScrollContentPresenterMargin="-5 -1 -1 -1"
+                                              Background="{x:Null}"
+                                              BorderThickness="0"
+                                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                              IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                                              IsTabStop="False"
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                              Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}"
+                                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+                            </Grid>
 
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
@@ -677,8 +691,8 @@
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Left">
                             <Setter TargetName="ButtonColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_ClearText" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_ContentHost" Property="Grid.Column" Value="1" />
                             <Setter TargetName="PART_FloatingMessageContainer" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_GridContentHost" Property="Grid.Column" Value="1" />
                             <Setter TargetName="PART_Message" Property="Grid.Column" Value="1" />
                             <Setter TargetName="TextColumn" Property="Width" Value="Auto" />
                         </DataTrigger>
@@ -707,7 +721,7 @@
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Right" />
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ClearTextButton)}" Value="False" />
                             </MultiDataTrigger.Conditions>
-                            <Setter TargetName="PART_ContentHost" Property="Grid.ColumnSpan" Value="2" />
+                            <Setter TargetName="PART_GridContentHost" Property="Grid.ColumnSpan" Value="2" />
                             <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
                         </MultiDataTrigger>
 
@@ -792,21 +806,29 @@
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
 
-                            <ScrollViewer x:Name="PART_ContentHost"
-                                          Grid.Row="1"
-                                          Grid.Column="0"
-                                          Margin="0"
-                                          Padding="{TemplateBinding Padding}"
-                                          VerticalAlignment="Stretch"
-                                          Background="{x:Null}"
-                                          BorderThickness="0"
-                                          IsTabStop="False"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <Grid x:Name="PART_GridContentHost"
+                                  Grid.Row="1"
+                                  Grid.Column="0">
+                                <ScrollViewer x:Name="PART_ContentHost"
+                                              Width="{Binding ElementName=PART_GridContentHost, Path=ActualWidth}"
+                                              Margin="0"
+                                              Padding="{TemplateBinding Padding}"
+                                              VerticalAlignment="Stretch"
+                                              mah:ScrollViewerHelper.ScrollContentPresenterMargin="-5 -1 -1 -1"
+                                              Background="{x:Null}"
+                                              BorderThickness="0"
+                                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                              IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                                              IsTabStop="False"
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                              Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}"
+                                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+                            </Grid>
 
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
                                        Grid.Column="0"
-                                       Margin="6 0"
+                                       Margin="4 0"
                                        Padding="{TemplateBinding Padding}"
                                        HorizontalAlignment="Stretch"
                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -892,8 +914,8 @@
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Left">
                             <Setter TargetName="ButtonColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_ClearText" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_ContentHost" Property="Grid.Column" Value="1" />
                             <Setter TargetName="PART_FloatingMessageContainer" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_GridContentHost" Property="Grid.Column" Value="1" />
                             <Setter TargetName="PART_Message" Property="Grid.Column" Value="1" />
                             <Setter TargetName="TextColumn" Property="Width" Value="Auto" />
                         </DataTrigger>
@@ -915,6 +937,15 @@
                             <MultiDataTrigger.ExitActions>
                                 <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.HideFloatingMessage}" />
                             </MultiDataTrigger.ExitActions>
+                        </MultiDataTrigger>
+
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Right" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.TextButton)}" Value="False" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_GridContentHost" Property="Grid.ColumnSpan" Value="2" />
+                            <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
                         </MultiDataTrigger>
 
                         <Trigger Property="IsMouseOver" Value="True">

--- a/src/MahApps.Metro/Styles/VS/TextBox.xaml
+++ b/src/MahApps.Metro/Styles/VS/TextBox.xaml
@@ -13,11 +13,13 @@
                 <ControlTemplate TargetType="{x:Type TextBox}">
                     <Grid Background="{TemplateBinding Background}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                         <ScrollViewer x:Name="PART_ContentHost"
-                                      Margin="{TemplateBinding Padding}"
+                                      Margin="0"
+                                      Padding="{TemplateBinding Padding}"
                                       Background="{x:Null}"
                                       BorderThickness="0"
                                       IsTabStop="False"
-                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                      Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="true">
@@ -47,11 +49,13 @@
                                    Text="Search ..."
                                    Visibility="Hidden" />
                         <ScrollViewer x:Name="PART_ContentHost"
-                                      Margin="{TemplateBinding Padding}"
+                                      Margin="0"
+                                      Padding="{TemplateBinding Padding}"
                                       Background="{x:Null}"
                                       BorderThickness="0"
                                       IsTabStop="False"
-                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                      Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="TextBox.Text" Value="">


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Remove the workaround for Documents PageWidth. The main problem here is that a RichTextBox inside a ScrollViewer with horizontal scrolling is still broken. The RichTextBox will wrap the text after each letter.

To solve this the ScrollViewer binds now the Width to the parent ActualWidth of a Grid.

Additional the wrong Margin of the ScrollViewer host for all text controls will be fixed by using the new attached property `ScrollViewerHelper.ScrollContentPresenterMargin`.

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Closed Issues

<!-- Closes #xxxx -->

Closes #4124 
