### PR TITLE
Add clear/custom button command to all input controls

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/DateExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/DateExamples.xaml
@@ -44,7 +44,7 @@
                             SelectedDate="{x:Static system:DateTime.Now}" />
                 <DatePicker Width="200"
                             Margin="{StaticResource ControlMargin}"
-                            mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd}"
+                            mah:TextBoxHelper.ButtonCommand="{Binding ControlButtonCommand}"
                             mah:TextBoxHelper.ButtonCommandParameter="{Binding RelativeSource={RelativeSource Self}}"
                             mah:TextBoxHelper.Watermark="" />
                 <DatePicker Width="200"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/MultiSelectionComboBoxExample.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/MultiSelectionComboBoxExample.xaml
@@ -196,8 +196,8 @@
                                       IsReadOnly="True"
                                       SelectedIndex="0"
                                       ToolTip="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Text}">
-                                <ComboBoxItem Content="Default: MahApps.Styles.MulitselectionComboBoxSelectedItem" Tag="{DynamicResource MahApps.Styles.MulitselectionComboBoxSelectedItem}" />
-                                <ComboBoxItem Content="Removeable: MahApps.Styles.MulitselectionComboBoxSelectedItem.Removeable" Tag="{StaticResource MahApps.Styles.MulitselectionComboBoxSelectedItem.Removeable}" />
+                                <ComboBoxItem Content="Default: MahApps.Styles.MultiSelectionComboBoxSelectedItem" Tag="{DynamicResource MahApps.Styles.MultiSelectionComboBoxSelectedItem}" />
+                                <ComboBoxItem Content="Removable: MahApps.Styles.MultiSelectionComboBoxSelectedItem.Removable" Tag="{StaticResource MahApps.Styles.MultiSelectionComboBoxSelectedItem.Removable}" />
                             </ComboBox>
                         </mah:MetroHeader>
                     </StackPanel>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SelectionExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/SelectionExamples.xaml
@@ -253,6 +253,28 @@
                         <ComboBoxItem Content="Item 4" />
                     </ComboBox>
 
+                    <!--  Entypo MagnifyingGlass  -->
+                    <ComboBox Width="200"
+                              Margin="{StaticResource ControlMargin}"
+                              mah:TextBoxHelper.ButtonCommand="{Binding ControlButtonCommand, Mode=OneWay}"
+                              mah:TextBoxHelper.ButtonContent="M17.545,15.467l-3.779-3.779c0.57-0.935,0.898-2.035,0.898-3.21c0-3.417-2.961-6.377-6.378-6.377  C4.869,2.1,2.1,4.87,2.1,8.287c0,3.416,2.961,6.377,6.377,6.377c1.137,0,2.2-0.309,3.115-0.844l3.799,3.801  c0.372,0.371,0.975,0.371,1.346,0l0.943-0.943C18.051,16.307,17.916,15.838,17.545,15.467z M4.004,8.287  c0-2.366,1.917-4.283,4.282-4.283c2.366,0,4.474,2.107,4.474,4.474c0,2.365-1.918,4.283-4.283,4.283  C6.111,12.76,4.004,10.652,4.004,8.287z"
+                              mah:TextBoxHelper.Watermark="Please select an item..."
+                              SelectedIndex="0">
+                        <mah:TextBoxHelper.ButtonContentTemplate>
+                            <DataTemplate>
+                                <mah:PathIcon Width="{Binding RelativeSource={RelativeSource AncestorType=ComboBox}, Path=(mah:TextBoxHelper.ButtonWidth), Mode=OneWay}"
+                                              Height="{Binding RelativeSource={RelativeSource AncestorType=ComboBox}, Path=(mah:TextBoxHelper.ButtonWidth), Mode=OneWay}"
+                                              Padding="3"
+                                              Data="{Binding Mode=OneWay}" />
+                            </DataTemplate>
+                        </mah:TextBoxHelper.ButtonContentTemplate>
+                        <ComboBoxItem Content="Item 1" />
+                        <ComboBoxItem Content="Item 2" />
+                        <ComboBoxItem Content="Very long Item 3 for MahApps.Metro" />
+                        <ComboBoxItem Content="Item 4" />
+                        <ComboBoxItem Content="Item 4" />
+                    </ComboBox>
+
                     <ComboBox Width="200"
                               Margin="{StaticResource ControlMargin}"
                               SelectedIndex="0">
@@ -308,7 +330,7 @@
                     <ComboBox Width="200"
                               Margin="{StaticResource ControlMargin}"
                               mah:TextBoxHelper.UseFloatingWatermark="True"
-                              mah:TextBoxHelper.Watermark="Autocompletion"
+                              mah:TextBoxHelper.Watermark="Auto completion"
                               DisplayMemberPath="Title"
                               IsEditable="True"
                               ItemsSource="{Binding Albums}"
@@ -319,7 +341,7 @@
                     <ComboBox x:Name="groupingComboBox"
                               Width="200"
                               Margin="{StaticResource ControlMargin}"
-                              mah:TextBoxHelper.Watermark="Autocompletion with grouping"
+                              mah:TextBoxHelper.Watermark="Auto completion with grouping"
                               DisplayMemberPath="Title"
                               IsEditable="True"
                               IsEnabled="True"
@@ -348,7 +370,7 @@
                     </ComboBox>
                     <ComboBox Width="200"
                               Margin="0 10 0 0"
-                              mah:TextBoxHelper.Watermark="Autocompletion"
+                              mah:TextBoxHelper.Watermark="Auto completion"
                               DisplayMemberPath="Title"
                               IsEditable="True"
                               IsEnabled="False"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -216,8 +216,7 @@
                              mah:TextBoxHelper.ButtonContent="s"
                              mah:TextBoxHelper.Watermark="Type in..."
                              IsDocumentEnabled="True"
-                             SpellCheck.IsEnabled="True"
-                             Style="{StaticResource MahApps.Styles.RichTextBox.Button}" />
+                             SpellCheck.IsEnabled="True" />
                 <RichTextBox Height="120"
                              Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.SelectAllOnFocus="True"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -69,6 +69,13 @@
                   UseLayoutRounding="True">
             <AdornerDecorator>
                 <StackPanel>
+                    <TextBox Margin="{StaticResource ControlMargin}"
+                             mah:TextBoxHelper.ClearTextButton="True"
+                             Text="Clear with Escape">
+                        <TextBox.InputBindings>
+                            <KeyBinding Key="Escape" Command="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
+                        </TextBox.InputBindings>
+                    </TextBox>
                     <mah:MetroHeader Margin="{StaticResource ControlMargin}" Header="TextBox Header">
                         <mah:MetroHeader.HeaderTemplate>
                             <DataTemplate>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -276,33 +276,31 @@
                   UseLayoutRounding="True">
             <StackPanel>
                 <PasswordBox Margin="{StaticResource ControlMargin}"
-                             mah:TextBoxHelper.Watermark="Password"
+                             mah:TextBoxHelper.Watermark="Password..."
                              Password="Password" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.ClearTextButton="True"
                              mah:TextBoxHelper.UseFloatingWatermark="True"
-                             mah:TextBoxHelper.Watermark="Win8"
+                             mah:TextBoxHelper.Watermark="Win8..."
                              Password="Win8"
                              Style="{StaticResource MahApps.Styles.PasswordBox.Win8}" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.ClearTextButton="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.HasText), Mode=OneWay}"
                              mah:TextBoxHelper.IsWaitingForData="True"
                              mah:TextBoxHelper.UseFloatingWatermark="True"
-                             mah:TextBoxHelper.Watermark="Revealed PasswordBox"
-                             Style="{StaticResource MahApps.Styles.PasswordBox.Button.Revealed}" />
+                             mah:TextBoxHelper.Watermark="Revealed..."
+                             Style="{StaticResource MahApps.Styles.PasswordBox.Revealed}" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
-                             mah:TextBoxHelper.ClearTextButton="True"
                              mah:TextBoxHelper.UseFloatingWatermark="True"
-                             mah:TextBoxHelper.Watermark="Password"
+                             mah:TextBoxHelper.Watermark="Password..."
                              Password="Password" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"
                              mah:PasswordBoxHelper.CapsLockIcon="!"
                              mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
                              mah:TextBoxHelper.ButtonContent="4"
                              mah:TextBoxHelper.UseFloatingWatermark="True"
-                             mah:TextBoxHelper.Watermark="Custom icon style"
-                             Style="{DynamicResource MahApps.Styles.PasswordBox.Button}">
+                             mah:TextBoxHelper.Watermark="Custom icon...">
                     <mah:PasswordBoxHelper.CapsLockWarningToolTip>
                         <TextBlock>
                             <Run Text="This is a custom Warning to show you that" />
@@ -320,8 +318,6 @@
                              mah:TextBoxHelper.ClearTextButton="True"
                              IsEnabled="False"
                              Password="Password" />
-
-                <Label Content="Select all on focus" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.SelectAllOnFocus="True"
                              Password="Password"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -96,7 +96,7 @@
                              mah:TextBoxHelper.Watermark="Watermark"
                              mah:TextBoxHelper.WatermarkAlignment="Right"
                              SpellCheck.IsEnabled="True"
-                             ToolTip="Default alignment">
+                             ToolTip="WatermarkAlignment Right">
                         <TextBox.ContextMenu>
                             <ContextMenu>
                                 <MenuItem Header="Custom Item" />
@@ -108,9 +108,8 @@
                         </TextBox.ContextMenu>
                     </TextBox>
                     <TextBox Margin="{StaticResource ControlMargin}"
-                             mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
                              ContextMenu="{x:Null}"
-                             Text="Clear button and no ContextMenu">
+                             Text="No ContextMenu...">
                         <TextBox.Style>
                             <Style BasedOn="{StaticResource MahApps.Styles.TextBox}" TargetType="{x:Type TextBox}">
                                 <Setter Property="mah:TextBoxHelper.ClearTextButton" Value="True" />
@@ -128,7 +127,6 @@
                     </TextBox>
                     <TextBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
-                             mah:TextBoxHelper.ClearTextButton="True"
                              mah:TextBoxHelper.UseFloatingWatermark="True"
                              mah:TextBoxHelper.Watermark="Search...">
                         <TextBox.InputBindings>
@@ -142,24 +140,32 @@
                                     <Trigger Property="mah:TextBoxHelper.HasText" Value="True">
                                         <Setter Property="mah:TextBoxHelper.ButtonContent" Value="r" />
                                         <Setter Property="mah:TextBoxHelper.ButtonContentTemplate" Value="{x:Null}" />
+                                        <Setter Property="mah:TextBoxHelper.ClearTextButton" Value="True" />
                                     </Trigger>
                                 </Style.Triggers>
                             </Style>
                         </TextBox.Style>
                     </TextBox>
                     <!--  Entypo MagnifyingGlass  -->
-                    <TextBox Name="test2"
-                             Margin="{StaticResource ControlMargin}"
+                    <TextBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmdWithParameter, Mode=OneWay}"
-                             mah:TextBoxHelper.ButtonCommandParameter="{Binding ElementName=test2, Path=Text}"
                              mah:TextBoxHelper.ButtonContent="M17.545,15.467l-3.779-3.779c0.57-0.935,0.898-2.035,0.898-3.21c0-3.417-2.961-6.377-6.378-6.377  C4.869,2.1,2.1,4.87,2.1,8.287c0,3.416,2.961,6.377,6.377,6.377c1.137,0,2.2-0.309,3.115-0.844l3.799,3.801  c0.372,0.371,0.975,0.371,1.346,0l0.943-0.943C18.051,16.307,17.916,15.838,17.545,15.467z M4.004,8.287  c0-2.366,1.917-4.283,4.282-4.283c2.366,0,4.474,2.107,4.474,4.474c0,2.365-1.918,4.283-4.283,4.283  C6.111,12.76,4.004,10.652,4.004,8.287z"
-                             mah:TextBoxHelper.Watermark="Enter parameter"
+                             mah:TextBoxHelper.Watermark="Search something..."
                              Style="{DynamicResource MahApps.Styles.TextBox.Search}" />
+                    <TextBox Margin="{StaticResource ControlMargin}"
+                             mah:TextBoxHelper.ButtonContent="M17.545,15.467l-3.779-3.779c0.57-0.935,0.898-2.035,0.898-3.21c0-3.417-2.961-6.377-6.378-6.377  C4.869,2.1,2.1,4.87,2.1,8.287c0,3.416,2.961,6.377,6.377,6.377c1.137,0,2.2-0.309,3.115-0.844l3.799,3.801  c0.372,0.371,0.975,0.371,1.346,0l0.943-0.943C18.051,16.307,17.916,15.838,17.545,15.467z M4.004,8.287  c0-2.366,1.917-4.283,4.282-4.283c2.366,0,4.474,2.107,4.474,4.474c0,2.365-1.918,4.283-4.283,4.283  C6.111,12.76,4.004,10.652,4.004,8.287z"
+                             mah:TextBoxHelper.Watermark="Find something..."
+                             Style="{DynamicResource MahApps.Styles.TextBox.Search}">
+                        <TextBox.CommandBindings>
+                            <CommandBinding CanExecute="TextBoxSearchOnCanExecute"
+                                            Command="{x:Static mah:MahAppsCommands.SearchCommand}"
+                                            Executed="TextBoxSearchOnExecuted" />
+                        </TextBox.CommandBindings>
+                    </TextBox>
                     <TextBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
                              mah:TextBoxHelper.ButtonContent="s"
-                             mah:TextBoxHelper.Watermark="Custom icon style"
-                             Style="{DynamicResource MahApps.Styles.TextBox.Button}" />
+                             mah:TextBoxHelper.Watermark="Custom icon style" />
                     <TextBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.Watermark="Number smaller than 10"
                              Text="{Binding IntegerGreater10Property, ValidatesOnExceptions=True, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}" />
@@ -178,7 +184,7 @@
                              IsEnabled="False"
                              Text="Clear button" />
                     <TextBox Margin="{StaticResource ControlMargin}"
-                             mah:TextBoxHelper.Watermark="Search style"
+                             mah:TextBoxHelper.Watermark="Search style..."
                              IsEnabled="False"
                              Style="{DynamicResource MahApps.Styles.TextBox.Search}" />
                     <TextBox Margin="{StaticResource ControlMargin}"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -126,12 +126,12 @@
                         </TextBox.Style>
                     </TextBox>
                     <TextBox Margin="{StaticResource ControlMargin}"
-                             mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
+                             mah:TextBoxHelper.ButtonCommand="{Binding ControlButtonCommand, Mode=OneWay}"
                              mah:TextBoxHelper.UseFloatingWatermark="True"
                              mah:TextBoxHelper.Watermark="Search...">
                         <TextBox.InputBindings>
                             <KeyBinding Key="Return"
-                                        Command="{Binding TextBoxButtonCmd, Mode=OneWay}"
+                                        Command="{Binding ControlButtonCommand, Mode=OneWay}"
                                         CommandParameter="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=TextBox}, Path=Text, Mode=OneWay}" />
                         </TextBox.InputBindings>
                         <TextBox.Style>
@@ -148,7 +148,7 @@
                     </TextBox>
                     <!--  Entypo MagnifyingGlass  -->
                     <TextBox Margin="{StaticResource ControlMargin}"
-                             mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmdWithParameter, Mode=OneWay}"
+                             mah:TextBoxHelper.ButtonCommand="{Binding ControlButtonCommandWithParameter, Mode=OneWay}"
                              mah:TextBoxHelper.ButtonContent="M17.545,15.467l-3.779-3.779c0.57-0.935,0.898-2.035,0.898-3.21c0-3.417-2.961-6.377-6.378-6.377  C4.869,2.1,2.1,4.87,2.1,8.287c0,3.416,2.961,6.377,6.377,6.377c1.137,0,2.2-0.309,3.115-0.844l3.799,3.801  c0.372,0.371,0.975,0.371,1.346,0l0.943-0.943C18.051,16.307,17.916,15.838,17.545,15.467z M4.004,8.287  c0-2.366,1.917-4.283,4.282-4.283c2.366,0,4.474,2.107,4.474,4.474c0,2.365-1.918,4.283-4.283,4.283  C6.111,12.76,4.004,10.652,4.004,8.287z"
                              mah:TextBoxHelper.Watermark="Search something..."
                              Style="{DynamicResource MahApps.Styles.TextBox.Search}" />
@@ -163,7 +163,7 @@
                         </TextBox.CommandBindings>
                     </TextBox>
                     <TextBox Margin="{StaticResource ControlMargin}"
-                             mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
+                             mah:TextBoxHelper.ButtonCommand="{Binding ControlButtonCommand, Mode=OneWay}"
                              mah:TextBoxHelper.ButtonContent="s"
                              mah:TextBoxHelper.Watermark="Custom icon style" />
                     <TextBox Margin="{StaticResource ControlMargin}"
@@ -218,7 +218,7 @@
                              IsDocumentEnabled="True"
                              SpellCheck.IsEnabled="True" />
                 <RichTextBox Margin="{StaticResource ControlMargin}"
-                             mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
+                             mah:TextBoxHelper.ButtonCommand="{Binding ControlButtonCommand, Mode=OneWay}"
                              mah:TextBoxHelper.ButtonContent="s"
                              mah:TextBoxHelper.Watermark="Type in..."
                              IsDocumentEnabled="True"
@@ -291,13 +291,13 @@
                              mah:TextBoxHelper.Watermark="Revealed..."
                              Style="{StaticResource MahApps.Styles.PasswordBox.Revealed}" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"
-                             mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
+                             mah:TextBoxHelper.ButtonCommand="{Binding ControlButtonCommand, Mode=OneWay}"
                              mah:TextBoxHelper.UseFloatingWatermark="True"
                              mah:TextBoxHelper.Watermark="Password..."
                              Password="Password" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"
                              mah:PasswordBoxHelper.CapsLockIcon="!"
-                             mah:TextBoxHelper.ButtonCommand="{Binding TextBoxButtonCmd, Mode=OneWay}"
+                             mah:TextBoxHelper.ButtonCommand="{Binding ControlButtonCommand, Mode=OneWay}"
                              mah:TextBoxHelper.ButtonContent="4"
                              mah:TextBoxHelper.UseFloatingWatermark="True"
                              mah:TextBoxHelper.Watermark="Custom icon...">

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -555,6 +555,12 @@
                                mah:TextBoxHelper.Watermark="Enter hot key"
                                AreModifierKeysRequired="{Binding ElementName=ModifierKeysRequired, Path=IsChecked}"
                                HotKey="{Binding HotKey, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}" />
+                <mah:HotKeyBox Margin="{StaticResource ControlMargin}"
+                               mah:TextBoxHelper.ButtonCommand="{Binding ControlButtonCommand, Mode=OneWay}"
+                               mah:TextBoxHelper.ButtonContent="s"
+                               mah:TextBoxHelper.Watermark="Enter hot key"
+                               AreModifierKeysRequired="{Binding ElementName=ModifierKeysRequired, Path=IsChecked}"
+                               HotKey="{Binding HotKey, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}" />
             </StackPanel>
         </GroupBox>
     </Grid>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows.Controls;
