### PR TITLE
Fix numericupdown preview input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,7 +265,3 @@ src/MahApps.Metro/Styles/Themes/*.xaml
 
 # cake
 tools/*
-/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
-/src/MahApps.Metro.sln
-/src/MahApps.Metro.sln
-/src/MahApps.Metro.sln

--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,7 @@ src/MahApps.Metro/Styles/Themes/*.xaml
 
 # cake
 tools/*
+/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
+/src/MahApps.Metro.sln
+/src/MahApps.Metro.sln
+/src/MahApps.Metro.sln

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1168,7 +1168,14 @@ namespace MahApps.Metro.Controls
         protected void OnPreviewTextInput(object sender, TextCompositionEventArgs e)
         {
             var textBox = (TextBox)sender;
-            var fullText = textBox.Text.Remove(textBox.SelectionStart, textBox.SelectionLength).Insert(textBox.CaretIndex, e.Text);
+
+            var inputText = e.Text;
+            if (inputText == "-" && this.SpecificCultureInfo.NumberFormat.NegativeSign != "-")
+            {
+                inputText = this.SpecificCultureInfo.NumberFormat.NegativeSign;
+            }
+
+            var fullText = textBox.Text.Remove(textBox.SelectionStart, textBox.SelectionLength).Insert(textBox.CaretIndex, inputText);
             var textIsValid = this.ValidateText(fullText, out var convertedValue);
             e.Handled = !textIsValid;
             this.manualChange = !e.Handled;
@@ -1676,6 +1683,9 @@ namespace MahApps.Metro.Controls
                 return true;
             }
 
+            number = number.Replace(this.SpecificCultureInfo.NumberFormat.NegativeSign, "-")
+                           .Replace(this.SpecificCultureInfo.NumberFormat.PositiveSign, "+");
+
             if (!double.TryParse(number, this.ParsingNumberStyle, this.SpecificCultureInfo, out convertedValue))
             {
                 return false;
@@ -1714,8 +1724,12 @@ namespace MahApps.Metro.Controls
 
             if (this.regexNumber is null)
             {
+                var negativeSign = Regex.Escape(this.SpecificCultureInfo.NumberFormat.NegativeSign);
+                var positiveSign = Regex.Escape(this.SpecificCultureInfo.NumberFormat.PositiveSign);
+
                 this.regexNumber = new Regex(RawRegexNumberString.Replace("<DecimalSeparator>", this.SpecificCultureInfo.NumberFormat.NumberDecimalSeparator)
-                                                                 .Replace("<GroupSeparator>", this.SpecificCultureInfo.NumberFormat.NumberGroupSeparator),
+                                                                 .Replace("<GroupSeparator>", this.SpecificCultureInfo.NumberFormat.NumberGroupSeparator)
+                                                                 .Replace("[-+]", $"[-+{negativeSign}{positiveSign}]"),
                                              RegexOptions.Compiled);
             }
 

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1170,9 +1170,7 @@ namespace MahApps.Metro.Controls
             var textBox = (TextBox)sender;
             var fullText = textBox.Text.Remove(textBox.SelectionStart, textBox.SelectionLength).Insert(textBox.CaretIndex, e.Text);
             var textIsValid = this.ValidateText(fullText, out var convertedValue);
-            // Value must be valid and not coerced
-            var coerceValue = CoerceValue(this, convertedValue as double?);
-            e.Handled = !textIsValid || !coerceValue.isValid;
+            e.Handled = !textIsValid;
             this.manualChange = !e.Handled;
         }
 


### PR DESCRIPTION
Fixed an issue where the NumericUpDown control did not support keyboard entry of culture-specific negative signs. Cultures such as Norwegian (nb-NO) use U+2212 (−) as their negative sign rather than the standard ASCII hyphen-minus (-). This caused any attempt to enter a negative number via keyboard or paste to be blocked or lost.

Three changes were made to NumericUpDown.cs:

- OnPreviewTextInput - converts ASCII - to the culture's actual negative sign before building the full text and validating, ensuring the correct character is inserted into the text box
- TryGetNumberFromText - updated the regex to include the culture's actual negative and positive signs so that U+2212 is correctly matched during text extraction
- ValidateText - normalises culture-specific negative and positive signs back to ASCII equivalents before calling double.TryParse, ensuring parsing succeeds regardless of the culture's sign characters

Unit test
A unit test should verify that a NumericUpDown configured with Norwegian culture (nb-NO) correctly accepts U+2212 (−) as a negative sign both via keyboard entry and paste, and that the resulting value is correctly parsed and stored as a negative number.

Additional context
This issue affects any culture where CultureInfo.NumberFormat.NegativeSign is not the standard ASCII hyphen-minus (-), including but not limited to Norwegian (nb-NO). The fix is culture-agnostic and will correctly handle any culture's negative and positive sign characters.

Closes #4560
