### PR TITLE
fix(TransitioningContentControl): coerce the transition and let a parent hand it down

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,5 @@
+---
+# The generated .g.i.cs half of a WPF code behind file is not part of the analysis, so the
+# partial modifier that the compiler requires there is reported as gratuitous (SonarC# S2333).
+exclude_paths:
+  - "**/*.xaml.cs"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/OtherExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/OtherExamples.xaml
@@ -16,13 +16,6 @@
     <UserControl.Resources>
         <ResourceDictionary>
 
-            <!--  better results for this examples  -->
-            <Style BasedOn="{StaticResource {x:Type mah:TransitioningContentControl}}" TargetType="{x:Type mah:TransitioningContentControl}">
-                <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
-                <Setter Property="TextOptions.TextFormattingMode" Value="Display" />
-                <Setter Property="TextOptions.TextRenderingMode" Value="ClearType" />
-            </Style>
-
             <DataTemplate x:Key="ImageDataTemplate" x:Shared="False">
                 <Image Source="{Binding Mode=OneWay, FallbackValue={x:Static DependencyProperty.UnsetValue}, Converter={mah:NullToUnsetValueConverter}}" Stretch="Fill" />
             </DataTemplate>
@@ -40,69 +33,6 @@
             <RowDefinition />
             <RowDefinition />
         </Grid.RowDefinitions>
-
-        <StackPanel Grid.Column="0">
-            <Label Content="Transitions" Style="{DynamicResource DescriptionHeaderStyle}" />
-            <mah:TransitioningContentControl x:Name="transitioning"
-                                             Width="250"
-                                             Height="50"
-                                             Margin="0 10 0 0"
-                                             Transition="Down" />
-            <mah:TransitioningContentControl x:Name="customTransitioning"
-                                             Width="250"
-                                             Height="50"
-                                             Margin="0 10 0 0"
-                                             Transition="Custom">
-                <mah:TransitioningContentControl.CustomVisualStates>
-                    <VisualState x:Name="CustomTransition">
-                        <Storyboard>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
-                                                           Storyboard.TargetName="CurrentContentPresentationSite"
-                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
-                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="0" />
-                                <SplineDoubleKeyFrame KeyTime="00:00:00.700" Value="1" />
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
-                                                           Storyboard.TargetName="PreviousContentPresentationSite"
-                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
-                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="1" />
-                                <SplineDoubleKeyFrame KeyTime="00:00:00.700" Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualState>
-                </mah:TransitioningContentControl.CustomVisualStates>
-            </mah:TransitioningContentControl>
-            <mah:TransitioningContentControl x:Name="SecondcustomTransitioning"
-                                             Width="250"
-                                             Height="50"
-                                             Margin="0 10 0 0"
-                                             CustomVisualStatesName="SecondCustomTransition"
-                                             Transition="Custom">
-                <mah:TransitioningContentControl.CustomVisualStates>
-                    <VisualState x:Name="SecondCustomTransition">
-                        <Storyboard>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
-                                                           Storyboard.TargetName="CurrentContentPresentationSite"
-                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
-                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="0" />
-                                <SplineDoubleKeyFrame KeyTime="00:00:00.5" Value="0" />
-                                <EasingDoubleKeyFrame KeyTime="00:00:01" Value="1">
-                                    <EasingDoubleKeyFrame.EasingFunction>
-                                        <SineEase />
-                                    </EasingDoubleKeyFrame.EasingFunction>
-                                </EasingDoubleKeyFrame>
-                            </DoubleAnimationUsingKeyFrames>
-                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
-                                                           Storyboard.TargetName="PreviousContentPresentationSite"
-                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
-                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="1" />
-                                <SplineDoubleKeyFrame KeyTime="00:00:00.5" Value="0" />
-                            </DoubleAnimationUsingKeyFrames>
-                        </Storyboard>
-                    </VisualState>
-                </mah:TransitioningContentControl.CustomVisualStates>
-            </mah:TransitioningContentControl>
-        </StackPanel>
 
         <StackPanel Grid.Row="0"
                     Grid.RowSpan="2"
@@ -255,7 +185,9 @@
             </StackPanel>
         </StackPanel>
 
-        <Grid Grid.Row="1" Grid.Column="0">
+        <Grid Grid.Row="0"
+              Grid.RowSpan="2"
+              Grid.Column="0">
             <Label Content="Context menu" Style="{DynamicResource DescriptionHeaderStyle}" />
             <Label HorizontalAlignment="Stretch"
                    VerticalAlignment="Stretch"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/OtherExamples.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/OtherExamples.xaml.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Windows.Controls;