+using System.Windows.Input;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Controls.Dialogs;
 
 namespace MetroDemo.ExampleViews
 {
@@ -23,6 +26,19 @@ namespace MetroDemo.ExampleViews
         public TextExamples()
         {
             this.InitializeComponent();
+        }
+
+        private void TextBoxSearchOnCanExecute(object sender, CanExecuteRoutedEventArgs e)
+        {
+            e.CanExecute = true;
+        }
+
+        private async void TextBoxSearchOnExecuted(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (e.Parameter is TextBox textBox)
+            {
+                await this.TryFindParent<MetroWindow>()!.ShowMessageAsync("TextBox Search Button was clicked!", textBox.Text).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
@@ -126,7 +126,7 @@ namespace MetroDemo
 
             this.CloseCmd = new SimpleCommand<Flyout>(f => f is not null && this.CanCloseFlyout, f => f!.IsOpen = false);
 
-            this.TextBoxButtonCmd = new SimpleCommand<object>(
+            this.ControlButtonCommand = new SimpleCommand<object>(
                 o =>
                     {
                         if (o is RichTextBox richTextBox)
@@ -163,10 +163,14 @@ namespace MetroDemo
                         {
                             await this._dialogCoordinator.ShowMessageAsync(this, "DatePicker Button was clicked!", datePicker.Text).ConfigureAwait(false);
                         }
+                        else if (o is ComboBox comboBox)
+                        {
+                            await this._dialogCoordinator.ShowMessageAsync(this, "ComboBox Button was clicked!", comboBox.Text).ConfigureAwait(false);
+                        }
                     }
             );
 
-            this.TextBoxButtonCmdWithParameter = new SimpleCommand<object>(
+            this.ControlButtonCommandWithParameter = new SimpleCommand<object>(
                 o => true,
                 async x => { await this._dialogCoordinator.ShowMessageAsync(this, "TextBox Button with parameter was clicked!", $"Parameter: {x}"); }
             );
@@ -375,9 +379,9 @@ namespace MetroDemo
             set => this.Set(ref this.isHamburgerMenuPaneOpen, value);
         }
 
-        public ICommand TextBoxButtonCmd { get; }
+        public ICommand ControlButtonCommand { get; }
 
-        public ICommand TextBoxButtonCmdWithParameter { get; }
+        public ICommand ControlButtonCommandWithParameter { get; }
 
         public string this[string columnName]
         {

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
@@ -133,6 +133,10 @@ namespace MetroDemo
                         {
                             return TextBoxHelper.GetHasText(richTextBox);
                         }
+                        else if (o is TextBox textBox)
+                        {
+                            return TextBoxHelper.GetHasText(textBox);
+                        }
 
                         return true;
                     },

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
@@ -129,43 +129,38 @@ namespace MetroDemo
             this.ControlButtonCommand = new SimpleCommand<object>(
                 o =>
                     {
-                        if (o is RichTextBox richTextBox)
+                        return o switch
                         {
-                            return TextBoxHelper.GetHasText(richTextBox);
-                        }
-                        else if (o is TextBox textBox)
-                        {
-                            return TextBoxHelper.GetHasText(textBox);
-                        }
-
-                        return true;
+                            RichTextBox richTextBox => TextBoxHelper.GetHasText(richTextBox),
+                            TextBox textBox => TextBoxHelper.GetHasText(textBox),
+                            _ => true
+                        };
                     },
                 async o =>
                     {
-                        if (o is string s)
+                        switch (o)
                         {
-                            await this._dialogCoordinator.ShowMessageAsync(this, "Wow, you typed Return and got", s).ConfigureAwait(false);
-                        }
-                        else if (o is RichTextBox richTextBox)
-                        {
-                            var text = new TextRange(richTextBox.Document.ContentStart, richTextBox.Document.ContentEnd).Text;
-                            await this._dialogCoordinator.ShowMessageAsync(this, "RichTextBox Button was clicked!", text).ConfigureAwait(false);
-                        }
-                        else if (o is TextBox textBox)
-                        {
-                            await this._dialogCoordinator.ShowMessageAsync(this, "TextBox Button was clicked!", textBox.Text).ConfigureAwait(false);
-                        }
-                        else if (o is PasswordBox passwordBox)
-                        {
-                            await this._dialogCoordinator.ShowMessageAsync(this, "PasswordBox Button was clicked!", passwordBox.Password).ConfigureAwait(false);
-                        }
-                        else if (o is DatePicker datePicker)
-                        {
-                            await this._dialogCoordinator.ShowMessageAsync(this, "DatePicker Button was clicked!", datePicker.Text).ConfigureAwait(false);
-                        }
-                        else if (o is ComboBox comboBox)
-                        {
-                            await this._dialogCoordinator.ShowMessageAsync(this, "ComboBox Button was clicked!", comboBox.Text).ConfigureAwait(false);
+                            case string s:
+                                await this._dialogCoordinator.ShowMessageAsync(this, "Wow, you typed Return and got", s).ConfigureAwait(false);
+                                break;
+                            case RichTextBox richTextBox:
+                                await this._dialogCoordinator.ShowMessageAsync(this, $"{o.GetType().Name} Button was clicked!", new TextRange(richTextBox.Document.ContentStart, richTextBox.Document.ContentEnd).Text).ConfigureAwait(false);
+                                break;
+                            case TextBox textBox:
+                                await this._dialogCoordinator.ShowMessageAsync(this, $"{o.GetType().Name} Button was clicked!", textBox.Text).ConfigureAwait(false);
+                                break;
+                            case PasswordBox passwordBox:
+                                await this._dialogCoordinator.ShowMessageAsync(this, $"{o.GetType().Name} Button was clicked!", passwordBox.Password).ConfigureAwait(false);
+                                break;
+                            case DatePicker datePicker:
+                                await this._dialogCoordinator.ShowMessageAsync(this, $"{o.GetType().Name} Button was clicked!", datePicker.Text).ConfigureAwait(false);
+                                break;
+                            case ComboBox comboBox:
+                                await this._dialogCoordinator.ShowMessageAsync(this, $"{o.GetType().Name} Button was clicked!", comboBox.Text).ConfigureAwait(false);
+                                break;
+                            case Control control:
+                                await this._dialogCoordinator.ShowMessageAsync(this, $"{o.GetType().Name} Button was clicked!", control.ToString() ?? string.Empty).ConfigureAwait(false);
+                                break;
                         }
                     }
             );

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
@@ -127,27 +127,35 @@ namespace MetroDemo
             this.CloseCmd = new SimpleCommand<Flyout>(f => f is not null && this.CanCloseFlyout, f => f!.IsOpen = false);
 
             this.TextBoxButtonCmd = new SimpleCommand<object>(
-                o => true,
-                async x =>
+                o =>
                     {
-                        if (x is string s)
+                        if (o is RichTextBox richTextBox)
+                        {
+                            return TextBoxHelper.GetHasText(richTextBox);
+                        }
+
+                        return true;
+                    },
+                async o =>
+                    {
+                        if (o is string s)
                         {
                             await this._dialogCoordinator.ShowMessageAsync(this, "Wow, you typed Return and got", s).ConfigureAwait(false);
                         }
-                        else if (x is RichTextBox richTextBox)
+                        else if (o is RichTextBox richTextBox)
                         {
                             var text = new TextRange(richTextBox.Document.ContentStart, richTextBox.Document.ContentEnd).Text;
                             await this._dialogCoordinator.ShowMessageAsync(this, "RichTextBox Button was clicked!", text).ConfigureAwait(false);
                         }
-                        else if (x is TextBox textBox)
+                        else if (o is TextBox textBox)
                         {
                             await this._dialogCoordinator.ShowMessageAsync(this, "TextBox Button was clicked!", textBox.Text).ConfigureAwait(false);
                         }
-                        else if (x is PasswordBox passwordBox)
+                        else if (o is PasswordBox passwordBox)
                         {
                             await this._dialogCoordinator.ShowMessageAsync(this, "PasswordBox Button was clicked!", passwordBox.Password).ConfigureAwait(false);
                         }
-                        else if (x is DatePicker datePicker)
+                        else if (o is DatePicker datePicker)
                         {
                             await this._dialogCoordinator.ShowMessageAsync(this, "DatePicker Button was clicked!", datePicker.Text).ConfigureAwait(false);
                         }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
@@ -158,6 +158,9 @@ namespace MetroDemo
                             case ComboBox comboBox:
                                 await this._dialogCoordinator.ShowMessageAsync(this, $"{o.GetType().Name} Button was clicked!", comboBox.Text).ConfigureAwait(false);
                                 break;
+                            case HotKeyBox hotKeyBox:
+                                await this._dialogCoordinator.ShowMessageAsync(this, $"{o.GetType().Name} Button was clicked!", hotKeyBox.Text ?? hotKeyBox.HotKey?.ToString() ?? string.Empty).ConfigureAwait(false);
+                                break;
                             case Control control:
                                 await this._dialogCoordinator.ShowMessageAsync(this, $"{o.GetType().Name} Button was clicked!", control.ToString() ?? string.Empty).ConfigureAwait(false);
                                 break;

--- a/src/MahApps.Metro.sln.DotSettings
+++ b/src/MahApps.Metro.sln.DotSettings
@@ -846,9 +846,11 @@ See the LICENSE file in the project root for more information.&#xD;
 	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=9B816E867235A24D95BD3141BD8338A3/Name/@EntryValue">To Revise</s:String>
 	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=9B816E867235A24D95BD3141BD8338A3/Pattern/@EntryValue">FeatureCurrentlyDisableException|FeatureRemovedException</s:String>
 	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=9B816E867235A24D95BD3141BD8338A3/TodoIconStyle/@EntryValue">Edit</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Chromeless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Flyout/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Flyouts/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Headered/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Templated/@EntryIndexedValue">True</s:Boolean>
 	
 	
 </wpf:ResourceDictionary>

--- a/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
+++ b/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
@@ -81,6 +81,10 @@ namespace MahApps.Metro.Controls
                     passwordBox.Clear();
                     passwordBox.GetBindingExpression(PasswordBoxBindingBehavior.PasswordProperty)?.UpdateSource();
                     break;
+                case ColorPickerBase colorPicker:
+                    colorPicker.SetCurrentValue(ColorPickerBase.SelectedColorProperty, null);
+                    colorPicker.GetBindingExpression(ColorPickerBase.SelectedColorProperty)?.UpdateSource();
+                    break;
                 case ComboBox comboBox:
                 {
                     if (comboBox is MultiSelectionComboBox multiSelectionComboBox)

--- a/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
+++ b/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
@@ -83,12 +83,12 @@ namespace MahApps.Metro.Controls
                 {
                     if (comboBox.IsEditable)
                     {
-                        comboBox.SetCurrentValue(ComboBox.TextProperty, null);
+                        comboBox.SetCurrentValue(ComboBox.TextProperty, string.Empty);
                         comboBox.GetBindingExpression(ComboBox.TextProperty)?.UpdateSource();
                     }
 
-                    comboBox.SetCurrentValue(ComboBox.SelectedItemProperty, null);
-                    comboBox.GetBindingExpression(ComboBox.SelectedItemProperty)?.UpdateSource();
+                    comboBox.SetCurrentValue(Selector.SelectedItemProperty, null);
+                    comboBox.GetBindingExpression(Selector.SelectedItemProperty)?.UpdateSource();
                     break;
                 }
             }

--- a/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
+++ b/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
@@ -72,6 +72,10 @@ namespace MahApps.Metro.Controls
                     timePicker.Clear();
                     timePicker.GetBindingExpression(TimePickerBase.SelectedDateTimeProperty)?.UpdateSource();
                     break;
+                case HotKeyBox hotKeyBox:
+                    hotKeyBox.SetCurrentValue(HotKeyBox.HotKeyProperty, null);
+                    hotKeyBox.GetBindingExpression(HotKeyBox.HotKeyProperty)?.UpdateSource();
+                    break;
                 case NumericUpDown numericUpDown:
                     numericUpDown.SetCurrentValue(NumericUpDown.ValueProperty, NumericUpDown.ValueProperty.DefaultMetadata.DefaultValue);
                     numericUpDown.GetBindingExpression(NumericUpDown.ValueProperty)?.UpdateSource();

--- a/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
+++ b/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
@@ -71,7 +71,10 @@ namespace MahApps.Metro.Controls
                 case TimePickerBase timePicker:
                     timePicker.Clear();
                     timePicker.GetBindingExpression(TimePickerBase.SelectedDateTimeProperty)?.UpdateSource();
-
+                    break;
+                case NumericUpDown numericUpDown:
+                    numericUpDown.SetCurrentValue(NumericUpDown.ValueProperty, NumericUpDown.ValueProperty.DefaultMetadata.DefaultValue);
+                    numericUpDown.GetBindingExpression(NumericUpDown.ValueProperty)?.UpdateSource();
                     break;
                 case TextBox textBox:
                     textBox.Clear();

--- a/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
+++ b/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -82,14 +83,46 @@ namespace MahApps.Metro.Controls
                     break;
                 case ComboBox comboBox:
                 {
-                    if (comboBox.IsEditable)
+                    if (comboBox is MultiSelectionComboBox multiSelectionComboBox)
                     {
-                        comboBox.SetCurrentValue(ComboBox.TextProperty, string.Empty);
+                        if (multiSelectionComboBox.HasCustomText)
+                        {
+                            multiSelectionComboBox.ResetEditableText(true);
+                        }
+                        else
+                        {
+                            switch (multiSelectionComboBox.SelectionMode)
+                            {
+                                case SelectionMode.Single:
+                                    multiSelectionComboBox.SetCurrentValue(MultiSelectionComboBox.SelectedItemProperty, null);
+                                    break;
+                                case SelectionMode.Multiple:
+                                case SelectionMode.Extended:
+                                    multiSelectionComboBox.SelectedItems?.Clear();
+                                    break;
+                                default:
+                                    throw new NotSupportedException("Unknown SelectionMode");
+                            }
+
+                            multiSelectionComboBox.ResetEditableText(true);
+                        }
+
                         comboBox.GetBindingExpression(ComboBox.TextProperty)?.UpdateSource();
+                        comboBox.GetBindingExpression(MultiSelectionComboBox.SelectedItemProperty)?.UpdateSource();
+                        comboBox.GetBindingExpression(MultiSelectionComboBox.SelectedItemsProperty)?.UpdateSource();
+                    }
+                    else
+                    {
+                        if (comboBox.IsEditable)
+                        {
+                            comboBox.SetCurrentValue(ComboBox.TextProperty, string.Empty);
+                            comboBox.GetBindingExpression(ComboBox.TextProperty)?.UpdateSource();
+                        }
+
+                        comboBox.SetCurrentValue(Selector.SelectedItemProperty, null);
+                        comboBox.GetBindingExpression(Selector.SelectedItemProperty)?.UpdateSource();
                     }
 
-                    comboBox.SetCurrentValue(Selector.SelectedItemProperty, null);
-                    comboBox.GetBindingExpression(Selector.SelectedItemProperty)?.UpdateSource();
                     break;
                 }
             }

--- a/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
+++ b/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
@@ -14,6 +14,8 @@ namespace MahApps.Metro.Controls
     {
         public static ICommand ClearControlCommand { get; } = new RoutedUICommand("Clear", nameof(ClearControlCommand), typeof(MahAppsCommands));
 
+        public static ICommand SearchCommand { get; } = new RoutedUICommand("Search", nameof(SearchCommand), typeof(MahAppsCommands));
+
         static MahAppsCommands()
         {
             // Register CommandBinding for all windows.

--- a/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
+++ b/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
@@ -64,7 +64,7 @@ namespace MahApps.Metro.Controls
                     break;
                 case DatePicker datePicker:
                     datePicker.SetCurrentValue(DatePicker.SelectedDateProperty, null);
-                    datePicker.SetCurrentValue(DatePicker.TextProperty, null);
+                    datePicker.SetCurrentValue(DatePicker.TextProperty, string.Empty);
                     datePicker.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
                     break;
                 case TimePickerBase timePicker:

--- a/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
+++ b/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
@@ -68,8 +68,9 @@ namespace MahApps.Metro.Controls
                     datePicker.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
                     break;
                 case TimePickerBase timePicker:
-                    timePicker.SetCurrentValue(TimePickerBase.SelectedDateTimeProperty, null);
+                    timePicker.Clear();
                     timePicker.GetBindingExpression(TimePickerBase.SelectedDateTimeProperty)?.UpdateSource();
+
                     break;
                 case TextBox textBox:
                     textBox.Clear();

--- a/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
@@ -15,7 +15,6 @@ using System.ComponentModel;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Windows.Data;
-using MahApps.Metro.Behaviors;
 using MahApps.Metro.ValueBoxes;
 
 namespace MahApps.Metro.Controls
@@ -463,30 +462,6 @@ namespace MahApps.Metro.Controls
             obj.SetValue(ClearTextButtonProperty, BooleanBoxes.Box(value));
         }
 
-        public static readonly DependencyProperty TextButtonProperty
-            = DependencyProperty.RegisterAttached(
-                "TextButton",
-                typeof(bool),
-                typeof(TextBoxHelper),
-                new FrameworkPropertyMetadata(BooleanBoxes.FalseBox, ButtonCommandOrClearTextChanged));
-
-        /// <summary>
-        /// Gets the text button visibility.
-        /// </summary>
-        [Category(AppName.MahApps)]
-        public static bool GetTextButton(DependencyObject d)
-        {
-            return (bool)d.GetValue(TextButtonProperty);
-        }
-
-        /// <summary>
-        /// Sets the text button visibility.
-        /// </summary>
-        public static void SetTextButton(DependencyObject obj, bool value)
-        {
-            obj.SetValue(TextButtonProperty, BooleanBoxes.Box(value));
-        }
-
         public static readonly DependencyProperty ButtonsAlignmentProperty
             = DependencyProperty.RegisterAttached(
                 "ButtonsAlignment",
@@ -509,35 +484,6 @@ namespace MahApps.Metro.Controls
         public static void SetButtonsAlignment(DependencyObject obj, ButtonsAlignment value)
         {
             obj.SetValue(ButtonsAlignmentProperty, value);
-        }
-
-        /// <summary>
-        /// The clear text button behavior property. It sets a click event to the button if the value is true.
-        /// </summary>
-        public static readonly DependencyProperty IsClearTextButtonBehaviorEnabledProperty
-            = DependencyProperty.RegisterAttached(
-                "IsClearTextButtonBehaviorEnabled",
-                typeof(bool),
-                typeof(TextBoxHelper),
-                new FrameworkPropertyMetadata(BooleanBoxes.FalseBox, IsClearTextButtonBehaviorEnabledChanged));
-
-        /// <summary>
-        /// Gets the clear text button behavior.
-        /// </summary>
-        [Category(AppName.MahApps)]
-        [AttachedPropertyBrowsableForType(typeof(ButtonBase))]
-        public static bool GetIsClearTextButtonBehaviorEnabled(Button d)
-        {
-            return (bool)d.GetValue(IsClearTextButtonBehaviorEnabledProperty);
-        }
-
-        /// <summary>
-        /// Sets the clear text button behavior.
-        /// </summary>
-        [AttachedPropertyBrowsableForType(typeof(ButtonBase))]
-        public static void SetIsClearTextButtonBehaviorEnabled(Button obj, bool value)
-        {
-            obj.SetValue(IsClearTextButtonBehaviorEnabledProperty, BooleanBoxes.Box(value));
         }
 
         /// <summary>
@@ -1043,93 +989,6 @@ namespace MahApps.Metro.Controls
                 if (GetSelectAllOnFocus(sender))
                 {
                     sender.Dispatcher.BeginInvoke(action, sender);
-                }
-            }
-        }
-
-        private static void IsClearTextButtonBehaviorEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            if (e.OldValue != e.NewValue && d is Button button)
-            {
-                button.Click -= ButtonClicked;
-                if ((bool)e.NewValue)
-                {
-                    button.Click += ButtonClicked;
-                }
-            }
-        }
-
-        public static void ButtonClicked(object sender, RoutedEventArgs e)
-        {
-            var button = (Button)sender;
-
-            var parent = button.GetAncestors().FirstOrDefault(a => a is RichTextBox || a is TextBox || a is PasswordBox || a is ComboBox || a is ColorPickerBase || a is MultiSelectionComboBox);
-            if (parent is null)
-            {
-                return;
-            }
-
-            var command = GetButtonCommand(parent);
-            var commandParameter = GetButtonCommandParameter(parent) ?? parent;
-            if (command != null && command.CanExecute(commandParameter))
-            {
-                if (parent is TextBox textBox)
-                {
-                    textBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
-                }
-
-                command.Execute(commandParameter);
-            }
-
-            if (GetClearTextButton(parent))
-            {
-                if (parent is TextBox textBox)
-                {
-                    textBox.Clear();
-                    textBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
-                }
-                else if (parent is PasswordBox passwordBox)
-                {
-                    passwordBox.Clear();
-                    passwordBox.GetBindingExpression(PasswordBoxBindingBehavior.PasswordProperty)?.UpdateSource();
-                }
-                else if (parent is MultiSelectionComboBox multiSelectionComboBox)
-                {
-                    if (multiSelectionComboBox.HasCustomText)
-                    {
-                        multiSelectionComboBox.ResetEditableText(true);
-                    }
-                    else
-                    {
-                        switch (multiSelectionComboBox.SelectionMode)
-                        {
-                            case SelectionMode.Single:
-                                multiSelectionComboBox.SetCurrentValue(MultiSelectionComboBox.SelectedItemProperty, null);
-                                break;
-                            case SelectionMode.Multiple:
-                            case SelectionMode.Extended:
-                                multiSelectionComboBox.SelectedItems?.Clear();
-                                break;
-                            default:
-                                throw new NotSupportedException("Unknown SelectionMode");
-                        }
-                        multiSelectionComboBox.ResetEditableText(true);
-                    }
-                }
-                else if (parent is ComboBox comboBox)
-                {
-                    if (comboBox.IsEditable)
-                    {
-                        comboBox.SetCurrentValue(ComboBox.TextProperty, string.Empty);
-                        comboBox.GetBindingExpression(ComboBox.TextProperty)?.UpdateSource();
-                    }
-
-                    comboBox.SetCurrentValue(ComboBox.SelectedItemProperty, null);
-                    comboBox.GetBindingExpression(ComboBox.SelectedItemProperty)?.UpdateSource();
-                }
-                else if (parent is ColorPickerBase colorPicker)
-                {
-                    colorPicker.SetCurrentValue(ColorPickerBase.SelectedColorProperty, null);
                 }
             }
         }

--- a/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
@@ -543,6 +543,24 @@ namespace MahApps.Metro.Controls
             obj.SetValue(ButtonCommandParameterProperty, value);
         }
 
+        public static readonly DependencyProperty ButtonCommandTargetProperty
+            = DependencyProperty.RegisterAttached(
+                "ButtonCommandTarget",
+                typeof(IInputElement),
+                typeof(TextBoxHelper),
+                new FrameworkPropertyMetadata(null));
+
+        [Category(AppName.MahApps)]
+        public static IInputElement? GetButtonCommandTarget(DependencyObject d)
+        {
+            return (IInputElement?)d.GetValue(ButtonCommandTargetProperty);
+        }
+
+        public static void SetButtonCommandTarget(DependencyObject obj, IInputElement? value)
+        {
+            obj.SetValue(ButtonCommandTargetProperty, value);
+        }
+
         public static readonly DependencyProperty ButtonContentProperty
             = DependencyProperty.RegisterAttached(
                 "ButtonContent",
@@ -879,6 +897,20 @@ namespace MahApps.Metro.Controls
                     passBox.PreviewMouseLeftButtonDown -= UIElementPreviewMouseLeftButtonDown;
                 }
             }
+            else if (d is HotKeyBox hotKeyBox)
+            {
+                if ((bool)e.NewValue)
+                {
+                    // Fixes #1343 and #2514: also triggers the show of the floating watermark if necessary
+                    hotKeyBox.BeginInvoke(() => OnHotKeyBoxHotKeyChanged(hotKeyBox, new RoutedEventArgs(HotKeyBox.HotKeyChangedEvent, hotKeyBox)));
+
+                    hotKeyBox.HotKeyChanged += OnHotKeyBoxHotKeyChanged;
+                }
+                else
+                {
+                    hotKeyBox.HotKeyChanged -= OnHotKeyBoxHotKeyChanged;
+                }
+            }
             else if (d is NumericUpDown numericUpDown)
             {
                 if ((bool)e.NewValue)
@@ -939,6 +971,11 @@ namespace MahApps.Metro.Controls
         private static void TextChanged(object sender, RoutedEventArgs e)
         {
             SetTextLength(sender as TextBox, textBox => textBox.Text.Length);
+        }
+
+        private static void OnHotKeyBoxHotKeyChanged(object sender, RoutedEventArgs e)
+        {
+            SetTextLength(sender as HotKeyBox, hotKeyBox => hotKeyBox.Text?.Length ?? (hotKeyBox.HotKey is not null ? 1 : 0));
         }
 
         private static void OnNumericUpDownValueChanged(object sender, RoutedEventArgs e)

--- a/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
@@ -1083,12 +1083,7 @@ namespace MahApps.Metro.Controls
 
             if (GetClearTextButton(parent))
             {
-                if (parent is RichTextBox richTextBox)
-                {
-                    richTextBox.Document?.Blocks?.Clear();
-                    richTextBox.Selection?.Select(richTextBox.CaretPosition, richTextBox.CaretPosition);
-                }
-                else if (parent is TextBox textBox)
+                if (parent is TextBox textBox)
                 {
                     textBox.Clear();
                     textBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();

--- a/src/MahApps.Metro/Controls/HotKeyBox.cs
+++ b/src/MahApps.Metro/Controls/HotKeyBox.cs
@@ -21,11 +21,19 @@ namespace MahApps.Metro.Controls
             = DependencyProperty.Register(nameof(HotKey),
                                           typeof(HotKey),
                                           typeof(HotKeyBox),
-                                          new FrameworkPropertyMetadata(default(HotKey), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnHotKeyPropertyChanged));
+                                          new FrameworkPropertyMetadata(default(HotKey?), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnHotKeyPropertyChanged));
 
         private static void OnHotKeyPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            (d as HotKeyBox)?.UpdateText();
+            if (d is HotKeyBox hotKeyBox)
+            {
+                if (e.OldValue != e.NewValue)
+                {
+                    hotKeyBox.RaiseEvent(new RoutedPropertyChangedEventArgs<HotKey?>(e.OldValue as HotKey, e.NewValue as HotKey, HotKeyChangedEvent));
+                }
+
+                hotKeyBox.UpdateText();
+            }
         }
 
         /// <summary>
@@ -69,6 +77,23 @@ namespace MahApps.Metro.Controls
         {
             get => (string?)this.GetValue(TextProperty);
             protected set => this.SetValue(TextPropertyKey, value);
+        }
+
+        /// <summary>Identifies the <see cref="HotKeyChanged"/> routed event.</summary>
+        public static readonly RoutedEvent HotKeyChangedEvent
+            = EventManager.RegisterRoutedEvent(nameof(HotKeyChanged),
+                                               RoutingStrategy.Bubble,
+                                               typeof(RoutedPropertyChangedEventHandler<HotKey?>),
+                                               typeof(HotKeyBox));
+
+        /// <summary>
+        /// Add / Remove HotKeyChangedEvent handler
+        /// Event which will be fired from this HotKeyBox when its value has been changed.
+        /// </summary>
+        public event RoutedPropertyChangedEventHandler<HotKey?> HotKeyChanged
+        {
+            add => this.AddHandler(HotKeyChangedEvent, value);
+            remove => this.RemoveHandler(HotKeyChangedEvent, value);
         }
 
         private TextBox? _textBox;
@@ -215,8 +240,8 @@ namespace MahApps.Metro.Controls
 
         private void UpdateText()
         {
-            var hotkey = this.HotKey;
-            this.Text = hotkey is null || hotkey.Key == Key.None ? string.Empty : hotkey.ToString();
+            var hotKey = this.HotKey;
+            this.SetValue(HotKeyBox.TextPropertyKey, hotKey is null || hotKey.Key == Key.None ? string.Empty : hotKey.ToString());
         }
     }
 }

