### PR TITLE
Remove methods to show an existing dialog externally

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
@@ -209,7 +209,6 @@
                 <MenuItem Click="ShowInputDialogOutside" Header="Show ShowInputDialog Externally" />
                 <MenuItem Click="ShowLoginDialogOutside" Header="Show ShowLoginDialog Externally" />
                 <MenuItem Click="ShowMessageDialogOutside" Header="Show ShowMessageDialog Externally" />
-                <MenuItem Click="ShowDialogOutside" Header="Show CustomDialog Externally" />
                 <Separator />
                 <MenuItem Command="{Binding ShowInputDialogCommand}" Header="Show InputDialog via VM" />
                 <MenuItem Command="{Binding ShowLoginDialogCommand}" Header="Show LoginDialog via VM ..." />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
@@ -473,16 +473,6 @@ namespace MetroDemo
             }
         }
 
-        private async void ShowDialogOutside(object sender, RoutedEventArgs e)
-        {
-            var dialog = new CustomDialog(this.MetroDialogOptions) { Content = this.Resources["CustomDialogTest"], Title = "This dialog allows arbitrary content." };
-            dialog = dialog.ShowDialogExternally();
-
-            await Task.Delay(5000);
-
-            await dialog.RequestCloseAsync();
-        }
-
         #endregion
 
         private void InteropDemo(object sender, RoutedEventArgs e)

--- a/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -390,16 +389,6 @@ namespace MahApps.Metro.Controls.Dialogs
                     this.SetCurrentValue(ForegroundProperty, TryGetResource(theme, "MahApps.Brushes.Dialog.Foreground.Accent"));
                     break;
             }
-
-            if (this.ParentDialogWindow != null)
-            {
-                this.ParentDialogWindow.SetCurrentValue(BackgroundProperty, this.Background);
-                var glowColor = TryGetResource(theme, "MahApps.Colors.Accent");
-                if (glowColor != null)
-                {
-                    this.ParentDialogWindow.SetCurrentValue(MetroWindow.GlowColorProperty, glowColor);
-                }
-            }
         }
 
         /// <summary>
@@ -476,37 +465,6 @@ namespace MahApps.Metro.Controls.Dialogs
             return tcs.Task;
         }
 
-        /// <summary>
-        /// Requests an externally shown Dialog to close. Will throw an exception if the Dialog is inside of a MetroWindow.
-        /// </summary>
-        public async Task RequestCloseAsync()
-        {
-            if (this.OnRequestClose())
-            {
-                // Technically, the Dialog is /always/ inside of a MetroWindow.
-                // If the dialog is inside of a user-created MetroWindow, not one created by the external dialog APIs.
-                if (this.ParentDialogWindow is null)
-                {
-                    // this is very bad, or the user called the close event before we can do this
-                    if (this.OwningWindow is null)
-                    {
-                        Trace.TraceWarning($"{this}: Can not request async closing, because the OwningWindow is already null. This can maybe happen if the dialog was closed manually.");
-                        return;
-                    }
-
-                    // This is from a user-created MetroWindow
-                    await this.OwningWindow.HideMetroDialogAsync(this);
-
-                    return;
-                }
-
-                // This is from a MetroWindow created by the external dialog APIs.
-                await this.WaitForCloseAsync();
-
-                this.ParentDialogWindow.Close();
-            }
-        }
-
         internal void FireOnShown()
         {
             this.OnShown();
@@ -519,28 +477,11 @@ namespace MahApps.Metro.Controls.Dialogs
         internal void FireOnClose()
         {
             this.OnClose();
-
-            // this is only set when a dialog is shown (externally) in it's OWN window.
-            this.ParentDialogWindow?.Close();
         }
 
         protected virtual void OnClose()
         {
         }
-
-        /// <summary>
-        /// A last chance virtual method for stopping an external dialog from closing.
-        /// </summary>
-        /// <returns></returns>
-        protected virtual bool OnRequestClose()
-        {
-            return true; //allow the dialog to close.
-        }
-
-        /// <summary>
-        /// Gets the window that owns the current Dialog IF AND ONLY IF the dialog is shown externally.
-        /// </summary>
-        protected internal Window? ParentDialogWindow { get; internal set; }
 
         /// <summary>
         /// Gets the window that owns the current Dialog IF AND ONLY IF the dialog is shown inside of a window.

--- a/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -490,46 +490,6 @@ namespace MahApps.Metro.Controls.Dialogs
             window.SetValue(MetroWindow.IsAnyDialogOpenPropertyKey, BooleanBoxes.Box(window.metroActiveDialogContainer.Children.Count > 0));
         }
 