-using System.Windows.Threading;
 
 namespace MetroDemo.ExampleViews
 {
@@ -16,21 +14,6 @@ namespace MetroDemo.ExampleViews
         public OtherExamples()
         {
             this.InitializeComponent();
-
-            var t = new DispatcherTimer(TimeSpan.FromSeconds(2), DispatcherPriority.Normal, this.Tick, this.Dispatcher);
-        }
-
-        void Tick(object? sender, EventArgs e)
-        {
-            if (this.IsVisible == false)
-            {
-                return;
-            }
-
-            var dateTime = DateTime.Now;
-            this.transitioning.Content = new TextBlock { Text = "Transitioning Content! " + dateTime, SnapsToDevicePixels = true };
-            this.customTransitioning.Content = new TextBlock { Text = "Custom transistion! " + dateTime, SnapsToDevicePixels = true };
-            this.SecondcustomTransitioning.Content = new TextBlock { Text = "Second custom transistion! " + dateTime, SnapsToDevicePixels = true };
         }
     }
 }

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TransitionExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TransitionExamples.xaml
@@ -1,0 +1,300 @@
+﻿<UserControl x:Class="MetroDemo.ExampleViews.TransitionExamples"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:models="clr-namespace:MetroDemo.Models"
+             xmlns:mx="clr-namespace:MetroDemo.Markup"
+             d:DesignHeight="800"
+             d:DesignWidth="1000"
+             mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+
+            <!--  better results for this examples  -->
+            <Style BasedOn="{StaticResource {x:Type mah:TransitioningContentControl}}" TargetType="{x:Type mah:TransitioningContentControl}">
+                <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
+                <Setter Property="TextOptions.TextFormattingMode" Value="Display" />
+                <Setter Property="TextOptions.TextRenderingMode" Value="ClearType" />
+            </Style>
+
+            <DataTemplate x:Key="TransitionContentTemplate" DataType="{x:Type models:TransitionContent}">
+                <Border x:Name="ContentBorder" Background="{DynamicResource MahApps.Brushes.Accent}">
+                    <TextBlock HorizontalAlignment="Center"
+                               VerticalAlignment="Center"
+                               Foreground="{DynamicResource MahApps.Brushes.IdealForeground}"
+                               Text="{Binding Text, Mode=OneWay}" />
+                </Border>
+                <DataTemplate.Triggers>
+                    <DataTrigger Binding="{Binding IsEven, Mode=OneWay}" Value="True">
+                        <Setter TargetName="ContentBorder" Property="Background" Value="{DynamicResource MahApps.Brushes.Accent3}" />
+                    </DataTrigger>
+                </DataTemplate.Triggers>
+            </DataTemplate>
+
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid Margin="4">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <StackPanel Grid.Column="0" Margin="0 0 20 0">
+
+            <Label Content="Playground" Style="{DynamicResource DescriptionHeaderStyle}" />
+
+            <TextBlock MaxWidth="340"
+                       Margin="0 4 0 0"
+                       HorizontalAlignment="Left"
+                       Text="Assign a new Content and the old one is animated out while the new one is animated in. Click Change content twice in a row to see what RestartTransitionOnContentChange does."
+                       TextWrapping="Wrap" />
+
+            <Grid Margin="0 8 0 0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Label Grid.Row="0"
+                       Grid.Column="0"
+                       VerticalAlignment="Center"
+                       Content="Transition" />
+                <ComboBox Grid.Row="0"
+                          Grid.Column="1"
+                          Width="160"
+                          Margin="4"
+                          HorizontalAlignment="Left"
+                          ItemsSource="{Binding Source={mx:EnumBindingSource {x:Type mah:TransitionType}}, Mode=OneTime}"
+                          SelectedValue="{Binding ElementName=PlaygroundTransition, Path=Transition, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                <CheckBox Grid.Row="1"
+                          Grid.Column="1"
+                          Margin="4"
+                          Content="RestartTransitionOnContentChange"
+                          IsChecked="{Binding ElementName=PlaygroundTransition, Path=RestartTransitionOnContentChange, Mode=TwoWay}" />
+            </Grid>
+
+            <mah:TransitioningContentControl x:Name="PlaygroundTransition"
+                                             Width="340"
+                                             Height="120"
+                                             Margin="0 8 0 0"
+                                             HorizontalAlignment="Left"
+                                             Content="{Binding PlaygroundContent, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=OneWay}"
+                                             ContentTemplate="{StaticResource TransitionContentTemplate}"
+                                             CustomVisualStatesName="PlaygroundCustomTransition"
+                                             TransitionCompleted="OnPlaygroundTransitionCompleted">
+                <mah:TransitioningContentControl.CustomVisualStates>
+                    <VisualState x:Name="PlaygroundCustomTransition">
+                        <Storyboard>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                                           Storyboard.TargetName="CurrentContentPresentationSite"
+                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
+                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="0" />
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.700" Value="1" />
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                                           Storyboard.TargetName="PreviousContentPresentationSite"
+                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
+                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="1" />
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.700" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                </mah:TransitioningContentControl.CustomVisualStates>
+            </mah:TransitioningContentControl>
+
+            <StackPanel Margin="0 8 0 0" Orientation="Horizontal">
+                <Button Width="120"
+                        Margin="0 0 4 0"
+                        Click="OnChangeContentClick"
+                        Content="Change content" />
+                <Button Width="120"
+                        Margin="0 0 4 0"
+                        Click="OnReloadTransitionClick"
+                        Content="ReloadTransition" />
+                <Button Width="120"
+                        Click="OnAbortTransitionClick"
+                        Content="AbortTransition" />
+            </StackPanel>
+
+            <TextBlock Margin="0 8 0 0">
+                <Run Text="IsTransitioning:" />
+                <Run FontWeight="Bold" Text="{Binding ElementName=PlaygroundTransition, Path=IsTransitioning, Mode=OneWay}" />
+                <Run Text="   TransitionCompleted was raised" />
+                <Run FontWeight="Bold" Text="{Binding CompletedCount, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=OneWay}" />
+                <Run Text="times" />
+            </TextBlock>
+
+            <Separator Margin="0 12" />
+
+            <Label Content="Custom transitions" Style="{DynamicResource DescriptionHeaderStyle}" />
+
+            <TextBlock MaxWidth="340"
+                       Margin="0 4 0 0"
+                       HorizontalAlignment="Left"
+                       Text="Transition Custom plays the VisualState named by CustomVisualStatesName, which defaults to CustomTransition. The state itself goes into CustomVisualStates and animates the two presenters CurrentContentPresentationSite and PreviousContentPresentationSite."
+                       TextWrapping="Wrap" />
+
+            <mah:TransitioningContentControl x:Name="CustomTransitioning"
+                                             Width="340"
+                                             Height="50"
+                                             Margin="0 8 0 0"
+                                             HorizontalAlignment="Left"
+                                             Content="{Binding TickContent, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=OneWay}"
+                                             ContentTemplate="{StaticResource TransitionContentTemplate}"
+                                             Transition="Custom">
+                <mah:TransitioningContentControl.CustomVisualStates>
+                    <VisualState x:Name="CustomTransition">
+                        <Storyboard>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                                           Storyboard.TargetName="CurrentContentPresentationSite"
+                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
+                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="0" />
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.700" Value="1" />
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                                           Storyboard.TargetName="PreviousContentPresentationSite"
+                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
+                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="1" />
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.700" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                </mah:TransitioningContentControl.CustomVisualStates>
+            </mah:TransitioningContentControl>
+
+            <mah:TransitioningContentControl x:Name="SecondCustomTransitioning"
+                                             Width="340"
+                                             Height="50"
+                                             Margin="0 8 0 0"
+                                             HorizontalAlignment="Left"
+                                             Content="{Binding TickContent, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=OneWay}"
+                                             ContentTemplate="{StaticResource TransitionContentTemplate}"
+                                             CustomVisualStatesName="SecondCustomTransition"
+                                             Transition="Custom">
+                <mah:TransitioningContentControl.CustomVisualStates>
+                    <VisualState x:Name="SecondCustomTransition">
+                        <Storyboard>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                                           Storyboard.TargetName="CurrentContentPresentationSite"
+                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
+                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="0" />
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.5" Value="0" />
+                                <EasingDoubleKeyFrame KeyTime="00:00:01" Value="1">
+                                    <EasingDoubleKeyFrame.EasingFunction>
+                                        <SineEase />
+                                    </EasingDoubleKeyFrame.EasingFunction>
+                                </EasingDoubleKeyFrame>
+                            </DoubleAnimationUsingKeyFrames>
+                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                                           Storyboard.TargetName="PreviousContentPresentationSite"
+                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
+                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="1" />
+                                <SplineDoubleKeyFrame KeyTime="00:00:00.5" Value="0" />
+                            </DoubleAnimationUsingKeyFrames>
+                        </Storyboard>
+                    </VisualState>
+                </mah:TransitioningContentControl.CustomVisualStates>
+            </mah:TransitioningContentControl>
+
+            <Separator Margin="0 12" />
+
+            <Label Content="Inherited transition" Style="{DynamicResource DescriptionHeaderStyle}" />
+
+            <TextBlock MaxWidth="340"
+                       Margin="0 4 0 0"
+                       HorizontalAlignment="Left"
+                       Text="Transition is an attached property with FrameworkPropertyMetadataOptions.Inherits. Set it once on a parent panel and every TransitioningContentControl underneath follows, as long as it has no transition of its own."
+                       TextWrapping="Wrap" />
+
+            <ComboBox x:Name="InheritedTransitionComboBox"
+                      Width="160"
+                      Margin="4"
+                      HorizontalAlignment="Left"
+                      ItemsSource="{Binding Source={mx:EnumBindingSource {x:Type mah:TransitionType}}, Mode=OneTime}"
+                      SelectedValue="{x:Static mah:TransitionType.Right}" />
+
+            <StackPanel mah:TransitioningContentControl.Transition="{Binding ElementName=InheritedTransitionComboBox, Path=SelectedValue, Mode=OneWay}">
+                <mah:TransitioningContentControl Width="340"
+                                                 Height="50"
+                                                 Margin="0 4 0 0"
+                                                 HorizontalAlignment="Left"
+                                                 Content="{Binding TickContent, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=OneWay}"
+                                                 ContentTemplate="{StaticResource TransitionContentTemplate}" />
+                <mah:TransitioningContentControl Width="340"
+                                                 Height="50"
+                                                 Margin="0 4 0 0"
+                                                 HorizontalAlignment="Left"
+                                                 Content="{Binding TickContent, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=OneWay}"
+                                                 ContentTemplate="{StaticResource TransitionContentTemplate}" />
+            </StackPanel>
+
+        </StackPanel>
+
+        <StackPanel Grid.Column="1" HorizontalAlignment="Left">
+
+            <Label Content="All transition types" Style="{DynamicResource DescriptionHeaderStyle}" />
+
+            <TextBlock MaxWidth="760"
+                       Margin="0 4 0 8"
+                       HorizontalAlignment="Left"
+                       Text="Every value of TransitionType, fed with the same content every two seconds. Custom plays the state named CustomTransition, which is a slow cross fade here."
+                       TextWrapping="Wrap" />
+
+            <ItemsControl MaxWidth="760"
+                          HorizontalAlignment="Left"
+                          ItemsSource="{Binding Source={mx:EnumBindingSource {x:Type mah:TransitionType}}, Mode=OneTime}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <UniformGrid Columns="3" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Margin="0 0 8 12">
+                            <TextBlock Margin="0 0 0 2"
+                                       FontWeight="Bold"
+                                       Text="{Binding Mode=OneWay}" />
+                            <mah:TransitioningContentControl Width="230"
+                                                             Height="70"
+                                                             HorizontalAlignment="Left"
+                                                             Content="{Binding TickContent, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=OneWay}"
+                                                             ContentTemplate="{StaticResource TransitionContentTemplate}"
+                                                             Transition="{Binding Mode=OneWay}">
+                                <mah:TransitioningContentControl.CustomVisualStates>
+                                    <VisualState x:Name="CustomTransition">
+                                        <Storyboard>
+                                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                                                           Storyboard.TargetName="CurrentContentPresentationSite"
+                                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="0" />
+                                                <SplineDoubleKeyFrame KeyTime="00:00:01" Value="1" />
+                                            </DoubleAnimationUsingKeyFrames>
+                                            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00"
+                                                                           Storyboard.TargetName="PreviousContentPresentationSite"
+                                                                           Storyboard.TargetProperty="(UIElement.Opacity)">
+                                                <SplineDoubleKeyFrame KeyTime="00:00:00" Value="1" />
+                                                <SplineDoubleKeyFrame KeyTime="00:00:01" Value="0" />
+                                            </DoubleAnimationUsingKeyFrames>
+                                        </Storyboard>
+                                    </VisualState>
+                                </mah:TransitioningContentControl.CustomVisualStates>
+                            </mah:TransitioningContentControl>
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+        </StackPanel>
+
+    </Grid>
+
+</UserControl>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TransitionExamples.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/TransitionExamples.xaml.cs
@@ -1,0 +1,126 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using MetroDemo.Models;
+
+namespace MetroDemo.ExampleViews
+{
+    /// <summary>
+    /// Interaction logic for TransitionExamples.xaml
+    /// </summary>
+    public partial class TransitionExamples : UserControl
+    {
+        private readonly DispatcherTimer timer;
+        private int contentNumber;
+
+        /// <summary>Identifies the <see cref="TickContent"/> dependency property.</summary>
+        public static readonly DependencyProperty TickContentProperty
+            = DependencyProperty.Register(nameof(TickContent),
+                                          typeof(object),
+                                          typeof(TransitionExamples),
+                                          new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets the content which is replaced every two seconds.
+        /// </summary>
+        public object? TickContent
+        {
+            get => this.GetValue(TickContentProperty);
+            private set => this.SetValue(TickContentProperty, value);
+        }
+
+        /// <summary>Identifies the <see cref="PlaygroundContent"/> dependency property.</summary>
+        public static readonly DependencyProperty PlaygroundContentProperty
+            = DependencyProperty.Register(nameof(PlaygroundContent),
+                                          typeof(object),
+                                          typeof(TransitionExamples),
+                                          new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets the content which is replaced by the Change content button.
+        /// </summary>
+        public object? PlaygroundContent
+        {
+            get => this.GetValue(PlaygroundContentProperty);
+            private set => this.SetValue(PlaygroundContentProperty, value);
+        }
+
+        /// <summary>Identifies the <see cref="CompletedCount"/> dependency property.</summary>
+        public static readonly DependencyProperty CompletedCountProperty
+            = DependencyProperty.Register(nameof(CompletedCount),
+                                          typeof(int),
+                                          typeof(TransitionExamples),
+                                          new PropertyMetadata(0));
+
+        /// <summary>
+        /// Gets how often the playground control has raised its TransitionCompleted event.
+        /// </summary>
+        public int CompletedCount
+        {
+            get => (int)this.GetValue(CompletedCountProperty);
+            private set => this.SetValue(CompletedCountProperty, value);
+        }
+
+        public TransitionExamples()
+        {
+            this.InitializeComponent();
+
+            this.TickContent = this.NextContent();
+            this.PlaygroundContent = this.NextContent();
+
+
+            this.timer = new DispatcherTimer(TimeSpan.FromSeconds(2), DispatcherPriority.Normal, this.OnTick, this.Dispatcher);
+            this.timer.Stop();
+
+            this.IsVisibleChanged += this.OnIsVisibleChanged;
+        }
+
+        private TransitionContent NextContent()
+        {
+            return new TransitionContent(++this.contentNumber);
+        }
+
+        private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if ((bool)e.NewValue)
+            {
+                this.timer.Start();
+            }
+            else
+            {
+                this.timer.Stop();
+            }
+        }
+
+        private void OnTick(object? sender, EventArgs e)
+        {
+            this.TickContent = this.NextContent();
+        }
+
+        private void OnChangeContentClick(object sender, RoutedEventArgs e)
+        {
+            this.PlaygroundContent = this.NextContent();
+        }
+
+        private void OnReloadTransitionClick(object sender, RoutedEventArgs e)
+        {
+            this.PlaygroundTransition.ReloadTransition();
+        }
+
+        private void OnAbortTransitionClick(object sender, RoutedEventArgs e)
+        {
+            this.PlaygroundTransition.AbortTransition();
+        }
+
+        private void OnPlaygroundTransitionCompleted(object sender, RoutedEventArgs e)
+        {
+            this.CompletedCount++;
+        }
+
+    }
+}

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
@@ -395,6 +395,14 @@
                 <exampleViews:MultiSelectionComboBoxExample />
             </TabItem>
 
+            <TabItem Header="transitions">
+                <ScrollViewer Margin="2"
+                              HorizontalScrollBarVisibility="Auto"
+                              VerticalScrollBarVisibility="Auto">
+                    <exampleViews:TransitionExamples />
+                </ScrollViewer>
+            </TabItem>
+
             <TabItem Header="others">
                 <ScrollViewer Margin="2"
                               HorizontalScrollBarVisibility="Auto"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/TransitionContent.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/TransitionContent.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MetroDemo.Models
+{
+    /// <summary>
+    /// The content used by the TransitioningContentControl examples. It is a plain data object, so the
+    /// same instance can be the content of more than one control at a time.
+    /// </summary>
+    public class TransitionContent
+    {
+        public TransitionContent(int number)
+        {
+            this.Number = number;
+        }
+
+        public int Number { get; }
+
+        public string Text => $"Content {this.Number}";
+
+        /// <summary>
+        /// Used by the example template to alternate the background, which makes the transition easier to follow.
+        /// </summary>
+        public bool IsEven => this.Number % 2 == 0;
+    }
+}

--- a/src/MahApps.Metro/Controls/TransitioningContentControl.cs
+++ b/src/MahApps.Metro/Controls/TransitioningContentControl.cs
@@ -107,7 +107,7 @@ namespace MahApps.Metro.Controls
             = DependencyProperty.Register(nameof(Transition),
                                           typeof(TransitionType),
                                           typeof(TransitioningContentControl),
-                                          new FrameworkPropertyMetadata(TransitionType.Default, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits, OnTransitionPropertyChanged));
+                                          new FrameworkPropertyMetadata(TransitionType.Default, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits, OnTransitionPropertyChanged, CoerceTransition));
 
         /// <summary>
         /// Gets or sets the transition type.
