### PR TITLE
fix: add JSON fallback for SaveWindowPosition on .NET 9

### DIFF
--- a/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
+++ b/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
@@ -135,12 +135,14 @@ namespace MahApps.Metro.Behaviors
             }
 
             // check for existing placement and prevent empty bounds
-            if (settings.Placement is null || settings.Placement.normalPosition.IsEmpty)
+            var placement = settings.Placement;
+            if (placement is null || placement.normalPosition.IsEmpty)
             {
 #if !NET462
                 // Fallback: try to load from JSON backup if settings has no valid placement
                 if (TryLoadFromJsonFallback(window, out var fallbackPlacement))
                 {
+                    placement = fallbackPlacement;
                     settings.Placement = fallbackPlacement;
                 }
                 else
@@ -154,7 +156,7 @@ namespace MahApps.Metro.Behaviors
 
             try
             {
-                var wp = settings.Placement.ToWINDOWPLACEMENT();
+                var wp = placement.ToWINDOWPLACEMENT();
                 WinApiHelper.SetWindowPlacement(window, wp);
             }
             catch (Exception ex)

--- a/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
+++ b/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
@@ -143,13 +143,13 @@ namespace MahApps.Metro.Behaviors
                 {
                     settings.Placement = fallbackPlacement;
                 }
-#endif
-            }
-
-            // If we still have no valid placement, nothing to restore
-            if (settings.Placement is null || settings.Placement.normalPosition.IsEmpty)
-            {
+                else
+                {
+                    return;
+                }
+#else
                 return;
+#endif
             }
 
             try

--- a/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
+++ b/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
@@ -156,7 +156,7 @@ namespace MahApps.Metro.Behaviors
 
             try
             {
-                var wp = placement.ToWINDOWPLACEMENT();
+                var wp = placement!.ToWINDOWPLACEMENT();
                 WinApiHelper.SetWindowPlacement(window, wp);
             }
             catch (Exception ex)

--- a/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
+++ b/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Windows;
 using System.Windows.Interop;
 using Windows.Win32;
@@ -127,10 +129,20 @@ namespace MahApps.Metro.Behaviors
             catch (Exception e)
             {
                 Trace.TraceError($"{this}: The settings for {window} could not be reloaded! {e}");
-                return;
+                // Don't return yet — try JSON fallback below
             }
 
             // check for existing placement and prevent empty bounds
+            if (settings.Placement is null || settings.Placement.normalPosition.IsEmpty)
+            {
+                // Fallback: try to load from JSON backup if settings has no valid placement
+                if (TryLoadFromJsonFallback(window, out var fallbackPlacement))
+                {
+                    settings.Placement = fallbackPlacement;
+                }
+            }
+
+            // If we still have no valid placement, nothing to restore
             if (settings.Placement is null || settings.Placement.normalPosition.IsEmpty)
             {
                 return;
@@ -210,11 +222,78 @@ namespace MahApps.Metro.Behaviors
             try
             {
                 settings.Save();
+
+                // On successful save, also save to JSON fallback for .NET version resilience
+                SaveToJsonFallback(window, settings.Placement);
             }
             catch (Exception e)
             {
                 Trace.TraceError($"{this}: The settings could not be saved! {e}");
+                // Fallback: save to JSON file when ApplicationSettingsBase.Save() fails
+                // (e.g. .NET 9 < 9.0.3 bug where ClientConfigurationHost fails on UNC paths)
+                try
+                {
+                    SaveToJsonFallback(window, settings.Placement);
+                    Trace.TraceInformation($"{this}: Window placement saved to JSON fallback instead.");
+                }
+                catch (Exception fallbackEx)
+                {
+                    Trace.TraceError($"{this}: The JSON fallback save also failed! {fallbackEx}");
+                }
             }
+        }
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            IncludeFields = true
+        };
+
+        private void SaveToJsonFallback(Window window, WindowPlacementSetting? placement)
+        {
+            if (placement is null)
+            {
+                return;
+            }
+
+            var filePath = GetFallbackFilePath(window);
+            var directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var json = JsonSerializer.Serialize(placement, JsonOptions);
+            File.WriteAllText(filePath, json);
+        }
+
+        private bool TryLoadFromJsonFallback(Window window, out WindowPlacementSetting? placement)
+        {
+            placement = null;
+
+            try
+            {
+                var filePath = GetFallbackFilePath(window);
+                if (!File.Exists(filePath))
+                {
+                    return false;
+                }
+
+                var json = File.ReadAllText(filePath);
+                placement = JsonSerializer.Deserialize<WindowPlacementSetting>(json, JsonOptions);
+                return placement != null;
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceWarning($"{this}: Could not load JSON fallback for {window}: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static string GetFallbackFilePath(Window window)
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var appName = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Name ?? "MahApps.Metro";
+            var windowTypeName = window.GetType().FullName?.Replace('.', '_') ?? "MetroWindow";
+            return Path.Combine(localAppData, appName, "WindowPlacement", $"{windowTypeName}.json");
         }
     }
 }