--- a/src/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
+++ b/src/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
@@ -545,6 +545,12 @@ namespace MahApps.Metro.Controls
 
         #endregion
 
+        public void Clear()
+        {
+            this.SetCurrentValue(SelectedDateTimeProperty, null);
+            this.WriteValueToTextBox();
+        }
+
         static TimePickerBase()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(TimePickerBase), new FrameworkPropertyMetadata(typeof(TimePickerBase)));

--- a/src/MahApps.Metro/Styles/Controls.CheckBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.CheckBox.xaml
@@ -390,6 +390,47 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="MahApps.Styles.CheckBox.MultiSelectionComboBoxItem"
+           BasedOn="{StaticResource MahApps.Styles.CheckBox}"
+           TargetType="CheckBox">
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillChecked" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillChecked}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillCheckedDisabled" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillCheckedDisabled}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillCheckedMouseOver" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillCheckedMouseOver}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillCheckedPressed" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillCheckedPressed}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillIndeterminate" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillIndeterminate}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillIndeterminateDisabled" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillIndeterminateDisabled}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillIndeterminateMouseOver" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillIndeterminateMouseOver}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillIndeterminatePressed" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillIndeterminatePressed}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillUnchecked" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillUnchecked}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillUncheckedDisabled" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillUncheckedDisabled}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillUncheckedMouseOver" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillUncheckedMouseOver}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundFillUncheckedPressed" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundFillUncheckedPressed}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeChecked" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeChecked}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeCheckedDisabled" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeCheckedDisabled}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeCheckedMouseOver" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeCheckedMouseOver}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeCheckedPressed" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeCheckedPressed}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeIndeterminate" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeIndeterminate}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeIndeterminateDisabled" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeIndeterminateDisabled}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeIndeterminateMouseOver" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeIndeterminateMouseOver}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeIndeterminatePressed" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeIndeterminatePressed}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeUnchecked" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeUnchecked}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeUncheckedDisabled" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeUncheckedDisabled}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeUncheckedMouseOver" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeUncheckedMouseOver}" />
+        <Setter Property="mah:CheckBoxHelper.CheckBackgroundStrokeUncheckedPressed" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckBackgroundStrokeUncheckedPressed}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundChecked" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundChecked}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundCheckedDisabled" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundCheckedDisabled}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundCheckedMouseOver" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundCheckedMouseOver}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundCheckedPressed" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundCheckedPressed}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundIndeterminate" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundIndeterminate}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundIndeterminateDisabled" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundIndeterminateDisabled}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundIndeterminateMouseOver" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundIndeterminateMouseOver}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundIndeterminatePressed" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundIndeterminatePressed}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundUnchecked" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundUnchecked}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundUncheckedDisabled" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundUncheckedDisabled}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundUncheckedMouseOver" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundUncheckedMouseOver}" />
+        <Setter Property="mah:CheckBoxHelper.CheckGlyphForegroundUncheckedPressed" Value="{DynamicResource MahApps.Brushes.CheckBox.CheckGlyphForegroundUncheckedPressed}" />
+    </Style>
+
     <Style x:Key="MahApps.Styles.CheckBox.Win10"
            BasedOn="{StaticResource MahApps.Styles.CheckBox}"
            TargetType="CheckBox">

--- a/src/MahApps.Metro/Styles/Controls.CheckBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.CheckBox.xaml
@@ -447,7 +447,7 @@
         <Setter Property="mah:CheckBoxHelper.CheckGlyphCheckedTemplate">
             <Setter.Value>
                 <DataTemplate>
-                    <mah:FontIcon x:Name="CheckGlyph"
+                    <mah:FontIcon x:Name="CheckGlyphCheckedFontIcon"
                                   FontFamily="{DynamicResource MahApps.Fonts.Family.SymbolTheme}"
                                   FontSize="20"
                                   Glyph="&#xE001;"
@@ -470,7 +470,7 @@
         <Setter Property="mah:CheckBoxHelper.CheckGlyphIndeterminateTemplate">
             <Setter.Value>
                 <DataTemplate>
-                    <mah:FontIcon x:Name="CheckGlyph"
+                    <mah:FontIcon x:Name="CheckGlyphIndeterminateFontIcon"
                                   FontFamily="{DynamicResource MahApps.Fonts.Family.SymbolTheme}"
                                   FontSize="20"
                                   Glyph="&#xE73C;"

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -7,6 +7,8 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TextBox.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
+    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
     <Thickness x:Key="ComboBoxBorderThemeThickness">1</Thickness>
     <CornerRadius x:Key="ComboBoxPopupBorderThemeCornerRadius">0</CornerRadius>
     <Thickness x:Key="ComboBoxPopupBorderThemeThickness">1</Thickness>

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -7,8 +7,6 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.TextBox.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-
     <Thickness x:Key="ComboBoxBorderThemeThickness">1</Thickness>
     <CornerRadius x:Key="ComboBoxPopupBorderThemeCornerRadius">0</CornerRadius>
     <Thickness x:Key="ComboBoxPopupBorderThemeThickness">1</Thickness>

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -27,7 +27,6 @@
                         <Grid x:Name="PART_InnerGrid">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="TextColumn" Width="*" />
-                                <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
@@ -99,22 +98,6 @@
                                     </TextBlock.RenderTransform>
                                 </TextBlock>
                             </ContentControl>
-
-                            <Button x:Name="PART_ClearText"
-                                    Grid.Row="0"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="1"
-                                    Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                    mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay}"
-                                    Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
-                                    ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
-                                    Focusable="False"
-                                    FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
-                                    FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
-                                    IsTabStop="False"
-                                    Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
                         </Grid>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -137,24 +120,9 @@
                             </MultiDataTrigger.ExitActions>
                         </MultiDataTrigger>
 
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ClearTextButton)}" Value="False">
-                            <Setter TargetName="PART_ContentHost" Property="Grid.ColumnSpan" Value="2" />
-                            <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
-                        </DataTrigger>
-                        <Trigger Property="IsReadOnly" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="IsEnabled" Value="False" />
-                        </Trigger>
                         <Trigger Property="IsFocused" Value="True">
                             <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource MahApps.Brushes.TextBlock.FloatingMessage}" />
                             <Setter TargetName="PART_FloatingMessage" Property="Opacity" Value="1" />
-                        </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
-                        </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
                         </Trigger>
 
                         <MultiTrigger>
@@ -202,16 +170,18 @@
                         <Button x:Name="PART_ClearText"
                                 Grid.Column="1"
                                 Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay}"
+                                Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                                CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ComboBox}}, Mode=OneWay}"
                                 Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                 ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                 Focusable="False"
                                 FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                 FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                Foreground="{TemplateBinding Foreground}"
                                 IsTabStop="False"
                                 Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                Visibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type ComboBox}}, Path=(mah:TextBoxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
+                                Visibility="Visible" />
 
                         <Grid x:Name="BtnArrowBackground"
                               Grid.Column="2"
@@ -229,17 +199,30 @@
                         </Grid>
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="mah:TextBoxHelper.ClearTextButton" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Command" Value="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
+                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_ClearText" Property="Visibility" Value="Collapsed" />
+                        </MultiTrigger>
+
                         <Trigger SourceName="BtnArrowBackground" Property="IsMouseOver" Value="True">
                             <Setter TargetName="BtnArrowBackground" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray5}" />
                         </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
-                        </Trigger>
+
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True">
                             <Setter TargetName="BtnArrowBackground" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray3}" />
                             <Setter TargetName="ToggleButtonRootGrid" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray7}" />
                         </DataTrigger>
+
+                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
+                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
+                        </Trigger>
                         <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
                             <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
@@ -295,10 +278,13 @@
                                           Margin="0"
                                           VerticalAlignment="Stretch"
                                           mah:ControlsHelper.CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                          mah:TextBoxHelper.ButtonCommand="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                                          mah:TextBoxHelper.ButtonCommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
                                           mah:TextBoxHelper.ButtonContent="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                           mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                           mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                           mah:TextBoxHelper.ButtonFontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
+                                          mah:TextBoxHelper.ButtonTemplate="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
                                           mah:TextBoxHelper.ButtonWidth="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                           mah:TextBoxHelper.ClearTextButton="{TemplateBinding mah:TextBoxHelper.ClearTextButton}"
                                           Background="Transparent"
@@ -337,6 +323,7 @@
                                      mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                      mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                      mah:TextBoxHelper.ButtonFontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
+                                     mah:TextBoxHelper.ButtonTemplate="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
                                      mah:TextBoxHelper.ButtonWidth="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                      mah:TextBoxHelper.HasText="{TemplateBinding mah:TextBoxHelper.HasText}"
                                      mah:TextBoxHelper.UseFloatingWatermark="{TemplateBinding mah:TextBoxHelper.UseFloatingWatermark}"
@@ -345,13 +332,13 @@
                                      mah:TextBoxHelper.WatermarkTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}"
                                      Background="{x:Null}"
                                      BorderThickness="0"
-                                     CharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ComboBoxHelper.CharacterCasing), Mode=OneWay}"
+                                     CharacterCasing="{TemplateBinding mah:ComboBoxHelper.CharacterCasing}"
                                      Focusable="True"
                                      FontFamily="{TemplateBinding FontFamily}"
                                      FontSize="{TemplateBinding FontSize}"
                                      Foreground="{TemplateBinding Foreground}"
                                      IsReadOnly="{TemplateBinding IsReadOnly}"
-                                     MaxLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ComboBoxHelper.MaxLength), Mode=OneWay}"
+                                     MaxLength="{TemplateBinding mah:ComboBoxHelper.MaxLength}"
                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                      Style="{StaticResource MahApps.Styles.TextBox.ComboBox.Editable}"
                                      Visibility="Collapsed" />
@@ -524,11 +511,16 @@
                             </MultiDataTrigger.ExitActions>
                         </MultiDataTrigger>
 
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ClearTextButton)}" Value="False">
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
+                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
                             <Setter TargetName="ContentSite" Property="Grid.ColumnSpan" Value="2" />
                             <Setter TargetName="PART_EditableTextBox" Property="Grid.ColumnSpan" Value="2" />
                             <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
-                        </DataTrigger>
+                        </MultiTrigger>
+
                         <Trigger Property="IsEditable" Value="True">
                             <Setter Property="IsTabStop" Value="false" />
                             <Setter TargetName="ContentSite" Property="Visibility" Value="Collapsed" />
@@ -577,10 +569,15 @@
         </Setter>
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource MahApps.Templates.ValidationError}" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
+
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.ComboBox.Border.Focus}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.ComboBox.Border.MouseOver}" />
+
+        <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
+        <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
+
         <Style.Triggers>
             <Trigger Property="VirtualizingStackPanel.IsVirtualizing" Value="True">
                 <Setter Property="ItemsPanel">

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -170,7 +170,7 @@
                                 Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                 Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                 CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
-                                CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ComboBox}}, Mode=OneWay}"
+                                CommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                 Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                 ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                 Focusable="False"
@@ -278,6 +278,7 @@
                                           mah:ControlsHelper.CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                                           mah:TextBoxHelper.ButtonCommand="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                           mah:TextBoxHelper.ButtonCommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                          mah:TextBoxHelper.ButtonCommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                           mah:TextBoxHelper.ButtonContent="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                           mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                           mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
@@ -572,6 +573,7 @@
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.ComboBox.Border.MouseOver}" />
 
         <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
+        <Setter Property="mah:TextBoxHelper.ButtonCommandTarget" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />

--- a/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -120,7 +120,6 @@
                                     Focusable="False"
                                     FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                     FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
                                     Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
                                     Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
@@ -136,7 +135,6 @@
                                     Focusable="False"
                                     FontFamily="{TemplateBinding mah:DatePickerHelper.DropDownButtonFontFamily}"
                                     FontSize="{TemplateBinding mah:DatePickerHelper.DropDownButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
                                     Style="{DynamicResource MahApps.Styles.Button.Chromeless}" />
 
@@ -163,8 +161,15 @@
 
                     <ControlTemplate.Triggers>
                         <Trigger Property="mah:TextBoxHelper.ClearTextButton" Value="True">
-                            <Setter Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
+                            <Setter TargetName="PART_ClearText" Property="Command" Value="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
                         </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
+                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_ClearText" Property="Visibility" Value="Collapsed" />
+                        </MultiTrigger>
 
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Left">
                             <Setter TargetName="ButtonColumn" Property="Width" Value="*" />
@@ -202,17 +207,6 @@
                             <Setter TargetName="PART_Button" Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
                         </Trigger>
 
-                        <Trigger Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}">
-                            <Setter TargetName="PART_ClearText" Property="Visibility" Value="Collapsed" />
-                        </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="mah:ControlsHelper.IsReadOnly" Value="True" />
-                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_ClearText" Property="IsEnabled" Value="False" />
-                        </MultiTrigger>
                         <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
                             <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
@@ -241,8 +235,10 @@
             </Setter.Value>
         </Setter>
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource MahApps.Templates.ValidationError}" />
+
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.Focus}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.MouseOver}" />
+
         <!--  Modern - Calendar14  -->
         <Setter Property="mah:DatePickerHelper.DropDownButtonContent" Value="M 34.0047,52.0073L 31.0042,52.0073L 31.0042,38.5053C 29.6649,39.8964 28.157,40.7849 26.3412,41.4502L 26.3412,37.7553C 27.2998,37.4474 28.3405,36.8645 29.4634,36.0068C 30.5862,35.149 31.3572,34.1483 31.7762,33.0046L 34.0047,33.0046L 34.0047,52.0073 Z M 45.0063,52.0073L 45.0063,48.0067L 37.0052,48.0067L 37.0052,45.0063L 45.0063,33.0046L 48.0067,33.0046L 48.0067,45.0063L 50.007,45.0063L 50.007,48.0067L 48.0067,48.0067L 48.0067,52.0073L 45.0063,52.0073 Z M 45.0063,45.0063L 45.0063,38.2555L 40.2556,45.0063L 45.0063,45.0063 Z M 18.0025,57.0082L 18.0025,23.0033L 23.0032,23.0033L 23.0032,20.0029C 23.0033,18.898 23.8988,18.0026 25.0035,18.0026L 29.004,18.0026C 30.1087,18.0026 31.0042,18.898 31.0043,20.0026L 31.0043,23.0033L 45.0063,23.0033L 45.0062,20.0026C 45.0062,18.8979 45.9018,18.0023 47.0065,18.0023L 51.0071,18.0023C 52.1118,18.0023 53.0074,18.8979 53.0074,20.0026L 53.0074,23.0033L 58.0081,23.0033L 58.0081,57.0082L 18.0025,57.0082 Z M 21.0029,54.0078L 55.0076,54.0078L 55.0076,31.0044L 21.0029,31.0044L 21.0029,54.0078 Z M 48.5067,20.0029C 47.6782,20.0029 47.0065,20.6746 47.0065,21.5031L 47.0065,24.5035C 47.0065,25.3321 47.6782,26.0038 48.5067,26.0038L 49.5068,26.0038C 50.3354,26.0038 51.007,25.3321 51.007,24.5035L 51.007,21.5031C 51.007,20.6746 50.3354,20.0029 49.5068,20.0029L 48.5067,20.0029 Z M 26.5037,20.0029C 25.6751,20.0029 25.0035,20.6745 25.0035,21.5031L 25.0035,24.5035C 25.0035,25.3321 25.6751,26.0037 26.5037,26.0037L 27.5038,26.0037C 28.3324,26.0037 29.004,25.3321 29.004,24.5035L 29.004,21.5031C 29.004,20.6745 28.3324,20.0029 27.5038,20.0029L 26.5037,20.0029 Z" />
         <Setter Property="mah:DatePickerHelper.DropDownButtonContentTemplate">
@@ -255,6 +251,8 @@
                 </DataTemplate>
             </Setter.Value>
         </Setter>
+
+        <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
@@ -357,6 +355,7 @@
             </Setter.Value>
         </Setter>
         <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
+        <Setter Property="mah:TextBoxHelper.WatermarkWrapping" Value="{Binding RelativeSource={RelativeSource Self}, Path=TextWrapping, Mode=OneWay}" />
     </Style>
 
     <Style x:Key="MahApps.Styles.DatePickerTextBox.TimePickerBase"

--- a/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:accessibility="clr-namespace:MahApps.Metro.Accessibility"
                     xmlns:behaviors="clr-namespace:MahApps.Metro.Behaviors"
+                    xmlns:controlzex="urn:controlzex"
                     xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
                     xmlns:mah="clr-namespace:MahApps.Metro.Controls"
                     xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
@@ -138,14 +139,15 @@
                                     IsTabStop="False"
                                     Style="{DynamicResource MahApps.Styles.Button.Chromeless}" />
 
-                            <Popup x:Name="PART_Popup"
-                                   Grid.Row="1"
-                                   Grid.Column="0"
-                                   AllowsTransparency="True"
-                                   Placement="Bottom"
-                                   PlacementTarget="{Binding ElementName=PART_Root}"
-                                   PopupAnimation="Fade"
-                                   StaysOpen="False" />
+                            <controlzex:PopupEx x:Name="PART_Popup"
+                                                Grid.Row="1"
+                                                Grid.Column="0"
+                                                AllowsTransparency="True"
+                                                Focusable="False"
+                                                Placement="Bottom"
+                                                PlacementTarget="{Binding ElementName=PART_Root}"
+                                                PopupAnimation="Fade"
+                                                StaysOpen="False" />
                         </Grid>
 
                         <Border x:Name="DisabledVisualElement"

--- a/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DatePicker.xaml
@@ -115,7 +115,7 @@
                                     Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                     Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                     CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
-                                    CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type DatePicker}}, Mode=OneWay}"
+                                    CommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                     Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                     ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                     Focusable="False"
@@ -255,6 +255,7 @@
         </Setter>
 
         <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
+        <Setter Property="mah:TextBoxHelper.ButtonCommandTarget" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />

--- a/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -9,8 +9,6 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Buttons.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-
     <mahConverters:StringToVisibilityConverter x:Key="StringToVisibilityConverter" />
 
     <!--  Button Style for MahApps.Styles.PasswordBox.Win8  -->
@@ -196,16 +194,18 @@
                                     Grid.RowSpan="2"
                                     Grid.Column="2"
                                     Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                    mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay}"
+                                    Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                                    CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                    CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type PasswordBox}}, Mode=OneWay}"
                                     Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                     ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                     Focusable="False"
                                     FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                     FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
                                     Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
+                                    Visibility="Visible" />
                         </Grid>
 
                         <Border x:Name="DisabledVisualElement"
@@ -219,6 +219,17 @@
                                 Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}" />
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="mah:TextBoxHelper.ClearTextButton" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Command" Value="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
+                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_ClearText" Property="Visibility" Value="Collapsed" />
+                        </MultiTrigger>
+
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Left">
                             <Setter TargetName="ButtonColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_ClearText" Property="Grid.Column" Value="0" />
@@ -258,6 +269,7 @@
                             <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource MahApps.Brushes.TextBlock.FloatingMessage}" />
                             <Setter TargetName="PART_FloatingMessage" Property="Opacity" Value="1" />
                         </Trigger>
+
                         <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
                             <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
@@ -315,247 +327,17 @@
                 </behaviors:StylizedBehaviorCollection>
             </Setter.Value>
         </Setter>
+
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.Focus}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.MouseOver}" />
+
         <Setter Property="mah:PasswordBoxHelper.CapsLockIcon" Value="{StaticResource MahApps.Controls.CapsLockIcon}" />
+
+        <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
+        <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
-    </Style>
-
-    <!--  Button Command PasswordBox Style  -->
-    <Style x:Key="MahApps.Styles.PasswordBox.Button"
-           BasedOn="{StaticResource MahApps.Styles.PasswordBox}"
-           TargetType="{x:Type PasswordBox}">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type PasswordBox}">
-                    <Grid>
-                        <AdornerDecorator x:Name="PART_WaitingForDataEffectAdornerDecorator" Visibility="Collapsed">
-                            <Border x:Name="PART_WaitingForDataEffectGrid"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="Transparent"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    Effect="{DynamicResource MahApps.DropShadowEffect.WaitingForData}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </AdornerDecorator>
-
-                        <Border x:Name="Base"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-
-                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding BorderThickness}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="TextColumn" Width="*" />
-                                <ColumnDefinition x:Name="CapsLockColumn" Width="Auto" />
-                                <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition x:Name="ButtonRow" Height="*" />
-                            </Grid.RowDefinitions>
-
-                            <ScrollViewer x:Name="PART_ContentHost"
-                                          Grid.Row="1"
-                                          Grid.Column="0"
-                                          Margin="0"
-                                          Padding="{TemplateBinding Padding}"
-                                          VerticalAlignment="Stretch"
-                                          Background="{x:Null}"
-                                          BorderThickness="0"
-                                          IsTabStop="False"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                          Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
-
-                            <TextBlock x:Name="PART_Message"
-                                       Grid.Row="1"
-                                       Grid.Column="0"
-                                       Margin="4 0"
-                                       Padding="{TemplateBinding Padding}"
-                                       HorizontalAlignment="Stretch"
-                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                       Foreground="{TemplateBinding Foreground}"
-                                       Style="{DynamicResource MahApps.Styles.TextBlock.Watermark}"
-                                       Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
-                                       TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
-                                       TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}"
-                                       Visibility="Collapsed" />
-
-                            <ContentControl x:Name="PART_FloatingMessageContainer"
-                                            Grid.Row="0"
-                                            Grid.Column="0"
-                                            Margin="4 0"
-                                            Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
-                                <ContentControl.Height>
-                                    <MultiBinding Converter="{mahConverters:MathMultiplyConverter}" FallbackValue="0">
-                                        <Binding ElementName="PART_FloatingMessage"
-                                                 Mode="OneWay"
-                                                 Path="ActualHeight" />
-                                        <Binding ElementName="PART_FloatingMessageContainer"
-                                                 Mode="OneWay"
-                                                 Path="Opacity" />
-                                    </MultiBinding>
-                                </ContentControl.Height>
-                                <TextBlock x:Name="PART_FloatingMessage"
-                                           HorizontalAlignment="Stretch"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                           Foreground="{TemplateBinding Foreground}"
-                                           Style="{DynamicResource MahApps.Styles.TextBlock.AutoCollapsing}"
-                                           Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}">
-                                    <TextBlock.RenderTransform>
-                                        <TranslateTransform x:Name="FloatingMessageTransform">
-                                            <TranslateTransform.Y>
-                                                <MultiBinding Converter="{mahConverters:MathSubtractConverter}" FallbackValue="0">
-                                                    <Binding ElementName="PART_FloatingMessage"
-                                                             Mode="OneWay"
-                                                             Path="ActualHeight" />
-                                                    <Binding ElementName="PART_FloatingMessageContainer"
-                                                             Mode="OneWay"
-                                                             Path="ActualHeight" />
-                                                </MultiBinding>
-                                            </TranslateTransform.Y>
-                                        </TranslateTransform>
-                                    </TextBlock.RenderTransform>
-                                </TextBlock>
-                            </ContentControl>
-
-                            <ContentPresenter x:Name="PART_CapsLockIndicator"
-                                              Grid.Row="0"
-                                              Grid.RowSpan="2"
-                                              Grid.Column="1"
-                                              Margin="1"
-                                              HorizontalAlignment="Right"
-                                              VerticalAlignment="Center"
-                                              Content="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:PasswordBoxHelper.CapsLockIcon), Mode=TwoWay}"
-                                              TextBlock.Foreground="{DynamicResource MahApps.Brushes.Control.Validation}"
-                                              ToolTip="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:PasswordBoxHelper.CapsLockWarningToolTip), Mode=OneWay}"
-                                              Visibility="Collapsed" />
-
-                            <Button x:Name="PART_ClearText"
-                                    Grid.Row="0"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="2"
-                                    Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                    mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="True"
-                                    Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
-                                    ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
-                                    Focusable="False"
-                                    FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
-                                    FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
-                                    IsTabStop="False"
-                                    Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                    Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
-                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.TextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                        </Grid>
-
-                        <Border x:Name="DisabledVisualElement"
-                                Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                BorderBrush="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                IsHitTestVisible="False"
-                                Opacity="0"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}" />
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Left">
-                            <Setter TargetName="ButtonColumn" Property="Width" Value="*" />
-                            <Setter TargetName="PART_ClearText" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_ContentHost" Property="Grid.Column" Value="2" />
-                            <Setter TargetName="PART_FloatingMessageContainer" Property="Grid.Column" Value="2" />
-                            <Setter TargetName="PART_Message" Property="Grid.Column" Value="2" />
-                            <Setter TargetName="TextColumn" Property="Width" Value="Auto" />
-                        </DataTrigger>
-
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Password, Mode=OneWay}" Value="">
-                            <Setter TargetName="PART_Message" Property="Visibility" Value="Visible" />
-                        </DataTrigger>
-
-                        <MultiDataTrigger>
-                            <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding Path=IsVisible, RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.Watermark), RelativeSource={RelativeSource Self}, Converter={x:Static mahConverters:StringIsNullOrEmptyConverter.Default}}" Value="False" />
-                            </MultiDataTrigger.Conditions>
-                            <MultiDataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ShowFloatingMessage}" />
-                            </MultiDataTrigger.EnterActions>
-                            <MultiDataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.HideFloatingMessage}" />
-                            </MultiDataTrigger.ExitActions>
-                        </MultiDataTrigger>
-
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.MouseOverBorderBrush)}" />
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
-                        </Trigger>
-                        <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderBrush)}" />
-                            <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource MahApps.Brushes.TextBlock.FloatingMessage}" />
-                            <Setter TargetName="PART_FloatingMessage" Property="Opacity" Value="1" />
-                        </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
-                        </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-                        </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="mah:TextBoxHelper.HasText" Value="False" />
-                                <Condition Property="IsFocused" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <MultiTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.EnterGotFocus}" />
-                            </MultiTrigger.EnterActions>
-                            <MultiTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ExitGotFocus}" />
-                            </MultiTrigger.ExitActions>
-                        </MultiTrigger>
-
-                        <Trigger Property="mah:TextBoxHelper.HasText" Value="True">
-                            <Setter TargetName="PART_Message" Property="Visibility" Value="Visible" />
-                            <Trigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.EnterHasText}" />
-                            </Trigger.EnterActions>
-                            <Trigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ExitHasText}" />
-                            </Trigger.ExitActions>
-                        </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsVisible" Value="True" />
-                                <Condition Property="mah:TextBoxHelper.IsWaitingForData" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_WaitingForDataEffectAdornerDecorator" Property="Visibility" Value="Visible" />
-                            <MultiTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.WaitingForData}" />
-                            </MultiTrigger.EnterActions>
-                        </MultiTrigger>
-                        <Trigger Property="mah:TextBoxHelper.IsWaitingForData" Value="False">
-                            <Setter TargetName="PART_WaitingForDataEffectAdornerDecorator" Property="Visibility" Value="Collapsed" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
-        <Setter Property="mah:TextBoxHelper.TextButton" Value="True" />
     </Style>
 
     <Style x:Key="MahApps.Styles.TextBox.PasswordBox.Revealed" TargetType="{x:Type TextBox}">