@@ -195,41 +195,51 @@ namespace MahApps.Metro.Controls
             }
         }
 
+        private static object CoerceTransition(DependencyObject d, object? baseValue)
+        {
+            var source = (TransitioningContentControl)d;
+
+            if (baseValue is not TransitionType newTransition)
+            {
+                return DefaultTransitionState;
+            }
+
+            // Could be during initialization of xaml that the presentation group was not yet defined.
+            // The value is checked again in OnApplyTemplate, so take it as it is for now.
+            if (VisualStates.TryGetVisualStateGroup(source, PresentationGroup) is null)
+            {
+                return baseValue;
+            }
+
+            if (source.GetStoryboard(newTransition) is not null)
+            {
+                return baseValue;
+            }
+
+            // The transition could not be found, so keep the transition the control has right now.
+            // Coercing instead of writing the old value back from inside the changed callback leaves
+            // a binding on Transition alone and cannot recurse. If that transition cannot be resolved
+            // either, which happens for a template without any of the known states, fall back to the
+            // default one and let the control live without a transition.
+            var currentTransition = (TransitionType)source.GetValue(TransitionProperty);
+
+            return source.GetStoryboard(currentTransition) is not null
+                ? currentTransition
+                : DefaultTransitionState;
+        }
+
         private static void OnTransitionPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var source = (TransitioningContentControl)d;
