### PR TITLE
Feature: Center window command

### DIFF
--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -7,7 +7,7 @@
 
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFrameworks>net6.0-windows</TargetFrameworks>
+        <TargetFrameworks>net462;net47;net48;netcoreapp3.1;net5.0-windows;net6.0-windows</TargetFrameworks>
         <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AutoGenerateBindingRedirects Condition="$(DefineConstants.Contains(NETCOREAPP)) == false">true</AutoGenerateBindingRedirects>

--- a/src/Directory.Build.Props
+++ b/src/Directory.Build.Props
@@ -7,7 +7,7 @@
 
     <!-- Project properties -->
     <PropertyGroup>
-        <TargetFrameworks>net462;net47;net48;netcoreapp3.1;net5.0-windows;net6.0-windows</TargetFrameworks>
+        <TargetFrameworks>net6.0-windows</TargetFrameworks>
         <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
         <AutoGenerateBindingRedirects Condition="$(DefineConstants.Contains(NETCOREAPP)) == false">true</AutoGenerateBindingRedirects>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/CleanWindowDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/CleanWindowDemo.xaml
@@ -45,6 +45,15 @@
         </mah:WindowCommands>
     </mah:MetroWindow.LeftWindowCommands>
 
+
+    <mah:MetroWindow.CenterWindowCommands>
+        <mah:WindowCommands>
+            <Button Content="Another Test" />
+            <ToggleButton Content="ToggleButton" />
+        </mah:WindowCommands>
+    </mah:MetroWindow.CenterWindowCommands>
+
+    
     <mah:MetroWindow.RightWindowCommands>
         <mah:WindowCommands>
             <Button Content="Another Test" />

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/CleanWindowDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/CleanWindowDemo.xaml
@@ -44,15 +44,6 @@
             <Button Content="Test" />
         </mah:WindowCommands>
     </mah:MetroWindow.LeftWindowCommands>
-
-
-    <mah:MetroWindow.CenterWindowCommands>
-        <mah:WindowCommands>
-            <Button Content="Another Test" />
-            <ToggleButton Content="ToggleButton" />
-        </mah:WindowCommands>
-    </mah:MetroWindow.CenterWindowCommands>
-
     
     <mah:MetroWindow.RightWindowCommands>
         <mah:WindowCommands>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
@@ -23,7 +23,7 @@
                  NonActiveGlowColor="#CDFF0000"
                  ResizeMode="CanResizeWithGrip"
                  ShowIconOnTitleBar="True"
-                 WindowStartupLocation="CenterScreen"                 
+                 WindowStartupLocation="CenterScreen"
                  mc:Ignorable="d">
     <!--    
         if using DialogParticipation on Windows which open/close frequently you will get a
@@ -59,37 +59,50 @@
             <Style x:Key="AppThemeMenuItemStyle"
                    BasedOn="{StaticResource MahApps.Styles.MenuItem}"
                    TargetType="{x:Type MenuItem}">
-                <Setter Property="Command" Value="{Binding ChangeAccentCommand}" />
-                <Setter Property="CommandParameter" Value="{Binding Name, Mode=OneWay}" />
-                <Setter Property="Header" Value="{Binding Name, Mode=OneWay}" />
-                <Setter Property="Icon" Value="{StaticResource AppThemeMenuIcon}" />
+                <Setter Property="Command"
+                        Value="{Binding ChangeAccentCommand}" />
+                <Setter Property="CommandParameter"
+                        Value="{Binding Name, Mode=OneWay}" />
+                <Setter Property="Header"
+                        Value="{Binding Name, Mode=OneWay}" />
+                <Setter Property="Icon"
+                        Value="{StaticResource AppThemeMenuIcon}" />
             </Style>
 
             <Style x:Key="AccentColorMenuItemStyle"
                    BasedOn="{StaticResource MahApps.Styles.MenuItem}"
                    TargetType="{x:Type MenuItem}">
-                <Setter Property="Command" Value="{Binding ChangeAccentCommand}" />
-                <Setter Property="CommandParameter" Value="{Binding Name, Mode=OneWay}" />
-                <Setter Property="Header" Value="{Binding Name, Mode=OneWay}" />
-                <Setter Property="Icon" Value="{StaticResource AccentMenuIcon}" />
+                <Setter Property="Command"
+                        Value="{Binding ChangeAccentCommand}" />
+                <Setter Property="CommandParameter"
+                        Value="{Binding Name, Mode=OneWay}" />
+                <Setter Property="Header"
+                        Value="{Binding Name, Mode=OneWay}" />
+                <Setter Property="Icon"
+                        Value="{StaticResource AccentMenuIcon}" />
             </Style>
 
             <Style x:Key="SyncModeMenuItemStyle"
                    BasedOn="{StaticResource MahApps.Styles.MenuItem}"
                    TargetType="{x:Type MenuItem}">
-                <Setter Property="Command" Value="{Binding DataContext.ChangeSyncModeCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
-                <Setter Property="CommandParameter" Value="{Binding Mode=OneTime}" />
-                <Setter Property="Header" Value="{Binding Mode=OneTime}" />
+                <Setter Property="Command"
+                        Value="{Binding DataContext.ChangeSyncModeCommand, RelativeSource={RelativeSource AncestorType=Window}}" />
+                <Setter Property="CommandParameter"
+                        Value="{Binding Mode=OneTime}" />
+                <Setter Property="Header"
+                        Value="{Binding Mode=OneTime}" />
             </Style>
 
             <UserControl x:Key="CustomDialogTest"
                          x:Name="CustomDialogTest"
                          MinHeight="200">
 
-                <TextBlock x:Name="MessageTextBlock" Text="Message shown by this custom Dialog." />
+                <TextBlock x:Name="MessageTextBlock"
+                           Text="Message shown by this custom Dialog." />
             </UserControl>
 
-            <UserControl x:Key="CustomCloseDialogTest" x:Name="CustomCloseDialogTest">
+            <UserControl x:Key="CustomCloseDialogTest"
+                         x:Name="CustomCloseDialogTest">
 
                 <StackPanel>
                     <TextBlock Height="30"
@@ -118,7 +131,8 @@
     </Window.Resources>
     <mah:MetroWindow.LeftWindowCommands>
         <mah:WindowCommands>
-            <Button Click="LaunchMahAppsOnGitHub" ToolTip="MahApps.Metro on GitHub">
+            <Button Click="LaunchMahAppsOnGitHub"
+                    ToolTip="MahApps.Metro on GitHub">
                 <iconPacks:PackIconModern Width="22"
                                           Height="22"
                                           Kind="SocialGithubOctocat" />
@@ -129,29 +143,36 @@
         <mah:WindowCommands ShowSeparators="False">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <Grid Grid.Column="0" Grid.Row="0">
-                    <Rectangle Width="28" Fill="{DynamicResource MahApps.Brushes.Gray10}"/>
-                    <Rectangle Width="20" Height="20" HorizontalAlignment="Right" Fill="{DynamicResource MahApps.Brushes.Gray8}">
+                <Grid Grid.Column="0"
+                      Grid.Row="0">
+                    <Rectangle Width="28"
+                               Fill="{DynamicResource MahApps.Brushes.Gray10}" />
+                    <Rectangle Width="20"
+                               Height="20"
+                               HorizontalAlignment="Right"
+                               Fill="{DynamicResource MahApps.Brushes.Gray8}">
                         <Rectangle.OpacityMask>
-                            <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=ChevronRight}" />
+                            <VisualBrush Stretch="Uniform"
+                                         Visual="{iconPacks:Material Kind=ChevronRight}" />
                         </Rectangle.OpacityMask>
                     </Rectangle>
                 </Grid>
                 <ComboBox x:Name="CenterWindowCommandComboBox"
-                         Grid.Column="1" Grid.Row="0"
-                         GotKeyboardFocus="CenterWindowCommandComboBox_GotFocus"
-                         LostKeyboardFocus="CenterWindowCommandComboBox_LostFocus"
-                         DropDownClosed="CenterWindowCommandComboBox_DropDownClosed"
-                         Width="150"
-                         VerticalContentAlignment="Center"
-                         BorderThickness="0"
-                         FontSize="14"
-                         IsEditable="True"
-                         Background="{DynamicResource MahApps.Brushes.Gray10}"
-                         mah:TextBoxHelper.Watermark="Run command...">
+                          Grid.Column="1"
+                          Grid.Row="0"
+                          GotKeyboardFocus="CenterWindowCommandComboBox_GotFocus"
+                          LostKeyboardFocus="CenterWindowCommandComboBox_LostFocus"
+                          DropDownClosed="CenterWindowCommandComboBox_DropDownClosed"
+                          Width="150"
+                          VerticalContentAlignment="Center"
+                          BorderThickness="0"
+                          FontSize="14"
+                          IsEditable="True"
+                          Background="{DynamicResource MahApps.Brushes.Gray10}"
+                          mah:TextBoxHelper.Watermark="Run command...">
                     <ComboBoxItem Content="switch theme" />
                     <ComboBoxItem Content="switch accent" />
                     <ComboBoxItem Content="help" />
@@ -211,7 +232,8 @@
                           IsCheckable="True"
                           IsChecked="{Binding Options.UseHSL, Source={x:Static controlzEx:RuntimeThemeGenerator.Current}, Mode=TwoWay}" />
 
-                <MenuItem Command="{Binding DataContext.SyncThemeNowCommand, RelativeSource={RelativeSource AncestorType=Window}}" Header="Sync now" />
+                <MenuItem Command="{Binding DataContext.SyncThemeNowCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                          Header="Sync now" />
             </MenuItem>
             <MenuItem Header="Dialogs">
                 <MenuItem Header="Use Accent?"
@@ -227,24 +249,40 @@
                           IsCheckable="True"
                           IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:MetroWindow}}, Path=ShowDialogsOverTitleBar}" />
                 <Separator />