@@ -578,7 +360,7 @@
     </Style>
 
     <!--  Button Revealed PasswordBox Style  -->
-    <Style x:Key="MahApps.Styles.PasswordBox.Button.Revealed"
+    <Style x:Key="MahApps.Styles.PasswordBox.Revealed"
            BasedOn="{StaticResource MahApps.Styles.PasswordBox}"
            TargetType="{x:Type PasswordBox}">
         <Setter Property="Template">
@@ -720,7 +502,6 @@
                                     Content="{TemplateBinding mah:PasswordBoxHelper.RevealButtonContent}"
                                     ContentTemplate="{TemplateBinding mah:PasswordBoxHelper.RevealButtonContentTemplate}"
                                     Focusable="False"
-                                    Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
                                     Style="{DynamicResource MahApps.Styles.Button.Reveal}"
                                     Visibility="{Binding ElementName=RevealedPassword, Path=Text, Converter={StaticResource StringToVisibilityConverter}}" />
@@ -730,17 +511,18 @@
                                     Grid.RowSpan="2"
                                     Grid.Column="3"
                                     Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                    mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay}"
+                                    Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                                    CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                    CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type PasswordBox}}, Mode=OneWay}"
                                     Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                     ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                     Focusable="False"
                                     FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                     FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
                                     Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
                                     Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
-                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    Visibility="Visible" />
                         </Grid>
 
                         <Border x:Name="DisabledVisualElement"
@@ -754,6 +536,17 @@
                                 Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}" />
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="mah:TextBoxHelper.ClearTextButton" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Command" Value="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
+                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_ClearText" Property="Visibility" Value="Collapsed" />
+                        </MultiTrigger>
+
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Left">
                             <Setter TargetName="ButtonColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_CapsLockIndicator" Property="Grid.Column" Value="2" />
@@ -796,6 +589,7 @@
                             <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource MahApps.Brushes.TextBlock.FloatingMessage}" />
                             <Setter TargetName="PART_FloatingMessage" Property="Opacity" Value="1" />
                         </Trigger>
+
                         <Trigger SourceName="PART_RevealButton" Property="IsMouseOver" Value="True">
                             <Setter TargetName="PART_RevealButton" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
                             <Setter TargetName="PART_RevealButton" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
@@ -806,6 +600,7 @@
                             <Setter TargetName="PART_RevealButton" Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
                             <Setter TargetName="RevealedPassword" Property="Visibility" Value="Visible" />
                         </Trigger>
+
                         <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
                             <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
@@ -856,12 +651,11 @@
             </Setter.Value>
         </Setter>
         <Setter Property="mah:PasswordBoxHelper.RevealButtonContent" Value="{StaticResource MahApps.Controls.RevealIcon}" />
-        <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
     </Style>
 
     <!--  MahApps.Styles.PasswordBox.Win8 Style  -->
     <Style x:Key="MahApps.Styles.PasswordBox.Win8"
-           BasedOn="{StaticResource MahApps.Styles.PasswordBox.Button.Revealed}"
+           BasedOn="{StaticResource MahApps.Styles.PasswordBox.Revealed}"
            TargetType="{x:Type PasswordBox}">
         <Setter Property="AllowDrop" Value="true" />
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />

--- a/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -196,7 +196,7 @@
                                     Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                     Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                     CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
-                                    CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type PasswordBox}}, Mode=OneWay}"
+                                    CommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                     Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                     ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                     Focusable="False"
@@ -334,6 +334,7 @@
         <Setter Property="mah:PasswordBoxHelper.CapsLockIcon" Value="{StaticResource MahApps.Controls.CapsLockIcon}" />
 
         <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
+        <Setter Property="mah:TextBoxHelper.ButtonCommandTarget" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
@@ -513,7 +514,7 @@
                                     Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                     Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                     CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
-                                    CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type PasswordBox}}, Mode=OneWay}"
+                                    CommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                     Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                     ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                     Focusable="False"

--- a/src/MahApps.Metro/Styles/Controls.RichTextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.RichTextBox.xaml
@@ -284,7 +284,6 @@
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="mah:TextBoxHelper.IsSpellCheckContextMenuEnabled" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
-        <Setter Property="mah:TextBoxHelper.WatermarkWrapping" Value="{Binding RelativeSource={RelativeSource Self}, Path=TextWrapping, Mode=OneWay}" />
     </Style>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro/Styles/Controls.RichTextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.RichTextBox.xaml
@@ -160,16 +160,18 @@
                                     Grid.RowSpan="2"
                                     Grid.Column="1"
                                     Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                    mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{TemplateBinding mah:TextBoxHelper.ClearTextButton}"
+                                    Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                                    CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                    CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type RichTextBox}}, Mode=OneWay}"
                                     Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                     ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                     Focusable="False"
                                     FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                     FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
                                     Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
+                                    Visibility="Visible" />
                         </Grid>
 
                         <Border x:Name="DisabledVisualElement"
@@ -183,6 +185,17 @@
                                 Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}" />
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="mah:TextBoxHelper.ClearTextButton" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Command" Value="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
+                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_ClearText" Property="Visibility" Value="Collapsed" />
+                        </MultiTrigger>
+
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Left">
                             <Setter TargetName="ButtonColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_ClearText" Property="Grid.Column" Value="0" />
@@ -211,15 +224,6 @@
                             </MultiDataTrigger.ExitActions>
                         </MultiDataTrigger>
 
-                        <MultiDataTrigger>
-                            <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Right" />
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ClearTextButton)}" Value="False" />
-                            </MultiDataTrigger.Conditions>
-                            <Setter TargetName="PART_GridContentHost" Property="Grid.ColumnSpan" Value="2" />
-                            <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
-                        </MultiDataTrigger>
-
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="BorderElement" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.MouseOverBorderBrush)}" />
                         </Trigger>
@@ -234,6 +238,7 @@
                             <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource MahApps.Brushes.TextBlock.FloatingMessage}" />
                             <Setter TargetName="PART_FloatingMessage" Property="Opacity" Value="1" />
                         </Trigger>
+
                         <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
                             <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
@@ -269,234 +274,17 @@
             </Setter.Value>
         </Setter>
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource MahApps.Templates.ValidationError}" />
+
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.Focus}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.MouseOver}" />
+
+        <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
+        <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="mah:TextBoxHelper.IsSpellCheckContextMenuEnabled" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
-    </Style>
-
-    <Style x:Key="MahApps.Styles.RichTextBox.Button"
-           BasedOn="{StaticResource MahApps.Styles.RichTextBox}"
-           TargetType="{x:Type RichTextBox}">
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type TextBoxBase}">
-                    <Grid>
-                        <Border x:Name="BorderElement"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-
-                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding BorderThickness}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="TextColumn" Width="*" />
-                                <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
-
-                            <Grid x:Name="PART_GridContentHost"
-                                  Grid.Row="1"
-                                  Grid.Column="0">
-                                <ScrollViewer x:Name="PART_ContentHost"
-                                              Width="{Binding ElementName=PART_GridContentHost, Path=ActualWidth}"
-                                              Margin="0"
-                                              Padding="{TemplateBinding Padding}"
-                                              VerticalAlignment="Stretch"
-                                              mah:ScrollViewerHelper.ScrollContentPresenterMargin="-5 -1 -1 -1"
-                                              Background="{x:Null}"
-                                              BorderThickness="0"
-                                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                              IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
-                                              IsTabStop="False"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                              Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}"
-                                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
-                            </Grid>
-
-                            <TextBlock x:Name="PART_Message"
-                                       Grid.Row="1"
-                                       Grid.Column="0"
-                                       Margin="4 0"
-                                       Padding="{TemplateBinding Padding}"
-                                       HorizontalAlignment="Stretch"
-                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                       Foreground="{TemplateBinding Foreground}"
-                                       Style="{DynamicResource MahApps.Styles.TextBlock.Watermark}"
-                                       Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
-                                       TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
-                                       TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}"
-                                       TextWrapping="{TemplateBinding mah:TextBoxHelper.WatermarkWrapping}"
-                                       Visibility="Collapsed" />
-
-                            <ContentControl x:Name="PART_FloatingMessageContainer"
-                                            Grid.Row="0"
-                                            Grid.Column="0"
-                                            Margin="6 0"
-                                            Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
-                                <ContentControl.Height>
-                                    <MultiBinding Converter="{mahConverters:MathMultiplyConverter}" FallbackValue="0">
-                                        <Binding ElementName="PART_FloatingMessage"
-                                                 Mode="OneWay"
-                                                 Path="ActualHeight" />
-                                        <Binding ElementName="PART_FloatingMessageContainer"
-                                                 Mode="OneWay"
-                                                 Path="Opacity" />
-                                    </MultiBinding>
-                                </ContentControl.Height>
-                                <TextBlock x:Name="PART_FloatingMessage"
-                                           HorizontalAlignment="Stretch"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                           Foreground="{TemplateBinding Foreground}"
-                                           Style="{DynamicResource MahApps.Styles.TextBlock.AutoCollapsing}"
-                                           Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}">
-                                    <TextBlock.RenderTransform>
-                                        <TranslateTransform x:Name="FloatingMessageTransform">
-                                            <TranslateTransform.Y>
-                                                <MultiBinding Converter="{mahConverters:MathSubtractConverter}" FallbackValue="0">
-                                                    <Binding ElementName="PART_FloatingMessage"
-                                                             Mode="OneWay"
-                                                             Path="ActualHeight" />
-                                                    <Binding ElementName="PART_FloatingMessageContainer"
-                                                             Mode="OneWay"
-                                                             Path="ActualHeight" />
-                                                </MultiBinding>
-                                            </TranslateTransform.Y>
-                                        </TranslateTransform>
-                                    </TextBlock.RenderTransform>
-                                </TextBlock>
-                            </ContentControl>
-
-                            <Button x:Name="PART_ClearText"
-                                    Grid.Row="0"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="1"
-                                    Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                    mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="False"
-                                    Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
-                                    CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
-                                    Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
-                                    ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
-                                    Focusable="False"
-                                    FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
-                                    FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
-                                    IsTabStop="False"
-                                    Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                    Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
-                                    Visibility="Visible" />
-                        </Grid>
-
-                        <Border x:Name="DisabledVisualElement"
-                                Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                BorderBrush="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                IsHitTestVisible="False"
-                                Opacity="0"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}" />
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Left">
-                            <Setter TargetName="ButtonColumn" Property="Width" Value="*" />
-                            <Setter TargetName="PART_ClearText" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_FloatingMessageContainer" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="PART_GridContentHost" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="PART_Message" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="TextColumn" Property="Width" Value="Auto" />
-                        </DataTrigger>
-
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.HasText)}" Value="False">
-                            <Setter TargetName="PART_Message" Property="Visibility" Value="Visible" />
-                        </DataTrigger>
-
-                        <MultiDataTrigger>
-                            <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding Path=IsVisible, RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.Watermark), RelativeSource={RelativeSource Self}, Converter={x:Static mahConverters:StringIsNullOrEmptyConverter.Default}}" Value="False" />
-                            </MultiDataTrigger.Conditions>
-                            <MultiDataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ShowFloatingMessage}" />
-                            </MultiDataTrigger.EnterActions>
-                            <MultiDataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.HideFloatingMessage}" />
-                            </MultiDataTrigger.ExitActions>
-                        </MultiDataTrigger>
-
-                        <MultiDataTrigger>
-                            <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Right" />
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.TextButton)}" Value="False" />
-                            </MultiDataTrigger.Conditions>
-                            <Setter TargetName="PART_GridContentHost" Property="Grid.ColumnSpan" Value="2" />
-                            <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
-                        </MultiDataTrigger>
-
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="BorderElement" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.MouseOverBorderBrush)}" />
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
-                        </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsReadOnly" Value="True" />
-                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_ClearText" Property="IsEnabled" Value="False" />
-                        </MultiTrigger>
-                        <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="BorderElement" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderBrush)}" />
-                            <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource MahApps.Brushes.TextBlock.FloatingMessage}" />
-                            <Setter TargetName="PART_FloatingMessage" Property="Opacity" Value="1" />
-                        </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
-                        </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-                        </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="mah:TextBoxHelper.HasText" Value="False" />
-                                <Condition Property="IsFocused" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <MultiTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.EnterGotFocus}" />
-                            </MultiTrigger.EnterActions>
-                            <MultiTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ExitGotFocus}" />
-                            </MultiTrigger.ExitActions>
-                        </MultiTrigger>
-
-                        <Trigger Property="mah:TextBoxHelper.HasText" Value="True">
-                            <Trigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.EnterHasText}" />
-                            </Trigger.EnterActions>
-                            <Trigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ExitHasText}" />
-                            </Trigger.ExitActions>
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}}" />
-        <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
+        <Setter Property="mah:TextBoxHelper.WatermarkWrapping" Value="{Binding RelativeSource={RelativeSource Self}, Path=TextWrapping, Mode=OneWay}" />
     </Style>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro/Styles/Controls.RichTextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.RichTextBox.xaml
@@ -160,7 +160,7 @@
                                     Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                     Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                     CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
-                                    CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type RichTextBox}}, Mode=OneWay}"
+                                    CommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                     Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                     ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                     Focusable="False"
@@ -277,6 +277,7 @@
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.MouseOver}" />
 
         <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
+        <Setter Property="mah:TextBoxHelper.ButtonCommandTarget" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />

--- a/src/MahApps.Metro/Styles/Controls.RichTextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.RichTextBox.xaml
@@ -228,9 +228,6 @@
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
                         </Trigger>
-                        <Trigger Property="IsReadOnly" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="IsEnabled" Value="False" />
-                        </Trigger>
                         <Trigger Property="IsFocused" Value="True">
                             <Setter TargetName="BorderElement" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderBrush)}" />
                             <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource MahApps.Brushes.TextBlock.FloatingMessage}" />

--- a/src/MahApps.Metro/Styles/Controls.RichTextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.RichTextBox.xaml
@@ -7,8 +7,6 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Shared.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-
     <Style x:Key="MahApps.Styles.RichTextBox" TargetType="{x:Type RichTextBox}">
         <Style.Resources>
             <Style BasedOn="{StaticResource {x:Type Hyperlink}}" TargetType="{x:Type Hyperlink}">

--- a/src/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -195,9 +195,6 @@
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
                         </Trigger>
-                        <Trigger Property="IsReadOnly" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="IsEnabled" Value="False" />
-                        </Trigger>
                         <Trigger Property="IsFocused" Value="True">
                             <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderBrush)}" />
                             <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource MahApps.Brushes.TextBlock.FloatingMessage}" />

--- a/src/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -127,16 +127,18 @@
                                     Grid.RowSpan="2"
                                     Grid.Column="1"
                                     Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                    mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay}"
+                                    Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                                    CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                    CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TextBox}}, Mode=OneWay}"
                                     Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                     ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                     Focusable="False"
                                     FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                     FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
                                     Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
+                                    Visibility="Visible" />
                         </Grid>
 
                         <Border x:Name="DisabledVisualElement"
@@ -150,6 +152,17 @@
                                 Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}" />
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="mah:TextBoxHelper.ClearTextButton" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Command" Value="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
+                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_ClearText" Property="Visibility" Value="Collapsed" />
+                        </MultiTrigger>
+
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Left">
                             <Setter TargetName="ButtonColumn" Property="Width" Value="*" />
                             <Setter TargetName="PART_ClearText" Property="Grid.Column" Value="0" />
@@ -178,15 +191,6 @@
                             </MultiDataTrigger.ExitActions>
                         </MultiDataTrigger>
 
-                        <MultiDataTrigger>
-                            <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Right" />
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ClearTextButton)}" Value="False" />
-                            </MultiDataTrigger.Conditions>
-                            <Setter TargetName="PART_ContentHost" Property="Grid.ColumnSpan" Value="2" />
-                            <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
-                        </MultiDataTrigger>
-
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.MouseOverBorderBrush)}" />
                         </Trigger>
@@ -201,6 +205,7 @@
                             <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource MahApps.Brushes.TextBlock.FloatingMessage}" />
                             <Setter TargetName="PART_FloatingMessage" Property="Opacity" Value="1" />
                         </Trigger>
+
                         <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
                             <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
@@ -250,257 +255,24 @@
             </Setter.Value>
         </Setter>
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource MahApps.Templates.ValidationError}" />
+
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.Focus}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.MouseOver}" />
+
+        <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
+        <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="mah:TextBoxHelper.IsSpellCheckContextMenuEnabled" Value="{Binding RelativeSource={RelativeSource Self}, Path=(SpellCheck.IsEnabled)}" />
         <Setter Property="mah:TextBoxHelper.WatermarkWrapping" Value="{Binding RelativeSource={RelativeSource Self}, Path=TextWrapping, Mode=OneWay}" />
     </Style>
 
-    <Style x:Key="MahApps.Styles.TextBox.Button"
+    <Style x:Key="MahApps.Styles.TextBox.Search"
            BasedOn="{StaticResource MahApps.Styles.TextBox}"
            TargetType="{x:Type TextBox}">
