### PR TITLE
test(TimePicker): pin the date the drop down falls back to

### DIFF
--- a/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
@@ -229,6 +229,10 @@ namespace MahApps.Metro.Tests.Tests
 
                 Assert.That(picker.SelectedDateTime, Is.Not.Null, "selecting an hour did not set a value");
                 Assert.That(picker.SelectedDateTime!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+
+                // On an empty picker the drop down fills the date from today, where the text
+                // path uses default(DateTime). Documented on the TimePicker page.
+                Assert.That(picker.SelectedDateTime!.Value.Date, Is.EqualTo(DateTime.Today));
             }
             finally
             {

--- a/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
@@ -225,14 +225,19 @@ namespace MahApps.Metro.Tests.Tests
                 var hourPicker = content.FindChild<Selector>("PART_HourPicker");
                 Assert.That(hourPicker, Is.Not.Null, "no PART_HourPicker inside the popup");
 
+                // The control reads DateTime.Today itself, so bracket the selection instead of
+                // reading it again afterwards. Both values are the same day unless the test
+                // happens to cross local midnight, and then either day is correct.
+                var dayBefore = DateTime.Today;
                 hourPicker.SetCurrentValue(Selector.SelectedIndexProperty, 7);
+                var dayAfter = DateTime.Today;
 
                 Assert.That(picker.SelectedDateTime, Is.Not.Null, "selecting an hour did not set a value");
                 Assert.That(picker.SelectedDateTime!.Value.Kind, Is.EqualTo(DateTimeKind.Unspecified));
 
                 // On an empty picker the drop down fills the date from today, where the text
                 // path uses default(DateTime). Documented on the TimePicker page.
-                Assert.That(picker.SelectedDateTime!.Value.Date, Is.EqualTo(DateTime.Today));
+                Assert.That(picker.SelectedDateTime!.Value.Date, Is.AnyOf(dayBefore, dayAfter));
             }
             finally
             {


### PR DESCRIPTION
Follow-up to #4587 and to the TimePicker page in [mahapps.com](https://github.com/MahApps/mahapps.com).

On an empty picker the date part depends on how the time was set:

| path | date | why |
| --- | --- | --- |
| typing | `0001-01-01` | `SetSelectedDateTime` keeps `SelectedDateTime.GetValueOrDefault().Date` |
| drop-down | today | `ClockSelectedTimeChanged` falls back to it |

The typing half was covered by `MilitaryTimeShouldBeConvertedToDateTime` and `ShouldParseTimeWithWhitespace`. The drop-down test asserted the kind but not the date, so half of the documented behaviour was unguarded. Four lines, no production change.

279 pass on net9.0, net8.0, net6.0 and net462.