-            var oldTransition = (TransitionType)e.OldValue;
-            var newTransition = (TransitionType)e.NewValue;
 
             if (source.IsTransitioning)
             {
                 source.AbortTransition();
             }
 
-            // find new transition
-            var newStoryboard = source.GetStoryboard(newTransition);
-
-            // unable to find the transition.
-            if (newStoryboard is null)
-            {
-                // could be during initialization of xaml that presentationgroups was not yet defined
-                if (VisualStates.TryGetVisualStateGroup(source, PresentationGroup) is null)
-                {
-                    // will delay check
-                    source.CurrentTransition = null;
-                }
-                else
-                {
-                    // revert to old value
-                    source.SetValue(TransitionProperty, oldTransition);
-
-                    throw new MahAppsException($"'{newTransition}' transition could not be found!");
-                }
-            }
-            else
-            {
-                source.CurrentTransition = newStoryboard;
-            }
+            // The value passed the coercion, so it is either a transition that could be found
+            // or one that has to be checked again as soon as the template is applied.
+            source.CurrentTransition = source.GetStoryboard((TransitionType)e.NewValue);
         }
 
         private static void OnRestartTransitionOnContentChangePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -272,16 +282,9 @@ namespace MahApps.Metro.Controls
             this.currentContentPresentationSite = this.GetTemplateChild(CurrentContentPresentationSitePartName) as ContentPresenter;
 
             // hookup currenttransition