-                <MenuItem Click="ShowInputDialog" Header="Show InputDialog" />
-                <MenuItem Click="ShowInputDialogCustomButtonSizes" Header="Show InputDialog (with custom button font sizes)" />
-                <MenuItem Click="ShowLoginDialog" Header="Show LoginDialog" />
-                <MenuItem Click="ShowLoginDialogPasswordPreview" Header="Show Password Preview LoginDialog" />
-                <MenuItem Click="ShowLoginDialogOnlyPassword" Header="Show LoginDialog (Only Password)" />
-                <MenuItem Click="ShowLoginDialogWithRememberCheckBox" Header="Show LoginDialog (With Remember CheckBox)" />
-                <MenuItem Click="ShowMessageDialog" Header="Show MessageDialog" />
-                <MenuItem Click="ShowLimitedMessageDialog" Header="Show MessageDialog (Limited Size)" />
-                <MenuItem Click="ShowProgressDialog" Header="Show ProgressDialog" />
-                <MenuItem Click="ShowCustomDialog" Header="Show CustomDialog" />
-                <MenuItem Click="ShowAwaitCustomDialog" Header="Await CustomDialog" />
+                <MenuItem Click="ShowInputDialog"
+                          Header="Show InputDialog" />
+                <MenuItem Click="ShowInputDialogCustomButtonSizes"
+                          Header="Show InputDialog (with custom button font sizes)" />
+                <MenuItem Click="ShowLoginDialog"
+                          Header="Show LoginDialog" />
+                <MenuItem Click="ShowLoginDialogPasswordPreview"
+                          Header="Show Password Preview LoginDialog" />
+                <MenuItem Click="ShowLoginDialogOnlyPassword"
+                          Header="Show LoginDialog (Only Password)" />
+                <MenuItem Click="ShowLoginDialogWithRememberCheckBox"
+                          Header="Show LoginDialog (With Remember CheckBox)" />
+                <MenuItem Click="ShowMessageDialog"
+                          Header="Show MessageDialog" />
+                <MenuItem Click="ShowLimitedMessageDialog"
+                          Header="Show MessageDialog (Limited Size)" />
+                <MenuItem Click="ShowProgressDialog"
+                          Header="Show ProgressDialog" />
+                <MenuItem Click="ShowCustomDialog"
+                          Header="Show CustomDialog" />
+                <MenuItem Click="ShowAwaitCustomDialog"
+                          Header="Await CustomDialog" />
                 <Separator />
-                <MenuItem Click="ShowInputDialogOutside" Header="Show ShowInputDialog Externally" />
-                <MenuItem Click="ShowLoginDialogOutside" Header="Show ShowLoginDialog Externally" />
-                <MenuItem Click="ShowMessageDialogOutside" Header="Show ShowMessageDialog Externally" />
+                <MenuItem Click="ShowInputDialogOutside"
+                          Header="Show ShowInputDialog Externally" />
+                <MenuItem Click="ShowLoginDialogOutside"
+                          Header="Show ShowLoginDialog Externally" />
+                <MenuItem Click="ShowMessageDialogOutside"
+                          Header="Show ShowMessageDialog Externally" />
                 <Separator />
-                <MenuItem Command="{Binding ShowInputDialogCommand}" Header="Show InputDialog via VM" />
-                <MenuItem Command="{Binding ShowLoginDialogCommand}" Header="Show LoginDialog via VM ..." />
+                <MenuItem Command="{Binding ShowInputDialogCommand}"
+                          Header="Show InputDialog via VM" />
+                <MenuItem Command="{Binding ShowLoginDialogCommand}"
+                          Header="Show LoginDialog via VM ..." />
                 <MenuItem Header="Show MessageDialog via VM">
                     <MenuItem Command="{Binding ShowMessageDialogCommand}"
                               CommandParameter="DISPATCHER_THREAD"
@@ -254,8 +292,10 @@
                               Header="... from Background Thread" />
                 </MenuItem>
 
-                <MenuItem Command="{Binding ShowProgressDialogCommand}" Header="Show ProgressDialog via VM" />
-                <MenuItem Command="{Binding ShowCustomDialogCommand}" Header="Show CustomDialog via VM" />
+                <MenuItem Command="{Binding ShowProgressDialogCommand}"
+                          Header="Show ProgressDialog via VM" />
+                <MenuItem Command="{Binding ShowCustomDialogCommand}"
+                          Header="Show CustomDialog via VM" />
             </MenuItem>
             <MenuItem Header="Window">
                 <MenuItem Header="Chrome">
@@ -297,11 +337,16 @@
                           IsCheckable="True"
                           IsChecked="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:MetroWindow}}, Path=ToggleFullScreen}" />
                 <Separator />
-                <MenuItem Click="MenuWindowWithGlowOnClick" Header="Window with Glow" />
-                <MenuItem Click="MenuWindowWithoutGlowOnClick" Header="Window without Glow" />
-                <MenuItem Click="MenuWindowWithBorderOnClick" Header="Window with Border (and Glow)" />
-                <MenuItem Click="MenuWindowWithRoundedBorderOnClick" Header="Window with rounded Border (without Glow)" />
-                <MenuItem Click="LaunchSizeToContentDemo" Header="Window with SizeToContent" />
+                <MenuItem Click="MenuWindowWithGlowOnClick"
+                          Header="Window with Glow" />
+                <MenuItem Click="MenuWindowWithoutGlowOnClick"
+                          Header="Window without Glow" />
+                <MenuItem Click="MenuWindowWithBorderOnClick"
+                          Header="Window with Border (and Glow)" />
+                <MenuItem Click="MenuWindowWithRoundedBorderOnClick"
+                          Header="Window with rounded Border (without Glow)" />
+                <MenuItem Click="LaunchSizeToContentDemo"
+                          Header="Window with SizeToContent" />
                 <Separator />
                 <MenuItem x:Name="ShowSeparatorsMI"
                           Header="ShowSeparators (RightWindowCommands)"
@@ -332,7 +377,8 @@
             </MenuItem>
         </Menu>
 
-        <mah:MetroAnimatedSingleRowTabControl x:Name="MainTabControl" Grid.Row="1">
+        <mah:MetroAnimatedSingleRowTabControl x:Name="MainTabControl"
+                                              Grid.Row="1">
             <TabItem Header="buttons">
                 <ScrollViewer Margin="2"
                               HorizontalScrollBarVisibility="Auto"
@@ -372,7 +418,8 @@
                 </ScrollViewer>
             </TabItem>
             <TabItem Header="splitview">
-                <ScrollViewer Margin="2" VerticalScrollBarVisibility="Auto">
+                <ScrollViewer Margin="2"
+                              VerticalScrollBarVisibility="Auto">
                     <exampleViews:SplitViewExamples DataContext="{Binding}" />
                 </ScrollViewer>
             </TabItem>
@@ -398,7 +445,8 @@
                 </ScrollViewer>
             </TabItem>
             <TabItem Header="colors">
-                <exampleViews:ColorExample Margin="2" DataContext="{Binding}" />
+                <exampleViews:ColorExample Margin="2"
+                                           DataContext="{Binding}" />
             </TabItem>
 
             <TabItem Header="ColorPicker">

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
@@ -25,7 +25,7 @@
                  ShowIconOnTitleBar="True"
                  WindowStartupLocation="CenterScreen"
                  mc:Ignorable="d">
-    <!--
+    <!--    
         if using DialogParticipation on Windows which open/close frequently you will get a
         memory leak unless you unregister.  The easiest way to do this is in your Closing/Unloaded
         event, as so:
@@ -127,6 +127,16 @@
         </mah:WindowCommands>
     </mah:MetroWindow.LeftWindowCommands>
 
+    <mah:MetroWindow.CenterWindowCommands>
+        <mah:WindowCommands ShowSeparators="False">
+            <TextBox                 Width="250" 
+                                     BorderThickness="0"
+                                     FontSize="14"
+                                     Background="{DynamicResource MahApps.Brushes.Gray10}"
+                                     mah:TextBoxHelper.Watermark="Run Command... (Ctrl+Shit+P)"></TextBox>
+        </mah:WindowCommands>
+    </mah:MetroWindow.CenterWindowCommands>
+    
     <mah:MetroWindow.RightWindowCommands>
         <mah:WindowCommands ShowLastSeparator="False">
             <Button Click="LaunchFlyoutDemo"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
@@ -23,7 +23,7 @@
                  NonActiveGlowColor="#CDFF0000"
                  ResizeMode="CanResizeWithGrip"
                  ShowIconOnTitleBar="True"
-                 WindowStartupLocation="CenterScreen"
+                 WindowStartupLocation="CenterScreen"                 
                  mc:Ignorable="d">
     <!--    
         if using DialogParticipation on Windows which open/close frequently you will get a
@@ -116,7 +116,6 @@
             </ObjectDataProvider>
         </ResourceDictionary>
     </Window.Resources>
-
     <mah:MetroWindow.LeftWindowCommands>
         <mah:WindowCommands>
             <Button Click="LaunchMahAppsOnGitHub" ToolTip="MahApps.Metro on GitHub">
@@ -126,17 +125,41 @@
             </Button>
         </mah:WindowCommands>
     </mah:MetroWindow.LeftWindowCommands>
-
     <mah:MetroWindow.CenterWindowCommands>
         <mah:WindowCommands ShowSeparators="False">
-            <TextBox                 Width="250" 
-                                     BorderThickness="0"
-                                     FontSize="14"
-                                     Background="{DynamicResource MahApps.Brushes.Gray10}"
-                                     mah:TextBoxHelper.Watermark="Run Command... (Ctrl+Shit+P)"></TextBox>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Grid Grid.Column="0" Grid.Row="0">
+                    <Rectangle Width="28" Fill="{DynamicResource MahApps.Brushes.Gray10}"/>
+                    <Rectangle Width="20" Height="20" HorizontalAlignment="Right" Fill="{DynamicResource MahApps.Brushes.Gray8}">
+                        <Rectangle.OpacityMask>
+                            <VisualBrush Stretch="Uniform" Visual="{iconPacks:Material Kind=ChevronRight}" />
+                        </Rectangle.OpacityMask>
+                    </Rectangle>
+                </Grid>
+                <ComboBox x:Name="CenterWindowCommandComboBox"
+                         Grid.Column="1" Grid.Row="0"
+                         GotKeyboardFocus="CenterWindowCommandComboBox_GotFocus"
+                         LostKeyboardFocus="CenterWindowCommandComboBox_LostFocus"
+                         DropDownClosed="CenterWindowCommandComboBox_DropDownClosed"
+                         Width="150"
+                         VerticalContentAlignment="Center"
+                         BorderThickness="0"
+                         FontSize="14"
+                         IsEditable="True"
+                         Background="{DynamicResource MahApps.Brushes.Gray10}"
+                         mah:TextBoxHelper.Watermark="Run command...">
+                    <ComboBoxItem Content="switch theme" />
+                    <ComboBoxItem Content="switch accent" />
+                    <ComboBoxItem Content="help" />
+                </ComboBox>
+            </Grid>
         </mah:WindowCommands>
     </mah:MetroWindow.CenterWindowCommands>
