### PR TITLE
when restoring window size use the DPI scale factor

### DIFF
--- a/src/MahApps.Metro/Controls/WinApiHelper.cs
+++ b/src/MahApps.Metro/Controls/WinApiHelper.cs
@@ -89,10 +89,13 @@ namespace MahApps.Metro.Controls
                 return;
             }
 
+            // Get the current DPI scale factor
+            var dpiScale = VisualTreeHelper.GetDpi(window);
+
             var x = CalcIntValue(wp?.rcNormalPosition.left, window.Left);
             var y = CalcIntValue(wp?.rcNormalPosition.top, window.Top);
-            var width = CalcIntValue(wp?.rcNormalPosition.GetWidth(), window.ActualWidth);
-            var height = CalcIntValue(wp?.rcNormalPosition.GetHeight(), window.ActualHeight);
+            var width = CalcIntValue(wp?.rcNormalPosition.GetWidth() * dpiScale.DpiScaleX, window.ActualWidth);
+            var height = CalcIntValue(wp?.rcNormalPosition.GetHeight() * dpiScale.DpiScaleY, window.ActualHeight);
 
             var placement = new WINDOWPLACEMENT
                             {


### PR DESCRIPTION
## Describe the changes you have made to improve this project

I noticed that restoring the window size wasn't very consistent - and on a brand new test project it would get smaller each time it was opened and closed. Reviewing the code it looks like WindowPlacementSetting uses the DPI to adjust the scale factor when saving the settings - but that isn't used when restoring the window.  This change takes the DPI scale factor into account when restoring. 

This fixes the issue for me. Don't have enough experience with the codebase to add a unit test.