-        /// <summary>
-        /// Create and show an external dialog.
-        /// </summary>
-        /// <param name="dialog">The dialog which will be shown externally.</param>
-        /// <param name="windowOwner">The owner for the external window. If it's null the main window will be use.</param>
-        /// <param name="handleExternalDialogWindow">The delegate for customizing dialog window. It can be null.</param>
-        /// <returns>The given dialog.</returns>
-        public static TDialog ShowDialogExternally<TDialog>(this TDialog dialog, Window? windowOwner = null, Action<Window>? handleExternalDialogWindow = null)
-            where TDialog : BaseMetroDialog
-        {
-            var win = SetupExternalDialogWindow(dialog, windowOwner);
-
-            handleExternalDialogWindow?.Invoke(win);
-
-            dialog.FireOnShown();
-            win.Show();
-
-            return dialog;
-        }
-
-        /// <summary>
-        /// Create and show an external modal dialog.
-        /// </summary>
-        /// <param name="dialog">The dialog which will be shown externally.</param>
-        /// <param name="windowOwner">The owner for the external window. If it's null the main window will be use.</param>
-        /// <param name="handleExternalDialogWindow">The delegate for customizing dialog window. It can be null.</param>
-        /// <returns>The given dialog.</returns>
-        public static TDialog ShowModalDialogExternally<TDialog>(this TDialog dialog, Window? windowOwner = null, Action<Window>? handleExternalDialogWindow = null)
-            where TDialog : BaseMetroDialog
-        {
-            var win = SetupExternalDialogWindow(dialog, windowOwner);
-
-            handleExternalDialogWindow?.Invoke(win);
-
-            dialog.FireOnShown();
-            win.ShowDialog();
-
-            return dialog;
-        }
-
         private static MetroWindow CreateExternalWindow(Window? windowOwner = null)
         {
             var window = new MetroWindow
@@ -566,46 +526,6 @@ namespace MahApps.Metro.Controls.Dialogs
             }
 
             return window;
-        }
-
-        private static MetroWindow SetupExternalDialogWindow(BaseMetroDialog dialog, Window? windowOwner = null)
-        {
-            var win = CreateExternalWindow(windowOwner ?? Application.Current?.MainWindow);
-
-            // Get the monitor working area
-            var monitorWorkingArea = win.Owner.GetMonitorWorkSize();
-            if (monitorWorkingArea != default)
-            {
-                win.Width = monitorWorkingArea.Width;
-                win.MinHeight = monitorWorkingArea.Height / 4.0;
-                win.MaxHeight = monitorWorkingArea.Height;
-            }
-            else
-            {
-                win.Width = SystemParameters.PrimaryScreenWidth;
-                win.MinHeight = SystemParameters.PrimaryScreenHeight / 4.0;
-                win.MaxHeight = SystemParameters.PrimaryScreenHeight;
-            }
-
-            dialog.ParentDialogWindow = win; //THIS IS ONLY, I REPEAT, ONLY SET FOR EXTERNAL DIALOGS!
-
-            win.Content = dialog;
-
-            dialog.HandleThemeChange();
-
-            EventHandler? closedHandler = null;
-            closedHandler = (_, _) =>
-                {
-                    win.Closed -= closedHandler;
-                    dialog.ParentDialogWindow = null;
-                    win.Content = null;
-                };
-
-            win.Closed += closedHandler;
-
-            win.SizeToContent = SizeToContent.Height;
-
-            return win;
         }
 
         private static MetroWindow CreateModalExternalWindow(MetroWindow windowOwner)


### PR DESCRIPTION
## Describe the changes you have made to improve this project
This PR removes the methods to show an existing dialog externally:

- ShowDialogExternally<TDialog>
- ShowModalDialogExternally<TDialog>

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Additional context
I will not continue to maintain these 2 methods.

<!-- Add any other context or screenshots about the feature request here. -->

## Closed Issues

<!-- Closes #xxxx -->
