### PR TITLE
fix(MetroWindow): add GlowBrush dependency property (fixes #4564)

### DIFF
--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -558,6 +558,35 @@ namespace MahApps.Metro.Controls
             set => this.SetValue(NonActiveBorderBrushProperty, value);
         }
 
+        /// <summary>Identifies the <see cref="GlowBrush"/> dependency property.</summary>
+        public static readonly DependencyProperty GlowBrushProperty
+            = DependencyProperty.Register(nameof(GlowBrush),
+                                          typeof(Brush),
+                                          typeof(MetroWindow),
+                                          new PropertyMetadata(default(Brush), OnGlowBrushChanged));
+
+        /// <summary>
+        /// Gets or sets the brush used for the glow effect of the window border when the window is active.
+        /// This property wraps the inherited <see cref="GlowColor"/> property from ControlzEx.
+        /// </summary>
+        public Brush GlowBrush
+        {
+            get => (Brush)this.GetValue(GlowBrushProperty);
+            set => this.SetValue(GlowBrushProperty, value);
+        }
+
+        private static void OnGlowBrushChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is MetroWindow window && e.NewValue is SolidColorBrush brush)
+            {
+                window.GlowColor = brush.Color;
+            }
+            else if (d is MetroWindow window && e.NewValue is null)
+            {
+                window.GlowColor = null;
+            }
+        }
+
         /// <summary>Identifies the <see cref="OverlayBrush"/> dependency property.</summary>
         public static readonly DependencyProperty OverlayBrushProperty
             = DependencyProperty.Register(nameof(OverlayBrush),


### PR DESCRIPTION
Fixes #4564 — GlowBrush invalid property on MetroWindow.

### Problem
The MahApps.Metro documentation references a GlowBrush property on MetroWindow, but this property was never implemented. Users following the docs example get 'GlowBrush invalid property' at design time.

### Root cause
MetroWindow inherits GlowColor (Color?) from ControlzEx.WindowChromeWindow, but no GlowBrush convenience property was exposed.

### Fix
Added a GlowBrush dependency property (of type Brush) that wraps the inherited GlowColor:
- Setting GlowBrush to a SolidColorBrush extracts the Color and assigns it to GlowColor
- Setting GlowBrush to null clears GlowColor
- The getter returns the current GlowBrushProperty value

This matches the pattern used by other brush properties on MetroWindow (e.g. NonActiveBorderBrush).