### PR TITLE
Remove the IsWaitingForData attached property

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -98,9 +98,8 @@
                     <TextBox Margin="{StaticResource ControlMargin}"
                              HorizontalContentAlignment="Stretch"
                              mah:TextBoxHelper.ClearTextButton="True"
-                             mah:TextBoxHelper.IsWaitingForData="True"
                              mah:TextBoxHelper.UseFloatingWatermark="True"
-                             mah:TextBoxHelper.Watermark="Watermark"
+                             mah:TextBoxHelper.Watermark="Watermark..."
                              mah:TextBoxHelper.WatermarkAlignment="Right"
                              SpellCheck.IsEnabled="True"
                              ToolTip="WatermarkAlignment Right">
@@ -293,7 +292,6 @@
                              Style="{StaticResource MahApps.Styles.PasswordBox.Win8}" />
                 <PasswordBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.ClearTextButton="{Binding RelativeSource={RelativeSource Self}, Path=(mah:TextBoxHelper.HasText), Mode=OneWay}"
-                             mah:TextBoxHelper.IsWaitingForData="True"
                              mah:TextBoxHelper.UseFloatingWatermark="True"
                              mah:TextBoxHelper.Watermark="Revealed..."
                              Style="{StaticResource MahApps.Styles.PasswordBox.Revealed}" />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/CleanWindowDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/CleanWindowDemo.xaml
@@ -116,11 +116,9 @@
                         </ContextMenu>
                     </TextBlock.ContextMenu>
                 </TextBlock>
-                <!--  This would cause a memory leak with MahApps.DropShadowEffect.WaitingForData: [x:Shared = True]  -->
                 <TextBox Width="120"
                          Margin="4"
                          VerticalAlignment="Center"
-                         mah:TextBoxHelper.IsWaitingForData="True"
                          DockPanel.Dock="Right" />
                 <TextBlock HorizontalAlignment="Right"
                            VerticalAlignment="Center"

--- a/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/TextBoxHelper.cs
@@ -671,29 +671,6 @@ namespace MahApps.Metro.Controls
             obj.SetValue(SelectAllOnFocusProperty, BooleanBoxes.Box(value));
         }
 
-        public static readonly DependencyProperty IsWaitingForDataProperty
-            = DependencyProperty.RegisterAttached(
-                "IsWaitingForData",
-                typeof(bool),
-                typeof(TextBoxHelper),
-                new UIPropertyMetadata(BooleanBoxes.FalseBox));
-
-        [Category(AppName.MahApps)]
-        [AttachedPropertyBrowsableForType(typeof(TextBoxBase))]
-        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
-        public static bool GetIsWaitingForData(DependencyObject obj)
-        {
-            return (bool)obj.GetValue(IsWaitingForDataProperty);
-        }
-
-        [Category(AppName.MahApps)]
-        [AttachedPropertyBrowsableForType(typeof(TextBoxBase))]
-        [AttachedPropertyBrowsableForType(typeof(PasswordBox))]
-        public static void SetIsWaitingForData(DependencyObject obj, bool value)
-        {
-            obj.SetValue(IsWaitingForDataProperty, BooleanBoxes.Box(value));
-        }
-
         public static readonly DependencyProperty IsSpellCheckContextMenuEnabledProperty
             = DependencyProperty.RegisterAttached(
                 "IsSpellCheckContextMenuEnabled",

--- a/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.PasswordBox.xaml
@@ -83,16 +83,6 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type PasswordBox}">
                     <Grid>
-                        <AdornerDecorator x:Name="PART_WaitingForDataEffectAdornerDecorator" Visibility="Collapsed">
-                            <Border x:Name="PART_WaitingForDataEffectGrid"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="Transparent"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    Effect="{DynamicResource MahApps.DropShadowEffect.WaitingForData}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </AdornerDecorator>
-
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -301,20 +291,6 @@
                                 <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ExitHasText}" />
                             </Trigger.ExitActions>
                         </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsVisible" Value="True" />
-                                <Condition Property="mah:TextBoxHelper.IsWaitingForData" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_WaitingForDataEffectAdornerDecorator" Property="Visibility" Value="Visible" />
-                            <MultiTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.WaitingForData}" />
-                            </MultiTrigger.EnterActions>
-                        </MultiTrigger>
-                        <Trigger Property="mah:TextBoxHelper.IsWaitingForData" Value="False">
-                            <Setter TargetName="PART_WaitingForDataEffectAdornerDecorator" Property="Visibility" Value="Collapsed" />
-                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -368,16 +344,6 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type PasswordBox}">
                     <Grid>
-                        <AdornerDecorator x:Name="PART_WaitingForDataEffectAdornerDecorator" Visibility="Collapsed">
-                            <Border x:Name="PART_WaitingForDataEffectGrid"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="Transparent"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    Effect="{DynamicResource MahApps.DropShadowEffect.WaitingForData}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </AdornerDecorator>
-
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -632,20 +598,6 @@
                             <Trigger.ExitActions>
                                 <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ExitHasText}" />
                             </Trigger.ExitActions>