--- a/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
+++ b/src/MahApps.Metro/Behaviors/WindowsSettingBehavior.cs
@@ -6,7 +6,9 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+#if !NET462
 using System.Text.Json;
+#endif
 using System.Windows;
 using System.Windows.Interop;
 using Windows.Win32;
@@ -135,11 +137,13 @@ namespace MahApps.Metro.Behaviors
             // check for existing placement and prevent empty bounds
             if (settings.Placement is null || settings.Placement.normalPosition.IsEmpty)
             {
+#if !NET462
                 // Fallback: try to load from JSON backup if settings has no valid placement
                 if (TryLoadFromJsonFallback(window, out var fallbackPlacement))
                 {
                     settings.Placement = fallbackPlacement;
                 }
+#endif
             }
 
             // If we still have no valid placement, nothing to restore
@@ -223,12 +227,15 @@ namespace MahApps.Metro.Behaviors
             {
                 settings.Save();
 
+#if !NET462
                 // On successful save, also save to JSON fallback for .NET version resilience
                 SaveToJsonFallback(window, settings.Placement);
+#endif
             }
             catch (Exception e)
             {
                 Trace.TraceError($"{this}: The settings could not be saved! {e}");
+#if !NET462
                 // Fallback: save to JSON file when ApplicationSettingsBase.Save() fails
                 // (e.g. .NET 9 < 9.0.3 bug where ClientConfigurationHost fails on UNC paths)
                 try
@@ -240,8 +247,11 @@ namespace MahApps.Metro.Behaviors
                 {
                     Trace.TraceError($"{this}: The JSON fallback save also failed! {fallbackEx}");
                 }
+#endif
             }
         }
+
+#if !NET462
         private static readonly JsonSerializerOptions JsonOptions = new()
         {
             IncludeFields = true
@@ -295,5 +305,6 @@ namespace MahApps.Metro.Behaviors
             var windowTypeName = window.GetType().FullName?.Replace('.', '_') ?? "MetroWindow";
             return Path.Combine(localAppData, appName, "WindowPlacement", $"{windowTypeName}.json");
         }
+#endif
     }
 }


### PR DESCRIPTION
- ApplicationSettingsBase.Save() fails on .NET 9 < 9.0.3 due to a runtime bug (dotnet/runtime#112410) where ClientConfigurationHost receives an empty path on UNC/network locations.
- SaveWindowState() now saves a JSON backup to %LocalAppData% as a fallback when the settings save fails.
- LoadWindowState() tries the JSON fallback when settings reload fails or returns an empty placement.
- On successful save via ApplicationSettingsBase, the JSON backup is also updated to stay in sync.

## Description

Fixes #4541 — .NET 9 breaks SaveWindowPosition in MetroWindow.

### Problem
On .NET 9 prior to version 9.0.3, ApplicationSettingsBase.Save() throws a 
ConfigurationErrorsException when the project path is on a UNC/network location. 
This is a known .NET runtime bug (dotnet/runtime#112410), fixed in .NET 9.0.3.

### Fix
Adds a JSON-based fallback for window placement persistence:
- Save: if settings.Save() fails → placement saved to 
  %LocalAppData%/<app>/WindowPlacement/<WindowType>.json
- Load: if settings.Reload() fails or returns empty → loads from JSON fallback
- On success: JSON stays in sync

No new dependencies — uses System.Text.Json.