-            var transition = this.GetStoryboard(this.Transition);
-            this.CurrentTransition = transition;
-            if (transition is null)
-            {
-                var invalidTransition = this.Transition;
-                // revert to default
-                this.Transition = DefaultTransitionState;
-
-                throw new MahAppsException($"'{invalidTransition}' transition could not be found!");
-            }
+            // The states are known now, so let the coercion decide whether the current transition survives the new template.
+            this.CoerceValue(TransitionProperty);
+            this.CurrentTransition = this.GetStoryboard(this.Transition);
 
             VisualStateManager.GoToState(this, HiddenState, false);
         }

--- a/src/MahApps.Metro/Controls/TransitioningContentControl.cs
+++ b/src/MahApps.Metro/Controls/TransitioningContentControl.cs
@@ -103,11 +103,30 @@ namespace MahApps.Metro.Controls
             }
         }
 
+        /// <summary>Identifies the <see cref="Transition"/> dependency property.</summary>
+        /// <remarks>
+        /// This is an attached property, so the transition can be set on any element above the control and
+        /// every <see cref="TransitioningContentControl"/> underneath inherits it.
+        /// </remarks>
         public static readonly DependencyProperty TransitionProperty
-            = DependencyProperty.Register(nameof(Transition),
-                                          typeof(TransitionType),
-                                          typeof(TransitioningContentControl),
-                                          new FrameworkPropertyMetadata(TransitionType.Default, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits, OnTransitionPropertyChanged, CoerceTransition));
+            = DependencyProperty.RegisterAttached(nameof(Transition),
+                                                  typeof(TransitionType),
+                                                  typeof(TransitioningContentControl),
+                                                  new FrameworkPropertyMetadata(TransitionType.Default, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.Inherits, OnTransitionPropertyChanged, CoerceTransition));
+
+        /// <summary>Helper for getting <see cref="TransitionProperty"/> from <paramref name="element"/>.</summary>
+        [AttachedPropertyBrowsableForType(typeof(DependencyObject))]
+        public static TransitionType GetTransition(DependencyObject element)
+        {
+            return (TransitionType)element.GetValue(TransitionProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="TransitionProperty"/> on <paramref name="element"/>.</summary>
+        [AttachedPropertyBrowsableForType(typeof(DependencyObject))]
+        public static void SetTransition(DependencyObject element, TransitionType value)
+        {
+            element.SetValue(TransitionProperty, value);
+        }
 
         /// <summary>
         /// Gets or sets the transition type.
@@ -197,11 +216,16 @@ namespace MahApps.Metro.Controls
 
         private static object CoerceTransition(DependencyObject d, object? baseValue)
         {
-            var source = (TransitioningContentControl)d;
-
             if (baseValue is not TransitionType newTransition)
             {
                 return DefaultTransitionState;
+            }
+
+            // The property is attached, so it can sit on any element above the control. Only a control
+            // knows its visual states, everything else passes the value on to its children untouched.
+            if (d is not TransitioningContentControl source)
+            {
+                return baseValue;
             }
 
             // Could be during initialization of xaml that the presentation group was not yet defined.
@@ -230,7 +254,10 @@ namespace MahApps.Metro.Controls
 
         private static void OnTransitionPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            var source = (TransitioningContentControl)d;
+            if (d is not TransitioningContentControl source)
+            {
+                return;
+            }
 
             if (source.IsTransitioning)
             {

--- a/src/MahApps.Metro/Themes/TransitioningContentControl.xaml
+++ b/src/MahApps.Metro/Themes/TransitioningContentControl.xaml
@@ -371,7 +371,6 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="Transition" Value="Default" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
     </Style>
 

--- a/src/Mahapps.Metro.Tests/Tests/TransitioningContentControlTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/TransitioningContentControlTests.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Data;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Tests.TestHelpers;
@@ -17,26 +17,24 @@ namespace MahApps.Metro.Tests.Tests
     {
         private TransitioningContentControlWindow? window;
 
-        private sealed class TransitionViewModel : INotifyPropertyChanged
+        /// <summary>
+        /// The binding source for the tests. A DependencyObject notifies the binding on its own,
+        /// so the source needs no INotifyPropertyChanged of its own.
+        /// </summary>
+        private sealed class TransitionSource : DependencyObject
         {
-            private TransitionType transition;
+            /// <summary>Identifies the <see cref="Transition"/> dependency property.</summary>
+            public static readonly DependencyProperty TransitionProperty
+                = DependencyProperty.Register(nameof(Transition),
+                                              typeof(TransitionType),
+                                              typeof(TransitionSource),
+                                              new PropertyMetadata(TransitioningContentControl.DefaultTransitionState));
 
             public TransitionType Transition
             {
-                get => this.transition;
-                set
-                {
-                    if (value == this.transition)
-                    {
-                        return;
-                    }
-
-                    this.transition = value;
-                    this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.Transition)));
-                }
+                get => (TransitionType)this.GetValue(TransitionProperty);
+                set => this.SetValue(TransitionProperty, value);
             }
-
-            public event PropertyChangedEventHandler? PropertyChanged;
         }
 
         [OneTimeSetUp]
@@ -80,18 +78,18 @@ namespace MahApps.Metro.Tests.Tests
 
             this.window.TheTransitioningContentControl.CustomVisualStatesName = "ThisStateDoesNotExist";
 
-            var viewModel = new TransitionViewModel { Transition = TransitionType.Left };
+            var source = new TransitionSource { Transition = TransitionType.Left };
             BindingOperations.SetBinding(this.window.TheTransitioningContentControl,
                                          TransitioningContentControl.TransitionProperty,
-                                         new Binding(nameof(TransitionViewModel.Transition)) { Source = viewModel });
+                                         new Binding(nameof(TransitionSource.Transition)) { Source = source });
 
             Assert.That(this.window.TheTransitioningContentControl.Transition, Is.EqualTo(TransitionType.Left));
 
-            Assert.DoesNotThrow(() => viewModel.Transition = TransitionType.Custom);
+            Assert.DoesNotThrow(() => source.Transition = TransitionType.Custom);
 
             Assert.That(this.window.TheTransitioningContentControl.Transition, Is.EqualTo(TransitionType.Left));
 
-            viewModel.Transition = TransitionType.Up;
+            source.Transition = TransitionType.Up;
 
             Assert.That(this.window.TheTransitioningContentControl.Transition, Is.EqualTo(TransitionType.Up));
         }