-        <!--  change SnapsToDevicePixels to True to view a better border and validation error  -->
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type TextBox}">
-                    <Grid>
-                        <AdornerDecorator x:Name="PART_WaitingForDataEffectAdornerDecorator" Visibility="Collapsed">
-                            <Border x:Name="PART_WaitingForDataEffectGrid"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="Transparent"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    Effect="{DynamicResource MahApps.DropShadowEffect.WaitingForData}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </AdornerDecorator>
-
-                        <Border x:Name="Base"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-
-                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding BorderThickness}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="TextColumn" Width="*" />
-                                <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition x:Name="ButtonRow" Height="*" />
-                            </Grid.RowDefinitions>
-
-                            <ScrollViewer x:Name="PART_ContentHost"
-                                          Grid.Row="1"
-                                          Grid.Column="0"
-                                          Margin="0"
-                                          Padding="{TemplateBinding Padding}"
-                                          VerticalAlignment="Stretch"
-                                          Background="{x:Null}"
-                                          BorderThickness="0"
-                                          IsTabStop="False"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                          Style="{DynamicResource MahApps.Styles.ScrollViewer.TextControlContentHost}" />
-
-                            <TextBlock x:Name="PART_Message"
-                                       Grid.Row="1"
-                                       Grid.Column="0"
-                                       Margin="4 0"
-                                       Padding="{TemplateBinding Padding}"
-                                       HorizontalAlignment="Stretch"
-                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                       Foreground="{TemplateBinding Foreground}"
-                                       Style="{DynamicResource MahApps.Styles.TextBlock.Watermark}"
-                                       Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
-                                       TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
-                                       TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}"
-                                       TextWrapping="{TemplateBinding mah:TextBoxHelper.WatermarkWrapping}"
-                                       Visibility="Collapsed" />
-
-                            <ContentControl x:Name="PART_FloatingMessageContainer"
-                                            Grid.Row="0"
-                                            Grid.Column="0"
-                                            Margin="4 0"
-                                            Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
-                                <ContentControl.Height>
-                                    <MultiBinding Converter="{mahConverters:MathMultiplyConverter}" FallbackValue="0">
-                                        <Binding ElementName="PART_FloatingMessage"
-                                                 Mode="OneWay"
-                                                 Path="ActualHeight" />
-                                        <Binding ElementName="PART_FloatingMessageContainer"
-                                                 Mode="OneWay"
-                                                 Path="Opacity" />
-                                    </MultiBinding>
-                                </ContentControl.Height>
-                                <TextBlock x:Name="PART_FloatingMessage"
-                                           HorizontalAlignment="Stretch"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                           Foreground="{TemplateBinding Foreground}"
-                                           Style="{DynamicResource MahApps.Styles.TextBlock.AutoCollapsing}"
-                                           Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}">
-                                    <TextBlock.RenderTransform>
-                                        <TranslateTransform x:Name="FloatingMessageTransform">
-                                            <TranslateTransform.Y>
-                                                <MultiBinding Converter="{mahConverters:MathSubtractConverter}" FallbackValue="0">
-                                                    <Binding ElementName="PART_FloatingMessage"
-                                                             Mode="OneWay"
-                                                             Path="ActualHeight" />
-                                                    <Binding ElementName="PART_FloatingMessageContainer"
-                                                             Mode="OneWay"
-                                                             Path="ActualHeight" />
-                                                </MultiBinding>
-                                            </TranslateTransform.Y>
-                                        </TranslateTransform>
-                                    </TextBlock.RenderTransform>
-                                </TextBlock>
-                            </ContentControl>
-
-                            <Button x:Name="PART_ClearText"
-                                    Grid.Row="0"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="1"
-                                    Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                    mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="True"
-                                    Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
-                                    ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
-                                    Focusable="False"
-                                    FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
-                                    FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
-                                    IsTabStop="False"
-                                    Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                    Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
-                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.TextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                        </Grid>
-
-                        <Border x:Name="DisabledVisualElement"
-                                Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                BorderBrush="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                IsHitTestVisible="False"
-                                Opacity="0"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.DisabledVisualElementVisibility), Mode=OneWay}" />
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Left">
-                            <Setter TargetName="ButtonColumn" Property="Width" Value="*" />
-                            <Setter TargetName="PART_ClearText" Property="Grid.Column" Value="0" />
-                            <Setter TargetName="PART_ContentHost" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="PART_FloatingMessageContainer" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="PART_Message" Property="Grid.Column" Value="1" />
-                            <Setter TargetName="TextColumn" Property="Width" Value="Auto" />
-                        </DataTrigger>
-
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Text}" Value="">
-                            <Setter TargetName="PART_Message" Property="Visibility" Value="Visible" />
-                        </DataTrigger>
-
-                        <MultiDataTrigger>
-                            <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding Path=IsVisible, RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.Watermark), RelativeSource={RelativeSource Self}, Converter={x:Static mahConverters:StringIsNullOrEmptyConverter.Default}}" Value="False" />
-                            </MultiDataTrigger.Conditions>
-                            <MultiDataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ShowFloatingMessage}" />
-                            </MultiDataTrigger.EnterActions>
-                            <MultiDataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.HideFloatingMessage}" />
-                            </MultiDataTrigger.ExitActions>
-                        </MultiDataTrigger>
-
-                        <MultiDataTrigger>
-                            <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Right" />
-                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.TextButton)}" Value="False" />
-                            </MultiDataTrigger.Conditions>
-                            <Setter TargetName="PART_ContentHost" Property="Grid.ColumnSpan" Value="2" />
-                            <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
-                        </MultiDataTrigger>
-
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.MouseOverBorderBrush)}" />
-                        </Trigger>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.6" />
-                        </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsReadOnly" Value="True" />
-                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_ClearText" Property="IsEnabled" Value="False" />
-                        </MultiTrigger>
-                        <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="Base" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderBrush)}" />
-                            <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource MahApps.Brushes.TextBlock.FloatingMessage}" />
-                            <Setter TargetName="PART_FloatingMessage" Property="Opacity" Value="1" />
-                        </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
-                        </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-                        </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="mah:TextBoxHelper.HasText" Value="False" />
-                                <Condition Property="IsFocused" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <MultiTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.EnterGotFocus}" />
-                            </MultiTrigger.EnterActions>
-                            <MultiTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ExitGotFocus}" />
-                            </MultiTrigger.ExitActions>
-                        </MultiTrigger>
-
-                        <Trigger Property="mah:TextBoxHelper.HasText" Value="True">
-                            <Trigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.EnterHasText}" />
-                            </Trigger.EnterActions>
-                            <Trigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ExitHasText}" />
-                            </Trigger.ExitActions>
-                        </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsVisible" Value="True" />
-                                <Condition Property="mah:TextBoxHelper.IsWaitingForData" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_WaitingForDataEffectAdornerDecorator" Property="Visibility" Value="Visible" />
-                            <MultiTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.WaitingForData}" />
-                            </MultiTrigger.EnterActions>
-                        </MultiTrigger>
-                        <Trigger Property="mah:TextBoxHelper.IsWaitingForData" Value="False">
-                            <Setter TargetName="PART_WaitingForDataEffectAdornerDecorator" Property="Visibility" Value="Collapsed" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
-        <Setter Property="mah:TextBoxHelper.TextButton" Value="True" />
-    </Style>
-
-    <Style x:Key="MahApps.Styles.TextBox.Search"
-           BasedOn="{StaticResource MahApps.Styles.TextBox.Button}"
-           TargetType="{x:Type TextBox}">
         <!--  Modern - Magnify  -->
+        <Setter Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Static mah:MahAppsCommands.SearchCommand}" />
         <Setter Property="mah:TextBoxHelper.ButtonContent" Value="M 42.5,22C 49.4036,22 55,27.5964 55,34.5C 55,41.4036 49.4036,47 42.5,47C 40.1356,47 37.9245,46.3435 36,45.2426L 26.9749,54.2678C 25.8033,55.4393 23.9038,55.4393 22.7322,54.2678C 21.5607,53.0962 21.5607,51.1967 22.7322,50.0251L 31.7971,40.961C 30.6565,39.0755 30,36.8644 30,34.5C 30,27.5964 35.5964,22 42.5,22 Z M 42.5,26C 37.8056,26 34,29.8056 34,34.5C 34,39.1944 37.8056,43 42.5,43C 47.1944,43 51,39.1944 51,34.5C 51,29.8056 47.1944,26 42.5,26 Z" />
         <Setter Property="mah:TextBoxHelper.ButtonContentTemplate">
             <Setter.Value>

--- a/src/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -7,8 +7,6 @@
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Shared.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-
     <!--  TextBox Style  -->
     <Style x:Key="MahApps.Styles.TextBox" TargetType="{x:Type TextBox}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}" />

--- a/src/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -127,7 +127,7 @@
                                     Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                     Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                     CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
-                                    CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TextBox}}, Mode=OneWay}"
+                                    CommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                     Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                     ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                     Focusable="False"
@@ -258,6 +258,7 @@
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.MouseOver}" />
 
         <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
+        <Setter Property="mah:TextBoxHelper.ButtonCommandTarget" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />

--- a/src/MahApps.Metro/Styles/VS/MetroWindow.xaml
+++ b/src/MahApps.Metro/Styles/VS/MetroWindow.xaml
@@ -53,7 +53,7 @@
     </Style>
 
     <Style x:Key="MahApps.Styles.TextBox.Window.QuickLaunch.VisualStudio"
-           BasedOn="{StaticResource MahApps.Styles.TextBox.Button}"
+           BasedOn="{StaticResource MahApps.Styles.TextBox}"
            TargetType="{x:Type TextBox}">
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.QuickLaunchTextBox.Border}" />
         <Setter Property="FontSize" Value="12" />

--- a/src/MahApps.Metro/Themes/ColorPicker/ColorPicker.xaml
+++ b/src/MahApps.Metro/Themes/ColorPicker/ColorPicker.xaml
@@ -81,7 +81,7 @@
                                 Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                 Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                 CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
-                                CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:ColorPicker}}, Mode=OneWay}"
+                                CommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                 Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                 ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                 Focusable="False"
@@ -213,6 +213,7 @@
                                           mah:ControlsHelper.CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                                           mah:TextBoxHelper.ButtonCommand="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                           mah:TextBoxHelper.ButtonCommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                          mah:TextBoxHelper.ButtonCommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                           mah:TextBoxHelper.ButtonContent="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                           mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                           mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
@@ -399,6 +400,7 @@
                                                 <mah:ColorCanvas mah:TextBoxHelper.AutoWatermark="{TemplateBinding mah:TextBoxHelper.AutoWatermark}"
                                                                  mah:TextBoxHelper.ButtonCommand="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                                                  mah:TextBoxHelper.ButtonCommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                                                 mah:TextBoxHelper.ButtonCommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                                                  mah:TextBoxHelper.ButtonContent="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                                                  mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                                                  mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
@@ -541,6 +543,7 @@
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.ComboBox.Border.MouseOver}" />
 
         <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
+        <Setter Property="mah:TextBoxHelper.ButtonCommandTarget" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />

--- a/src/MahApps.Metro/Themes/ColorPicker/ColorPicker.xaml
+++ b/src/MahApps.Metro/Themes/ColorPicker/ColorPicker.xaml
@@ -79,16 +79,18 @@
                         <Button x:Name="PART_ClearText"
                                 Grid.Column="1"
                                 Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource AncestorType={x:Type mah:ColorPicker}}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay}"
+                                Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                                CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:ColorPicker}}, Mode=OneWay}"
                                 Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                 ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                 Focusable="False"
                                 FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                 FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                Foreground="{TemplateBinding Foreground}"
                                 IsTabStop="False"
                                 Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                Visibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type mah:ColorPicker}}, Path=(mah:TextBoxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
+                                Visibility="Visible" />
 
                         <Grid x:Name="BtnArrowBackground"
                               Grid.Column="2"
@@ -106,17 +108,30 @@
                         </Grid>
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <Trigger Property="mah:TextBoxHelper.ClearTextButton" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Command" Value="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
+                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_ClearText" Property="Visibility" Value="Collapsed" />
+                        </MultiTrigger>
+
                         <Trigger SourceName="BtnArrowBackground" Property="IsMouseOver" Value="True">
                             <Setter TargetName="BtnArrowBackground" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray5}" />
                         </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
-                        </Trigger>
+
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True">
                             <Setter TargetName="BtnArrowBackground" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray3}" />
                             <Setter TargetName="ToggleButtonRootGrid" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray7}" />
                         </DataTrigger>
+
+                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
+                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
+                        </Trigger>
                         <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
                             <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
@@ -144,7 +159,7 @@
         <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
         <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
-        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="IsAdvancedTabVisible" Value="True" />
         <Setter Property="IsAvailableColorPaletteVisible" Value="True" />
         <Setter Property="IsColorPalettesTabVisible" Value="True" />
@@ -196,10 +211,13 @@
                                           Margin="0"
                                           VerticalAlignment="Stretch"
                                           mah:ControlsHelper.CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                          mah:TextBoxHelper.ButtonCommand="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                                          mah:TextBoxHelper.ButtonCommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
                                           mah:TextBoxHelper.ButtonContent="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                           mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                           mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                           mah:TextBoxHelper.ButtonFontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
+                                          mah:TextBoxHelper.ButtonTemplate="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
                                           mah:TextBoxHelper.ButtonWidth="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                           mah:TextBoxHelper.ClearTextButton="{TemplateBinding mah:TextBoxHelper.ClearTextButton}"
                                           Background="Transparent"
@@ -437,7 +455,6 @@
                         </VisualStateManager.VisualStateGroups>
                     </Grid>
                     <ControlTemplate.Triggers>
-
                         <MultiDataTrigger>
                             <MultiDataTrigger.Conditions>
                                 <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=SelectedColor}" Value="{x:Null}" />
@@ -485,10 +502,14 @@
                             </MultiDataTrigger.ExitActions>
                         </MultiDataTrigger>
 
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ClearTextButton)}" Value="False">
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
+                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
                             <Setter TargetName="ContentSite" Property="Grid.ColumnSpan" Value="2" />
                             <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
-                        </DataTrigger>
+                        </MultiTrigger>
 
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray9}" />
@@ -513,12 +534,16 @@
         </Setter>
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource MahApps.Templates.ValidationError}" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
+
         <Setter Property="mah:BuildInColorPalettes.MaximumRecentColorsCount" Value="18" />
+
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.ComboBox.Border.Focus}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.ComboBox.Border.MouseOver}" />
+
+        <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
+        <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
-        <Setter Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
     </Style>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -220,7 +220,6 @@
                                     Focusable="False"
                                     FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                     FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
                                     Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
                                     Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
@@ -236,7 +235,6 @@
                                     Focusable="False"
                                     FontFamily="{TemplateBinding mah:DatePickerHelper.DropDownButtonFontFamily}"
                                     FontSize="{TemplateBinding mah:DatePickerHelper.DropDownButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
                                     IsTabStop="False"
                                     Style="{DynamicResource MahApps.Styles.Button.Chromeless}" />
 
@@ -398,8 +396,15 @@
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="mah:TextBoxHelper.ClearTextButton" Value="True">
-                            <Setter Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
+                            <Setter TargetName="PART_ClearText" Property="Command" Value="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
                         </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
+                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="PART_ClearText" Property="Visibility" Value="Collapsed" />
+                        </MultiTrigger>
 
                         <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ButtonsAlignment)}" Value="Left">
                             <Setter TargetName="ButtonColumn" Property="Width" Value="*" />
@@ -446,17 +451,6 @@
                             <Setter TargetName="PART_Calendar" Property="Visibility" Value="Visible" />
                         </Trigger>
 
-                        <Trigger Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}">
-                            <Setter TargetName="PART_ClearText" Property="Visibility" Value="Collapsed" />
-                        </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsReadOnly" Value="True" />
-                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_ClearText" Property="IsEnabled" Value="False" />
-                        </MultiTrigger>
                         <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
                             <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
                             <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
@@ -486,8 +480,10 @@
             </Setter.Value>
         </Setter>
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource MahApps.Templates.ValidationError}" />
+
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.Focus}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.MouseOver}" />
+
         <!--  Modern - Calendar14  -->
         <Setter Property="mah:DatePickerHelper.DropDownButtonContent" Value="M 34.0047,52.0073L 31.0042,52.0073L 31.0042,38.5053C 29.6649,39.8964 28.157,40.7849 26.3412,41.4502L 26.3412,37.7553C 27.2998,37.4474 28.3405,36.8645 29.4634,36.0068C 30.5862,35.149 31.3572,34.1483 31.7762,33.0046L 34.0047,33.0046L 34.0047,52.0073 Z M 45.0063,52.0073L 45.0063,48.0067L 37.0052,48.0067L 37.0052,45.0063L 45.0063,33.0046L 48.0067,33.0046L 48.0067,45.0063L 50.007,45.0063L 50.007,48.0067L 48.0067,48.0067L 48.0067,52.0073L 45.0063,52.0073 Z M 45.0063,45.0063L 45.0063,38.2555L 40.2556,45.0063L 45.0063,45.0063 Z M 18.0025,57.0082L 18.0025,23.0033L 23.0032,23.0033L 23.0032,20.0029C 23.0033,18.898 23.8988,18.0026 25.0035,18.0026L 29.004,18.0026C 30.1087,18.0026 31.0042,18.898 31.0043,20.0026L 31.0043,23.0033L 45.0063,23.0033L 45.0062,20.0026C 45.0062,18.8979 45.9018,18.0023 47.0065,18.0023L 51.0071,18.0023C 52.1118,18.0023 53.0074,18.8979 53.0074,20.0026L 53.0074,23.0033L 58.0081,23.0033L 58.0081,57.0082L 18.0025,57.0082 Z M 21.0029,54.0078L 55.0076,54.0078L 55.0076,31.0044L 21.0029,31.0044L 21.0029,54.0078 Z M 48.5067,20.0029C 47.6782,20.0029 47.0065,20.6746 47.0065,21.5031L 47.0065,24.5035C 47.0065,25.3321 47.6782,26.0038 48.5067,26.0038L 49.5068,26.0038C 50.3354,26.0038 51.007,25.3321 51.007,24.5035L 51.007,21.5031C 51.007,20.6746 50.3354,20.0029 49.5068,20.0029L 48.5067,20.0029 Z M 26.5037,20.0029C 25.6751,20.0029 25.0035,20.6745 25.0035,21.5031L 25.0035,24.5035C 25.0035,25.3321 25.6751,26.0037 26.5037,26.0037L 27.5038,26.0037C 28.3324,26.0037 29.004,25.3321 29.004,24.5035L 29.004,21.5031C 29.004,20.6745 28.3324,20.0029 27.5038,20.0029L 26.5037,20.0029 Z" />
         <Setter Property="mah:DatePickerHelper.DropDownButtonContentTemplate">
@@ -500,6 +496,8 @@
                 </DataTemplate>
             </Setter.Value>
         </Setter>
+
+        <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />

--- a/src/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -214,7 +214,7 @@
                                     Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                     Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                     CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
-                                    CommandTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:TimePickerBase}}, Mode=OneWay}"
+                                    CommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                     Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                     ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                     Focusable="False"
@@ -498,6 +498,7 @@
         </Setter>
 
         <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
+        <Setter Property="mah:TextBoxHelper.ButtonCommandTarget" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />

--- a/src/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/src/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -20,18 +20,24 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type mah:HotKeyBox}">
                     <TextBox x:Name="PART_TextBox"
-                             MinHeight="{TemplateBinding MinHeight}"
+                             MinWidth="0"
+                             MinHeight="0"
                              Margin="0"
                              Padding="{TemplateBinding Padding}"
+                             HorizontalAlignment="Stretch"
                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                              mah:ControlsHelper.CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                              mah:ControlsHelper.FocusBorderBrush="{TemplateBinding mah:ControlsHelper.FocusBorderBrush}"
                              mah:ControlsHelper.MouseOverBorderBrush="{TemplateBinding mah:ControlsHelper.MouseOverBorderBrush}"
+                             mah:TextBoxHelper.ButtonCommand="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                             mah:TextBoxHelper.ButtonCommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                             mah:TextBoxHelper.ButtonCommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                              mah:TextBoxHelper.ButtonContent="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                              mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                              mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                              mah:TextBoxHelper.ButtonFontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
+                             mah:TextBoxHelper.ButtonTemplate="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
                              mah:TextBoxHelper.ButtonWidth="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                              mah:TextBoxHelper.ButtonsAlignment="{TemplateBinding mah:TextBoxHelper.ButtonsAlignment}"
                              mah:TextBoxHelper.ClearTextButton="{TemplateBinding mah:TextBoxHelper.ClearTextButton}"
@@ -41,6 +47,7 @@
                              mah:TextBoxHelper.Watermark="{TemplateBinding mah:TextBoxHelper.Watermark}"
                              mah:TextBoxHelper.WatermarkAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
                              mah:TextBoxHelper.WatermarkTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}"
+                             mah:TextBoxHelper.WatermarkWrapping="{TemplateBinding mah:TextBoxHelper.WatermarkWrapping}"
                              Background="{TemplateBinding Background}"
                              BorderBrush="{TemplateBinding BorderBrush}"
                              BorderThickness="{TemplateBinding BorderThickness}"
@@ -52,6 +59,7 @@
                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                              IsTabStop="{TemplateBinding IsTabStop}"
                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                             TabIndex="{TemplateBinding TabIndex}"
                              Text="{TemplateBinding Text}"
                              Validation.ErrorTemplate="{TemplateBinding Validation.ErrorTemplate}"
                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
@@ -70,9 +78,16 @@
             </Setter.Value>
         </Setter>
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource MahApps.Templates.ValidationError}" />
+
         <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{DynamicResource MahApps.CharacterCasing.HotKeyBox}" />
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.Focus}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.MouseOver}" />
+
+        <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
+        <Setter Property="mah:TextBoxHelper.ButtonCommandTarget" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
+        <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
+        <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
+        <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
     </Style>
 </ResourceDictionary>

--- a/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
+++ b/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:lang="clr-namespace:MahApps.Metro.Lang"
                     xmlns:mah="clr-namespace:MahApps.Metro.Controls"
@@ -35,7 +35,7 @@
 
     <!--#endregion-->
 
-    <!--#region ItemContainterStyles-->
+    <!--#region ItemContainerStyles-->
 
     <Style x:Key="MahApps.Styles.MultiSelectionComboBoxItem"
            BasedOn="{StaticResource MahApps.Styles.ListBoxItem}"
@@ -111,7 +111,7 @@
         </Setter>
     </Style>
 
-    <Style x:Key="MahApps.Styles.MulitselectionComboBoxSelectedItem" TargetType="ListBoxItem">
+    <Style x:Key="MahApps.Styles.MultiSelectionComboBoxSelectedItem" TargetType="ListBoxItem">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="Margin" Value="0 0 2 0" />
@@ -143,7 +143,7 @@
         <Setter Property="mah:ControlsHelper.CornerRadius" Value="{Binding RelativeSource={RelativeSource Mode=Self}, Path=ActualHeight, Converter={mahConverters:SizeToCornerRadiusConverter}}" />
     </Style>
 
-    <Style x:Key="MahApps.Styles.Button.MulitselectionComboBoxSelectedItem.RemoveItem"
+    <Style x:Key="MahApps.Styles.Button.MultiSelectionComboBoxSelectedItem.RemoveItem"
            BasedOn="{StaticResource MahApps.Styles.Button.Chromeless}"
            TargetType="Button">
         <Setter Property="ContentTemplate">
@@ -172,8 +172,8 @@
         </Style.Triggers>
     </Style>
 
-    <Style x:Key="MahApps.Styles.MulitselectionComboBoxSelectedItem.Removeable"
-           BasedOn="{StaticResource MahApps.Styles.MulitselectionComboBoxSelectedItem}"
+    <Style x:Key="MahApps.Styles.MultiSelectionComboBoxSelectedItem.Removable"
+           BasedOn="{StaticResource MahApps.Styles.MultiSelectionComboBoxSelectedItem}"
            TargetType="ListBoxItem">
         <Setter Property="Template">
             <Setter.Value>
@@ -192,7 +192,7 @@
                                     Command="mah:MultiSelectionComboBox.RemoveItemCommand"
                                     CommandParameter="{Binding}"
                                     DockPanel.Dock="Right"
-                                    Style="{DynamicResource MahApps.Styles.Button.MulitselectionComboBoxSelectedItem.RemoveItem}" />
+                                    Style="{DynamicResource MahApps.Styles.Button.MultiSelectionComboBoxSelectedItem.RemoveItem}" />
                             <ContentPresenter Margin="{TemplateBinding Padding}"
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -462,7 +462,7 @@
         <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
         <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
         <Setter Property="SelectItemsFromTextInputDelay" Value="-1" />
-        <Setter Property="SelectedItemContainerStyle" Value="{DynamicResource MahApps.Styles.MulitselectionComboBoxSelectedItem}" />
+        <Setter Property="SelectedItemContainerStyle" Value="{DynamicResource MahApps.Styles.MultiSelectionComboBoxSelectedItem}" />
         <Setter Property="SelectedItemsPanelTemplate">
             <Setter.Value>
                 <ItemsPanelTemplate>

--- a/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
+++ b/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:lang="clr-namespace:MahApps.Metro.Lang"
                     xmlns:mah="clr-namespace:MahApps.Metro.Controls"
@@ -53,18 +53,28 @@
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <CheckBox Margin="{TemplateBinding BorderThickness}" IsChecked="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=IsSelected, Mode=TwoWay}">
-                            <ContentPresenter x:Name="ContentPresenter"
-                                              Margin="{TemplateBinding Padding}"
-                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </CheckBox>
+                        <Grid Margin="{TemplateBinding BorderThickness}">
+                            <CheckBox x:Name="ContentPresenter"
+                                      Margin="{TemplateBinding Padding}"
+                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                      mah:CheckBoxHelper.ForegroundIndeterminatePressed="{TemplateBinding Foreground}"
+                                      mah:CheckBoxHelper.ForegroundUnchecked="{TemplateBinding Foreground}"
+                                      mah:CheckBoxHelper.ForegroundUncheckedPressed="{TemplateBinding Foreground}"
+                                      Content="{TemplateBinding Content}"
+                                      ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                      IsChecked="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=IsSelected, Mode=TwoWay}"
+                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                      Style="{DynamicResource MahApps.Styles.CheckBox.MultiSelectionComboBoxItem}" />
+                        </Grid>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedBackgroundBrush), Mode=OneWay}" />
-                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedForegroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="ContentPresenter" Property="mah:CheckBoxHelper.ForegroundChecked" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedForegroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="ContentPresenter" Property="mah:CheckBoxHelper.ForegroundCheckedPressed" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedForegroundBrush), Mode=OneWay}" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -72,7 +82,7 @@
                                 <Condition Property="Selector.IsSelectionActive" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionBackgroundBrush), Mode=OneWay}" />