-    
+
     <mah:MetroWindow.RightWindowCommands>
         <mah:WindowCommands ShowLastSeparator="False">
             <Button Click="LaunchFlyoutDemo"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
@@ -610,13 +610,17 @@ namespace MetroDemo
         private void CenterWindowCommandComboBox_LostFocus(object sender, RoutedEventArgs e)
         {
             if (!CenterWindowCommandComboBox.IsDropDownOpen)
+            {
                 CenterWindowCommandComboBox.Width = 150;
+            }
         }
 
         private void CenterWindowCommandComboBox_DropDownClosed(object sender, EventArgs e)
         {
             if (CenterWindowCommandComboBox.IsFocused)
+            {
                 CenterWindowCommandComboBox.Width = 150;
+            }
         }
     }
 }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml.cs
@@ -601,5 +601,22 @@ namespace MetroDemo
             w.WindowStyle = WindowStyle.None;
             w.Show();
         }
+
+        private void CenterWindowCommandComboBox_GotFocus(object sender, RoutedEventArgs e)
+        {
+            CenterWindowCommandComboBox.Width = 450;
+        }
+
+        private void CenterWindowCommandComboBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            if (!CenterWindowCommandComboBox.IsDropDownOpen)
+                CenterWindowCommandComboBox.Width = 150;
+        }
+
+        private void CenterWindowCommandComboBox_DropDownClosed(object sender, EventArgs e)
+        {
+            if (CenterWindowCommandComboBox.IsFocused)
+                CenterWindowCommandComboBox.Width = 150;
+        }
     }
 }

--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -41,6 +41,7 @@ namespace MahApps.Metro.Controls
     [TemplatePart(Name = PART_WindowTitleThumb, Type = typeof(Thumb))]
     [TemplatePart(Name = PART_FlyoutModalDragMoveThumb, Type = typeof(Thumb))]
     [TemplatePart(Name = PART_LeftWindowCommands, Type = typeof(ContentPresenter))]
+    [TemplatePart(Name = PART_CenterWindowCommands, Type = typeof(ContentPresenter))]
     [TemplatePart(Name = PART_RightWindowCommands, Type = typeof(ContentPresenter))]
     [TemplatePart(Name = PART_WindowButtonCommands, Type = typeof(ContentPresenter))]
     [TemplatePart(Name = PART_OverlayBox, Type = typeof(Grid))]
@@ -57,6 +58,7 @@ namespace MahApps.Metro.Controls
         private const string PART_WindowTitleThumb = "PART_WindowTitleThumb";
         private const string PART_FlyoutModalDragMoveThumb = "PART_FlyoutModalDragMoveThumb";
         private const string PART_LeftWindowCommands = "PART_LeftWindowCommands";
+        private const string PART_CenterWindowCommands = "PART_CenterWindowCommands";
         private const string PART_RightWindowCommands = "PART_RightWindowCommands";
         private const string PART_WindowButtonCommands = "PART_WindowButtonCommands";
         private const string PART_OverlayBox = "PART_OverlayBox";
@@ -73,6 +75,7 @@ namespace MahApps.Metro.Controls
         private Thumb? flyoutModalDragMoveThumb;
         private IInputElement? restoreFocus;
         private ContentPresenter? LeftWindowCommandsPresenter;
+        private ContentPresenter? CenterWindowCommandsPresenter;
         private ContentPresenter? RightWindowCommandsPresenter;
         private ContentPresenter? WindowButtonCommandsPresenter;
 
@@ -718,6 +721,33 @@ namespace MahApps.Metro.Controls
             set => this.SetValue(LeftWindowCommandsProperty, value);
         }
 
+        /// <summary>Identifies the <see cref="CenterWindowCommands"/> dependency property.</summary>
+        public static readonly DependencyProperty CenterWindowCommandsProperty
+            = DependencyProperty.Register(nameof(CenterWindowCommands),
+                                          typeof(WindowCommands),
+                                          typeof(MetroWindow),
+                                          new PropertyMetadata(null, OnCenterWindowCommandsPropertyChanged));
+
+        private static void OnCenterWindowCommandsPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is WindowCommands windowCommands)
+            {
+                AutomationProperties.SetName(windowCommands, nameof(CenterWindowCommands));
+            }
+
+            UpdateLogicalChildren(d, e);
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="WindowCommands"/> host on the center of the TitleBar.
+        /// </summary>
+        public WindowCommands? CenterWindowCommands
+        {
+            get => (WindowCommands?)this.GetValue(CenterWindowCommandsProperty);
+            set => this.SetValue(CenterWindowCommandsProperty, value);
+        }
+
+        
         /// <summary>Identifies the <see cref="RightWindowCommands"/> dependency property.</summary>
         public static readonly DependencyProperty RightWindowCommandsProperty
             = DependencyProperty.Register(nameof(RightWindowCommands),
@@ -784,6 +814,22 @@ namespace MahApps.Metro.Controls
             set => this.SetValue(LeftWindowCommandsOverlayBehaviorProperty, value);
         }
 
+        /// <summary>Identifies the <see cref="CenterWindowCommandsOverlayBehavior"/> dependency property.</summary>
+        public static readonly DependencyProperty CenterWindowCommandsOverlayBehaviorProperty
+            = DependencyProperty.Register(nameof(CenterWindowCommandsOverlayBehavior),
+                                          typeof(WindowCommandsOverlayBehavior),
+                                          typeof(MetroWindow),
+                                          new PropertyMetadata(WindowCommandsOverlayBehavior.Never, OnShowTitleBarPropertyChangedCallback));
+
+        /// <summary>
+        /// Gets or sets the overlay behavior for the <see cref="WindowCommands"/> host on the center.
+        /// </summary>
+        public WindowCommandsOverlayBehavior CenterWindowCommandsOverlayBehavior
+        {
+            get => (WindowCommandsOverlayBehavior)this.GetValue(CenterWindowCommandsOverlayBehaviorProperty);
+            set => this.SetValue(CenterWindowCommandsOverlayBehaviorProperty, value);
+        }
+        
         /// <summary>Identifies the <see cref="RightWindowCommandsOverlayBehavior"/> dependency property.</summary>
         public static readonly DependencyProperty RightWindowCommandsOverlayBehaviorProperty
             = DependencyProperty.Register(nameof(RightWindowCommandsOverlayBehavior),
@@ -916,6 +962,9 @@ namespace MahApps.Metro.Controls
             var leftWindowCommandsVisibility = this.LeftWindowCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) ? Visibility.Visible : newVisibility;
             this.LeftWindowCommandsPresenter?.SetCurrentValue(VisibilityProperty, leftWindowCommandsVisibility);
 
+            var centerWindowCommandsVisibility = this.CenterWindowCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) ? Visibility.Visible : newVisibility;
+            this.CenterWindowCommandsPresenter?.SetCurrentValue(VisibilityProperty, centerWindowCommandsVisibility);
+            
             var rightWindowCommandsVisibility = this.RightWindowCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) ? Visibility.Visible : newVisibility;
             this.RightWindowCommandsPresenter?.SetCurrentValue(VisibilityProperty, rightWindowCommandsVisibility);
 
@@ -1193,6 +1242,11 @@ namespace MahApps.Metro.Controls
                 this.LeftWindowCommands.DataContext = this.DataContext;
             }
 
+            if (this.CenterWindowCommands != null)
+            {
+                this.CenterWindowCommands.DataContext = this.DataContext;
+            }
+            
             if (this.RightWindowCommands != null)
             {
                 this.RightWindowCommands.DataContext = this.DataContext;
@@ -1226,6 +1280,7 @@ namespace MahApps.Metro.Controls
 
             var iconWidth = this.icon?.ActualWidth ?? 0;
             var leftWindowCommandsWidth = this.LeftWindowCommands?.ActualWidth ?? 0;
+            var centerWindowCommandsWidth = this.CenterWindowCommands?.ActualWidth ?? 0;
             var rightWindowCommandsWidth = this.RightWindowCommands?.ActualWidth ?? 0;
             var windowButtonCommandsWith = this.WindowButtonCommands?.ActualWidth ?? 0;
 
@@ -1371,6 +1426,11 @@ namespace MahApps.Metro.Controls
                     children.Add(this.LeftWindowCommands);
                 }
 