-                        </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsVisible" Value="True" />
-                                <Condition Property="mah:TextBoxHelper.IsWaitingForData" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_WaitingForDataEffectAdornerDecorator" Property="Visibility" Value="Visible" />
-                            <MultiTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.WaitingForData}" />
-                            </MultiTrigger.EnterActions>
-                        </MultiTrigger>
-                        <Trigger Property="mah:TextBoxHelper.IsWaitingForData" Value="False">
-                            <Setter TargetName="PART_WaitingForDataEffectAdornerDecorator" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/Styles/Controls.Shadows.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Shadows.xaml
@@ -22,14 +22,6 @@
                       Color="{DynamicResource MahApps.Colors.ToolTipShadow}"
                       po:Freeze="True" />
 
-    <DropShadowEffect x:Key="MahApps.DropShadowEffect.WaitingForData"
-                      x:Shared="False"
-                      BlurRadius="10"
-                      Opacity="0"
-                      ShadowDepth="0"
-                      Color="{DynamicResource MahApps.Colors.ThemeForeground}"
-                      po:Freeze="True" />
-
     <DropShadowEffect x:Key="DropShadowBrush"
                       x:Shared="False"
                       BlurRadius="6"

--- a/src/MahApps.Metro/Styles/Controls.Shared.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Shared.xaml
@@ -77,17 +77,6 @@
                          Duration="0:0:0.2" />
     </Storyboard>
 
-    <Storyboard x:Key="MahApps.Storyboard.WaitingForData" po:Freeze="True">
-        <DoubleAnimation AutoReverse="True"
-                         RepeatBehavior="Forever"
-                         Timeline.DesiredFrameRate="30"
-                         Storyboard.TargetName="PART_WaitingForDataEffectGrid"
-                         Storyboard.TargetProperty="(Effect).Opacity"
-                         From="0"
-                         To="1"
-                         Duration="00:00:02" />
-    </Storyboard>
-
     <Storyboard x:Key="MahApps.Storyboard.HideFloatingMessage" po:Freeze="True">
         <DoubleAnimation EasingFunction="{StaticResource MahApps.ExponentialEase.EaseInOut}"
                          Storyboard.TargetName="PART_FloatingMessageContainer"

--- a/src/MahApps.Metro/Styles/Controls.TextBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TextBox.xaml
@@ -26,16 +26,6 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}">
                     <Grid>
-                        <AdornerDecorator x:Name="PART_WaitingForDataEffectAdornerDecorator" Visibility="Collapsed">
-                            <Border x:Name="PART_WaitingForDataEffectGrid"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="Transparent"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    Effect="{DynamicResource MahApps.DropShadowEffect.WaitingForData}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </AdornerDecorator>
-
                         <Border x:Name="Base"
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -230,20 +220,6 @@
                             <Trigger.ExitActions>
                                 <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.ExitHasText}" />
                             </Trigger.ExitActions>
-                        </Trigger>
-
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsVisible" Value="True" />
-                                <Condition Property="mah:TextBoxHelper.IsWaitingForData" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="PART_WaitingForDataEffectAdornerDecorator" Property="Visibility" Value="Visible" />
-                            <MultiTrigger.EnterActions>
-                                <BeginStoryboard Storyboard="{StaticResource MahApps.Storyboard.WaitingForData}" />
-                            </MultiTrigger.EnterActions>
-                        </MultiTrigger>
-                        <Trigger Property="mah:TextBoxHelper.IsWaitingForData" Value="False">
-                            <Setter TargetName="PART_WaitingForDataEffectAdornerDecorator" Property="Visibility" Value="Collapsed" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/MahApps.Metro/Themes/HotKeyBox.xaml
+++ b/src/MahApps.Metro/Themes/HotKeyBox.xaml
@@ -41,7 +41,6 @@
                              mah:TextBoxHelper.ButtonWidth="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
                              mah:TextBoxHelper.ButtonsAlignment="{TemplateBinding mah:TextBoxHelper.ButtonsAlignment}"
                              mah:TextBoxHelper.ClearTextButton="{TemplateBinding mah:TextBoxHelper.ClearTextButton}"
-                             mah:TextBoxHelper.IsWaitingForData="{TemplateBinding mah:TextBoxHelper.IsWaitingForData}"
                              mah:TextBoxHelper.SelectAllOnFocus="{TemplateBinding mah:TextBoxHelper.SelectAllOnFocus}"
                              mah:TextBoxHelper.UseFloatingWatermark="{TemplateBinding mah:TextBoxHelper.UseFloatingWatermark}"
                              mah:TextBoxHelper.Watermark="{TemplateBinding mah:TextBoxHelper.Watermark}"


### PR DESCRIPTION
## Describe the changes you have made to improve this project

BREAKING CHANGE: remove the IsWaitingForData attached property

Remove the IsWaitingForData attached property and all associated styles and effects.

The "mandatory" visual can be used with the WPF validation rules, so this extra attached property can be removed.

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->
