### PR TITLE
fix(HotKeyBox): raise HotKeyChanged only for a changed hot key

### DIFF
--- a/src/MahApps.Metro/Controls/HotKeyBox.cs
+++ b/src/MahApps.Metro/Controls/HotKeyBox.cs
@@ -27,9 +27,15 @@ namespace MahApps.Metro.Controls
         {
             if (d is HotKeyBox hotKeyBox)
             {
-                if (e.OldValue != e.NewValue)
+                // WPF compares dependency property values of reference types by reference, so this
+                // callback also runs for a new instance that describes the same hot key. Comparing
+                // the typed values keeps HotKeyChanged an event about a changed hot key.
+                var oldHotKey = e.OldValue as HotKey;
+                var newHotKey = e.NewValue as HotKey;
+
+                if (oldHotKey != newHotKey)
                 {
-                    hotKeyBox.RaiseEvent(new RoutedPropertyChangedEventArgs<HotKey?>(e.OldValue as HotKey, e.NewValue as HotKey, HotKeyChangedEvent));
+                    hotKeyBox.RaiseEvent(new RoutedPropertyChangedEventArgs<HotKey?>(oldHotKey, newHotKey, HotKeyChangedEvent));
                 }
 
                 hotKeyBox.UpdateText();

--- a/src/Mahapps.Metro.Tests/Tests/HotKeyBoxTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/HotKeyBoxTests.cs
@@ -1,0 +1,133 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class HotKeyBoxTests
+    {
+        private readonly IList<Action> detachHandlers = new List<Action>();
+
+        private HotKeyBoxWindow? window;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<HotKeyBoxWindow>().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.window?.TheHotKeyBox.ClearDependencyProperties();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // The window is shared by the whole fixture, so a recorder left attached would keep
+            // collecting the events of every test that follows.
+            foreach (var detach in this.detachHandlers)
+            {
+                detach();
+            }
+
+            this.detachHandlers.Clear();
+        }
+
+        [Test]
+        public void ShouldNotRaiseHotKeyChangedForAnEqualHotKey()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var recorded = this.RecordHotKeyChanges();
+
+            this.window.TheHotKeyBox.HotKey = new HotKey(Key.S, ModifierKeys.Control);
+            this.window.TheHotKeyBox.HotKey = new HotKey(Key.S, ModifierKeys.Control);
+
+            Assert.That(recorded, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public void ShouldRaiseHotKeyChangedForADifferentHotKey()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var recorded = this.RecordHotKeyChanges();
+
+            this.window.TheHotKeyBox.HotKey = new HotKey(Key.S, ModifierKeys.Control);
+            this.window.TheHotKeyBox.HotKey = new HotKey(Key.S, ModifierKeys.Control | ModifierKeys.Shift);
+            this.window.TheHotKeyBox.HotKey = new HotKey(Key.O, ModifierKeys.Control | ModifierKeys.Shift);
+
+            Assert.That(recorded, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public void ShouldRaiseHotKeyChangedWithTheOldAndTheNewHotKey()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var recorded = this.RecordHotKeyChanges();
+
+            this.window.TheHotKeyBox.HotKey = new HotKey(Key.S, ModifierKeys.Control);
+            this.window.TheHotKeyBox.HotKey = new HotKey(Key.O, ModifierKeys.Control);
+            this.window.TheHotKeyBox.HotKey = null;
+
+            Assert.That(recorded, Has.Count.EqualTo(3));
+
+            Assert.That(recorded[0].OldHotKey, Is.Null);
+            Assert.That(recorded[0].NewHotKey, Is.EqualTo(new HotKey(Key.S, ModifierKeys.Control)));
+
+            Assert.That(recorded[1].OldHotKey, Is.EqualTo(new HotKey(Key.S, ModifierKeys.Control)));
+            Assert.That(recorded[1].NewHotKey, Is.EqualTo(new HotKey(Key.O, ModifierKeys.Control)));
+
+            Assert.That(recorded[2].OldHotKey, Is.EqualTo(new HotKey(Key.O, ModifierKeys.Control)));
+            Assert.That(recorded[2].NewHotKey, Is.Null);
+        }
+
+        [Test]
+        public void ShouldUpdateTheTextWhenTheHotKeyChanges()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var hotKey = new HotKey(Key.S, ModifierKeys.Control);
+
+            this.window.TheHotKeyBox.HotKey = hotKey;
+            Assert.That(this.window.TheHotKeyBox.Text, Is.EqualTo(hotKey.ToString()));
+
+            this.window.TheHotKeyBox.HotKey = null;
+            Assert.That(this.window.TheHotKeyBox.Text, Is.Empty);
+        }
+
+        private IList<(HotKey? OldHotKey, HotKey? NewHotKey)> RecordHotKeyChanges()
+        {
+            var recorded = new List<(HotKey? OldHotKey, HotKey? NewHotKey)>();
+            this.window!.TheHotKeyBox.HotKeyChanged += OnHotKeyChanged;
+            this.detachHandlers.Add(() => this.window!.TheHotKeyBox.HotKeyChanged -= OnHotKeyChanged);
+            return recorded;
+
+            void OnHotKeyChanged(object sender, RoutedPropertyChangedEventArgs<HotKey?> e)
+            {
+                recorded.Add((e.OldValue, e.NewValue));
+            }
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Views/HotKeyBoxWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/HotKeyBoxWindow.xaml
@@ -1,0 +1,14 @@
+﻿<tests:TestWindow x:Class="MahApps.Metro.Tests.Views.HotKeyBoxWindow"
+                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                  xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:tests="clr-namespace:MahApps.Metro.Tests"
+                  d:DesignHeight="300"
+                  d:DesignWidth="300"
+                  mc:Ignorable="d">
+    <StackPanel>
+        <mah:HotKeyBox x:Name="TheHotKeyBox" />
+    </StackPanel>
+</tests:TestWindow>

--- a/src/Mahapps.Metro.Tests/Views/HotKeyBoxWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/HotKeyBoxWindow.xaml.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MahApps.Metro.Tests.Views
+{
+    public partial class HotKeyBoxWindow : TestWindow
+    {
+        public HotKeyBoxWindow()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Closes #4590

`OnHotKeyPropertyChanged` compared `e.OldValue` against `e.NewValue`. Both are typed as `object`, so the comparison stayed reference equality and the `HotKey` operators from #4589 never applied. WPF compares dependency property values of reference types by reference as well, which is why the callback runs for a new but equal instance in the first place, and `TextBoxOnPreviewKeyDown2` builds a new instance on every keystroke. Pressing Ctrl+S twice raised `HotKeyChanged` twice with two equal values.

The callback now compares the values as `HotKey`, so the event reports a hot key that actually changed. `UpdateText` still runs on every callback.

New fixture `HotKeyBoxTests` with the test window `Views/HotKeyBoxWindow.xaml` covers the repeated hot key, a changed hot key, the old and new values in the event args, and the text following the hot key. The first of those failed before the change.

The only handler in the library is `TextBoxHelper.OnHotKeyBoxHotKeyChanged`, which recomputes `TextLength` and `HasText` and gets the same values for an equal hot key. For consumers this changes when the event arrives, so it is worth a line in the release notes. The [mahapps.com](https://github.com/MahApps/mahapps.com) page now documents the event and its semantics.