--- a/src/Mahapps.Metro.Tests/Tests/TransitioningContentControlTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/TransitioningContentControlTests.cs
@@ -63,6 +63,7 @@ namespace MahApps.Metro.Tests.Tests
         {
             this.window?.TheTransitioningContentControl.ClearDependencyProperties(new[] { nameof(TransitioningContentControl.Transition), nameof(TransitioningContentControl.CustomVisualStatesName) });
             this.window?.TheTransitioningContentControlWithoutAnyTransition.ClearDependencyProperties(new[] { nameof(TransitioningContentControl.Transition), nameof(TransitioningContentControl.CustomVisualStatesName) });
+            this.window?.TheInheritedTransitionPanel.ClearValue(TransitioningContentControl.TransitionProperty);
         }
 
         [Test]
@@ -117,6 +118,24 @@ namespace MahApps.Metro.Tests.Tests
             Assert.That(this.window, Is.Not.Null);
 
             Assert.That(this.window.TheTransitioningContentControlWithTransitionFromXaml.Transition, Is.EqualTo(TransitionType.Custom));
+        }
+
+        [Test]
+        public void ShouldInheritTheTransitionFromAParentPanel()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            this.window.TheInheritedTransitionPanel.SetValue(TransitioningContentControl.TransitionProperty, TransitionType.Up);
+
+            Assert.That(this.window.TheInheritedTransitioningContentControl.Transition, Is.EqualTo(TransitionType.Up));
+        }
+
+        [Test]
+        public void ShouldInheritTheTransitionSetOnAParentPanelInXaml()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            Assert.That(this.window.TheTransitioningContentControlWithInheritedTransitionFromXaml.Transition, Is.EqualTo(TransitionType.LeftReplace));
         }
 
         [Test]

