### PR TITLE
Don't change NUD value on lost focus event (because of binding problems)

### DIFF
--- a/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
+++ b/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
@@ -77,7 +77,7 @@ namespace MahApps.Metro.Controls
                     hotKeyBox.GetBindingExpression(HotKeyBox.HotKeyProperty)?.UpdateSource();
                     break;
                 case NumericUpDown numericUpDown:
-                    numericUpDown.SetCurrentValue(NumericUpDown.ValueProperty, NumericUpDown.ValueProperty.DefaultMetadata.DefaultValue);
+                    numericUpDown.SetCurrentValue(NumericUpDown.ValueProperty, numericUpDown.DefaultValue);
                     numericUpDown.GetBindingExpression(NumericUpDown.ValueProperty)?.UpdateSource();
                     break;
                 case TextBox textBox:


### PR DESCRIPTION
## Describe the changes you have made to improve this project

The NUD has a strange behavior if it's located inside a TabItem and the value is bound to a MVVM property which is used then in all TabItems (via DataTemplate).

So updating the value from the textbox is not a good way. Instead it should only update the text inside the textbox because the value is now converted on the fly when the text is changed by the user or the up down buttons.

BREAKING CHANGE: remove ChangeValueOnTextChanged property

The ChangeValueOnTextChanged is removed, because of the ugly lost focus problem. So after all it should now work and convert the text on the fly to it's value.

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Unit test

NumericUpDownTests

<!-- If it's possible then make a unit test for your changes. -->

## Closed Issues

Closes #4257 

<!-- Closes #xxxx -->