-                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionForegroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="ContentPresenter" Property="mah:CheckBoxHelper.ForegroundChecked" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionForegroundBrush), Mode=OneWay}" />
                         </MultiTrigger>
 
                         <MultiTrigger>
@@ -81,7 +91,7 @@
                                 <Condition Property="IsSelected" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedBackgroundBrush), Mode=OneWay}" />
-                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedForegroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="ContentPresenter" Property="mah:CheckBoxHelper.ForegroundCheckedMouseOver" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedForegroundBrush), Mode=OneWay}" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -89,12 +99,12 @@
                                 <Condition Property="IsSelected" Value="False" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverBackgroundBrush), Mode=OneWay}" />
-                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverForegroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="ContentPresenter" Property="mah:CheckBoxHelper.ForegroundUncheckedMouseOver" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverForegroundBrush), Mode=OneWay}" />
                         </MultiTrigger>
 
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledBackgroundBrush), Mode=OneWay}" />
-                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledForegroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="ContentPresenter" Property="mah:CheckBoxHelper.ForegroundUncheckedDisabled" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledForegroundBrush), Mode=OneWay}" />
                             <Setter TargetName="RootGrid" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background, Mode=OneWay}" />
                         </Trigger>
                         <MultiTrigger>
@@ -103,7 +113,7 @@
                                 <Condition Property="IsSelected" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedBackgroundBrush), Mode=OneWay}" />
-                            <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedForegroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="ContentPresenter" Property="mah:CheckBoxHelper.ForegroundCheckedDisabled" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedForegroundBrush), Mode=OneWay}" />
                         </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
+++ b/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
@@ -271,6 +271,7 @@
                                           mah:ControlsHelper.CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                                           mah:TextBoxHelper.ButtonCommand="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                           mah:TextBoxHelper.ButtonCommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                          mah:TextBoxHelper.ButtonCommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                           mah:TextBoxHelper.ButtonContent="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                           mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                           mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"

--- a/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
+++ b/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
@@ -217,259 +217,19 @@
     <!--#endregion-->
 
     <Style x:Key="MahApps.Styles.TextBox.MultiSelectionComboBox.Editable"
-           BasedOn="{StaticResource MahApps.Styles.TextBox}"
-           TargetType="{x:Type TextBox}">
-        <Setter Property="MinHeight" Value="0" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type TextBox}">
-                    <Grid Background="{TemplateBinding Background}">
-                        <Grid x:Name="PART_InnerGrid">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="TextColumn" Width="*" />
-                                <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition x:Name="ButtonRow" Height="*" />
-                            </Grid.RowDefinitions>
-
-                            <ScrollViewer x:Name="PART_ContentHost"
-                                          Grid.Row="1"
-                                          Grid.Column="0"
-                                          Margin="0"
-                                          Padding="{TemplateBinding Padding}"
-                                          VerticalAlignment="Stretch"
-                                          Background="{x:Null}"
-                                          BorderThickness="0"
-                                          IsTabStop="False"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-
-                            <TextBlock x:Name="PART_Message"
-                                       Grid.Row="1"
-                                       Grid.Column="0"
-                                       Margin="4 0"
-                                       Padding="{TemplateBinding Padding}"
-                                       HorizontalAlignment="Stretch"
-                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                       Foreground="{TemplateBinding Foreground}"
-                                       Style="{DynamicResource MahApps.Styles.TextBlock.Watermark}"
-                                       Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
-                                       TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
-                                       TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}"
-                                       Visibility="Collapsed" />
-
-                            <ContentControl x:Name="PART_FloatingMessageContainer"
-                                            Grid.Row="0"
-                                            Grid.Column="0"
-                                            Margin="4 0"
-                                            Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
-                                <ContentControl.Height>
-                                    <MultiBinding Converter="{mahConverters:MathMultiplyConverter}" FallbackValue="0">
-                                        <Binding ElementName="PART_FloatingMessage"
-                                                 Mode="OneWay"
-                                                 Path="ActualHeight" />
-                                        <Binding ElementName="PART_FloatingMessageContainer"
-                                                 Mode="OneWay"
-                                                 Path="Opacity" />
-                                    </MultiBinding>
-                                </ContentControl.Height>
-                                <TextBlock x:Name="PART_FloatingMessage"
-                                           HorizontalAlignment="Stretch"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                           Foreground="{TemplateBinding Foreground}"
-                                           Style="{DynamicResource MahApps.Styles.TextBlock.AutoCollapsing}"
-                                           Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}">
-                                    <TextBlock.RenderTransform>
-                                        <TranslateTransform x:Name="FloatingMessageTransform">
-                                            <TranslateTransform.Y>
-                                                <MultiBinding Converter="{mahConverters:MathSubtractConverter}" FallbackValue="0">
-                                                    <Binding ElementName="PART_FloatingMessage"
-                                                             Mode="OneWay"
-                                                             Path="ActualHeight" />
-                                                    <Binding ElementName="PART_FloatingMessageContainer"
-                                                             Mode="OneWay"
-                                                             Path="ActualHeight" />
-                                                </MultiBinding>
-                                            </TranslateTransform.Y>
-                                        </TranslateTransform>
-                                    </TextBlock.RenderTransform>
-                                </TextBlock>
-                            </ContentControl>
-
-                            <Button x:Name="PART_ClearText"
-                                    Grid.Row="0"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="1"
-                                    Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                    mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="False"
-                                    Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
-                                    CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
-                                    Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
-                                    ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
-                                    Focusable="False"
-                                    FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
-                                    FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    Foreground="{TemplateBinding Foreground}"
-                                    IsTabStop="False"
-                                    Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                    Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}" />
-                        </Grid>
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Text}" Value="">
-                            <Setter TargetName="PART_Message" Property="Visibility" Value="Visible" />
-                        </DataTrigger>
-
-                        <MultiDataTrigger>
-                            <MultiDataTrigger.Conditions>
-                                <Condition Binding="{Binding Path=IsVisible, RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.UseFloatingWatermark), RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.HasText), RelativeSource={RelativeSource Self}}" Value="True" />
-                                <Condition Binding="{Binding Path=(mah:TextBoxHelper.Watermark), RelativeSource={RelativeSource Self}, Converter={x:Static mahConverters:StringIsNullOrEmptyConverter.Default}}" Value="False" />
-                            </MultiDataTrigger.Conditions>
-                            <MultiDataTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ShowFloatingMessage}" />
-                            </MultiDataTrigger.EnterActions>
-                            <MultiDataTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.HideFloatingMessage}" />
-                            </MultiDataTrigger.ExitActions>
-                        </MultiDataTrigger>
-
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ClearTextButton)}" Value="False">
-                            <Setter TargetName="PART_ContentHost" Property="Grid.ColumnSpan" Value="2" />
-                            <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
-                        </DataTrigger>
-                        <Trigger Property="IsReadOnly" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="IsEnabled" Value="False" />
-                        </Trigger>
-                        <Trigger Property="IsFocused" Value="True">
-                            <Setter TargetName="PART_FloatingMessage" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
-                            <Setter TargetName="PART_FloatingMessage" Property="Opacity" Value="1" />
-                        </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
-                        </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-                        </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="mah:TextBoxHelper.HasText" Value="False" />
-                                <Condition Property="IsFocused" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <MultiTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.EnterGotFocus}" />
-                            </MultiTrigger.EnterActions>
-                            <MultiTrigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ExitGotFocus}" />
-                            </MultiTrigger.ExitActions>
-                        </MultiTrigger>
-
-                        <Trigger Property="mah:TextBoxHelper.HasText" Value="True">
-                            <Trigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.EnterHasText}" />
-                            </Trigger.EnterActions>
-                            <Trigger.ExitActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ExitHasText}" />
-                            </Trigger.ExitActions>
-                        </Trigger>
-
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+           BasedOn="{StaticResource MahApps.Styles.TextBox.ComboBox.Editable}"
+           TargetType="{x:Type TextBox}" />
 
     <Style x:Key="MahApps.Styles.ToggleButton.MultiSelectionComboBox.DropDown"
            BasedOn="{StaticResource MahApps.Styles.ToggleButton.ComboBoxDropDown}"
-           TargetType="{x:Type ToggleButton}">
-        <Setter Property="ClickMode" Value="Press" />
-        <Setter Property="Focusable" Value="False" />
-        <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ToggleButton}">
-                    <Grid x:Name="ToggleButtonRootGrid" Background="{TemplateBinding Background}">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition x:Name="TextColumn" Width="*" />
-                            <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
-                            <ColumnDefinition x:Name="ToggleButtonColumn" Width="Auto" />
-                        </Grid.ColumnDefinitions>
+           TargetType="{x:Type ToggleButton}" />
 
-                        <Button x:Name="PART_ClearText"
-                                Grid.Column="1"
-                                Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                mah:TextBoxHelper.IsClearTextButtonBehaviorEnabled="{Binding RelativeSource={RelativeSource AncestorType={x:Type mah:MultiSelectionComboBox}}, Path=(mah:TextBoxHelper.ClearTextButton), Mode=OneWay}"
-                                Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
-                                ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
-                                Focusable="False"
-                                FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
-                                FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                Foreground="{TemplateBinding Foreground}"
-                                IsTabStop="False"
-                                Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                Visibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type mah:MultiSelectionComboBox}}, Path=(mah:TextBoxHelper.ClearTextButton), Converter={StaticResource BooleanToVisibilityConverter}}" />
-
-                        <Grid x:Name="BtnArrowBackground"
-                              Grid.Column="2"
-                              Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                              Background="Transparent">
-                            <Path x:Name="Arrow"
-                                  Width="8"
-                                  Height="4"
-                                  HorizontalAlignment="Center"
-                                  Data="{DynamicResource ComboBoxDownArrowGeometry}"
-                                  Fill="{DynamicResource MahApps.Brushes.Gray1}"
-                                  IsHitTestVisible="false"
-                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                  Stretch="Uniform" />
-                        </Grid>
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger SourceName="BtnArrowBackground" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="BtnArrowBackground" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray5}" />
-                        </Trigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsMouseOver" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.Accent}" />
-                        </Trigger>
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True">
-                            <Setter TargetName="BtnArrowBackground" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray3}" />
-                            <Setter TargetName="ToggleButtonRootGrid" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray7}" />
-                        </DataTrigger>
-                        <Trigger SourceName="PART_ClearText" Property="IsPressed" Value="True">
-                            <Setter TargetName="PART_ClearText" Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="PART_ClearText" Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-                            <Setter TargetName="ToggleButtonRootGrid" Property="Background" Value="{DynamicResource MahApps.Brushes.Gray7}" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
-
-    <Style x:Key="MahApps.Styles.MultiSelectionComboBox" TargetType="{x:Type mah:MultiSelectionComboBox}">
-        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Control.Background}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border}" />
-        <Setter Property="BorderThickness" Value="{DynamicResource ComboBoxBorderThemeThickness}" />
+    <Style x:Key="MahApps.Styles.MultiSelectionComboBox"
+           BasedOn="{StaticResource MahApps.Styles.ComboBox}"
+           TargetType="{x:Type mah:MultiSelectionComboBox}">
         <Setter Property="DisabledPopupOverlayContentTemplate" Value="{DynamicResource MahApps.DataTemplates.MultiSelectionComboBox.DisabledPopupOverlay}" />
-        <Setter Property="FontFamily" Value="{DynamicResource MahApps.Fonts.Family.Control}" />
-        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
-        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}" />
-        <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="HorizontalScrollBarVisibility" Value="Disabled" />
-        <Setter Property="IsDropDownOpen" Value="False" />
-        <Setter Property="IsTextSearchEnabled" Value="False" />
         <Setter Property="ItemContainerStyle" Value="{DynamicResource MahApps.Styles.MultiSelectionComboBoxItem}" />
-        <Setter Property="MinHeight" Value="26" />
-        <Setter Property="Padding" Value="4" />
-        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
         <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
         <Setter Property="SelectItemsFromTextInputDelay" Value="-1" />
         <Setter Property="SelectedItemContainerStyle" Value="{DynamicResource MahApps.Styles.MultiSelectionComboBoxSelectedItem}" />
@@ -481,8 +241,6 @@
             </Setter.Value>
         </Setter>
         <Setter Property="SelectionMode" Value="Multiple" />
-        <!--  change SnapsToDevicePixels to true to view a better border and validation error  -->
-        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type mah:MultiSelectionComboBox}">
@@ -511,10 +269,13 @@
                                           Margin="0"
                                           VerticalAlignment="Stretch"
                                           mah:ControlsHelper.CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                          mah:TextBoxHelper.ButtonCommand="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                                          mah:TextBoxHelper.ButtonCommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
                                           mah:TextBoxHelper.ButtonContent="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                           mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                           mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                           mah:TextBoxHelper.ButtonFontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
+                                          mah:TextBoxHelper.ButtonTemplate="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
                                           mah:TextBoxHelper.ButtonWidth="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                           mah:TextBoxHelper.ClearTextButton="{TemplateBinding mah:TextBoxHelper.ClearTextButton}"
                                           Background="Transparent"
@@ -544,7 +305,8 @@
                                          ItemsSource="{TemplateBinding DisplaySelectedItems}"
                                          ScrollViewer.CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
                                          ScrollViewer.HorizontalScrollBarVisibility="{TemplateBinding HorizontalScrollBarVisibility}"
-                                         ScrollViewer.VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}" />
+                                         ScrollViewer.VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}"
+                                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Grid>
 
                             <TextBox x:Name="PART_EditableTextBox"
@@ -570,20 +332,20 @@
                                      AcceptsReturn="{TemplateBinding AcceptsReturn}"
                                      Background="{x:Null}"
                                      BorderThickness="0"
-                                     CharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ComboBoxHelper.CharacterCasing), Mode=OneWay}"
+                                     CharacterCasing="{TemplateBinding mah:ComboBoxHelper.CharacterCasing}"
                                      Focusable="True"
                                      FontFamily="{TemplateBinding FontFamily}"
                                      FontSize="{TemplateBinding FontSize}"
                                      Foreground="{TemplateBinding Foreground}"
                                      IsReadOnly="{TemplateBinding IsReadOnly}"
-                                     MaxLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ComboBoxHelper.MaxLength), Mode=OneWay}"
+                                     MaxLength="{TemplateBinding mah:ComboBoxHelper.MaxLength}"
                                      ScrollViewer.HorizontalScrollBarVisibility="{TemplateBinding HorizontalScrollBarVisibility}"
                                      ScrollViewer.VerticalScrollBarVisibility="{TemplateBinding VerticalScrollBarVisibility}"
                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                      Style="{DynamicResource MahApps.Styles.TextBox.MultiSelectionComboBox.Editable}"
-                                     Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Text}"
                                      TextWrapping="{TemplateBinding TextWrapping}"
                                      Visibility="Collapsed" />
+                            <!--  Text="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=Text}"  -->
 
                             <TextBlock x:Name="PART_Message"
                                        Grid.Row="1"
@@ -660,13 +422,14 @@
                                PlacementTarget="{Binding ElementName=PART_DropDownToggle}"
                                PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
                             <Grid MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}" MaxHeight="{Binding MaxDropDownHeight, RelativeSource={RelativeSource TemplatedParent}}">
-                                <Border x:Name="PopupBorder"
-                                        Height="200"
-                                        HorizontalAlignment="Stretch"
-                                        Background="{DynamicResource MahApps.Brushes.ThemeBackground}"
-                                        BorderBrush="{DynamicResource MahApps.Brushes.ComboBox.PopupBorder}"
-                                        BorderThickness="{DynamicResource ComboBoxPopupBorderThemeThickness}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                <mah:ClipBorder x:Name="PopupBorder"
+                                                Height="200"
+                                                HorizontalAlignment="Stretch"
+                                                Background="{DynamicResource MahApps.Brushes.ThemeBackground}"
+                                                BorderBrush="{DynamicResource MahApps.Brushes.ComboBox.PopupBorder}"
+                                                BorderThickness="{DynamicResource ComboBoxPopupBorderThemeThickness}"
+                                                CornerRadius="{DynamicResource ComboBoxPopupBorderThemeCornerRadius}"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto" />
@@ -706,6 +469,7 @@
                                                         Visibility="{TemplateBinding IsDropDownFooterVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
                                         <ContentControl x:Name="PART_PopupOverlay"
+                                                        Grid.Row="0"
                                                         Grid.RowSpan="3"
                                                         HorizontalAlignment="Stretch"
                                                         VerticalAlignment="Stretch"
@@ -713,7 +477,7 @@
                                                         ContentTemplate="{TemplateBinding DisabledPopupOverlayContentTemplate}"
                                                         Visibility="Collapsed" />
                                     </Grid>
-                                </Border>
+                                </mah:ClipBorder>
                             </Grid>
                         </Popup>
                         <VisualStateManager.VisualStateGroups>
@@ -796,11 +560,16 @@
                             </MultiDataTrigger.ExitActions>
                         </MultiDataTrigger>
 
-                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.ClearTextButton)}" Value="False">
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="mah:TextBoxHelper.ClearTextButton" Value="False" />
+                                <Condition Property="mah:TextBoxHelper.ButtonCommand" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
                             <Setter TargetName="ContentSite" Property="Grid.ColumnSpan" Value="2" />
                             <Setter TargetName="PART_EditableTextBox" Property="Grid.ColumnSpan" Value="2" />
                             <Setter TargetName="PART_Message" Property="Grid.ColumnSpan" Value="2" />
-                        </DataTrigger>
+                        </MultiTrigger>
+
                         <Trigger Property="IsEditable" Value="True">
                             <Setter Property="IsTabStop" Value="false" />
                             <Setter TargetName="ContentSite" Property="Visibility" Value="Collapsed" />
@@ -853,14 +622,10 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource MahApps.Templates.ValidationError}" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+
         <Setter Property="mah:ComboBoxHelper.InterceptMouseWheelSelection" Value="False" />
-        <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.ComboBox.Border.Focus}" />
-        <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.ComboBox.Border.MouseOver}" />
-        <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
-        <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
+
         <Style.Triggers>
             <Trigger Property="VirtualizingStackPanel.IsVirtualizing" Value="True">
                 <Setter Property="ItemsPanel">

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -138,6 +138,7 @@
                                      mah:TextBoxHelper.AutoWatermark="{TemplateBinding mah:TextBoxHelper.AutoWatermark}"
                                      mah:TextBoxHelper.ButtonCommand="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
                                      mah:TextBoxHelper.ButtonCommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                     mah:TextBoxHelper.ButtonCommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
                                      mah:TextBoxHelper.ButtonContent="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                      mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                      mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
@@ -324,6 +325,7 @@
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.MouseOver}" />
 
         <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
+        <Setter Property="mah:TextBoxHelper.ButtonCommandTarget" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
         <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -117,12 +117,14 @@
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+
                         <Grid Margin="{TemplateBinding BorderThickness}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="PART_LeftColumn" Width="*" />
                                 <ColumnDefinition x:Name="PART_MiddleColumn" Width="Auto" />
                                 <ColumnDefinition x:Name="PART_RightColumn" Width="Auto" />
                             </Grid.ColumnDefinitions>
+
                             <TextBox x:Name="PART_TextBox"
                                      Grid.Column="0"
                                      MinWidth="20"
@@ -133,10 +135,14 @@
                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                      mah:ControlsHelper.DisabledVisualElementVisibility="Collapsed"
+                                     mah:TextBoxHelper.AutoWatermark="{TemplateBinding mah:TextBoxHelper.AutoWatermark}"
+                                     mah:TextBoxHelper.ButtonCommand="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                                     mah:TextBoxHelper.ButtonCommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
                                      mah:TextBoxHelper.ButtonContent="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
                                      mah:TextBoxHelper.ButtonContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
                                      mah:TextBoxHelper.ButtonFontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
                                      mah:TextBoxHelper.ButtonFontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
+                                     mah:TextBoxHelper.ButtonTemplate="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
                                      mah:TextBoxHelper.ButtonWidth="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                                      mah:TextBoxHelper.ButtonsAlignment="{TemplateBinding ButtonsAlignment}"
                                      mah:TextBoxHelper.ClearTextButton="{TemplateBinding mah:TextBoxHelper.ClearTextButton}"
@@ -146,6 +152,7 @@
                                      mah:TextBoxHelper.Watermark="{TemplateBinding mah:TextBoxHelper.Watermark}"
                                      mah:TextBoxHelper.WatermarkAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
                                      mah:TextBoxHelper.WatermarkTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}"
+                                     mah:TextBoxHelper.WatermarkWrapping="{TemplateBinding mah:TextBoxHelper.WatermarkWrapping}"
                                      Background="{x:Null}"
                                      BorderThickness="0"
                                      ContextMenu="{TemplateBinding ContextMenu}"
@@ -160,6 +167,7 @@
                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                      TabIndex="{TemplateBinding TabIndex}"
                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}" />
+
                             <RepeatButton x:Name="PART_NumericUp"
                                           Grid.Column="1"
                                           Width="{TemplateBinding UpDownButtonsWidth}"
@@ -172,6 +180,7 @@
                                           Delay="{TemplateBinding Delay}"
                                           Focusable="{TemplateBinding UpDownButtonsFocusable}"
                                           Style="{TemplateBinding SpinButtonStyle}" />
+
                             <RepeatButton x:Name="PART_NumericDown"
                                           Grid.Column="2"
                                           Width="{TemplateBinding UpDownButtonsWidth}"
@@ -185,12 +194,14 @@
                                           Focusable="{TemplateBinding UpDownButtonsFocusable}"
                                           Style="{TemplateBinding SpinButtonStyle}" />
                         </Grid>
+
                         <Border x:Name="FocusBorder"
                                 Background="{x:Null}"
                                 BorderBrush="{x:Null}"
                                 BorderThickness="0"
                                 CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
                                 BorderBrush="{DynamicResource MahApps.Brushes.Control.Disabled}"
@@ -308,9 +319,13 @@
         <Setter Property="TextAlignment" Value="Right" />
         <Setter Property="UpDownButtonsWidth" Value="22" />
         <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource MahApps.Templates.ValidationError}" />
+
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.Focus}" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.TextBox.Border.MouseOver}" />
+
+        <Setter Property="mah:TextBoxHelper.ButtonCommandParameter" Value="{Binding RelativeSource={RelativeSource Self}, Mode=OneWay}" />
         <Setter Property="mah:TextBoxHelper.ButtonFontSize" Value="{DynamicResource MahApps.Font.Size.Button.ClearText}" />
+        <Setter Property="mah:TextBoxHelper.ButtonTemplate" Value="{DynamicResource MahApps.Templates.Button.Chromeless}" />
         <Setter Property="mah:TextBoxHelper.ButtonWidth" Value="22" />
         <Setter Property="mah:TextBoxHelper.IsMonitoring" Value="True" />
         <Setter Property="mah:TextBoxHelper.WatermarkAlignment" Value="Right" />

--- a/src/Mahapps.Metro.Tests/Tests/HeaderedControlHelperTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/HeaderedControlHelperTests.cs
@@ -33,19 +33,19 @@ namespace MahApps.Metro.Tests.Tests
 
             // GroupBox
 
-            this.fixture.Window?.TestGroupBox.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestGroupBox.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestGroupBox.FindChild<Border>("HeaderSite")?.Background);
 
-            this.fixture.Window?.TestGroupBoxClean.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestGroupBoxClean.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestGroupBoxClean.FindChild<Grid>("HeaderSite")?.Background);
 
-            this.fixture.Window?.TestGroupBoxVS.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestGroupBoxVS.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestGroupBoxVS.FindChild<Grid>("HeaderSite")?.Background);
 
-            this.fixture.Window?.TestMetroHeader.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestMetroHeader.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestMetroHeader.FindChild<Grid>("PART_Header")?.Background);
 
