### PR TITLE
Fix NumericUpDown not accepting keyboard input below minimum.

### DIFF
--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1170,9 +1170,7 @@ namespace MahApps.Metro.Controls
             var textBox = (TextBox)sender;
             var fullText = textBox.Text.Remove(textBox.SelectionStart, textBox.SelectionLength).Insert(textBox.CaretIndex, e.Text);
             var textIsValid = this.ValidateText(fullText, out var convertedValue);
-            // Value must be valid and not coerced
-            var coerceValue = CoerceValue(this, convertedValue as double?);
-            e.Handled = !textIsValid || !coerceValue.isValid;
+            e.Handled = !textIsValid;
             this.manualChange = !e.Handled;
         }
 


### PR DESCRIPTION
## Describe the changes you have made to improve this project
NumericUpDown was evaluating every single keyboard input.  When minimum was greater then double digits it evaluated to the minimum appearing to  not accept keyboard input. Fixed the input validation to allow keyboard entry below the minimum value, because minimum and maximum are evaluated at focus lost.

## Unit test
No unit test added. Existing tests cover this control.

## Additional context
Fixes keyboard input issue reported in #4561

## Closed Issues
Closes #4561