--- a/src/Mahapps.Metro.Tests/Tests/TransitioningContentControlTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/TransitioningContentControlTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows.Data;
 using MahApps.Metro.Controls;
@@ -18,7 +17,7 @@ namespace MahApps.Metro.Tests.Tests
     {
         private TransitioningContentControlWindow? window;
 
-        private class TransitionViewModel : INotifyPropertyChanged
+        private sealed class TransitionViewModel : INotifyPropertyChanged
         {
             private TransitionType transition;
 
@@ -33,16 +32,11 @@ namespace MahApps.Metro.Tests.Tests
                     }
 
                     this.transition = value;
-                    this.OnPropertyChanged();
+                    this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.Transition)));
                 }
             }
 
             public event PropertyChangedEventHandler? PropertyChanged;
-
-            private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
-            {
-                this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-            }
         }
 
         [OneTimeSetUp]

--- a/src/Mahapps.Metro.Tests/Tests/TransitioningContentControlTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/TransitioningContentControlTests.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using System.Windows.Data;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Tests.TestHelpers;
 using MahApps.Metro.Tests.Views;
@@ -14,6 +17,33 @@ namespace MahApps.Metro.Tests.Tests
     public class TransitioningContentControlTests
     {
         private TransitioningContentControlWindow? window;
+
+        private class TransitionViewModel : INotifyPropertyChanged
+        {
+            private TransitionType transition;
+
+            public TransitionType Transition
+            {
+                get => this.transition;
+                set
+                {
+                    if (value == this.transition)
+                    {
+                        return;
+                    }
+
+                    this.transition = value;
+                    this.OnPropertyChanged();
+                }
+            }
+
+            public event PropertyChangedEventHandler? PropertyChanged;
+
+            private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+            {
+                this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
 
         [OneTimeSetUp]
         public async Task OneTimeSetUp()
@@ -32,18 +62,7 @@ namespace MahApps.Metro.Tests.Tests
         public void SetUp()
         {
             this.window?.TheTransitioningContentControl.ClearDependencyProperties(new[] { nameof(TransitioningContentControl.Transition), nameof(TransitioningContentControl.CustomVisualStatesName) });
-        }
-
-        [Test]
-        public void ShouldNameTheTransitionThatCouldNotBeFound()
-        {
-            Assert.That(this.window, Is.Not.Null);
-
-            this.window.TheTransitioningContentControl.CustomVisualStatesName = "ThisStateDoesNotExist";
-
-            var exception = Assert.Throws<MahAppsException>(() => this.window.TheTransitioningContentControl.Transition = TransitionType.Custom);
-
-            Assert.That(exception?.Message, Is.EqualTo("'Custom' transition could not be found!"));
+            this.window?.TheTransitioningContentControlWithoutAnyTransition.ClearDependencyProperties(new[] { nameof(TransitioningContentControl.Transition), nameof(TransitioningContentControl.CustomVisualStatesName) });
         }
 
         [Test]
@@ -54,9 +73,50 @@ namespace MahApps.Metro.Tests.Tests
             this.window.TheTransitioningContentControl.Transition = TransitionType.Left;
             this.window.TheTransitioningContentControl.CustomVisualStatesName = "ThisStateDoesNotExist";
 
-            Assert.Throws<MahAppsException>(() => this.window.TheTransitioningContentControl.Transition = TransitionType.Custom);
+            Assert.DoesNotThrow(() => this.window.TheTransitioningContentControl.Transition = TransitionType.Custom);
 
             Assert.That(this.window.TheTransitioningContentControl.Transition, Is.EqualTo(TransitionType.Left));
+        }
+
+        [Test]
+        public void ShouldKeepABindingOnTransitionWhenTheTransitionCouldNotBeFound()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            this.window.TheTransitioningContentControl.CustomVisualStatesName = "ThisStateDoesNotExist";
+
+            var viewModel = new TransitionViewModel { Transition = TransitionType.Left };
+            BindingOperations.SetBinding(this.window.TheTransitioningContentControl,
+                                         TransitioningContentControl.TransitionProperty,
+                                         new Binding(nameof(TransitionViewModel.Transition)) { Source = viewModel });
+
+            Assert.That(this.window.TheTransitioningContentControl.Transition, Is.EqualTo(TransitionType.Left));
+
+            Assert.DoesNotThrow(() => viewModel.Transition = TransitionType.Custom);
+
+            Assert.That(this.window.TheTransitioningContentControl.Transition, Is.EqualTo(TransitionType.Left));
+
+            viewModel.Transition = TransitionType.Up;
+
+            Assert.That(this.window.TheTransitioningContentControl.Transition, Is.EqualTo(TransitionType.Up));
+        }
+
+        [Test]
+        public void ShouldNotRecurseWhenTheFallbackTransitionIsMissingAsWell()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            Assert.DoesNotThrow(() => this.window.TheTransitioningContentControlWithoutAnyTransition.Transition = TransitionType.Up);
+
+            Assert.That(this.window.TheTransitioningContentControlWithoutAnyTransition.Transition, Is.EqualTo(TransitioningContentControl.DefaultTransitionState));
+        }
+
+        [Test]
+        public void ShouldKeepATransitionThatWasSetBeforeTheTemplateWasApplied()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            Assert.That(this.window.TheTransitioningContentControlWithTransitionFromXaml.Transition, Is.EqualTo(TransitionType.Custom));
         }
 
         [Test]
@@ -67,6 +127,8 @@ namespace MahApps.Metro.Tests.Tests
             Assert.That(this.window.TheTransitioningContentControl.CustomVisualStatesName, Is.EqualTo("CustomTransition"));
 
             Assert.DoesNotThrow(() => this.window.TheTransitioningContentControl.Transition = TransitionType.Custom);
