### PR TITLE
Add an option to always show ErrorTemplate text

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TextExamples.xaml
@@ -174,6 +174,7 @@
                              mah:TextBoxHelper.Watermark="Custom icon style" />
                     <TextBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.Watermark="Number smaller than 10"
+                             mah:ValidationHelper.AlwaysShowValidationError="True"
                              Text="{Binding IntegerGreater10Property, ValidatesOnExceptions=True, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged, NotifyOnValidationError=True}" />
                     <TextBox Margin="{StaticResource ControlMargin}"
                              mah:TextBoxHelper.SelectAllOnFocus="True"

--- a/src/MahApps.Metro/Controls/CustomValidationPopup.cs
+++ b/src/MahApps.Metro/Controls/CustomValidationPopup.cs
@@ -240,9 +240,10 @@ namespace MahApps.Metro.Controls
             var adornedElement = this.AdornedElement;
             var isOpen = adornedElement is not null
                          && Validation.GetHasError(adornedElement)
-                         && adornedElement.IsKeyboardFocusWithin
-                         && this.ShowValidationErrorOnKeyboardFocus
-                         && ValidationHelper.GetShowValidationErrorOnKeyboardFocus(adornedElement);
+                         && (ValidationHelper.GetAlwaysShowValidationError(adornedElement)
+                             || (adornedElement.IsKeyboardFocusWithin
+                                 && this.ShowValidationErrorOnKeyboardFocus
+                                 && ValidationHelper.GetShowValidationErrorOnKeyboardFocus(adornedElement)));
             return isOpen;
         }
 

--- a/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -98,6 +98,36 @@ namespace MahApps.Metro.Controls
         public static void SetShowValidationErrorOnKeyboardFocus(UIElement element, bool value)
         {
             element.SetValue(ShowValidationErrorOnKeyboardFocusProperty, BooleanBoxes.Box(value));
+        }
+
+        /// <summary>
+        /// Identifies the AlwaysShowValidationError attached property.
+        /// </summary>
+        public static readonly DependencyProperty AlwaysShowValidationErrorProperty
+            = DependencyProperty.RegisterAttached(
+                "AlwaysShowValidationError",
+                typeof(bool),
+                typeof(ValidationHelper),
+                new PropertyMetadata(BooleanBoxes.TrueBox));
+
+        /// <summary>
+        /// Gets whether the validation error text should always be shown, regardless of focus or mouse position.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static bool GetAlwaysShowValidationError(UIElement element)
+        {
+            return (bool)element.GetValue(AlwaysShowValidationErrorProperty);
+        }
+
+        /// <summary>
+        /// Sets whether the validation error text should always be shown, regardless of focus or mouse position.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static void SetAlwaysShowValidationError(UIElement element, bool value)
+        {
+            element.SetValue(AlwaysShowValidationErrorProperty, BooleanBoxes.Box(value));
         }
     }
 }

--- a/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ValidationHelper.cs
@@ -108,7 +108,7 @@ namespace MahApps.Metro.Controls
                 "AlwaysShowValidationError",
                 typeof(bool),
                 typeof(ValidationHelper),
-                new PropertyMetadata(BooleanBoxes.TrueBox));
+                new PropertyMetadata(BooleanBoxes.FalseBox));
 
         /// <summary>
         /// Gets whether the validation error text should always be shown, regardless of focus or mouse position.

--- a/src/MahApps.Metro/Styles/Controls.ValidationError.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ValidationError.xaml
@@ -132,10 +132,19 @@
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
                     <Condition Binding="{Binding ElementName=ValidationPopup, Path=CanShow, Mode=OneWay}" Value="True" />
-                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay}" Value="True" />
                     <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.HasError), Mode=OneWay}" Value="True" />
+                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay}" Value="True" />
                     <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(mah:ValidationHelper.ShowValidationErrorOnKeyboardFocus), Mode=OneWay}" Value="True" />
                     <Condition Binding="{Binding ElementName=ValidationPopup, Path=ShowValidationErrorOnKeyboardFocus, Mode=OneWay}" Value="True" />
+                </MultiDataTrigger.Conditions>
+                <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
+            </MultiDataTrigger>
+
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding ElementName=ValidationPopup, Path=CanShow, Mode=OneWay}" Value="True" />
+                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.HasError), Mode=OneWay}" Value="True" />
+                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(mah:ValidationHelper.AlwaysShowValidationError), Mode=OneWay}" Value="True" />
                 </MultiDataTrigger.Conditions>
                 <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
             </MultiDataTrigger>
@@ -153,13 +162,6 @@
                     <Condition Binding="{Binding ElementName=RedTriangle, Path=IsMouseOver, Mode=OneWay}" Value="True" />
                     <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.HasError), Mode=OneWay}" Value="True" />
                     <Condition Binding="{Binding ElementName=ValidationPopup, Path=ShowValidationErrorOnMouseOver, Mode=OneWay}" Value="True" />
-                </MultiDataTrigger.Conditions>
-                <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
-            </MultiDataTrigger>
-            <MultiDataTrigger>
-                <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.HasError), Mode=OneWay}" Value="True" />
-                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(mah:ValidationHelper.AlwaysShowValidationError), Mode=OneWay}" Value="True" />
                 </MultiDataTrigger.Conditions>
                 <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
             </MultiDataTrigger>

--- a/src/MahApps.Metro/Styles/Controls.ValidationError.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ValidationError.xaml
@@ -156,6 +156,13 @@
                 </MultiDataTrigger.Conditions>
                 <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
             </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(Validation.HasError), Mode=OneWay}" Value="True" />
+                    <Condition Binding="{Binding ElementName=placeholder, Path=AdornedElement.(mah:ValidationHelper.AlwaysShowValidationError), Mode=OneWay}" Value="True" />
+                </MultiDataTrigger.Conditions>
+                <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True" />
+            </MultiDataTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 


### PR DESCRIPTION
## Describe the changes you have made to improve this project

Original change from #4451 added by @nekizalb 

Add an option to always show ErrorTemplate text, regardless of focus or mouse over.

This change introduces a new attached property in ValidationHelper to enable the behavior and a new style trigger that will enable when the template has errors and the new attached property, ValidationHelper.AlwaysShowValidationError, is set to true for the element.

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Unit test

<!-- If it's possible then make a unit test for your changes. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->

## Closed Issues

<!-- Closes #xxxx -->

Closes #4451 