-            this.fixture.Window?.TestColorPalette.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestColorPalette.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestColorPalette.FindChild<Border>("HeaderSite")?.Background);
         }
 
@@ -60,10 +60,10 @@ namespace MahApps.Metro.Tests.Tests
 
             // Expander
 
-            this.fixture.Window?.TestExpander.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestExpander.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestExpander.FindChild<Border>("HeaderSite")?.Background);
 
-            this.fixture.Window?.TestExpanderVS.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestExpanderVS.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestExpanderVS.FindChild<ToggleButton>("ToggleSite")?.Background);
         }
 
@@ -81,19 +81,19 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabItem
 
-            this.fixture.Window?.TestTabItem.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestTabItem.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestTabItem.Background);
             Assert.Equal(headerBackground, this.fixture.Window?.TestTabItem.FindChild<Border>("Border")?.Background);
 
-            this.fixture.Window?.TestTabItemVSUnselected.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestTabItemVSUnselected.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestTabItemVSUnselected.Background);
             Assert.Equal(headerBackground, this.fixture.Window?.TestTabItemVSUnselected.FindChild<Border>("Border")?.Background);
 
-            this.fixture.Window?.TestTabItemVS.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestTabItemVS.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(selectedHeaderBackground, this.fixture.Window?.TestTabItemVS.Background);
             Assert.Equal(selectedHeaderBackground, this.fixture.Window?.TestTabItemVS.FindChild<Border>("Border")?.Background);
 
-            this.fixture.Window?.TestMetroTabItem.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestMetroTabItem.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestMetroTabItem.Background);
             Assert.Equal(headerBackground, this.fixture.Window?.TestMetroTabItem.FindChild<Border>("Border")?.Background);
         }
@@ -112,17 +112,17 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabControl
 
-            this.fixture.Window?.TestTabControl.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestTabControl.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestTabItem.Background);
             Assert.Equal(headerBackground, this.fixture.Window?.TestTabItem.FindChild<Border>("Border")?.Background);
 
-            this.fixture.Window?.TestTabControlVS.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestTabControlVS.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(selectedHeaderBackground, this.fixture.Window?.TestTabItemVS.Background);
             Assert.Equal(selectedHeaderBackground, this.fixture.Window?.TestTabItemVS.FindChild<Border>("Border")?.Background);
             Assert.Equal(headerBackground, this.fixture.Window?.TestTabItemVSUnselected.Background);
             Assert.Equal(headerBackground, this.fixture.Window?.TestTabItemVSUnselected.FindChild<Border>("Border")?.Background);
 
-            this.fixture.Window?.TestMetroTabControl.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestMetroTabControl.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestMetroTabItem.Background);
             Assert.Equal(headerBackground, this.fixture.Window?.TestMetroTabItem.FindChild<Border>("Border")?.Background);
         }
@@ -138,7 +138,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // Flyout
 
-            this.fixture.Window?.TestFlyout.SetValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
+            this.fixture.Window?.TestFlyout.SetCurrentValue(HeaderedControlHelper.HeaderBackgroundProperty, headerBackground);
             Assert.Equal(headerBackground, this.fixture.Window?.TestFlyout.FindChild<MetroThumbContentControl>("PART_Header")?.Background);
         }
 
@@ -153,19 +153,19 @@ namespace MahApps.Metro.Tests.Tests
 
             // GroupBox
 
-            this.fixture.Window?.TestGroupBox.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestGroupBox.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestGroupBox.FindChild<ContentControlEx>("HeaderContent")?.Foreground);
 
-            this.fixture.Window?.TestGroupBoxClean.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestGroupBoxClean.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestGroupBoxClean.FindChild<ContentControlEx>("HeaderContent")?.Foreground);
 
-            this.fixture.Window?.TestGroupBoxVS.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestGroupBoxVS.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestGroupBoxVS.FindChild<ContentControlEx>("HeaderContent")?.Foreground);
 
-            this.fixture.Window?.TestMetroHeader.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestMetroHeader.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestMetroHeader.FindChild<ContentControlEx>("HeaderContent")?.Foreground);
 
-            this.fixture.Window?.TestColorPalette.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestColorPalette.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestColorPalette.FindChild<ContentControlEx>("HeaderContent")?.Foreground);
         }
 
@@ -180,7 +180,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // ToggleSwitch
 
-            this.fixture.Window?.TestToggleSwitch.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestToggleSwitch.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(headerForeground, TextElement.GetForeground(this.fixture.Window?.TestToggleSwitch.FindChild<ContentPresenter>("HeaderContentPresenter")));
         }
 
@@ -195,10 +195,10 @@ namespace MahApps.Metro.Tests.Tests
 
             // Expander
 
-            this.fixture.Window?.TestExpander.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestExpander.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestExpander.FindChild<ToggleButton>("ToggleSite")?.Foreground);
 
-            this.fixture.Window?.TestExpanderVS.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestExpanderVS.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestExpanderVS.FindChild<ToggleButton>("ToggleSite")?.Foreground);
         }
 
@@ -219,27 +219,27 @@ namespace MahApps.Metro.Tests.Tests
             var tabForeground = Brushes.Aqua;
 
             this.fixture.Window?.TestTabItemUnselected.SetCurrentValue(TabItem.ForegroundProperty, tabForeground);
-            this.fixture.Window?.TestTabItemUnselected.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestTabItemUnselected.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(tabForeground, this.fixture.Window?.TestTabItemUnselected.Foreground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestTabItemUnselected.FindChild<ContentControlEx>("ContentSite")?.Foreground);
 
             this.fixture.Window?.TestTabItem.SetCurrentValue(TabItem.ForegroundProperty, tabForeground);
-            this.fixture.Window?.TestTabItem.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestTabItem.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(tabForeground, this.fixture.Window?.TestTabItem.Foreground);
             Assert.Equal(selectedHeaderForeground, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.Foreground);
 
             this.fixture.Window?.TestTabItemVS.SetCurrentValue(TabItem.ForegroundProperty, tabForeground);
-            this.fixture.Window?.TestTabItemVS.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestTabItemVS.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(tabForeground, this.fixture.Window?.TestTabItemVS.Foreground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.Foreground);
 
             this.fixture.Window?.TestMetroTabItemUnselected.SetCurrentValue(TabItem.ForegroundProperty, tabForeground);
-            this.fixture.Window?.TestMetroTabItemUnselected.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestMetroTabItemUnselected.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(tabForeground, this.fixture.Window?.TestMetroTabItemUnselected.Foreground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestMetroTabItemUnselected.FindChild<ContentControlEx>("ContentSite")?.Foreground);
 
             this.fixture.Window?.TestMetroTabItem.SetCurrentValue(TabItem.ForegroundProperty, tabForeground);
-            this.fixture.Window?.TestMetroTabItem.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestMetroTabItem.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(tabForeground, this.fixture.Window?.TestMetroTabItem.Foreground);
             Assert.Equal(selectedHeaderForeground, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.Foreground);
         }
@@ -258,15 +258,15 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabControl
 
-            this.fixture.Window?.TestTabControl.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestTabControl.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(selectedHeaderForeground, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.Foreground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestTabItemUnselected.FindChild<ContentControlEx>("ContentSite")?.Foreground);
 
-            this.fixture.Window?.TestTabControlVS.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestTabControlVS.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.Foreground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestTabItemVSUnselected.FindChild<ContentControlEx>("ContentSite")?.Foreground);
 
-            this.fixture.Window?.TestMetroTabControl.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestMetroTabControl.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(selectedHeaderForeground, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.Foreground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestMetroTabItemUnselected.FindChild<ContentControlEx>("ContentSite")?.Foreground);
         }
@@ -285,7 +285,7 @@ namespace MahApps.Metro.Tests.Tests
             var flyoutForeground = Brushes.Aqua;
 
             this.fixture.Window?.TestFlyout.SetCurrentValue(Flyout.ForegroundProperty, flyoutForeground);
-            this.fixture.Window?.TestFlyout.SetValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
+            this.fixture.Window?.TestFlyout.SetCurrentValue(HeaderedControlHelper.HeaderForegroundProperty, headerForeground);
             Assert.Equal(flyoutForeground, this.fixture.Window?.TestFlyout.Foreground);
             Assert.Equal(headerForeground, this.fixture.Window?.TestFlyout.FindChild<MetroThumbContentControl>("PART_Header")?.Foreground);
         }
@@ -301,19 +301,19 @@ namespace MahApps.Metro.Tests.Tests
 
             // GroupBox
 
-            this.fixture.Window?.TestGroupBox.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestGroupBox.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestGroupBox.FindChild<ContentControlEx>("HeaderContent")?.Margin);
 
-            this.fixture.Window?.TestGroupBoxClean.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestGroupBoxClean.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestGroupBoxClean.FindChild<ContentControlEx>("HeaderContent")?.Margin);
 
-            this.fixture.Window?.TestGroupBoxVS.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestGroupBoxVS.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestGroupBoxVS.FindChild<ContentControlEx>("HeaderContent")?.Margin);
 
-            this.fixture.Window?.TestMetroHeader.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestMetroHeader.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestMetroHeader.FindChild<ContentControlEx>("HeaderContent")?.Margin);
 
-            this.fixture.Window?.TestColorPalette.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestColorPalette.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestColorPalette.FindChild<ContentControlEx>("HeaderContent")?.Margin);
         }
 
@@ -328,7 +328,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // ToggleSwitch
 
-            this.fixture.Window?.TestToggleSwitch.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestToggleSwitch.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestToggleSwitch.FindChild<ContentPresenter>("HeaderContentPresenter")?.Margin);
         }
 
@@ -343,10 +343,10 @@ namespace MahApps.Metro.Tests.Tests
 
             // Expander
 
-            this.fixture.Window?.TestExpander.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestExpander.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestExpander.FindChild<ToggleButton>("ToggleSite")?.Padding);
 
-            this.fixture.Window?.TestExpanderVS.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestExpanderVS.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestExpanderVS.FindChild<ToggleButton>("ToggleSite")?.Padding);
         }
 
@@ -361,17 +361,17 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabItem
 
-            this.fixture.Window?.TestTabItem.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestTabItem.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.Margin);
             this.fixture.Window?.TestTabItem.SetCurrentValue(TabItem.PaddingProperty, new Thickness(8));
             Assert.Equal(new Thickness(8), this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.Margin);
 
-            this.fixture.Window?.TestTabItemVS.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestTabItemVS.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.Margin);
             this.fixture.Window?.TestTabItemVS.SetCurrentValue(TabItem.PaddingProperty, new Thickness(8));
             Assert.Equal(new Thickness(8), this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.Margin);
 
-            this.fixture.Window?.TestMetroTabItem.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestMetroTabItem.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestMetroTabItem.FindChild<Grid>("PART_ContentSite")?.Margin);
             this.fixture.Window?.TestMetroTabItem.SetCurrentValue(TabItem.PaddingProperty, new Thickness(8));
             Assert.Equal(new Thickness(8), this.fixture.Window?.TestMetroTabItem.FindChild<Grid>("PART_ContentSite")?.Margin);
@@ -388,13 +388,13 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabControl
 
-            this.fixture.Window?.TestTabControl.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestTabControl.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.Margin);
 
-            this.fixture.Window?.TestTabControlVS.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestTabControlVS.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.Margin);
 
-            this.fixture.Window?.TestMetroTabControl.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestMetroTabControl.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestMetroTabItem.FindChild<Grid>("PART_ContentSite")?.Margin);
         }
 
@@ -409,7 +409,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // Flyout
 
-            this.fixture.Window?.TestFlyout.SetValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
+            this.fixture.Window?.TestFlyout.SetCurrentValue(HeaderedControlHelper.HeaderMarginProperty, headerMargin);
             Assert.Equal(headerMargin, this.fixture.Window?.TestFlyout.FindChild<MetroThumbContentControl>("PART_Header")?.Padding);
         }
 
@@ -425,29 +425,29 @@ namespace MahApps.Metro.Tests.Tests
 
             // GroupBox
 
-            this.fixture.Window?.TestGroupBox.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestGroupBox.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestGroupBox.FindChild<ContentControlEx>("HeaderContent")?.HorizontalAlignment);
-            this.fixture.Window?.TestGroupBox.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestGroupBox.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestGroupBox.FindChild<ContentControlEx>("HeaderContent")?.VerticalAlignment);
 
-            this.fixture.Window?.TestGroupBoxClean.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestGroupBoxClean.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestGroupBoxClean.FindChild<ContentControlEx>("HeaderContent")?.HorizontalAlignment);
-            this.fixture.Window?.TestGroupBoxClean.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestGroupBoxClean.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestGroupBoxClean.FindChild<ContentControlEx>("HeaderContent")?.VerticalAlignment);
 
-            this.fixture.Window?.TestGroupBoxVS.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestGroupBoxVS.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestGroupBoxVS.FindChild<ContentControlEx>("HeaderContent")?.HorizontalAlignment);
-            this.fixture.Window?.TestGroupBoxVS.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestGroupBoxVS.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestGroupBoxVS.FindChild<ContentControlEx>("HeaderContent")?.VerticalAlignment);
 
-            this.fixture.Window?.TestMetroHeader.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestMetroHeader.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestMetroHeader.FindChild<ContentControlEx>("HeaderContent")?.HorizontalAlignment);
-            this.fixture.Window?.TestMetroHeader.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestMetroHeader.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestMetroHeader.FindChild<ContentControlEx>("HeaderContent")?.VerticalAlignment);
 
-            this.fixture.Window?.TestColorPalette.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestColorPalette.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestColorPalette.FindChild<ContentControlEx>("HeaderContent")?.HorizontalAlignment);
-            this.fixture.Window?.TestColorPalette.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestColorPalette.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestColorPalette.FindChild<ContentControlEx>("HeaderContent")?.VerticalAlignment);
         }
 
@@ -463,9 +463,9 @@ namespace MahApps.Metro.Tests.Tests
 
             // ToggleSwitch
 
-            this.fixture.Window?.TestToggleSwitch.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestToggleSwitch.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestToggleSwitch.FindChild<ContentPresenter>("HeaderContentPresenter")?.HorizontalAlignment);
-            this.fixture.Window?.TestToggleSwitch.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestToggleSwitch.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestToggleSwitch.FindChild<ContentPresenter>("HeaderContentPresenter")?.VerticalAlignment);
         }
 
@@ -481,14 +481,14 @@ namespace MahApps.Metro.Tests.Tests
 
             // Expander
 
-            this.fixture.Window?.TestExpander.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestExpander.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestExpander.FindChild<ToggleButton>("ToggleSite")?.HorizontalContentAlignment);
-            this.fixture.Window?.TestExpander.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestExpander.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestExpander.FindChild<ToggleButton>("ToggleSite")?.VerticalContentAlignment);
 
-            this.fixture.Window?.TestExpanderVS.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestExpanderVS.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestExpanderVS.FindChild<ToggleButton>("ToggleSite")?.HorizontalContentAlignment);
-            this.fixture.Window?.TestExpanderVS.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestExpanderVS.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestExpanderVS.FindChild<ToggleButton>("ToggleSite")?.VerticalContentAlignment);
         }
 
@@ -504,19 +504,19 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabItem
 
-            this.fixture.Window?.TestTabItem.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestTabItem.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.HorizontalAlignment);
-            this.fixture.Window?.TestTabItem.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestTabItem.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.VerticalAlignment);
 
-            this.fixture.Window?.TestTabItemVS.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestTabItemVS.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.HorizontalAlignment);
-            this.fixture.Window?.TestTabItemVS.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestTabItemVS.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.VerticalAlignment);
 
-            this.fixture.Window?.TestMetroTabItem.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestMetroTabItem.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.HorizontalAlignment);
-            this.fixture.Window?.TestMetroTabItem.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestMetroTabItem.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.VerticalAlignment);
         }
 
@@ -532,19 +532,19 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabControl
 
-            this.fixture.Window?.TestTabControl.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestTabControl.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.HorizontalAlignment);
-            this.fixture.Window?.TestTabControl.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestTabControl.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.VerticalAlignment);
 
-            this.fixture.Window?.TestTabControlVS.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestTabControlVS.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.HorizontalAlignment);
-            this.fixture.Window?.TestTabControlVS.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestTabControlVS.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.VerticalAlignment);
 
-            this.fixture.Window?.TestMetroTabControl.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestMetroTabControl.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.HorizontalAlignment);
-            this.fixture.Window?.TestMetroTabControl.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestMetroTabControl.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.VerticalAlignment);
         }
 
@@ -560,9 +560,9 @@ namespace MahApps.Metro.Tests.Tests
 
             // Flyout
 
-            this.fixture.Window?.TestFlyout.SetValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
+            this.fixture.Window?.TestFlyout.SetCurrentValue(HeaderedControlHelper.HeaderHorizontalContentAlignmentProperty, horizontalAlignment);
             Assert.Equal(horizontalAlignment, this.fixture.Window?.TestFlyout.FindChild<MetroThumbContentControl>("PART_Header")?.HorizontalContentAlignment);
-            this.fixture.Window?.TestFlyout.SetValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
+            this.fixture.Window?.TestFlyout.SetCurrentValue(HeaderedControlHelper.HeaderVerticalContentAlignmentProperty, verticalAlignment);
             Assert.Equal(verticalAlignment, this.fixture.Window?.TestFlyout.FindChild<MetroThumbContentControl>("PART_Header")?.VerticalContentAlignment);
         }
 
@@ -577,19 +577,19 @@ namespace MahApps.Metro.Tests.Tests
 
             // GroupBox
 
-            this.fixture.Window?.TestGroupBox.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestGroupBox.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestGroupBox.FindChild<ContentControlEx>("HeaderContent")?.FontFamily);
 
-            this.fixture.Window?.TestGroupBoxClean.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestGroupBoxClean.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestGroupBoxClean.FindChild<ContentControlEx>("HeaderContent")?.FontFamily);
 
-            this.fixture.Window?.TestGroupBoxVS.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestGroupBoxVS.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestGroupBoxVS.FindChild<ContentControlEx>("HeaderContent")?.FontFamily);
 
-            this.fixture.Window?.TestMetroHeader.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestMetroHeader.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestMetroHeader.FindChild<ContentControlEx>("HeaderContent")?.FontFamily);
 
-            this.fixture.Window?.TestColorPalette.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestColorPalette.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestColorPalette.FindChild<ContentControlEx>("HeaderContent")?.FontFamily);
         }
 
@@ -604,7 +604,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // ToggleSwitch
 
-            this.fixture.Window?.TestToggleSwitch.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestToggleSwitch.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, TextElement.GetFontFamily(this.fixture.Window?.TestToggleSwitch.FindChild<ContentPresenter>("HeaderContentPresenter")));
         }
 
@@ -619,10 +619,10 @@ namespace MahApps.Metro.Tests.Tests
 
             // Expander
 
-            this.fixture.Window?.TestExpander.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestExpander.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestExpander.FindChild<ToggleButton>("ToggleSite")?.FontFamily);
 
-            this.fixture.Window?.TestExpanderVS.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestExpanderVS.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestExpanderVS.FindChild<ToggleButton>("ToggleSite")?.FontFamily);
         }
 
@@ -637,13 +637,13 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabItem
 
-            this.fixture.Window?.TestTabItem.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestTabItem.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.FontFamily);
 
-            this.fixture.Window?.TestTabItemVS.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestTabItemVS.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.FontFamily);
 
-            this.fixture.Window?.TestMetroTabItem.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestMetroTabItem.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.FontFamily);
         }
 
@@ -658,13 +658,13 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabControl
 
-            this.fixture.Window?.TestTabControl.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestTabControl.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.FontFamily);
 
-            this.fixture.Window?.TestTabControlVS.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestTabControlVS.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.FontFamily);
 
-            this.fixture.Window?.TestMetroTabControl.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestMetroTabControl.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.FontFamily);
         }
 
@@ -679,7 +679,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // Flyout
 
-            this.fixture.Window?.TestFlyout.SetValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
+            this.fixture.Window?.TestFlyout.SetCurrentValue(HeaderedControlHelper.HeaderFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestFlyout.FindChild<MetroThumbContentControl>("PART_Header")?.FontFamily);
         }
 
@@ -694,19 +694,19 @@ namespace MahApps.Metro.Tests.Tests
 
             // GroupBox
 
-            this.fixture.Window?.TestGroupBox.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestGroupBox.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestGroupBox.FindChild<ContentControlEx>("HeaderContent")?.FontSize);
 
-            this.fixture.Window?.TestGroupBoxClean.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestGroupBoxClean.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestGroupBoxClean.FindChild<ContentControlEx>("HeaderContent")?.FontSize);
 
-            this.fixture.Window?.TestGroupBoxVS.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestGroupBoxVS.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestGroupBoxVS.FindChild<ContentControlEx>("HeaderContent")?.FontSize);
 
-            this.fixture.Window?.TestMetroHeader.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestMetroHeader.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestMetroHeader.FindChild<ContentControlEx>("HeaderContent")?.FontSize);
 
-            this.fixture.Window?.TestColorPalette.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestColorPalette.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestColorPalette.FindChild<ContentControlEx>("HeaderContent")?.FontSize);
         }
 
@@ -721,7 +721,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // ToggleSwitch
 
-            this.fixture.Window?.TestToggleSwitch.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestToggleSwitch.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, TextElement.GetFontSize(this.fixture.Window?.TestToggleSwitch.FindChild<ContentPresenter>("HeaderContentPresenter")));
         }
 
@@ -736,10 +736,10 @@ namespace MahApps.Metro.Tests.Tests
 
             // Expander
 
-            this.fixture.Window?.TestExpander.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestExpander.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestExpander.FindChild<ToggleButton>("ToggleSite")?.FontSize);
 
-            this.fixture.Window?.TestExpanderVS.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestExpanderVS.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestExpanderVS.FindChild<ToggleButton>("ToggleSite")?.FontSize);
         }
 
@@ -754,13 +754,13 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabItem
 
-            this.fixture.Window?.TestTabItem.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestTabItem.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.FontSize);
 
-            this.fixture.Window?.TestTabItemVS.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestTabItemVS.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.FontSize);
 
-            this.fixture.Window?.TestMetroTabItem.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestMetroTabItem.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.FontSize);
         }
 
@@ -775,13 +775,13 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabControl
 
-            this.fixture.Window?.TestTabControl.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestTabControl.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.FontSize);
 
-            this.fixture.Window?.TestTabControlVS.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestTabControlVS.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.FontSize);
 
-            this.fixture.Window?.TestMetroTabControl.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestMetroTabControl.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.FontSize);
         }
 
@@ -796,7 +796,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // Flyout
 
-            this.fixture.Window?.TestFlyout.SetValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
+            this.fixture.Window?.TestFlyout.SetCurrentValue(HeaderedControlHelper.HeaderFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestFlyout.FindChild<MetroThumbContentControl>("PART_Header")?.FontSize);
         }
 
@@ -811,19 +811,19 @@ namespace MahApps.Metro.Tests.Tests
 
             // GroupBox
 
-            this.fixture.Window?.TestGroupBox.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestGroupBox.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestGroupBox.FindChild<ContentControlEx>("HeaderContent")?.FontStretch);
 
-            this.fixture.Window?.TestGroupBoxClean.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestGroupBoxClean.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestGroupBoxClean.FindChild<ContentControlEx>("HeaderContent")?.FontStretch);
 
-            this.fixture.Window?.TestGroupBoxVS.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestGroupBoxVS.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestGroupBoxVS.FindChild<ContentControlEx>("HeaderContent")?.FontStretch);
 
-            this.fixture.Window?.TestMetroHeader.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestMetroHeader.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestMetroHeader.FindChild<ContentControlEx>("HeaderContent")?.FontStretch);
 
