### PR TITLE
Add an option to always show ErrorTemplate text

### DIFF
--- a/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
@@ -67,5 +67,35 @@ namespace MahApps.Metro.Controls
         {
             element.SetValue(ShowValidationErrorOnMouseOverProperty, BooleanBoxes.Box(value));
         }
+
+        /// <summary>
+        /// Identifies the AlwaysShowValidationError attached property.
+        /// </summary>
+        public static readonly DependencyProperty AlwaysShowValidationErrorProperty
+            = DependencyProperty.RegisterAttached(
+                "AlwaysShowValidationError",
+                typeof(bool),
+                typeof(ValidationHelper),
+                new PropertyMetadata(BooleanBoxes.TrueBox));
+
+        /// <summary>
+        /// Gets whether the validation error text should always be shown, regardless of focus or mouse position.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static bool GetAlwaysShowValidationError(UIElement element)
+        {
+            return (bool)element.GetValue(AlwaysShowValidationErrorProperty);
+        }
+
+        /// <summary>
+        /// Sets whether the validation error text should always be shown, regardless of focus or mouse position.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetAlwaysShowValidationError(UIElement element, bool value)
+        {
+            element.SetValue(AlwaysShowValidationErrorProperty, BooleanBoxes.Box(value));
+        }
     }
 }

--- a/src/MahApps.Metro/Styles/Controls.ValidationError.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ValidationError.xaml
@@ -152,6 +152,13 @@
                 </MultiDataTrigger.Conditions>
                 <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
             </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.HasError), Mode=OneWay}" Value="True" />
+                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(mah:ValidationHelper.AlwaysShowValidationError), Mode=OneWay}" Value="True" />
+                </MultiDataTrigger.Conditions>
+                <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
+            </MultiDataTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 


### PR DESCRIPTION
Add an option to always show ErrorTemplate text, regardless of focus or mouse over.

## This change extends the Validation Error Template text show options to include an 'always show' option. 

The existing options of showing on focus or on mouseover did not work well for me when trying to apply the error template to a border surrounding a group of radio buttons used primarily on a touch interface. Mouseover isn't a thing on touch, and focus meant the text would only show when a radio button was selected, which removed the error entirely. 

This change introduces a new attached property in ValidationHelper to enable the behavior and a new style trigger that will enable when the template has errors and the new attached property, ValidationHelper.AlwaysShowValidationError, is set to true for the element. 


## Unit test

I did not find existing unit testing of the ValidationHelper properties to model any new test after. 
