### PR TITLE
fix(TransitioningContentControl): name the transition that could not be found

### DIFF
--- a/src/MahApps.Metro/Controls/TransitioningContentControl.cs
+++ b/src/MahApps.Metro/Controls/TransitioningContentControl.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -224,7 +223,7 @@ namespace MahApps.Metro.Controls
                     // revert to old value
                     source.SetValue(TransitionProperty, oldTransition);
 
-                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Temporary removed exception message", newTransition));
+                    throw new MahAppsException($"'{newTransition}' transition could not be found!");
                 }
             }
             else

--- a/src/Mahapps.Metro.Tests/Tests/TransitioningContentControlTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/TransitioningContentControlTests.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class TransitioningContentControlTests
+    {
+        private TransitioningContentControlWindow? window;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<TransitioningContentControlWindow>().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.window?.TheTransitioningContentControl.ClearDependencyProperties(new[] { nameof(TransitioningContentControl.Transition), nameof(TransitioningContentControl.CustomVisualStatesName) });
+        }
+
+        [Test]
+        public void ShouldNameTheTransitionThatCouldNotBeFound()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            this.window.TheTransitioningContentControl.CustomVisualStatesName = "ThisStateDoesNotExist";
+
+            var exception = Assert.Throws<MahAppsException>(() => this.window.TheTransitioningContentControl.Transition = TransitionType.Custom);
+
+            Assert.That(exception?.Message, Is.EqualTo("'Custom' transition could not be found!"));
+        }
+
+        [Test]
+        public void ShouldKeepThePreviousTransitionWhenTheNewOneCouldNotBeFound()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            this.window.TheTransitioningContentControl.Transition = TransitionType.Left;
+            this.window.TheTransitioningContentControl.CustomVisualStatesName = "ThisStateDoesNotExist";
+
+            Assert.Throws<MahAppsException>(() => this.window.TheTransitioningContentControl.Transition = TransitionType.Custom);
+
+            Assert.That(this.window.TheTransitioningContentControl.Transition, Is.EqualTo(TransitionType.Left));
+        }
+
+        [Test]
+        public void ShouldAcceptACustomTransitionThatExists()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            Assert.That(this.window.TheTransitioningContentControl.CustomVisualStatesName, Is.EqualTo("CustomTransition"));
+
+            Assert.DoesNotThrow(() => this.window.TheTransitioningContentControl.Transition = TransitionType.Custom);
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Views/TransitioningContentControlWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/TransitioningContentControlWindow.xaml
@@ -1,0 +1,27 @@
+﻿<tests:TestWindow x:Class="MahApps.Metro.Tests.Views.TransitioningContentControlWindow"
+                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                  xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:tests="clr-namespace:MahApps.Metro.Tests"
+                  d:DesignHeight="300"
+                  d:DesignWidth="300"
+                  mc:Ignorable="d">
+    <StackPanel>
+        <mah:TransitioningContentControl x:Name="TheTransitioningContentControl">
+            <mah:TransitioningContentControl.CustomVisualStates>
+                <VisualState x:Name="CustomTransition">
+                    <Storyboard>
+                        <DoubleAnimation Storyboard.TargetName="CurrentContentPresentationSite"
+                                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                                         From="0"
+                                         To="1"
+                                         Duration="00:00:00.100" />
+                    </Storyboard>
+                </VisualState>
+            </mah:TransitioningContentControl.CustomVisualStates>
+            <TextBlock Text="Content" />
+        </mah:TransitioningContentControl>
+    </StackPanel>
+</tests:TestWindow>

--- a/src/Mahapps.Metro.Tests/Views/TransitioningContentControlWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/TransitioningContentControlWindow.xaml.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MahApps.Metro.Tests.Views
+{
+    public partial class TransitioningContentControlWindow : TestWindow
+    {
+        public TransitioningContentControlWindow()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Closes #4584

`OnTransitionPropertyChanged` threw an `ArgumentException` whose message was the placeholder `Temporary removed exception message`. The format string had no placeholder either, so `newTransition`, the one useful piece of information, went into `string.Format` and was dropped.

The callback now throws the same `MahAppsException` that `OnApplyTemplate` already throws when a transition cannot be found, so both paths report it the same way. `System.Globalization` became unused and the using is gone.

New fixture `TransitioningContentControlTests` with the test window `Views/TransitioningContentControlWindow.xaml` covers the exception type and message, the revert to the previous transition, and a custom transition that exists. The first two failed before the change, the stack trace showing `System.ArgumentException: Temporary removed exception message`.

Two things for the release notes:

- The message names the `TransitionType`, so a mistyped `CustomVisualStatesName` reads as `'Custom' transition could not be found!` rather than naming the state. That matches `OnApplyTemplate` and is what the issue asked for. Naming the looked-up state in both paths would be a separate change.
- The exception type changes from `ArgumentException` to `MahAppsException`, which derives from `Exception`. A consumer catching `ArgumentException` around a `Transition` assignment no longer catches it. Real-world risk is small, since the old message was the placeholder.

The [mahapps.com](https://github.com/MahApps/mahapps.com) page documented the placeholder and is updated.

What the revert around the throw does with a binding, and two older problems in the same method, are filed separately in #4593.