+                if (this.CenterWindowCommands != null)
+                {
+                    children.Add(this.CenterWindowCommands);
+                }
+                
                 if (this.RightWindowCommands != null)
                 {
                     children.Add(this.RightWindowCommands);
@@ -1395,14 +1455,17 @@ namespace MahApps.Metro.Controls
             base.OnApplyTemplate();
 
             this.LeftWindowCommandsPresenter = this.GetTemplateChild(PART_LeftWindowCommands) as ContentPresenter;
+            this.CenterWindowCommandsPresenter = this.GetTemplateChild(PART_CenterWindowCommands) as ContentPresenter;
             this.RightWindowCommandsPresenter = this.GetTemplateChild(PART_RightWindowCommands) as ContentPresenter;
             this.WindowButtonCommandsPresenter = this.GetTemplateChild(PART_WindowButtonCommands) as ContentPresenter;
 
             this.LeftWindowCommands ??= new WindowCommands();
+            this.CenterWindowCommands ??= new WindowCommands();
             this.RightWindowCommands ??= new WindowCommands();
             this.WindowButtonCommands ??= new WindowButtonCommands();
 
             this.LeftWindowCommands.SetValue(WindowCommands.ParentWindowPropertyKey, this);
+            this.CenterWindowCommands.SetValue(WindowCommands.ParentWindowPropertyKey, this);
             this.RightWindowCommands.SetValue(WindowCommands.ParentWindowPropertyKey, this);
             this.WindowButtonCommands.SetValue(WindowButtonCommands.ParentWindowPropertyKey, this);
 
@@ -1694,6 +1757,7 @@ namespace MahApps.Metro.Controls
             //if the the corresponding behavior has the right flag, set the window commands' and icon zIndex to a number that is higher than the Flyout's.
             this.icon?.SetValue(Panel.ZIndexProperty, flyout.IsModal && flyout.IsOpen ? 0 : (this.IconOverlayBehavior.HasFlag(OverlayBehavior.Flyouts) ? zIndex : 1));
             this.LeftWindowCommandsPresenter?.SetValue(Panel.ZIndexProperty, flyout is { IsModal: true, IsOpen: true } ? 0 : 1);
+            this.CenterWindowCommandsPresenter?.SetValue(Panel.ZIndexProperty, flyout is { IsModal: true, IsOpen: true } ? 0 : 1);
             this.RightWindowCommandsPresenter?.SetValue(Panel.ZIndexProperty, flyout is { IsModal: true, IsOpen: true } ? 0 : 1);
             this.WindowButtonCommandsPresenter?.SetValue(Panel.ZIndexProperty, flyout is { IsModal: true, IsOpen: true } ? 0 : (this.WindowButtonCommandsOverlayBehavior.HasFlag(OverlayBehavior.Flyouts) ? zIndex : 1));
 

--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -1279,8 +1279,7 @@ namespace MahApps.Metro.Controls
             var distanceToCenter = (this.titleBar.DesiredSize.Width - margin.Left - margin.Right) / 2;
 
             var iconWidth = this.icon?.ActualWidth ?? 0;
-            var leftWindowCommandsWidth = this.LeftWindowCommands?.ActualWidth ?? 0;
-            var centerWindowCommandsWidth = this.CenterWindowCommands?.ActualWidth ?? 0;
+            var leftWindowCommandsWidth = this.LeftWindowCommands?.ActualWidth ?? 0;            
             var rightWindowCommandsWidth = this.RightWindowCommands?.ActualWidth ?? 0;
             var windowButtonCommandsWith = this.WindowButtonCommands?.ActualWidth ?? 0;
 
@@ -1294,15 +1293,13 @@ namespace MahApps.Metro.Controls
             var dLeft = distanceFromLeft + distanceToCenter + horizontalMargin;
             var dRight = distanceFromRight + distanceToCenter + horizontalMargin;
             if ((dLeft < halfDistance) && (dRight < halfDistance))
-            {
-                this.titleBar.SetCurrentValue(MarginProperty, default(Thickness));
+            {                
                 Grid.SetColumn(this.titleBar, 0);
-                Grid.SetColumnSpan(this.titleBar, 3);
+                Grid.SetColumnSpan(this.titleBar, 5);
             }
             else
-            {
-                this.titleBar.SetCurrentValue(MarginProperty, new Thickness(leftWindowCommandsWidth, 0, rightWindowCommandsWidth, 0));
-                Grid.SetColumn(this.titleBar, 1);
+            {             
+                Grid.SetColumn(this.titleBar, 2);
                 Grid.SetColumnSpan(this.titleBar, 1);
             }
         }

--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -747,7 +747,6 @@ namespace MahApps.Metro.Controls
             set => this.SetValue(CenterWindowCommandsProperty, value);
         }
 
-        
         /// <summary>Identifies the <see cref="RightWindowCommands"/> dependency property.</summary>
         public static readonly DependencyProperty RightWindowCommandsProperty
             = DependencyProperty.Register(nameof(RightWindowCommands),
@@ -829,7 +828,7 @@ namespace MahApps.Metro.Controls
             get => (WindowCommandsOverlayBehavior)this.GetValue(CenterWindowCommandsOverlayBehaviorProperty);
             set => this.SetValue(CenterWindowCommandsOverlayBehaviorProperty, value);
         }
-        
+
         /// <summary>Identifies the <see cref="RightWindowCommandsOverlayBehavior"/> dependency property.</summary>
         public static readonly DependencyProperty RightWindowCommandsOverlayBehaviorProperty
             = DependencyProperty.Register(nameof(RightWindowCommandsOverlayBehavior),
@@ -964,7 +963,7 @@ namespace MahApps.Metro.Controls
 
             var centerWindowCommandsVisibility = this.CenterWindowCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) ? Visibility.Visible : newVisibility;
             this.CenterWindowCommandsPresenter?.SetCurrentValue(VisibilityProperty, centerWindowCommandsVisibility);
-            
+
             var rightWindowCommandsVisibility = this.RightWindowCommandsOverlayBehavior.HasFlag(WindowCommandsOverlayBehavior.HiddenTitleBar) ? Visibility.Visible : newVisibility;
             this.RightWindowCommandsPresenter?.SetCurrentValue(VisibilityProperty, rightWindowCommandsVisibility);
 
@@ -1246,7 +1245,7 @@ namespace MahApps.Metro.Controls
             {
                 this.CenterWindowCommands.DataContext = this.DataContext;
             }
-            
+
             if (this.RightWindowCommands != null)
             {
                 this.RightWindowCommands.DataContext = this.DataContext;
@@ -1279,7 +1278,7 @@ namespace MahApps.Metro.Controls
             var distanceToCenter = (this.titleBar.DesiredSize.Width - margin.Left - margin.Right) / 2;
 
             var iconWidth = this.icon?.ActualWidth ?? 0;
-            var leftWindowCommandsWidth = this.LeftWindowCommands?.ActualWidth ?? 0;            
+            var leftWindowCommandsWidth = this.LeftWindowCommands?.ActualWidth ?? 0;
             var rightWindowCommandsWidth = this.RightWindowCommands?.ActualWidth ?? 0;
             var windowButtonCommandsWith = this.WindowButtonCommands?.ActualWidth ?? 0;
 
@@ -1293,12 +1292,12 @@ namespace MahApps.Metro.Controls
             var dLeft = distanceFromLeft + distanceToCenter + horizontalMargin;
             var dRight = distanceFromRight + distanceToCenter + horizontalMargin;
             if ((dLeft < halfDistance) && (dRight < halfDistance))
-            {                
+            {
                 Grid.SetColumn(this.titleBar, 0);
                 Grid.SetColumnSpan(this.titleBar, 5);
             }
             else
-            {             
+            {
                 Grid.SetColumn(this.titleBar, 2);
                 Grid.SetColumnSpan(this.titleBar, 1);
             }
@@ -1427,7 +1426,7 @@ namespace MahApps.Metro.Controls
                 {
                     children.Add(this.CenterWindowCommands);
                 }
-                
+
                 if (this.RightWindowCommands != null)
                 {
                     children.Add(this.RightWindowCommands);

--- a/src/MahApps.Metro/Controls/MetroWindowHelpers.cs
+++ b/src/MahApps.Metro/Controls/MetroWindowHelpers.cs
@@ -158,6 +158,7 @@ namespace MahApps.Metro.Controls
             if (foregroundBrush is null)
             {
                 window.LeftWindowCommands?.ClearValue(Control.ForegroundProperty);
+                window.CenterWindowCommands?.ClearValue(Control.ForegroundProperty);
                 window.RightWindowCommands?.ClearValue(Control.ForegroundProperty);
             }
 
@@ -168,12 +169,14 @@ namespace MahApps.Metro.Controls
 
             // set the theme to light by default
             window.LeftWindowCommands?.SetValue(WindowCommands.ThemeProperty, theme);
+            window.CenterWindowCommands?.SetValue(WindowCommands.ThemeProperty, theme);
             window.RightWindowCommands?.SetValue(WindowCommands.ThemeProperty, theme);
 
             // clear or set the foreground property
             if (foregroundBrush != null)
             {
                 window.LeftWindowCommands?.SetValue(Control.ForegroundProperty, foregroundBrush);
+                window.CenterWindowCommands?.SetValue(Control.ForegroundProperty, foregroundBrush);
                 window.RightWindowCommands?.SetValue(Control.ForegroundProperty, foregroundBrush);
             }
         }

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -109,17 +109,6 @@
                             </ContentControl.Foreground>
                         </mah:MetroThumbContentControl>
 
-                        <!--  the center window commands  -->
-                        <mah:ContentPresenterEx x:Name="PART_CenterWindowCommands"
-                        Grid.Row="0"
-                        Grid.Column="0"
-                                                Grid.ColumnSpan="5"
-                        Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                        VerticalAlignment="Top"
-                        Content="{Binding CenterWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                                    
-                        HorizontalAlignment="Center"
-                        Focusable="False" />
-
                         <!--  the right window commands  -->                            
                             <mah:ContentPresenterEx x:Name="PART_RightWindowCommands"
                                                     Grid.Row="0"
@@ -127,9 +116,20 @@
                                                     Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                     VerticalAlignment="Top"
                                                     Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    Focusable="False" />                            
-                                                        
-                                <!--  the window button commands  -->
+                                                    Focusable="False" />
+
+                        <!--  the center window commands  -->
+                        <mah:ContentPresenterEx x:Name="PART_CenterWindowCommands"
+ Grid.Row="0"
+ Grid.Column="0"
+                         Grid.ColumnSpan="5"
+ Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+ VerticalAlignment="Top"
+ Content="{Binding CenterWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                                    
+ HorizontalAlignment="Center"
+ Focusable="False" />
+
+                        <!--  the window button commands  -->
                         <mah:ContentPresenterEx x:Name="PART_WindowButtonCommands"
                                                 Grid.Row="0"
                                                 Grid.RowSpan="2"
@@ -340,17 +340,18 @@
 
                         <!--  the left window commands  -->
                         <mah:ContentPresenterEx x:Name="PART_LeftWindowCommands"
-                                                Grid.Row="0"
-                                                    Grid.Column="1"
-                        Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                        VerticalAlignment="Top"
-                        Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                                    
-                        Focusable="False" />
-
+                                  Grid.Row="0"
+                                                    Grid.Column="1"                
+                          Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                          VerticalAlignment="Top"
+                          Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                          
+                          Focusable="False" />
+                        
                         <!--  the title bar  -->
                         <mah:MetroThumbContentControl x:Name="PART_TitleBar"
                                                       Grid.Row="0"
-                                                      Grid.Column="2"                                                      
+                                                      Grid.Column="0"
+                                                      Grid.ColumnSpan="5"
                                                       Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                       HorizontalAlignment="{TemplateBinding TitleAlignment}"
                                                       HorizontalContentAlignment="Center"
@@ -371,29 +372,26 @@
                             </ContentControl.Foreground>
                         </mah:MetroThumbContentControl>
 
-                       
-                            
-                                
-                            <!--  the center window commands  -->
-                            <mah:ContentPresenterEx x:Name="PART_CenterWindowCommands"
-                                                    Grid.Row="0"
-                        Grid.Column="0"
-                                                Grid.ColumnSpan="5"
-                                                    Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    VerticalAlignment="Top"
-                                                    Content="{Binding CenterWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                
-                                                    Focusable="False" />
-                                
-                            <!--  the right window commands  -->
+                        <!--  the right window commands  -->
                             <mah:ContentPresenterEx x:Name="PART_RightWindowCommands"
-                                                     Grid.Row="0"
+                                                    Grid.Row="0"
                                                     Grid.Column="3"
                                                     Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                     VerticalAlignment="Top"
-                                                    Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                
+                                                    Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                    DockPanel.Dock="Right"
                                                     Focusable="False" />
-                            <!--  the fake title bar  -->
-                            <Grid />                       
+
+                        <!--  the center window commands  -->                        
+                        <mah:ContentPresenterEx x:Name="PART_CenterWindowCommands"
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="5"
+                        Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                        VerticalAlignment="Top"
+                        Content="{Binding CenterWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                                    
+                        HorizontalAlignment="Center"
+                        Focusable="False" />
 
                         <!--  the window button commands  -->
                         <mah:ContentPresenterEx x:Name="PART_WindowButtonCommands"
@@ -510,11 +508,11 @@
         <ControlTemplate.Triggers>
             <Trigger Property="ShowDialogsOverTitleBar" Value="False">
                 <Setter TargetName="PART_MetroActiveDialogContainer" Property="Grid.Row" Value="1" />
-                <Setter TargetName="PART_MetroActiveDialogContainer" Property="Grid.RowSpan" Value="1" />
+                <Setter TargetName="PART_MetroActiveDialogContainer" Property="Grid.RowSpan" Value="2" />
                 <Setter TargetName="PART_MetroInactiveDialogsContainer" Property="Grid.Row" Value="1" />
-                <Setter TargetName="PART_MetroInactiveDialogsContainer" Property="Grid.RowSpan" Value="1" />
+                <Setter TargetName="PART_MetroInactiveDialogsContainer" Property="Grid.RowSpan" Value="2" />
                 <Setter TargetName="PART_OverlayBox" Property="Grid.Row" Value="1" />
-                <Setter TargetName="PART_OverlayBox" Property="Grid.RowSpan" Value="1" />
+                <Setter TargetName="PART_OverlayBox" Property="Grid.RowSpan" Value="2" />
             </Trigger>
 
             <Trigger Property="ShowFlyoutsOverDialogs" Value="True">
@@ -522,12 +520,12 @@
             </Trigger>
 
             <Trigger Property="WindowStyle" Value="None">
-                <Setter TargetName="PART_FlyoutModalDragMoveThumb" Property="Grid.RowSpan" Value="2" />
-                <Setter TargetName="PART_WindowTitleThumb" Property="Grid.RowSpan" Value="2" />
+                <Setter TargetName="PART_FlyoutModalDragMoveThumb" Property="Grid.RowSpan" Value="4" />
+                <Setter TargetName="PART_WindowTitleThumb" Property="Grid.RowSpan" Value="4" />
             </Trigger>
             <Trigger Property="ShowTitleBar" Value="False">
-                <Setter TargetName="PART_FlyoutModalDragMoveThumb" Property="Grid.RowSpan" Value="2" />
-                <Setter TargetName="PART_WindowTitleThumb" Property="Grid.RowSpan" Value="2" />
+                <Setter TargetName="PART_FlyoutModalDragMoveThumb" Property="Grid.RowSpan" Value="4" />
+                <Setter TargetName="PART_WindowTitleThumb" Property="Grid.RowSpan" Value="4" />
             </Trigger>
             <!--  handle active/inactive state  -->
             <Trigger Property="IsActive" Value="False">

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -31,8 +31,12 @@
                         <Grid.ColumnDefinitions>
                             <!--  icon  -->
                             <ColumnDefinition Width="Auto" />
-                            <!--  left window commands, title, right window commands  -->
+                            <!--  left window commands -->
+                            <ColumnDefinition Width="Auto" />
+                            <!-- title / center window commands -->                            
                             <ColumnDefinition Width="*" />
+                            <!-- right window commands  -->
+                            <ColumnDefinition Width="Auto" />
                             <!--  min,max,close buttons  -->
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
@@ -44,7 +48,7 @@
                         <Rectangle x:Name="PART_WindowTitleBackground"
                                    Grid.Row="0"
                                    Grid.Column="0"
-                                   Grid.ColumnSpan="3"
+                                   Grid.ColumnSpan="5"
                                    Fill="{TemplateBinding WindowTitleBrush}"
                                    Focusable="False"
                                    StrokeThickness="0" />
@@ -67,56 +71,69 @@
                         <mah:MetroThumb x:Name="PART_WindowTitleThumb"
                                         Grid.Row="0"
                                         Grid.Column="0"
-                                        Grid.ColumnSpan="3"
+                                        Grid.ColumnSpan="5"
                                         Style="{StaticResource MahApps.Styles.Thumb.WindowTitle}"
                                         UseLayoutRounding="True" />
 
-                        <DockPanel Grid.Row="0"
-                                   Grid.Column="1"
-                                   VerticalAlignment="Top"
-                                   Focusable="False">
+                       
                             <!--  the left window commands  -->
                             <mah:ContentPresenterEx x:Name="PART_LeftWindowCommands"
+                                                    Grid.Row="0"
+                                                    Grid.Column="1"
                                                     Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                     VerticalAlignment="Top"
                                                     Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    DockPanel.Dock="Left"
                                                     Focusable="False" />
-                            <!--  the right window commands  -->
+
+                        <!--  the title bar  -->
+                        <mah:MetroThumbContentControl x:Name="PART_TitleBar"
+                              Grid.Row="0"
+                              Grid.Column="2"
+                              Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                              HorizontalAlignment="{TemplateBinding TitleAlignment}"
+                              HorizontalContentAlignment="Stretch"
+                              VerticalContentAlignment="Stretch"
+                              Content="{TemplateBinding Title}"
+                              ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
+                              ContentTemplate="{TemplateBinding TitleTemplate}"
+                              Focusable="False">
+                            <ContentControl.Foreground>
+                                <MultiBinding Converter="{x:Static mahConverters:BackgroundToForegroundConverter.Instance}">
+                                    <Binding ElementName="PART_WindowTitleBackground"
+                     Mode="OneWay"
+                     Path="Fill" />
+                                    <Binding Mode="OneWay"
+                     Path="TitleForeground"
+                     RelativeSource="{RelativeSource TemplatedParent}" />
+                                </MultiBinding>
+                            </ContentControl.Foreground>
+                        </mah:MetroThumbContentControl>
+
+                        <!--  the center window commands  -->
+                        <mah:ContentPresenterEx x:Name="PART_CenterWindowCommands"
+                        Grid.Row="0"
+                        Grid.Column="0"
+                                                Grid.ColumnSpan="5"
+                        Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                        VerticalAlignment="Top"
+                        Content="{Binding CenterWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                                    
+                        HorizontalAlignment="Center"
+                        Focusable="False" />
+
+                        <!--  the right window commands  -->                            
                             <mah:ContentPresenterEx x:Name="PART_RightWindowCommands"
+                                                    Grid.Row="0"
+                                                    Grid.Column="3"
                                                     Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                     VerticalAlignment="Top"
                                                     Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    DockPanel.Dock="Right"
-                                                    Focusable="False" />
-                            <!--  the title bar  -->
-                            <mah:MetroThumbContentControl x:Name="PART_TitleBar"
-                                                          Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                          HorizontalAlignment="{TemplateBinding TitleAlignment}"
-                                                          HorizontalContentAlignment="Stretch"
-                                                          VerticalContentAlignment="Stretch"
-                                                          Content="{TemplateBinding Title}"
-                                                          ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
-                                                          ContentTemplate="{TemplateBinding TitleTemplate}"
-                                                          Focusable="False">
-                                <ContentControl.Foreground>
-                                    <MultiBinding Converter="{x:Static mahConverters:BackgroundToForegroundConverter.Instance}">
-                                        <Binding ElementName="PART_WindowTitleBackground"
-                                                 Mode="OneWay"
-                                                 Path="Fill" />
-                                        <Binding Mode="OneWay"
-                                                 Path="TitleForeground"
-                                                 RelativeSource="{RelativeSource TemplatedParent}" />
-                                    </MultiBinding>
-                                </ContentControl.Foreground>
-                            </mah:MetroThumbContentControl>
-                        </DockPanel>
-
-                        <!--  the window button commands  -->
+                                                    Focusable="False" />                            
+                                                        
+                                <!--  the window button commands  -->
                         <mah:ContentPresenterEx x:Name="PART_WindowButtonCommands"
                                                 Grid.Row="0"
                                                 Grid.RowSpan="2"
-                                                Grid.Column="2"
+                                                Grid.Column="4"
                                                 Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                 VerticalAlignment="Top"
                                                 Panel.ZIndex="1"
@@ -127,7 +144,7 @@
                         <mah:MetroContentControl x:Name="PART_Content"
                                                  Grid.Row="1"
                                                  Grid.Column="0"
-                                                 Grid.ColumnSpan="3"
+                                                 Grid.ColumnSpan="5"
                                                  Background="{x:Null}"
                                                  FocusVisualStyle="{x:Null}"
                                                  IsTabStop="False"
@@ -142,13 +159,13 @@
                                    Grid.Row="0"
                                    Grid.RowSpan="2"
                                    Grid.Column="0"
-                                   Grid.ColumnSpan="3"
+                                   Grid.ColumnSpan="5"
                                    Fill="{TemplateBinding FlyoutOverlayBrush}"
                                    Visibility="Hidden" />
                         <mah:MetroThumb x:Name="PART_FlyoutModalDragMoveThumb"
                                         Grid.Row="0"
                                         Grid.Column="0"
-                                        Grid.ColumnSpan="3"
+                                        Grid.ColumnSpan="5"
                                         Style="{StaticResource MahApps.Styles.Thumb.WindowTitle}"
                                         Visibility="{Binding ElementName=PART_FlyoutModal, Path=Visibility, Mode=OneWay}" />
 
@@ -157,7 +174,7 @@
                                         Grid.Row="0"
                                         Grid.RowSpan="2"
                                         Grid.Column="0"
-                                        Grid.ColumnSpan="3"
+                                        Grid.ColumnSpan="5"
                                         VerticalAlignment="Stretch"
                                         Panel.ZIndex="2"
                                         Content="{Binding Flyouts, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
@@ -169,7 +186,7 @@
                               Grid.Row="0"
                               Grid.RowSpan="2"
                               Grid.Column="0"
-                              Grid.ColumnSpan="3"
+                              Grid.ColumnSpan="5"
                               Panel.ZIndex="3"
                               FocusVisualStyle="{x:Null}" />
 
@@ -178,7 +195,7 @@
                               Grid.Row="0"
                               Grid.RowSpan="2"
                               Grid.Column="0"
-                              Grid.ColumnSpan="3"
+                              Grid.ColumnSpan="5"
                               Panel.ZIndex="4"
                               Background="{TemplateBinding OverlayBrush}"
                               FocusVisualStyle="{x:Null}"
@@ -191,7 +208,7 @@
                               Grid.Row="0"
                               Grid.RowSpan="2"
                               Grid.Column="0"
-                              Grid.ColumnSpan="3"
+                              Grid.ColumnSpan="5"
                               Panel.ZIndex="5"
                               FocusVisualStyle="{x:Null}" />
                     </Grid>
@@ -277,8 +294,12 @@
                         <Grid.ColumnDefinitions>
                             <!--  icon  -->
                             <ColumnDefinition Width="Auto" />
-                            <!--  left window commands, title, right window commands  -->
+                            <!--  left window commands -->
+                            <ColumnDefinition Width="Auto" />
+                            <!-- title / center window commands -->
                             <ColumnDefinition Width="*" />
+                            <!-- right window commands  -->
+                            <ColumnDefinition Width="Auto" />
                             <!--  min,max,close buttons  -->
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
@@ -290,7 +311,7 @@
                         <Rectangle x:Name="PART_WindowTitleBackground"
                                    Grid.Row="0"
                                    Grid.Column="0"
-                                   Grid.ColumnSpan="3"
+                                   Grid.ColumnSpan="5"
                                    Fill="{TemplateBinding WindowTitleBrush}"
                                    Focusable="False"
                                    StrokeThickness="0" />
@@ -313,15 +334,23 @@
                         <mah:MetroThumb x:Name="PART_WindowTitleThumb"
                                         Grid.Row="0"
                                         Grid.Column="0"
-                                        Grid.ColumnSpan="3"
+                                        Grid.ColumnSpan="5"
                                         Style="{StaticResource MahApps.Styles.Thumb.WindowTitle}"
                                         UseLayoutRounding="True" />
+
+                        <!--  the left window commands  -->
+                        <mah:ContentPresenterEx x:Name="PART_LeftWindowCommands"
+                                                Grid.Row="0"
+                                                    Grid.Column="1"
+                        Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                        VerticalAlignment="Top"
+                        Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                                    
+                        Focusable="False" />
 
                         <!--  the title bar  -->
                         <mah:MetroThumbContentControl x:Name="PART_TitleBar"
                                                       Grid.Row="0"
-                                                      Grid.Column="0"
-                                                      Grid.ColumnSpan="3"
+                                                      Grid.Column="2"                                                      
                                                       Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                       HorizontalAlignment="{TemplateBinding TitleAlignment}"
                                                       HorizontalContentAlignment="Center"
@@ -342,34 +371,35 @@
                             </ContentControl.Foreground>
                         </mah:MetroThumbContentControl>
 
-                        <DockPanel Grid.Row="0"
-                                   Grid.Column="1"
-                                   VerticalAlignment="Top"
-                                   Panel.ZIndex="1"
-                                   Focusable="False">
-                            <!--  the left window commands  -->
-                            <mah:ContentPresenterEx x:Name="PART_LeftWindowCommands"
+                       
+                            
+                                
+                            <!--  the center window commands  -->
+                            <mah:ContentPresenterEx x:Name="PART_CenterWindowCommands"
+                                                    Grid.Row="0"
+                        Grid.Column="0"
+                                                Grid.ColumnSpan="5"
                                                     Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                     VerticalAlignment="Top"
-                                                    Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    DockPanel.Dock="Left"
+                                                    Content="{Binding CenterWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                
                                                     Focusable="False" />
+                                
                             <!--  the right window commands  -->
                             <mah:ContentPresenterEx x:Name="PART_RightWindowCommands"
+                                                     Grid.Row="0"
+                                                    Grid.Column="3"
                                                     Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                     VerticalAlignment="Top"
-                                                    Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    DockPanel.Dock="Right"
+                                                    Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                
                                                     Focusable="False" />
                             <!--  the fake title bar  -->
-                            <Grid />
-                        </DockPanel>
+                            <Grid />                       
 
                         <!--  the window button commands  -->
                         <mah:ContentPresenterEx x:Name="PART_WindowButtonCommands"
                                                 Grid.Row="0"
                                                 Grid.RowSpan="2"
-                                                Grid.Column="2"
+                                                Grid.Column="4"
                                                 Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                                 VerticalAlignment="Top"
                                                 Panel.ZIndex="1"
@@ -380,7 +410,7 @@
                         <mah:MetroContentControl x:Name="PART_Content"
                                                  Grid.Row="1"
                                                  Grid.Column="0"
-                                                 Grid.ColumnSpan="3"
+                                                 Grid.ColumnSpan="5"
                                                  Background="{x:Null}"
                                                  FocusVisualStyle="{x:Null}"
                                                  IsTabStop="False"
@@ -395,13 +425,13 @@
                                    Grid.Row="0"
                                    Grid.RowSpan="2"
                                    Grid.Column="0"
-                                   Grid.ColumnSpan="3"
+                                   Grid.ColumnSpan="5"
                                    Fill="{TemplateBinding FlyoutOverlayBrush}"
                                    Visibility="Hidden" />
                         <mah:MetroThumb x:Name="PART_FlyoutModalDragMoveThumb"
                                         Grid.Row="0"
                                         Grid.Column="0"
-                                        Grid.ColumnSpan="3"
+                                        Grid.ColumnSpan="5"
                                         Style="{StaticResource MahApps.Styles.Thumb.WindowTitle}"
                                         Visibility="{Binding ElementName=PART_FlyoutModal, Path=Visibility, Mode=OneWay}" />
 
@@ -410,7 +440,7 @@
                                         Grid.Row="0"
                                         Grid.RowSpan="2"
                                         Grid.Column="0"
-                                        Grid.ColumnSpan="3"
+                                        Grid.ColumnSpan="5"
                                         VerticalAlignment="Stretch"
                                         Panel.ZIndex="2"
                                         Content="{Binding Flyouts, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
@@ -422,7 +452,7 @@
                               Grid.Row="0"
                               Grid.RowSpan="2"
                               Grid.Column="0"
-                              Grid.ColumnSpan="3"
+                              Grid.ColumnSpan="5"
                               Panel.ZIndex="3"
                               FocusVisualStyle="{x:Null}" />
 
@@ -431,7 +461,7 @@
                               Grid.Row="0"
                               Grid.RowSpan="2"
                               Grid.Column="0"
-                              Grid.ColumnSpan="3"
+                              Grid.ColumnSpan="5"
                               Panel.ZIndex="4"
                               Background="{TemplateBinding OverlayBrush}"
                               FocusVisualStyle="{x:Null}"
@@ -444,7 +474,7 @@
                               Grid.Row="0"
                               Grid.RowSpan="2"
                               Grid.Column="0"
-                              Grid.ColumnSpan="3"
+                              Grid.ColumnSpan="5"
                               Panel.ZIndex="5"
                               FocusVisualStyle="{x:Null}" />
                     </Grid>

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -13,7 +13,8 @@
     <mahConverters:ThicknessBindingConverter x:Key="ThicknessBindingConverter" />
     <mahConverters:ThicknessToDoubleConverter x:Key="ThicknessToDoubleConverter" />
 
-    <ControlTemplate x:Key="MahApps.Templates.MetroWindow" TargetType="{x:Type mah:MetroWindow}">
+    <ControlTemplate x:Key="MahApps.Templates.MetroWindow"
+                     TargetType="{x:Type mah:MetroWindow}">
         <mah:ClipBorder x:Name="PART_Border"
                         Margin="{TemplateBinding Padding}"
                         Background="{TemplateBinding Background}"
@@ -33,7 +34,7 @@
                             <ColumnDefinition Width="Auto" />
                             <!--  left window commands -->
                             <ColumnDefinition Width="Auto" />
-                            <!-- title / center window commands -->                            
+                            <!-- title / center window commands -->
                             <ColumnDefinition Width="*" />
                             <!-- right window commands  -->
                             <ColumnDefinition Width="Auto" />
@@ -75,59 +76,58 @@
                                         Style="{StaticResource MahApps.Styles.Thumb.WindowTitle}"
                                         UseLayoutRounding="True" />
 
-                       
-                            <!--  the left window commands  -->
-                            <mah:ContentPresenterEx x:Name="PART_LeftWindowCommands"
-                                                    Grid.Row="0"
-                                                    Grid.Column="1"
-                                                    Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    VerticalAlignment="Top"
-                                                    Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    Focusable="False" />
+                        <!--  the left window commands  -->
+                        <mah:ContentPresenterEx x:Name="PART_LeftWindowCommands"
+                                                Grid.Row="0"
+                                                Grid.Column="1"
+                                                Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                VerticalAlignment="Top"
+                                                Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                Focusable="False" />
 
                         <!--  the title bar  -->
                         <mah:MetroThumbContentControl x:Name="PART_TitleBar"
-                              Grid.Row="0"
-                              Grid.Column="2"
-                              Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                              HorizontalAlignment="{TemplateBinding TitleAlignment}"
-                              HorizontalContentAlignment="Stretch"
-                              VerticalContentAlignment="Stretch"
-                              Content="{TemplateBinding Title}"
-                              ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
-                              ContentTemplate="{TemplateBinding TitleTemplate}"
-                              Focusable="False">
+                                                      Grid.Row="0"
+                                                      Grid.Column="2"
+                                                      Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                      HorizontalAlignment="{TemplateBinding TitleAlignment}"
+                                                      HorizontalContentAlignment="Stretch"
+                                                      VerticalContentAlignment="Stretch"
+                                                      Content="{TemplateBinding Title}"
+                                                      ContentCharacterCasing="{TemplateBinding TitleCharacterCasing}"
+                                                      ContentTemplate="{TemplateBinding TitleTemplate}"
+                                                      Focusable="False">
                             <ContentControl.Foreground>
                                 <MultiBinding Converter="{x:Static mahConverters:BackgroundToForegroundConverter.Instance}">
                                     <Binding ElementName="PART_WindowTitleBackground"
-                     Mode="OneWay"
-                     Path="Fill" />
+                                             Mode="OneWay"
+                                             Path="Fill" />
                                     <Binding Mode="OneWay"
-                     Path="TitleForeground"
-                     RelativeSource="{RelativeSource TemplatedParent}" />
+                                             Path="TitleForeground"
+                                             RelativeSource="{RelativeSource TemplatedParent}" />
                                 </MultiBinding>
                             </ContentControl.Foreground>
                         </mah:MetroThumbContentControl>
 
-                        <!--  the right window commands  -->                            
-                            <mah:ContentPresenterEx x:Name="PART_RightWindowCommands"
-                                                    Grid.Row="0"
-                                                    Grid.Column="3"
-                                                    Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    VerticalAlignment="Top"
-                                                    Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    Focusable="False" />
+                        <!--  the right window commands  -->
+                        <mah:ContentPresenterEx x:Name="PART_RightWindowCommands"
+                                                Grid.Row="0"
+                                                Grid.Column="3"
+                                                Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                VerticalAlignment="Top"
+                                                Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                Focusable="False" />
 
-                        <!--  the center window commands  -->
+                        <!--  the center window commands (must be after right window command to be in front of the view) -->
                         <mah:ContentPresenterEx x:Name="PART_CenterWindowCommands"
- Grid.Row="0"
- Grid.Column="0"
-                         Grid.ColumnSpan="5"
- Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
- VerticalAlignment="Top"
- Content="{Binding CenterWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                                    
- HorizontalAlignment="Center"
- Focusable="False" />
+                                                Grid.Row="0"
+                                                Grid.Column="0"
+                                                Grid.ColumnSpan="5"
+                                                Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                VerticalAlignment="Top"
+                                                Content="{Binding CenterWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                HorizontalAlignment="Center"
+                                                Focusable="False" />
 
                         <!--  the window button commands  -->
                         <mah:ContentPresenterEx x:Name="PART_WindowButtonCommands"
@@ -225,58 +225,102 @@
         </mah:ClipBorder>
 
         <ControlTemplate.Triggers>
-            <Trigger Property="ShowDialogsOverTitleBar" Value="False">
-                <Setter TargetName="PART_MetroActiveDialogContainer" Property="Grid.Row" Value="1" />
-                <Setter TargetName="PART_MetroActiveDialogContainer" Property="Grid.RowSpan" Value="1" />
-                <Setter TargetName="PART_MetroInactiveDialogsContainer" Property="Grid.Row" Value="1" />
-                <Setter TargetName="PART_MetroInactiveDialogsContainer" Property="Grid.RowSpan" Value="1" />
-                <Setter TargetName="PART_OverlayBox" Property="Grid.Row" Value="1" />
-                <Setter TargetName="PART_OverlayBox" Property="Grid.RowSpan" Value="1" />
+            <Trigger Property="ShowDialogsOverTitleBar"
+                     Value="False">
+                <Setter TargetName="PART_MetroActiveDialogContainer"
+                        Property="Grid.Row"
+                        Value="1" />
+                <Setter TargetName="PART_MetroActiveDialogContainer"
+                        Property="Grid.RowSpan"
+                        Value="1" />
+                <Setter TargetName="PART_MetroInactiveDialogsContainer"
+                        Property="Grid.Row"
+                        Value="1" />
+                <Setter TargetName="PART_MetroInactiveDialogsContainer"
+                        Property="Grid.RowSpan"
+                        Value="1" />
+                <Setter TargetName="PART_OverlayBox"
+                        Property="Grid.Row"
+                        Value="1" />
+                <Setter TargetName="PART_OverlayBox"
+                        Property="Grid.RowSpan"
+                        Value="1" />
             </Trigger>
 
-            <Trigger Property="ShowFlyoutsOverDialogs" Value="True">
-                <Setter TargetName="PART_Flyouts" Property="Panel.ZIndex" Value="6" />
+            <Trigger Property="ShowFlyoutsOverDialogs"
+                     Value="True">
+                <Setter TargetName="PART_Flyouts"
+                        Property="Panel.ZIndex"
+                        Value="6" />
             </Trigger>
 
-            <Trigger Property="WindowStyle" Value="None">
-                <Setter TargetName="PART_FlyoutModalDragMoveThumb" Property="Grid.RowSpan" Value="2" />
-                <Setter TargetName="PART_WindowTitleThumb" Property="Grid.RowSpan" Value="2" />
+            <Trigger Property="WindowStyle"
+                     Value="None">
+                <Setter TargetName="PART_FlyoutModalDragMoveThumb"
+                        Property="Grid.RowSpan"
+                        Value="2" />
+                <Setter TargetName="PART_WindowTitleThumb"
+                        Property="Grid.RowSpan"
+                        Value="2" />
             </Trigger>
-            <Trigger Property="ShowTitleBar" Value="False">
-                <Setter TargetName="PART_FlyoutModalDragMoveThumb" Property="Grid.RowSpan" Value="2" />
-                <Setter TargetName="PART_WindowTitleThumb" Property="Grid.RowSpan" Value="2" />
+            <Trigger Property="ShowTitleBar"
+                     Value="False">
+                <Setter TargetName="PART_FlyoutModalDragMoveThumb"
+                        Property="Grid.RowSpan"
+                        Value="2" />
+                <Setter TargetName="PART_WindowTitleThumb"
+                        Property="Grid.RowSpan"
+                        Value="2" />
             </Trigger>
             <!--  handle active/inactive state  -->
-            <Trigger Property="IsActive" Value="False">
-                <Setter TargetName="PART_Border" Property="BorderBrush" Value="{Binding Path=NonActiveGlowColor, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static mahConverters:ColorToSolidColorBrushConverter.DefaultInstance}}" />
-                <Setter TargetName="PART_WindowTitleBackground" Property="Fill" Value="{Binding Path=NonActiveWindowTitleBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+            <Trigger Property="IsActive"
+                     Value="False">
+                <Setter TargetName="PART_Border"
+                        Property="BorderBrush"
+                        Value="{Binding Path=NonActiveGlowColor, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static mahConverters:ColorToSolidColorBrushConverter.DefaultInstance}}" />
+                <Setter TargetName="PART_WindowTitleBackground"
+                        Property="Fill"
+                        Value="{Binding Path=NonActiveWindowTitleBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
             </Trigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsActive" Value="False" />
-                    <Condition Property="NonActiveGlowColor" Value="{x:Null}" />
+                    <Condition Property="IsActive"
+                               Value="False" />
+                    <Condition Property="NonActiveGlowColor"
+                               Value="{x:Null}" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Border" Property="BorderBrush" Value="{Binding Path=NonActiveBorderBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter TargetName="PART_Border"
+                        Property="BorderBrush"
+                        Value="{Binding Path=NonActiveBorderBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsActive" Value="True" />
-                    <Condition Property="GlowColor" Value="{x:Null}" />
+                    <Condition Property="IsActive"
+                               Value="True" />
+                    <Condition Property="GlowColor"
+                               Value="{x:Null}" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Border" Property="BorderBrush" Value="{Binding Path=BorderBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter TargetName="PART_Border"
+                        Property="BorderBrush"
+                        Value="{Binding Path=BorderBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="ResizeMode" Value="CanResizeWithGrip" />
-                    <Condition Property="WindowState" Value="Normal" />
+                    <Condition Property="ResizeMode"
+                               Value="CanResizeWithGrip" />
+                    <Condition Property="WindowState"
+                               Value="Normal" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="WindowResizeGrip" Property="Visibility" Value="Visible" />
+                <Setter TargetName="WindowResizeGrip"
+                        Property="Visibility"
+                        Value="Visible" />
             </MultiTrigger>
         </ControlTemplate.Triggers>
 
     </ControlTemplate>
 
-    <ControlTemplate x:Key="MahApps.Templates.MetroWindow.Center" TargetType="{x:Type mah:MetroWindow}">
+    <ControlTemplate x:Key="MahApps.Templates.MetroWindow.Center"
+                     TargetType="{x:Type mah:MetroWindow}">
         <mah:ClipBorder x:Name="PART_Border"
                         Margin="{TemplateBinding Padding}"
                         Background="{TemplateBinding Background}"
@@ -340,13 +384,13 @@
 
                         <!--  the left window commands  -->
                         <mah:ContentPresenterEx x:Name="PART_LeftWindowCommands"
-                                  Grid.Row="0"
-                                                    Grid.Column="1"                
-                          Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                          VerticalAlignment="Top"
-                          Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                          
-                          Focusable="False" />
-                        
+                                                Grid.Row="0"
+                                                Grid.Column="1"
+                                                Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                VerticalAlignment="Top"
+                                                Content="{Binding LeftWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                Focusable="False" />
+
                         <!--  the title bar  -->
                         <mah:MetroThumbContentControl x:Name="PART_TitleBar"
                                                       Grid.Row="0"
@@ -373,25 +417,25 @@
                         </mah:MetroThumbContentControl>
 
                         <!--  the right window commands  -->
-                            <mah:ContentPresenterEx x:Name="PART_RightWindowCommands"
-                                                    Grid.Row="0"
-                                                    Grid.Column="3"
-                                                    Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    VerticalAlignment="Top"
-                                                    Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                    DockPanel.Dock="Right"
-                                                    Focusable="False" />
+                        <mah:ContentPresenterEx x:Name="PART_RightWindowCommands"
+                                                Grid.Row="0"
+                                                Grid.Column="3"
+                                                Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                VerticalAlignment="Top"
+                                                Content="{Binding RightWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                DockPanel.Dock="Right"
+                                                Focusable="False" />
 
-                        <!--  the center window commands  -->                        
+                        <!--  the center window commands (must be after right window command to be in front of the view) -->
                         <mah:ContentPresenterEx x:Name="PART_CenterWindowCommands"
-                        Grid.Row="0"
-                        Grid.Column="0"
-                        Grid.ColumnSpan="5"
-                        Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                        VerticalAlignment="Top"
-                        Content="{Binding CenterWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"                                                    
-                        HorizontalAlignment="Center"
-                        Focusable="False" />
+                                                Grid.Row="0"
+                                                Grid.Column="0"
+                                                Grid.ColumnSpan="5"
+                                                Height="{Binding TitleBarHeight, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                VerticalAlignment="Top"
+                                                Content="{Binding CenterWindowCommands, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
+                                                HorizontalAlignment="Center"
+                                                Focusable="False" />
 
                         <!--  the window button commands  -->
                         <mah:ContentPresenterEx x:Name="PART_WindowButtonCommands"
@@ -506,52 +550,95 @@
         </ControlTemplate.Resources>
 
         <ControlTemplate.Triggers>
-            <Trigger Property="ShowDialogsOverTitleBar" Value="False">
-                <Setter TargetName="PART_MetroActiveDialogContainer" Property="Grid.Row" Value="1" />
-                <Setter TargetName="PART_MetroActiveDialogContainer" Property="Grid.RowSpan" Value="2" />
-                <Setter TargetName="PART_MetroInactiveDialogsContainer" Property="Grid.Row" Value="1" />
-                <Setter TargetName="PART_MetroInactiveDialogsContainer" Property="Grid.RowSpan" Value="2" />
-                <Setter TargetName="PART_OverlayBox" Property="Grid.Row" Value="1" />
-                <Setter TargetName="PART_OverlayBox" Property="Grid.RowSpan" Value="2" />
+            <Trigger Property="ShowDialogsOverTitleBar"
+                     Value="False">
+                <Setter TargetName="PART_MetroActiveDialogContainer"
+                        Property="Grid.Row"
+                        Value="1" />
+                <Setter TargetName="PART_MetroActiveDialogContainer"
+                        Property="Grid.RowSpan"
+                        Value="2" />
+                <Setter TargetName="PART_MetroInactiveDialogsContainer"
+                        Property="Grid.Row"
+                        Value="1" />
+                <Setter TargetName="PART_MetroInactiveDialogsContainer"
+                        Property="Grid.RowSpan"
+                        Value="2" />
+                <Setter TargetName="PART_OverlayBox"
+                        Property="Grid.Row"
+                        Value="1" />
+                <Setter TargetName="PART_OverlayBox"
+                        Property="Grid.RowSpan"
+                        Value="2" />
             </Trigger>
 
-            <Trigger Property="ShowFlyoutsOverDialogs" Value="True">
-                <Setter TargetName="PART_Flyouts" Property="Panel.ZIndex" Value="6" />
+            <Trigger Property="ShowFlyoutsOverDialogs"
+                     Value="True">
+                <Setter TargetName="PART_Flyouts"
+                        Property="Panel.ZIndex"
+                        Value="6" />
             </Trigger>
 
-            <Trigger Property="WindowStyle" Value="None">
-                <Setter TargetName="PART_FlyoutModalDragMoveThumb" Property="Grid.RowSpan" Value="4" />
-                <Setter TargetName="PART_WindowTitleThumb" Property="Grid.RowSpan" Value="4" />
+            <Trigger Property="WindowStyle"
+                     Value="None">
+                <Setter TargetName="PART_FlyoutModalDragMoveThumb"
+                        Property="Grid.RowSpan"
+                        Value="4" />
+                <Setter TargetName="PART_WindowTitleThumb"
+                        Property="Grid.RowSpan"
+                        Value="4" />
             </Trigger>
-            <Trigger Property="ShowTitleBar" Value="False">
-                <Setter TargetName="PART_FlyoutModalDragMoveThumb" Property="Grid.RowSpan" Value="4" />
-                <Setter TargetName="PART_WindowTitleThumb" Property="Grid.RowSpan" Value="4" />
+            <Trigger Property="ShowTitleBar"
+                     Value="False">
+                <Setter TargetName="PART_FlyoutModalDragMoveThumb"
+                        Property="Grid.RowSpan"
+                        Value="4" />
+                <Setter TargetName="PART_WindowTitleThumb"
+                        Property="Grid.RowSpan"
+                        Value="4" />
             </Trigger>
             <!--  handle active/inactive state  -->
-            <Trigger Property="IsActive" Value="False">
-                <Setter TargetName="PART_Border" Property="BorderBrush" Value="{Binding Path=NonActiveGlowColor, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static mahConverters:ColorToSolidColorBrushConverter.DefaultInstance}}" />
-                <Setter TargetName="PART_WindowTitleBackground" Property="Fill" Value="{Binding Path=NonActiveWindowTitleBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+            <Trigger Property="IsActive"
+                     Value="False">
+                <Setter TargetName="PART_Border"
+                        Property="BorderBrush"
+                        Value="{Binding Path=NonActiveGlowColor, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static mahConverters:ColorToSolidColorBrushConverter.DefaultInstance}}" />
+                <Setter TargetName="PART_WindowTitleBackground"
+                        Property="Fill"
+                        Value="{Binding Path=NonActiveWindowTitleBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
             </Trigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsActive" Value="False" />
-                    <Condition Property="NonActiveGlowColor" Value="{x:Null}" />
+                    <Condition Property="IsActive"
+                               Value="False" />
+                    <Condition Property="NonActiveGlowColor"
+                               Value="{x:Null}" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Border" Property="BorderBrush" Value="{Binding Path=NonActiveBorderBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter TargetName="PART_Border"
+                        Property="BorderBrush"
+                        Value="{Binding Path=NonActiveBorderBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsActive" Value="True" />
-                    <Condition Property="GlowColor" Value="{x:Null}" />
+                    <Condition Property="IsActive"
+                               Value="True" />
+                    <Condition Property="GlowColor"
+                               Value="{x:Null}" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="PART_Border" Property="BorderBrush" Value="{Binding Path=BorderBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
+                <Setter TargetName="PART_Border"
+                        Property="BorderBrush"
+                        Value="{Binding Path=BorderBrush, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}}" />
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="ResizeMode" Value="CanResizeWithGrip" />
-                    <Condition Property="WindowState" Value="Normal" />
+                    <Condition Property="ResizeMode"
+                               Value="CanResizeWithGrip" />
+                    <Condition Property="WindowState"
+                               Value="Normal" />
                 </MultiTrigger.Conditions>
-                <Setter TargetName="WindowResizeGrip" Property="Visibility" Value="Visible" />
+                <Setter TargetName="WindowResizeGrip"
+                        Property="Visibility"
+                        Value="Visible" />
             </MultiTrigger>
         </ControlTemplate.Triggers>
 
@@ -573,22 +660,38 @@
     </Storyboard>
 
     <Style TargetType="{x:Type mah:MetroWindow}">
-        <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.AccentBase}" />
-        <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="FlyoutOverlayBrush" Value="{DynamicResource MahApps.Brushes.Window.FlyoutOverlay}" />
-        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-        <Setter Property="GlowColor" Value="{DynamicResource MahApps.Colors.AccentBase}" />
-        <Setter Property="NonActiveBorderBrush" Value="{DynamicResource MahApps.Brushes.Border.NonActive}" />
-        <Setter Property="NonActiveGlowColor" Value="{DynamicResource MahApps.Colors.ThemeForeground}" />
-        <Setter Property="NonActiveWindowTitleBrush" Value="{DynamicResource MahApps.Brushes.WindowTitle.NonActive}" />
-        <Setter Property="OverlayBrush" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-        <Setter Property="OverlayFadeIn" Value="{StaticResource OverlayFastSemiFadeIn}" />
-        <Setter Property="OverlayFadeOut" Value="{StaticResource OverlayFastSemiFadeOut}" />
-        <Setter Property="SnapsToDevicePixels" Value="True" />
-        <Setter Property="Template" Value="{StaticResource MahApps.Templates.MetroWindow}" />
-        <Setter Property="TextElement.FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
-        <Setter Property="TitleForeground" Value="{DynamicResource MahApps.Brushes.IdealForeground}" />
+        <Setter Property="Background"
+                Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
+        <Setter Property="BorderBrush"
+                Value="{DynamicResource MahApps.Brushes.AccentBase}" />
+        <Setter Property="BorderThickness"
+                Value="0" />
+        <Setter Property="FlyoutOverlayBrush"
+                Value="{DynamicResource MahApps.Brushes.Window.FlyoutOverlay}" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
+        <Setter Property="GlowColor"
+                Value="{DynamicResource MahApps.Colors.AccentBase}" />
+        <Setter Property="NonActiveBorderBrush"
+                Value="{DynamicResource MahApps.Brushes.Border.NonActive}" />
+        <Setter Property="NonActiveGlowColor"
+                Value="{DynamicResource MahApps.Colors.ThemeForeground}" />
+        <Setter Property="NonActiveWindowTitleBrush"
+                Value="{DynamicResource MahApps.Brushes.WindowTitle.NonActive}" />
+        <Setter Property="OverlayBrush"
+                Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
+        <Setter Property="OverlayFadeIn"
+                Value="{StaticResource OverlayFastSemiFadeIn}" />
+        <Setter Property="OverlayFadeOut"
+                Value="{StaticResource OverlayFastSemiFadeOut}" />
+        <Setter Property="SnapsToDevicePixels"
+                Value="True" />
+        <Setter Property="Template"
+                Value="{StaticResource MahApps.Templates.MetroWindow}" />
+        <Setter Property="TextElement.FontSize"
+                Value="{DynamicResource MahApps.Font.Size.Content}" />
+        <Setter Property="TitleForeground"
+                Value="{DynamicResource MahApps.Brushes.IdealForeground}" />
         <Setter Property="TitleTemplate">
             <Setter.Value>
                 <DataTemplate>
@@ -601,9 +704,11 @@
                 </DataTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="WindowTitleBrush" Value="{DynamicResource MahApps.Brushes.WindowTitle}" />
+        <Setter Property="WindowTitleBrush"
+                Value="{DynamicResource MahApps.Brushes.WindowTitle}" />
         <Style.Triggers>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Icon, Mode=OneWay, Converter={x:Static mahConverters:IsNullConverter.Instance}}" Value="False">
+            <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=Icon, Mode=OneWay, Converter={x:Static mahConverters:IsNullConverter.Instance}}"
+                         Value="False">
                 <Setter Property="IconTemplate">
                     <Setter.Value>
                         <DataTemplate>
@@ -617,8 +722,10 @@
                     </Setter.Value>
                 </Setter>
             </DataTrigger>
-            <Trigger Property="TitleAlignment" Value="Center">
-                <Setter Property="Template" Value="{StaticResource MahApps.Templates.MetroWindow.Center}" />
+            <Trigger Property="TitleAlignment"
+                     Value="Center">
+                <Setter Property="Template"
+                        Value="{StaticResource MahApps.Templates.MetroWindow.Center}" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/src/global.json
+++ b/src/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": false
-  }
-}

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+      "version": "6.0.400",
+      "rollForward": "latestFeature",
+      "allowPrerelease": false
+    }
+}


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Add `CenterWindowCommand` to `MetroWindow`.

`CenterWindowCommand` will be in front of `RightWindowCommand` (if not enough space) and it will be in front of the Title if `TitleAlignment="Center"` is set.

I had to remove the `dockpanel` because it doesn't support center. I replaced it with the already existing `grid` and updated all (at least I hope so) `grid.columnspan`.

## Unit test

-/-

## Additional context


![image](https://github.com/MahApps/MahApps.Metro/assets/16019165/c6ce7726-0d05-4935-96b0-6ad3c1038b5e)

![image](https://github.com/MahApps/MahApps.Metro/assets/16019165/56326331-2489-4741-8549-53573a4b7a00)


## Closed Issues

Close #4419 