+
+            Assert.That(this.window.TheTransitioningContentControl.Transition, Is.EqualTo(TransitionType.Custom));
         }
     }
 }

--- a/src/Mahapps.Metro.Tests/Views/TransitioningContentControlWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/TransitioningContentControlWindow.xaml
@@ -60,5 +60,18 @@
             <TextBlock Text="Content" />
         </mah:TransitioningContentControl>
 
+        <!--  The transition is set in xaml on the panel above the control.  -->
+        <StackPanel mah:TransitioningContentControl.Transition="LeftReplace">
+            <mah:TransitioningContentControl x:Name="TheTransitioningContentControlWithInheritedTransitionFromXaml">
+                <TextBlock Text="Content" />
+            </mah:TransitioningContentControl>
+        </StackPanel>
+
+        <!--  The transition comes from the panel above the control.  -->
+        <StackPanel x:Name="TheInheritedTransitionPanel">
+            <mah:TransitioningContentControl x:Name="TheInheritedTransitioningContentControl">
+                <TextBlock Text="Content" />
+            </mah:TransitioningContentControl>
+        </StackPanel>
     </StackPanel>
 </tests:TestWindow>

--- a/src/Mahapps.Metro.Tests/Views/TransitioningContentControlWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/TransitioningContentControlWindow.xaml
@@ -8,6 +8,20 @@
                   d:DesignHeight="300"
                   d:DesignWidth="300"
                   mc:Ignorable="d">
+    <tests:TestWindow.Resources>
+        <!--  A template whose PresentationStates group knows no DefaultTransition at all.  -->
+        <ControlTemplate x:Key="TransitioningContentControlWithoutAnyTransition" TargetType="mah:TransitioningContentControl">
+            <Grid>
+                <ContentPresenter x:Name="PreviousContentPresentationSite" Content="{x:Null}" />
+                <ContentPresenter x:Name="CurrentContentPresentationSite" Content="{TemplateBinding Content}" />
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroup x:Name="PresentationStates">
+                        <VisualState x:Name="Hidden" />
+                    </VisualStateGroup>
+                </VisualStateManager.VisualStateGroups>
+            </Grid>
+        </ControlTemplate>
+    </tests:TestWindow.Resources>
     <StackPanel>
         <mah:TransitioningContentControl x:Name="TheTransitioningContentControl">
             <mah:TransitioningContentControl.CustomVisualStates>
@@ -23,5 +37,28 @@
             </mah:TransitioningContentControl.CustomVisualStates>
             <TextBlock Text="Content" />
         </mah:TransitioningContentControl>
+
+        <mah:TransitioningContentControl x:Name="TheTransitioningContentControlWithoutAnyTransition" Template="{StaticResource TransitioningContentControlWithoutAnyTransition}">
+            <TextBlock Text="Content" />
+        </mah:TransitioningContentControl>
+
+        <!--  The transition is set in xaml, so it is set before the template knows any state.  -->
+        <mah:TransitioningContentControl x:Name="TheTransitioningContentControlWithTransitionFromXaml"
+                                         CustomVisualStatesName="TransitionFromXaml"
+                                         Transition="Custom">
+            <mah:TransitioningContentControl.CustomVisualStates>
+                <VisualState x:Name="TransitionFromXaml">
+                    <Storyboard>
+                        <DoubleAnimation Storyboard.TargetName="CurrentContentPresentationSite"
+                                         Storyboard.TargetProperty="(UIElement.Opacity)"
+                                         From="0"
+                                         To="1"
+                                         Duration="00:00:00.100" />
+                    </Storyboard>
+                </VisualState>
+            </mah:TransitioningContentControl.CustomVisualStates>
+            <TextBlock Text="Content" />
+        </mah:TransitioningContentControl>
+
     </StackPanel>
 </tests:TestWindow>


### PR DESCRIPTION
Closes #4593

## Rejecting a transition

`OnTransitionPropertyChanged` and `OnApplyTemplate` wrote the previous transition back before throwing. Three consequences, all older than #4592:

| | before | now |
| --- | --- | --- |
| binding on `Transition` | replaced by the revert, never delivers again | survives and delivers the next value |
| rejected value | stays as the base value | never written |
| new and fallback both missing | the reverts recurse until the stack overflows | coercion writes nothing, so no recursion |

A `CoerceValueCallback` holds the last transition that resolves, and `OnApplyTemplate` coerces once the visual states are known.

## Inherits never worked

Two reasons, independent of each other:

- the default style carried `<Setter Property="Transition" Value="Default" />`, and a style setter beats an inherited value
- the property used `Register`, so only an ancestor that owns it could hand it down, and `<StackPanel mah:TransitioningContentControl.Transition="Left">` did not compile (`MC3015`)

`Transition` is an attached property now, with `GetTransition` and `SetTransition`, and the setter is gone. The instance property is unchanged, same name, owner and type, so this stays binary compatible.

## Demo

New `transitions` tab: playground for `Transition`, `RestartTransitionOnContentChange`, `ReloadTransition`, `AbortTransition`, `IsTransitioning` and `TransitionCompleted`, one control per `TransitionType`, the two custom transitions, and a panel handing its transition down. The three examples in `others` are gone.

## Release notes

- `MahAppsException` no longer comes out of a `Transition` assignment or out of `OnApplyTemplate`. An unknown transition is dropped and the control keeps the one it had, so code catching around a `Transition` assignment catches nothing now.
- `Transition` set on an ancestor had no effect before and has one now.

The [mahapps.com](https://github.com/MahApps/mahapps.com) page is updated in MahApps/mahapps.com#36.