-            this.fixture.Window?.TestColorPalette.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestColorPalette.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestColorPalette.FindChild<ContentControlEx>("HeaderContent")?.FontStretch);
         }
 
@@ -838,7 +838,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // ToggleSwitch
 
-            this.fixture.Window?.TestToggleSwitch.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestToggleSwitch.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, TextElement.GetFontStretch(this.fixture.Window?.TestToggleSwitch.FindChild<ContentPresenter>("HeaderContentPresenter")));
         }
 
@@ -853,10 +853,10 @@ namespace MahApps.Metro.Tests.Tests
 
             // Expander
 
-            this.fixture.Window?.TestExpander.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestExpander.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestExpander.FindChild<ToggleButton>("ToggleSite")?.FontStretch);
 
-            this.fixture.Window?.TestExpanderVS.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestExpanderVS.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestExpanderVS.FindChild<ToggleButton>("ToggleSite")?.FontStretch);
         }
 
@@ -871,13 +871,13 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabItem
 
-            this.fixture.Window?.TestTabItem.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestTabItem.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.FontStretch);
 
-            this.fixture.Window?.TestTabItemVS.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestTabItemVS.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.FontStretch);
 
-            this.fixture.Window?.TestMetroTabItem.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestMetroTabItem.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.FontStretch);
         }
 
@@ -892,13 +892,13 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabControl
 
-            this.fixture.Window?.TestTabControl.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestTabControl.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.FontStretch);
 
-            this.fixture.Window?.TestTabControlVS.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestTabControlVS.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.FontStretch);
 
-            this.fixture.Window?.TestMetroTabControl.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestMetroTabControl.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.FontStretch);
         }
 
@@ -913,7 +913,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // Flyout
 
-            this.fixture.Window?.TestFlyout.SetValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
+            this.fixture.Window?.TestFlyout.SetCurrentValue(HeaderedControlHelper.HeaderFontStretchProperty, fontStretch);
             Assert.Equal(fontStretch, this.fixture.Window?.TestFlyout.FindChild<MetroThumbContentControl>("PART_Header")?.FontStretch);
         }
 
@@ -928,19 +928,19 @@ namespace MahApps.Metro.Tests.Tests
 
             // GroupBox
 
-            this.fixture.Window?.TestGroupBox.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestGroupBox.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestGroupBox.FindChild<ContentControlEx>("HeaderContent")?.FontWeight);
 
-            this.fixture.Window?.TestGroupBoxClean.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestGroupBoxClean.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestGroupBoxClean.FindChild<ContentControlEx>("HeaderContent")?.FontWeight);
 
-            this.fixture.Window?.TestGroupBoxVS.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestGroupBoxVS.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestGroupBoxVS.FindChild<ContentControlEx>("HeaderContent")?.FontWeight);
 
-            this.fixture.Window?.TestMetroHeader.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestMetroHeader.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestMetroHeader.FindChild<ContentControlEx>("HeaderContent")?.FontWeight);
 
-            this.fixture.Window?.TestColorPalette.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestColorPalette.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestColorPalette.FindChild<ContentControlEx>("HeaderContent")?.FontWeight);
         }
 
@@ -955,7 +955,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // ToggleSwitch
 
-            this.fixture.Window?.TestToggleSwitch.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestToggleSwitch.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, TextElement.GetFontWeight(this.fixture.Window?.TestToggleSwitch.FindChild<ContentPresenter>("HeaderContentPresenter")));
         }
 
@@ -970,10 +970,10 @@ namespace MahApps.Metro.Tests.Tests
 
             // Expander
 
-            this.fixture.Window?.TestExpander.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestExpander.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestExpander.FindChild<ToggleButton>("ToggleSite")?.FontWeight);
 
-            this.fixture.Window?.TestExpanderVS.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestExpanderVS.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestExpanderVS.FindChild<ToggleButton>("ToggleSite")?.FontWeight);
         }
 
@@ -988,13 +988,13 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabItem
 
-            this.fixture.Window?.TestTabItem.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestTabItem.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.FontWeight);
 
-            this.fixture.Window?.TestTabItemVS.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestTabItemVS.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.FontWeight);
 
-            this.fixture.Window?.TestMetroTabItem.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestMetroTabItem.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.FontWeight);
         }
 
@@ -1009,13 +1009,13 @@ namespace MahApps.Metro.Tests.Tests
 
             // TabControl
 
-            this.fixture.Window?.TestTabControl.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestTabControl.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestTabItem.FindChild<ContentControlEx>("ContentSite")?.FontWeight);
 
-            this.fixture.Window?.TestTabControlVS.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestTabControlVS.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestTabItemVS.FindChild<ContentControlEx>("ContentSite")?.FontWeight);
 
-            this.fixture.Window?.TestMetroTabControl.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestMetroTabControl.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestMetroTabItem.FindChild<ContentControlEx>("ContentSite")?.FontWeight);
         }
 
@@ -1030,7 +1030,7 @@ namespace MahApps.Metro.Tests.Tests
 
             // Flyout
 
-            this.fixture.Window?.TestFlyout.SetValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
+            this.fixture.Window?.TestFlyout.SetCurrentValue(HeaderedControlHelper.HeaderFontWeightProperty, fontWeight);
             Assert.Equal(fontWeight, this.fixture.Window?.TestFlyout.FindChild<MetroThumbContentControl>("PART_Header")?.FontWeight);
         }
     }

--- a/src/Mahapps.Metro.Tests/Tests/TextBoxHelperTests.Fixture.cs
+++ b/src/Mahapps.Metro.Tests/Tests/TextBoxHelperTests.Fixture.cs
@@ -31,7 +31,6 @@ namespace MahApps.Metro.Tests.Tests
             this.Window?.TestTextBox.ClearDependencyProperties(properties);
             this.Window?.TestButtonTextBox.ClearDependencyProperties(properties);
             this.Window?.TestPasswordBox.ClearDependencyProperties(properties);
-            this.Window?.TestButtonPasswordBox.ClearDependencyProperties(properties);
             this.Window?.TestButtonRevealedPasswordBox.ClearDependencyProperties(properties);
             this.Window?.TestComboBox.ClearDependencyProperties(properties);
             this.Window?.TestEditableComboBox.ClearDependencyProperties(properties);

--- a/src/Mahapps.Metro.Tests/Tests/TextBoxHelperTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/TextBoxHelperTests.cs
@@ -46,8 +46,9 @@ namespace MahApps.Metro.Tests.Tests
             Assert.Equal(width, toggleButton?.FindChild<Grid>("BtnArrowBackground")?.Width);
 
             this.fixture.Window?.TestEditableComboBox.SetValue(TextBoxHelper.ButtonWidthProperty, width);
-            var edTextBox = this.fixture.Window?.TestEditableComboBox.FindChild<TextBox>("PART_EditableTextBox");
-            Assert.Equal(width, edTextBox?.FindChild<Button>("PART_ClearText")?.Width);
+            var toggleButtonEditable = this.fixture.Window?.TestEditableComboBox.FindChild<ToggleButton>("PART_DropDownToggle");
+            Assert.Equal(width, toggleButtonEditable?.FindChild<Button>("PART_ClearText")?.Width);
+            Assert.Equal(width, toggleButtonEditable?.FindChild<Grid>("BtnArrowBackground")?.Width);
 
             this.fixture.Window?.TestNumericUpDown.SetValue(TextBoxHelper.ButtonWidthProperty, width);
             Assert.Equal(width, this.fixture.Window?.TestNumericUpDown.FindChild<Button>("PART_ClearText")?.Width);
@@ -80,8 +81,8 @@ namespace MahApps.Metro.Tests.Tests
             Assert.Equal(content, toggleButton.FindChild<Button>("PART_ClearText")?.Content);
 
             this.fixture.Window?.TestEditableComboBox.SetValue(TextBoxHelper.ButtonContentProperty, content);
-            var edTextBox = this.fixture.Window?.TestEditableComboBox.FindChild<TextBox>("PART_EditableTextBox");
-            Assert.Equal(content, edTextBox.FindChild<Button>("PART_ClearText")?.Content);
+            var toggleButtonEditable = this.fixture.Window?.TestEditableComboBox.FindChild<ToggleButton>("PART_DropDownToggle");
+            Assert.Equal(content, toggleButtonEditable.FindChild<Button>("PART_ClearText")?.Content);
 
             this.fixture.Window?.TestNumericUpDown.SetValue(TextBoxHelper.ButtonContentProperty, content);
             Assert.Equal(content, this.fixture.Window?.TestNumericUpDown.FindChild<Button>("PART_ClearText")?.Content);
@@ -116,8 +117,8 @@ namespace MahApps.Metro.Tests.Tests
             Assert.Equal(dataTemplate, toggleButton.FindChild<Button>("PART_ClearText")?.ContentTemplate);
 
             this.fixture.Window?.TestEditableComboBox.SetResourceReference(TextBoxHelper.ButtonContentTemplateProperty, resourceKey);
-            var edTextBox = this.fixture.Window?.TestEditableComboBox.FindChild<TextBox>("PART_EditableTextBox");
-            Assert.Equal(dataTemplate, edTextBox.FindChild<Button>("PART_ClearText")?.ContentTemplate);
+            var toggleButtonEditable = this.fixture.Window?.TestEditableComboBox.FindChild<ToggleButton>("PART_DropDownToggle");
+            Assert.Equal(dataTemplate, toggleButtonEditable.FindChild<Button>("PART_ClearText")?.ContentTemplate);
 
             this.fixture.Window?.TestNumericUpDown.SetResourceReference(TextBoxHelper.ButtonContentTemplateProperty, resourceKey);
             Assert.Equal(dataTemplate, this.fixture.Window?.TestNumericUpDown.FindChild<Button>("PART_ClearText")?.ContentTemplate);
@@ -150,8 +151,8 @@ namespace MahApps.Metro.Tests.Tests
             Assert.Equal(fontFamily, toggleButton.FindChild<Button>("PART_ClearText")?.FontFamily);
 
             this.fixture.Window?.TestEditableComboBox.SetValue(TextBoxHelper.ButtonFontFamilyProperty, fontFamily);
-            var edTextBox = this.fixture.Window?.TestEditableComboBox.FindChild<TextBox>("PART_EditableTextBox");
-            Assert.Equal(fontFamily, edTextBox.FindChild<Button>("PART_ClearText")?.FontFamily);
+            var toggleButtonEditable = this.fixture.Window?.TestEditableComboBox.FindChild<ToggleButton>("PART_DropDownToggle");
+            Assert.Equal(fontFamily, toggleButtonEditable.FindChild<Button>("PART_ClearText")?.FontFamily);
 
             this.fixture.Window?.TestNumericUpDown.SetValue(TextBoxHelper.ButtonFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestNumericUpDown.FindChild<Button>("PART_ClearText")?.FontFamily);
@@ -184,8 +185,8 @@ namespace MahApps.Metro.Tests.Tests
             Assert.Equal(fontSize, toggleButton.FindChild<Button>("PART_ClearText")?.FontSize);
 
             this.fixture.Window?.TestEditableComboBox.SetValue(TextBoxHelper.ButtonFontSizeProperty, fontSize);
-            var edTextBox = this.fixture.Window?.TestEditableComboBox.FindChild<TextBox>("PART_EditableTextBox");
-            Assert.Equal(fontSize, edTextBox.FindChild<Button>("PART_ClearText")?.FontSize);
+            var toggleButtonEditable = this.fixture.Window?.TestEditableComboBox.FindChild<ToggleButton>("PART_DropDownToggle");
+            Assert.Equal(fontSize, toggleButtonEditable.FindChild<Button>("PART_ClearText")?.FontSize);
 
             this.fixture.Window?.TestNumericUpDown.SetValue(TextBoxHelper.ButtonFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestNumericUpDown.FindChild<Button>("PART_ClearText")?.FontSize);

--- a/src/Mahapps.Metro.Tests/Tests/TextBoxHelperTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/TextBoxHelperTests.cs
@@ -36,8 +36,6 @@ namespace MahApps.Metro.Tests.Tests
 
             this.fixture.Window?.TestPasswordBox.SetValue(TextBoxHelper.ButtonWidthProperty, width);
             Assert.Equal(width, this.fixture.Window?.TestPasswordBox.FindChild<Button>("PART_ClearText")?.Width);
-            this.fixture.Window?.TestButtonPasswordBox.SetValue(TextBoxHelper.ButtonWidthProperty, width);
-            Assert.Equal(width, this.fixture.Window?.TestButtonPasswordBox.FindChild<Button>("PART_ClearText")?.Width);
             this.fixture.Window?.TestButtonRevealedPasswordBox.SetValue(TextBoxHelper.ButtonWidthProperty, width);
             Assert.Equal(width, this.fixture.Window?.TestButtonRevealedPasswordBox.FindChild<Button>("PART_ClearText")?.Width);
             Assert.Equal(width, this.fixture.Window?.TestButtonRevealedPasswordBox.FindChild<Button>("PART_RevealButton")?.Width);
@@ -74,8 +72,6 @@ namespace MahApps.Metro.Tests.Tests
 
             this.fixture.Window?.TestPasswordBox.SetValue(TextBoxHelper.ButtonContentProperty, content);
             Assert.Equal(content, this.fixture.Window?.TestPasswordBox.FindChild<Button>("PART_ClearText")?.Content);
-            this.fixture.Window?.TestButtonPasswordBox.SetValue(TextBoxHelper.ButtonContentProperty, content);
-            Assert.Equal(content, this.fixture.Window?.TestButtonPasswordBox.FindChild<Button>("PART_ClearText")?.Content);
             this.fixture.Window?.TestButtonRevealedPasswordBox.SetValue(TextBoxHelper.ButtonContentProperty, content);
             Assert.Equal(content, this.fixture.Window?.TestButtonRevealedPasswordBox.FindChild<Button>("PART_ClearText")?.Content);
 
@@ -112,8 +108,6 @@ namespace MahApps.Metro.Tests.Tests
 
             this.fixture.Window?.TestPasswordBox.SetResourceReference(TextBoxHelper.ButtonContentTemplateProperty, resourceKey);
             Assert.Equal(dataTemplate, this.fixture.Window?.TestPasswordBox.FindChild<Button>("PART_ClearText")?.ContentTemplate);
-            this.fixture.Window?.TestButtonPasswordBox.SetResourceReference(TextBoxHelper.ButtonContentTemplateProperty, resourceKey);
-            Assert.Equal(dataTemplate, this.fixture.Window?.TestButtonPasswordBox.FindChild<Button>("PART_ClearText")?.ContentTemplate);
             this.fixture.Window?.TestButtonRevealedPasswordBox.SetResourceReference(TextBoxHelper.ButtonContentTemplateProperty, resourceKey);
             Assert.Equal(dataTemplate, this.fixture.Window?.TestButtonRevealedPasswordBox.FindChild<Button>("PART_ClearText")?.ContentTemplate);
 
@@ -148,8 +142,6 @@ namespace MahApps.Metro.Tests.Tests
 
             this.fixture.Window?.TestPasswordBox.SetValue(TextBoxHelper.ButtonFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestPasswordBox.FindChild<Button>("PART_ClearText")?.FontFamily);
-            this.fixture.Window?.TestButtonPasswordBox.SetValue(TextBoxHelper.ButtonFontFamilyProperty, fontFamily);
-            Assert.Equal(fontFamily, this.fixture.Window?.TestButtonPasswordBox.FindChild<Button>("PART_ClearText")?.FontFamily);
             this.fixture.Window?.TestButtonRevealedPasswordBox.SetValue(TextBoxHelper.ButtonFontFamilyProperty, fontFamily);
             Assert.Equal(fontFamily, this.fixture.Window?.TestButtonRevealedPasswordBox.FindChild<Button>("PART_ClearText")?.FontFamily);
 
@@ -184,8 +176,6 @@ namespace MahApps.Metro.Tests.Tests
 
             this.fixture.Window?.TestPasswordBox.SetValue(TextBoxHelper.ButtonFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestPasswordBox.FindChild<Button>("PART_ClearText")?.FontSize);
-            this.fixture.Window?.TestButtonPasswordBox.SetValue(TextBoxHelper.ButtonFontSizeProperty, fontSize);
-            Assert.Equal(fontSize, this.fixture.Window?.TestButtonPasswordBox.FindChild<Button>("PART_ClearText")?.FontSize);
             this.fixture.Window?.TestButtonRevealedPasswordBox.SetValue(TextBoxHelper.ButtonFontSizeProperty, fontSize);
             Assert.Equal(fontSize, this.fixture.Window?.TestButtonRevealedPasswordBox.FindChild<Button>("PART_ClearText")?.FontSize);
 
@@ -218,8 +208,6 @@ namespace MahApps.Metro.Tests.Tests
             this.fixture.Window?.TestButtonTextBox.SetResourceReference(TextBoxHelper.ButtonTemplateProperty, resourceKey);
             Assert.Equal(controlTemplate, this.fixture.Window?.TestButtonTextBox.FindChild<Button>("PART_ClearText")?.Template);
 
-            this.fixture.Window?.TestButtonPasswordBox.SetResourceReference(TextBoxHelper.ButtonTemplateProperty, resourceKey);
-            Assert.Equal(controlTemplate, this.fixture.Window?.TestButtonPasswordBox.FindChild<Button>("PART_ClearText")?.Template);
             this.fixture.Window?.TestButtonRevealedPasswordBox.SetResourceReference(TextBoxHelper.ButtonTemplateProperty, resourceKey);
             Assert.Equal(controlTemplate, this.fixture.Window?.TestButtonRevealedPasswordBox.FindChild<Button>("PART_ClearText")?.Template);
         }

--- a/src/Mahapps.Metro.Tests/Views/TextBoxHelperTestWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/TextBoxHelperTestWindow.xaml
@@ -19,8 +19,7 @@
         <TextBox x:Name="TestTextBox" />
         <TextBox x:Name="TestButtonTextBox" Style="{DynamicResource MahApps.Styles.TextBox.Search}" />
         <PasswordBox x:Name="TestPasswordBox" />
-        <PasswordBox x:Name="TestButtonPasswordBox" Style="{DynamicResource MahApps.Styles.PasswordBox.Button}" />
-        <PasswordBox x:Name="TestButtonRevealedPasswordBox" Style="{DynamicResource MahApps.Styles.PasswordBox.Button.Revealed}" />
+        <PasswordBox x:Name="TestButtonRevealedPasswordBox" Style="{DynamicResource MahApps.Styles.PasswordBox.Revealed}" />
         <ComboBox x:Name="TestComboBox" />
         <ComboBox x:Name="TestEditableComboBox" IsEditable="True" />
         <mah:NumericUpDown x:Name="TestNumericUpDown" />

--- a/src/Mahapps.Metro.Tests/Views/TextBoxHelperTestWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/TextBoxHelperTestWindow.xaml
@@ -17,7 +17,7 @@
     </mah:MetroWindow.Resources>
     <StackPanel>
         <TextBox x:Name="TestTextBox" />
-        <TextBox x:Name="TestButtonTextBox" Style="{DynamicResource MahApps.Styles.TextBox.Button}" />
+        <TextBox x:Name="TestButtonTextBox" Style="{DynamicResource MahApps.Styles.TextBox.Search}" />
         <PasswordBox x:Name="TestPasswordBox" />
         <PasswordBox x:Name="TestButtonPasswordBox" Style="{DynamicResource MahApps.Styles.PasswordBox.Button}" />
         <PasswordBox x:Name="TestButtonRevealedPasswordBox" Style="{DynamicResource MahApps.Styles.PasswordBox.Button.Revealed}" />


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Add clear/custom button command to all input controls and use the ClearControlCommand.

- RichTextBox
- TextBox
- ComboBox
- DatePicker
- DateTimePicker
- PasswordBox
- MultiSelectionComboBox
- ColorPicker
- NumericUpDown
- HotKeyBox

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Unit test

TextBoxHelperTests

<!-- If it's possible then make a unit test for your changes. -->

## Additional context

- Add new MahAppsCommands.SearchCommand
- Create new MahApps.Styles.CheckBox.MultiSelectionComboBoxItem for MahApps.Styles.MultiSelectionComboBoxItem.CheckBox
- Add new TextBoxHelper.ButtonCommandTarget. With this property it's easier to set the target for the clear command.
- Add a new HotKeyChanged event to the HotKeyBox

**BREAKING CHANGE**

- TextBoxHelper.IsClearTextButtonBehaviorEnabled and TextBoxHelper.TextButton attached properties removed
- MahApps.Styles.RichTextBox.Button style removed
- MahApps.Styles.TextBox.Button style removed
- MahApps.Styles.PasswordBox.Button style removed
- MahApps.Styles.PasswordBox.Button.Revealed style renamed to MahApps.Styles.PasswordBox.Revealed
- MahApps.Styles.MulitselectionComboBoxSelectedItem style renamed to MahApps.Styles.MultiSelectionComboBoxSelectedItem
- MahApps.Styles.Button.MulitselectionComboBoxSelectedItem.RemoveItem style renamed to MahApps.Styles.Button.MultiSelectionComboBoxSelectedItem.RemoveItem
- MahApps.Styles.MulitselectionComboBoxSelectedItem.Removeable style renamed to MahApps.Styles.MultiSelectionComboBoxSelectedItem.Removable

## Samples

To show the clear button on a control set the TextBoxHelper.ClearTextButton to true.

```xaml
<TextBox mah:TextBoxHelper.ClearTextButton="True" />
```

or

```xaml
<ComboBox mah:TextBoxHelper.ClearTextButton="True" />
```

For the TextBox you can use the MahApps.Styles.TextBox.Search style which uses the MahAppsCommands.SearchCommand for the button.

```xaml
<TextBox mah:TextBoxHelper.Watermark="Find something..."
         Style="{DynamicResource MahApps.Styles.TextBox.Search}">
    <TextBox.CommandBindings>
        <CommandBinding CanExecute="TextBoxSearchOnCanExecute"
                        Command="{x:Static mah:MahAppsCommands.SearchCommand}"
                        Executed="TextBoxSearchOnExecuted" />
    </TextBox.CommandBindings>
</TextBox>
```

```csharp
private void TextBoxSearchOnCanExecute(object sender, CanExecuteRoutedEventArgs e)
{
    e.CanExecute = true;
}

private async void TextBoxSearchOnExecuted(object sender, ExecutedRoutedEventArgs e)
{
    if (e.Parameter is TextBox textBox)
    {
        await this.TryFindParent<MetroWindow>()!.ShowMessageAsync("TextBox Search Button was clicked!", textBox.Text).ConfigureAwait(false);
    }
}
```

To use your own command on the clear button you need only set the TextBoxHelper.ButtonCommand to it.

```xaml
<TextBox mah:TextBoxHelper.ButtonCommand="{Binding ControlButtonCommandWithParameter, Mode=OneWay}"
         mah:TextBoxHelper.Watermark="Type something..." />
```

> **Note**
> If the TextBoxHelper.ClearTextButton is set to true and also the TextBoxHelper.ButtonCommand then the ClearTextButton will win.

It's now also possible to clear the control with the Escape key.

```xaml
<TextBox mah:TextBoxHelper.ClearTextButton="True"
         Text="Clear with Escape">
    <TextBox.InputBindings>
        <KeyBinding Key="Escape" Command="{x:Static mah:MahAppsCommands.ClearControlCommand}" />
    </TextBox.InputBindings>
</TextBox>
```

<!-- Add any other context or screenshots about the feature request here. -->

## Closed Issues

<!-- Closes #xxxx -->

Closes #3191 
Closes #3020 
Closes #3163 
Closes #3669 
Closes #2707 
