### PR TITLE
fix(NumericUpDown, TimePicker): defects from #4565, plus #4586 and #4551

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,4 +268,5 @@ tools/*
 
 # Local AI assistant files
 CLAUDE.md
+PRODUCT.md
 .claude/

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1407,16 +1407,23 @@ namespace MahApps.Metro.Controls
             var match = RegexStringFormatHexadecimal.Match(format);
             if (match.Success)
             {
+                // HEX DOES SUPPORT INTEGRAL TYPES ONLY. Inside the int range the operand stays an
+                // int, so negative values keep their 32 bit form (-1 renders as "ffffffff").
+                // Outside it, the cast to int saturates, which rendered 3e9 as 7FFFFFFF. A value
+                // beyond the long range still saturates, there is no integral type left for it.
+                var hexOperand = newValue >= int.MinValue && newValue <= int.MaxValue
+                                     ? (object)(int)newValue
+                                     : (long)newValue;
+
                 if (match.Groups["simpleHEX"].Success)
                 {
-                    // HEX DOES SUPPORT INT ONLY.
-                    output = ((int)newValue).ToString(match.Groups["simpleHEX"].Value, culture);
+                    output = ((IFormattable)hexOperand).ToString(match.Groups["simpleHEX"].Value, culture);
                     return true;
                 }
 
                 if (match.Groups["complexHEX"].Success)
                 {
-                    output = string.Format(culture, match.Groups["complexHEX"].Value, (int)newValue);
+                    output = string.Format(culture, match.Groups["complexHEX"].Value, hexOperand);
                     return true;
                 }
             }

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1020,6 +1020,20 @@ namespace MahApps.Metro.Controls
         {
             base.OnApplyTemplate();
 
+            // Detach the handlers of a previous template pass. Without this, every further pass
+            // leaves another handler on the same button and one click changes the value once per pass.
+            if (this.repeatUp is not null)
+            {
+                this.repeatUp.Click -= this.OnRepeatUpClick;
+                this.repeatUp.PreviewMouseUp -= this.OnRepeatButtonPreviewMouseUp;
+            }
+
+            if (this.repeatDown is not null)
+            {
+                this.repeatDown.Click -= this.OnRepeatDownClick;
+                this.repeatDown.PreviewMouseUp -= this.OnRepeatButtonPreviewMouseUp;
+            }
+
             this.repeatUp = this.GetTemplateChild(PART_NumericUp) as RepeatButton;
             this.repeatDown = this.GetTemplateChild(PART_NumericDown) as RepeatButton;
 
@@ -1032,15 +1046,31 @@ namespace MahApps.Metro.Controls
 
             this.ToggleReadOnlyMode(this.IsReadOnly);
 
-            this.repeatUp.Click += (_, _) => { this.ChangeValueWithSpeedUp(true); };
-            this.repeatDown.Click += (_, _) => { this.ChangeValueWithSpeedUp(false); };
+            // Named methods, so that a later template pass can detach them again.
+            this.repeatUp.Click += this.OnRepeatUpClick;
+            this.repeatDown.Click += this.OnRepeatDownClick;
 
-            this.repeatUp.PreviewMouseUp += (_, _) => this.ResetInternal();
-            this.repeatDown.PreviewMouseUp += (_, _) => this.ResetInternal();
+            this.repeatUp.PreviewMouseUp += this.OnRepeatButtonPreviewMouseUp;
+            this.repeatDown.PreviewMouseUp += this.OnRepeatButtonPreviewMouseUp;
 
             this.OnValueChanged(this.Value, this.Value);
 
             this.scrollViewer = null;
+        }
+
+        private void OnRepeatUpClick(object sender, RoutedEventArgs e)
+        {
+            this.ChangeValueWithSpeedUp(true);
+        }
+
+        private void OnRepeatDownClick(object sender, RoutedEventArgs e)
+        {
+            this.ChangeValueWithSpeedUp(false);
+        }
+
+        private void OnRepeatButtonPreviewMouseUp(object sender, MouseButtonEventArgs e)
+        {
+            this.ResetInternal();
         }
 
         /// <summary>
@@ -1191,10 +1221,11 @@ namespace MahApps.Metro.Controls
         {
             var textBox = (TextBox)sender;
             var fullText = textBox.Text.Remove(textBox.SelectionStart, textBox.SelectionLength).Insert(textBox.CaretIndex, e.Text);
-            var textIsValid = this.ValidateText(fullText, out var convertedValue);
-            // Value must be valid and not coerced
-            var coerceValue = CoerceValue(this, convertedValue as double?);
-            e.Handled = !textIsValid || !coerceValue.isValid;
+            var textIsValid = this.ValidateText(fullText, out _);
+            // Only the text format decides here. A number that is out of range on its own is
+            // still the beginning of an in-range one, so the keystroke must not be swallowed.
+            // Coercion happens when the value is committed.
+            e.Handled = !textIsValid;
             this.manualChange = !e.Handled;
         }
 
@@ -1628,8 +1659,9 @@ namespace MahApps.Metro.Controls
                 }
             }
 
-            this.OnValueChanged(oldValue, this.Value);
-
+            // No OnValueChanged call here: setting ValueProperty above already ran the property
+            // changed callback, which raises ValueChanged. Calling it again reported every
+            // change to the consumer twice.
             this.manualChange = false;
         }
 

--- a/src/MahApps.Metro/Controls/TimePicker/TimePicker.cs
+++ b/src/MahApps.Metro/Controls/TimePicker/TimePicker.cs
@@ -53,8 +53,8 @@ namespace MahApps.Metro.Controls
             }
 
             const DateTimeStyles dateTimeParseStyle = DateTimeStyles.AllowWhiteSpaces
-                                                      & DateTimeStyles.AssumeLocal
-                                                      & DateTimeStyles.NoCurrentDateDefault;
+                                                      | DateTimeStyles.AssumeLocal
+                                                      | DateTimeStyles.NoCurrentDateDefault;
 
             if (DateTime.TryParse(this.textBox.Text, this.SpecificCultureInfo, dateTimeParseStyle, out var timeSpan))
             {

--- a/src/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
+++ b/src/MahApps.Metro/Controls/TimePicker/TimePickerBase.cs
@@ -686,7 +686,10 @@ namespace MahApps.Metro.Controls
         protected virtual void ClockSelectedTimeChanged()
         {
             var time = this.GetSelectedTimeFromGUI() ?? TimeSpan.Zero;
-            var date = this.SelectedDateTime ?? DateTime.Today;
+
+            // Today's date, but without a kind: the calendar and the text box both produce
+            // Unspecified, and DateTime.Today would make this the one path yielding Local.
+            var date = this.SelectedDateTime ?? DateTime.SpecifyKind(DateTime.Today, DateTimeKind.Unspecified);
 
             this.SetCurrentValue(SelectedDateTimeProperty, date.Date + time);
         }

--- a/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
@@ -196,25 +197,43 @@ namespace MahApps.Metro.Tests.Tests
         }
 
         /// <summary>
-        /// GH-4551: picking the time first runs through ClockSelectedTimeChanged, which falls
-        /// back to DateTime.Today and thus produces DateTimeKind.Local, while every other path
-        /// of the control produces Unspecified. Consumers saw two kinds from one control.
+        /// GH-4551: picking the time before the date ran through ClockSelectedTimeChanged, whose
+        /// fallback was DateTime.Today and therefore carried DateTimeKind.Local, while the
+        /// calendar and the text box both produce Unspecified. One control handed its consumer
+        /// two different kinds depending on the order the user picked things in.
         /// </summary>
-        /// <remarks>
-        /// Drives the protected handler directly. The real trigger is a selection change inside
-        /// the drop down, whose template is not loaded in an off-screen test window.
-        /// </remarks>
         [Test]
-        public void ShouldReportUnspecifiedKindWhenTimeIsPickedFirst()
+        public void ShouldReportUnspecifiedKindWhenTimeIsPickedFromDropDown()
         {
-            var picker = new TestableTimePicker();
+            Assert.That(this.window, Is.Not.Null);
 
-            Assert.That(picker.SelectedDateTime, Is.Null, "the fallback path needs an empty picker");
+            var picker = this.window.EmptyTimePicker;
+            picker.SetCurrentValue(TimePickerBase.SelectedDateTimeProperty, null);
+            picker.ApplyTemplate();
+            picker.SetCurrentValue(TimePickerBase.IsDropDownOpenProperty, true);
 
-            picker.PickTimeFromClock();
+            try
+            {
+                var popup = picker.FindChild<Popup>(string.Empty);
+                Assert.That(popup, Is.Not.Null, "no popup found");
 
-            Assert.That(picker.SelectedDateTime, Is.Not.Null);
-            Assert.That(picker.SelectedDateTime!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+                var content = popup.Child as FrameworkElement;
+                Assert.That(content, Is.Not.Null, "popup has no child");
+
+                content.ApplyTemplate();
+
+                var hourPicker = content.FindChild<Selector>("PART_HourPicker");
+                Assert.That(hourPicker, Is.Not.Null, "no PART_HourPicker inside the popup");
+
+                hourPicker.SetCurrentValue(Selector.SelectedIndexProperty, 7);
+
+                Assert.That(picker.SelectedDateTime, Is.Not.Null, "selecting an hour did not set a value");
+                Assert.That(picker.SelectedDateTime!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+            }
+            finally
+            {
+                picker.SetCurrentValue(TimePickerBase.IsDropDownOpenProperty, false);
+            }
         }
 
         /// <summary>
@@ -237,16 +256,5 @@ namespace MahApps.Metro.Tests.Tests
                                          });
         }
 
-        /// <summary>
-        /// Exposes the protected clock handler, which is otherwise only reachable through the
-        /// drop down's item selection.
-        /// </summary>
-        private sealed class TestableTimePicker : TimePicker
-        {
-            public void PickTimeFromClock()
-            {
-                this.ClockSelectedTimeChanged();
-            }
-        }
     }
 }

--- a/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
@@ -148,5 +148,105 @@ namespace MahApps.Metro.Tests.Tests
 
             Assert.That((window.EmptyTimePicker).SelectedDateTime, Is.EqualTo(default(DateTime) + new TimeSpan(14, 42, 12)));
         }
+
+        /// <summary>
+        /// GH-4586: TimePicker.SetSelectedDateTime combined its DateTimeStyles flags with "&"
+        /// instead of "|", which folds the constant to DateTimeStyles.None.
+        /// Nails down the parse behaviour the control actually offers, so that correcting the
+        /// operator, or touching the flags later, cannot change it unnoticed.
+        /// </summary>
+        [Theory]
+        [TestCase("2:30:45 PM", 14, 30, 45)]
+        [TestCase("2 : 30 : 45 PM", 14, 30, 45)] // inner whitespace
+        [TestCase("  2:30:45 PM  ", 14, 30, 45)] // leading and trailing whitespace
+        [TestCase("2  :  30  :  45  PM", 14, 30, 45)]
+        public void ShouldParseTimeWithWhitespace(string text, int hours, int minutes, int seconds)
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var picker = this.window.EmptyTimePicker;
+            Assert.That(picker, Is.Not.Null);
+
+            picker.SetCurrentValue(TimePickerBase.SelectedDateTimeProperty, null);
+
+            CommitText(picker, text);
+
+            Assert.That(picker.SelectedDateTime, Is.EqualTo(default(DateTime) + new TimeSpan(hours, minutes, seconds)));
+        }
+
+        /// <summary>
+        /// GH-4586 and GH-4551: the DateTimeStyles of the TimePicker contain AssumeLocal, which
+        /// never reaches the stored value because the result is built from the previous value's
+        /// date. Documents that the control reports Unspecified, matching the calendar path.
+        /// </summary>
+        [Test]
+        public void ShouldReportUnspecifiedKindForTextInput()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var picker = this.window.EmptyTimePicker;
+            Assert.That(picker, Is.Not.Null);
+
+            picker.SetCurrentValue(TimePickerBase.SelectedDateTimeProperty, null);
+
+            CommitText(picker, "2:42:12 PM");
+
+            Assert.That(picker.SelectedDateTime, Is.Not.Null);
+            Assert.That(picker.SelectedDateTime!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+        }
+
+        /// <summary>
+        /// GH-4551: picking the time first runs through ClockSelectedTimeChanged, which falls
+        /// back to DateTime.Today and thus produces DateTimeKind.Local, while every other path
+        /// of the control produces Unspecified. Consumers saw two kinds from one control.
+        /// </summary>
+        /// <remarks>
+        /// Drives the protected handler directly. The real trigger is a selection change inside
+        /// the drop down, whose template is not loaded in an off-screen test window.
+        /// </remarks>
+        [Test]
+        public void ShouldReportUnspecifiedKindWhenTimeIsPickedFirst()
+        {
+            var picker = new TestableTimePicker();
+
+            Assert.That(picker.SelectedDateTime, Is.Null, "the fallback path needs an empty picker");
+
+            picker.PickTimeFromClock();
+
+            Assert.That(picker.SelectedDateTime, Is.Not.Null);
+            Assert.That(picker.SelectedDateTime!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+        }
+
+        /// <summary>
+        /// Commits text into a picker's text box the way a user does: type it, then press Return.
+        /// </summary>
+        private static void CommitText(TimePickerBase picker, string text)
+        {
+            var datePickerTextBox = picker.FindChild<DatePickerTextBox>(string.Empty);
+            Assert.That(datePickerTextBox, Is.Not.Null);
+
+            datePickerTextBox.SetCurrentValue(TextBox.TextProperty, text);
+
+            datePickerTextBox.RaiseEvent(new KeyEventArgs(
+                                             Keyboard.PrimaryDevice,
+                                             new HwndSource(0, 0, 0, 0, 0, "", IntPtr.Zero), // dummy presentation source
+                                             0,
+                                             Key.Return)
+                                         {
+                                             RoutedEvent = Keyboard.KeyDownEvent
+                                         });
+        }
+
+        /// <summary>
+        /// Exposes the protected clock handler, which is otherwise only reachable through the
+        /// drop down's item selection.
+        /// </summary>
+        private sealed class TestableTimePicker : TimePicker
+        {
+            public void PickTimeFromClock()
+            {
+                this.ClockSelectedTimeChanged();
+            }
+        }
     }
 }

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTemplateTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTemplateTests.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// Tests around the template lifecycle of the <see cref="NumericUpDown"/>.
+    /// These live in their own fixture, and thus on their own window, because re-applying a
+    /// template leaves event handlers on the control that no [SetUp] can clear again.
+    /// </summary>
+    [TestFixture]
+    public class NumericUpDownTemplateTests
+    {
+        private NumericUpDownWindow? window;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        /// <summary>
+        /// GH-4565: OnApplyTemplate attached the repeat button handlers without detaching the
+        /// previous ones, so every further template pass added another handler to the same button
+        /// and a single click changed the value once per pass.
+        /// </summary>
+        [Test]
+        public void ShouldNotAttachRepeatButtonClickHandlerTwiceOnReappliedTemplate()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var numUp = this.window.TheNUD.FindChild<RepeatButton>("PART_NumericUp");
+            Assert.That(numUp, Is.Not.Null);
+
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.SpeedupProperty, false);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.IntervalProperty, 1d);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.ValueProperty, 0d);
+
+            this.window.TheNUD.OnApplyTemplate();
+
+            numUp.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+
+            Assert.That(this.window.TheNUD.Value, Is.EqualTo(1d), "one click changed the value more than once");
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -43,6 +43,16 @@ namespace MahApps.Metro.Tests.Tests
             this.PreparePropertiesForTest();
         }
 
+        [TearDown]
+        public void TearDown()
+        {
+            // The control's editing flag is private state that ClearDependencyProperties cannot
+            // reach. A test that types without committing would leave it set, and OnValueChanged
+            // then stops updating the text box for every test that follows. Ending the edit here
+            // keeps that failure mode out of the fixture.
+            this.window?.TheNUD.FindChild<TextBox>()?.RaiseEvent(new RoutedEventArgs(UIElement.LostFocusEvent));
+        }
+
         private void PreparePropertiesForTest(IList<string>? properties = null)
         {
             this.window?.TheNUD.ClearDependencyProperties(properties);
@@ -123,6 +133,9 @@ namespace MahApps.Metro.Tests.Tests
         [TestCase(-1d, "x", "ffffffff")]
         [TestCase(255d, "x4", "00ff")]
         [TestCase(-1d, "X4", "FFFFFFFF")]
+        [TestCase(3000000000d, "X", "B2D05E00")] // GH-4565: was saturated to int.MaxValue and rendered 7FFFFFFF
+        [TestCase(2147483648d, "X", "80000000")] // GH-4565: int.MaxValue + 1
+        [TestCase(-3000000000d, "X", "FFFFFFFF4D2FA200")] // GH-4565: below int.MinValue
         public void ShouldFormatValueInput(object? value, string format, string expectedText)
         {
             Assert.That(this.window, Is.Not.Null);
@@ -665,16 +678,8 @@ namespace MahApps.Metro.Tests.Tests
 
             textBox.RaiseEvent(args);
 
-            try
-            {
-                Assert.That(args.Handled, Is.False, "the keystroke was swallowed, so the value can never be typed");
-            }
-            finally
-            {
-                // Raising PreviewTextInput on its own leaves the control in editing state, and
-                // that flag is private, so no [SetUp] can reset it. End the edit here instead.
-                textBox.RaiseEvent(new RoutedEventArgs(UIElement.LostFocusEvent));
-            }
+            // The edit is left open on purpose; [TearDown] closes it.
+            Assert.That(args.Handled, Is.False, "the keystroke was swallowed, so the value can never be typed");
         }
 
         /// <summary>

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -597,6 +597,105 @@ namespace MahApps.Metro.Tests.Tests
             TypeText(textBox, text);
 
             Assert.That(textBox.Text, Is.EqualTo(text));
+        }
+
+
+        /// <summary>
+        /// GH-4565: ChangeValueFromTextInput called OnValueChanged in addition to the change
+        /// already raised by the ValueProperty callback, so every single value change was
+        /// reported to the consumer twice.
+        /// </summary>
+        [Test]
+        public void ShouldRaiseValueChangedOnlyOncePerChangeOnManualTextInput()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.ValueProperty, 0d);
+
+            // Typing "42" legitimately walks the value through several states, so the count
+            // itself is not the contract. No single transition may be reported twice.
+            var transitions = new List<string>();
+
+            void OnValueChanged(object sender, RoutedPropertyChangedEventArgs<double?> e)
+            {
+                transitions.Add(FormattableString.Invariant($"{e.OldValue} -> {e.NewValue}"));
+            }
+
+            this.window.TheNUD.ValueChanged += OnValueChanged;
+            try
+            {
+                SetText(textBox, "42");
+            }
+            finally
+            {
+                this.window.TheNUD.ValueChanged -= OnValueChanged;
+            }
+
+            Assert.That(this.window.TheNUD.Value, Is.EqualTo(42d));
+            Assert.That(transitions, Is.Not.Empty);
+            Assert.That(transitions, Is.Unique, $"a value change was reported more than once: {string.Join(" | ", transitions)}");
+        }
+
+        /// <summary>
+        /// GH-4565: OnPreviewTextInput rejected any keystroke whose resulting text would be
+        /// coerced, so a value below Minimum could never be typed digit by digit.
+        /// </summary>
+        [Test]
+        public void ShouldNotBlockTypingADigitBelowMinimum()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MinimumProperty, 50d);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MaximumProperty, 100d);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.ValueProperty, 60d);
+
+            textBox.Clear();
+
+            // "5" is the first keystroke of "55", but on its own it is below Minimum.
+            var args = new TextCompositionEventArgs(Keyboard.PrimaryDevice, new TextComposition(InputManager.Current, textBox, "5"))
+                       {
+                           RoutedEvent = UIElement.PreviewTextInputEvent
+                       };
+
+            textBox.RaiseEvent(args);
+
+            try
+            {
+                Assert.That(args.Handled, Is.False, "the keystroke was swallowed, so the value can never be typed");
+            }
+            finally
+            {
+                // Raising PreviewTextInput on its own leaves the control in editing state, and
+                // that flag is private, so no [SetUp] can reset it. End the edit here instead.
+                textBox.RaiseEvent(new RoutedEventArgs(UIElement.LostFocusEvent));
+            }
+        }
+
+        /// <summary>
+        /// GH-4565: guards the hexadecimal formatting fallback. A value outside the int range
+        /// must not end up at double.ToString("X"), which throws a FormatException.
+        /// </summary>
+        [Test]
+        public void ShouldNotThrowWhenFormattingHexadecimalValueAboveIntMax()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.Culture = CultureInfo.InvariantCulture;
+            this.window.TheNUD.NumericInputMode = NumericInput.All;
+            this.window.TheNUD.StringFormat = "X";
+
+            Assert.That(() => this.window.TheNUD.SetCurrentValue(NumericUpDown.ValueProperty, (double)int.MaxValue + 1d),
+                        Throws.Nothing);
+            Assert.That(textBox.Text, Is.Not.Empty);
         }
 
         private sealed class ClampingTestViewModel : INotifyPropertyChanged


### PR DESCRIPTION
Supersedes #4565. Fixes #4586 and #4551.

## NumericUpDown

Taken from #4565, each with a test that fails without the change:

| Defect | Symptom |
| --- | --- |
| `ChangeValueFromTextInput` called `OnValueChanged` on top of the `ValueProperty` callback | typing `42` reports 6 transitions instead of 3, each duplicated |
| `OnPreviewTextInput` ran the coercion check against intermediate text | with `Minimum` at 50, the `5` of `55` never arrives |
| `OnApplyTemplate` attached lambdas without detaching the previous ones | after a second template pass, one click changes the value twice |

Hexadecimal overflow, spotted in #4565 but fixed differently: that PR returns `false` for values outside the int range, which reaches `double.ToString("X")` and throws a `FormatException`. Here the operand stays `int` inside the int range, so `-1` keeps rendering as `ffffffff`, and becomes `long` outside it.

| value | before | after |
| --- | --- | --- |
| `3000000000` | `7FFFFFFF` | `B2D05E00` |
| `2147483648` | `7FFFFFFF` | `80000000` |

Not taken from #4565: the `async void` cleanup and the removed coercion in `SetValueTo`. Both behaviour-neutral, so no test can pin them.

## TimePicker

#4551: `ClockSelectedTimeChanged` fell back to `DateTime.Today`, storing `DateTimeKind.Local`, while the calendar and the text box produce `Unspecified`. The fallback is kind-less now, so all three paths agree.

#4586: the `DateTimeStyles` constant combined its flags with `&` and folded to `None`. Corrected to `|`.

The typo had no observable effect, contrary to the issue text: `None` and the three intended flags give identical results across 12 inputs in en-US and de-DE, including the `2 : 30` case named as the visible symptom. `TryParse` tolerates whitespace around separators without `AllowInnerWhite`, `NoCurrentDateDefault` cannot matter because only `TimeOfDay` is read, and `AssumeLocal` is discarded because the kind comes from the left operand. Those tests pin the parse behaviour and pass on either side of the fix.

Not taken from #4565: `AssumeLocal` on the `DateTimePicker` text parse. It makes the text path `Local` while the calendar path stays `Unspecified`, which is the inconsistency of #4551 rather than its fix.

## Tests

279 pass on net9.0, net8.0, net6.0 and net462.

Two fixture hardenings:

- `[TearDown]` ends an open edit. The control's editing flag is private and survives `ClearDependencyProperties`, so a test that types without committing silenced the text box update for every test after it.
- The template test has its own fixture. Re-applying a template leaves handlers that no `[SetUp]` can clear, which broke four existing tests through the shared control.
