### PR TITLE
fix(HotKey): compare key and modifier keys with ==

### DIFF
--- a/src/MahApps.Metro/Controls/HotKey.cs
+++ b/src/MahApps.Metro/Controls/HotKey.cs
@@ -9,6 +9,10 @@ using Windows.Win32;
 
 namespace MahApps.Metro.Controls
 {
+    /// <summary>
+    /// An immutable key combination of one <see cref="System.Windows.Input.Key"/> and its <see cref="System.Windows.Input.ModifierKeys"/>.
+    /// Two instances that carry the same key and the same modifier keys are equal, for <see cref="Equals(HotKey)"/> as well as for <c>==</c>.
+    /// </summary>
     public class HotKey : IEquatable<HotKey>
     {
         public HotKey(Key key, ModifierKeys modifierKeys = ModifierKeys.None)
@@ -42,6 +46,28 @@ namespace MahApps.Metro.Controls
             }
 
             return this.Key == other.Key && this.ModifierKeys == other.ModifierKeys;
+        }
+
+        /// <summary>
+        /// Determines whether two <see cref="HotKey"/> instances describe the same key combination.
+        /// </summary>
+        /// <param name="left">The first hot key to compare, or <see langword="null"/>.</param>
+        /// <param name="right">The second hot key to compare, or <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> if both are <see langword="null"/> or both carry the same <see cref="Key"/> and <see cref="ModifierKeys"/>.</returns>
+        public static bool operator ==(HotKey? left, HotKey? right)
+        {
+            return left is null ? right is null : left.Equals(right);
+        }
+
+        /// <summary>
+        /// Determines whether two <see cref="HotKey"/> instances describe different key combinations.
+        /// </summary>
+        /// <param name="left">The first hot key to compare, or <see langword="null"/>.</param>
+        /// <param name="right">The second hot key to compare, or <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> if the two differ in <see cref="Key"/> or <see cref="ModifierKeys"/>, or if only one of them is <see langword="null"/>.</returns>
+        public static bool operator !=(HotKey? left, HotKey? right)
+        {
+            return !(left == right);
         }
 
         public override string ToString()

--- a/src/Mahapps.Metro.Tests/Tests/HotKeyTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/HotKeyTests.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Input;
+using MahApps.Metro.Controls;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class HotKeyTests
+    {
+        [Test]
+        public void ShouldTreatSameKeyAndModifierKeysAsEqual()
+        {
+            var first = new HotKey(Key.S, ModifierKeys.Control);
+            var second = new HotKey(Key.S, ModifierKeys.Control);
+
+            var areEqual = first == second;
+            var areNotEqual = first != second;
+
+            Assert.That(areEqual, Is.True);
+            Assert.That(areNotEqual, Is.False);
+        }
+
+        [Test]
+        public void ShouldNotTreatDifferentKeysAsEqual()
+        {
+            var first = new HotKey(Key.S, ModifierKeys.Control);
+            var second = new HotKey(Key.O, ModifierKeys.Control);
+
+            var areEqual = first == second;
+            var areNotEqual = first != second;
+
+            Assert.That(areEqual, Is.False);
+            Assert.That(areNotEqual, Is.True);
+        }
+
+        [Test]
+        public void ShouldNotTreatDifferentModifierKeysAsEqual()
+        {
+            var first = new HotKey(Key.S, ModifierKeys.Control);
+            var second = new HotKey(Key.S, ModifierKeys.Control | ModifierKeys.Shift);
+
+            var areEqual = first == second;
+            var areNotEqual = first != second;
+
+            Assert.That(areEqual, Is.False);
+            Assert.That(areNotEqual, Is.True);
+        }
+
+        [Test]
+        public void ShouldCompareAgainstNullWithoutThrowing()
+        {
+            var hotKey = new HotKey(Key.S, ModifierKeys.Control);
+            HotKey? nothing = null;
+            HotKey? alsoNothing = null;
+
+            var bothNullAreEqual = nothing == alsoNothing;
+            var nullOnTheRightIsEqual = hotKey == nothing;
+            var nullOnTheLeftIsEqual = nothing == hotKey;
+
+            Assert.That(bothNullAreEqual, Is.True);
+            Assert.That(nullOnTheRightIsEqual, Is.False);
+            Assert.That(nullOnTheLeftIsEqual, Is.False);
+            Assert.That(hotKey.Equals(null), Is.False);
+        }
+
+        [Test]
+        public void ShouldTreatTheSameInstanceAsEqual()
+        {
+            var hotKey = new HotKey(Key.S, ModifierKeys.Control);
+            var sameInstance = hotKey;
+
+            var areEqual = hotKey == sameInstance;
+
+            Assert.That(areEqual, Is.True);
+            Assert.That(hotKey.Equals(sameInstance), Is.True);
+        }
+
+        [Test]
+        public void ShouldReturnTheSameHashCodeForEqualHotKeys()
+        {
+            var first = new HotKey(Key.S, ModifierKeys.Control);
+            var second = new HotKey(Key.S, ModifierKeys.Control);
+
+            Assert.That(first.GetHashCode(), Is.EqualTo(second.GetHashCode()));
+        }
+    }
+}


### PR DESCRIPTION
Closes #4585

`HotKey` is immutable and overrides `Equals` and `GetHashCode`, but `==` fell back to reference equality. `HotKeyBox` hands out a new instance on every keystroke, so comparing a recorded hot key against a stored shortcut with `==` was always false.

`operator ==` and `operator !=` now delegate to `Equals` and take `null` on either side, and the class comment states the semantics.

New fixture `HotKeyTests` covers equal instances, a different key, different modifier keys, `null` on either side, the same instance, and hash code consistency. The first of those failed before the change.

The matching page in [mahapps.com](https://github.com/MahApps/mahapps.com) is already updated.

One thing left out on purpose: `HotKeyBox` raises `HotKeyChanged` even when the user presses the same combination again, because `OnHotKeyPropertyChanged` compares two `object` operands and WPF compares reference type DP values by reference. That is old behaviour and changing it changes when the event fires, so it is filed separately as #4590.