### PR TITLE
fix(RadioButton): keep the check glyph centred in the ring on a scaled display

### DIFF
--- a/src/MahApps.Metro/Controls/Helper/RadioButtonHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/RadioButtonHelper.cs
@@ -38,6 +38,37 @@ namespace MahApps.Metro.Controls
             element.SetValue(RadioSizeProperty, value);
         }
 
+        /// <summary>
+        /// The height of the box the radio circle is centred in. It keeps the circle on whole device pixels
+        /// on a scaled display, which centring the box inside the control does not.
+        /// </summary>
+        public static readonly DependencyProperty RadioBoxHeightProperty
+            = DependencyProperty.RegisterAttached(
+                "RadioBoxHeight",
+                typeof(double),
+                typeof(RadioButtonHelper),
+                new FrameworkPropertyMetadata(18.0));
+
+        /// <summary>Helper for getting <see cref="RadioBoxHeightProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="UIElement"/> to read <see cref="RadioBoxHeightProperty"/> from.</param>
+        /// <returns>RadioBoxHeight property value.</returns>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(RadioButton))]
+        public static double GetRadioBoxHeight(UIElement element)
+        {
+            return (double)element.GetValue(RadioBoxHeightProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="RadioBoxHeightProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="UIElement"/> to set <see cref="RadioBoxHeightProperty"/> on.</param>
+        /// <param name="value">RadioBoxHeight property value.</param>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(RadioButton))]
+        public static void SetRadioBoxHeight(UIElement element, double value)
+        {
+            element.SetValue(RadioBoxHeightProperty, value);
+        }
+
         public static readonly DependencyProperty RadioCheckSizeProperty
             = DependencyProperty.RegisterAttached(
                 "RadioCheckSize",

--- a/src/MahApps.Metro/Styles/Controls.RadioButton.xaml
+++ b/src/MahApps.Metro/Styles/Controls.RadioButton.xaml
@@ -31,9 +31,16 @@
                                 <ColumnDefinition x:Name="LeftCol" Width="Auto" />
                                 <ColumnDefinition x:Name="RightCol" Width="*" />
                             </Grid.ColumnDefinitions>
+                            <!--
+                                The ellipses sit in a box of their own, aligned to the top, the way the Windows
+                                template does it. Centring the box inside the control instead puts it on half a
+                                device pixel as soon as the display is scaled, which shifts the ring against the
+                                glyph inside it. The height is a setting of its own rather than the MinHeight of
+                                the control, which callers set for other reasons.
+                            -->
                             <Grid x:Name="Radio"
-                                  HorizontalAlignment="Center"
-                                  VerticalAlignment="Center">
+                                  MinHeight="{TemplateBinding mah:RadioButtonHelper.RadioBoxHeight}"
+                                  VerticalAlignment="Top">
                                 <Ellipse x:Name="OuterEllipse"
                                          Width="{TemplateBinding mah:RadioButtonHelper.RadioSize}"
                                          Height="{TemplateBinding mah:RadioButtonHelper.RadioSize}"
@@ -169,6 +176,7 @@
         <Setter Property="mah:RadioButtonHelper.OuterEllipseStrokeDisabled" Value="{DynamicResource MahApps.Brushes.CheckBox}" />
         <Setter Property="mah:RadioButtonHelper.OuterEllipseStrokePointerOver" Value="{DynamicResource MahApps.Brushes.CheckBox.MouseOver}" />
         <Setter Property="mah:RadioButtonHelper.OuterEllipseStrokePressed" Value="{DynamicResource MahApps.Brushes.CheckBox.MouseOver}" />
+        <Setter Property="mah:RadioButtonHelper.RadioBoxHeight" Value="18" />
         <Setter Property="mah:RadioButtonHelper.RadioSize" Value="18" />
         <Style.Triggers>
             <Trigger Property="mah:ToggleButtonHelper.ContentDirection" Value="RightToLeft">
@@ -223,6 +231,8 @@
         <Setter Property="mah:RadioButtonHelper.OuterEllipseStrokeDisabled" Value="{DynamicResource MahApps.Brushes.RadioButton.OuterEllipseStrokeDisabled}" />
         <Setter Property="mah:RadioButtonHelper.OuterEllipseStrokePointerOver" Value="{DynamicResource MahApps.Brushes.RadioButton.OuterEllipseStrokePointerOver}" />
         <Setter Property="mah:RadioButtonHelper.OuterEllipseStrokePressed" Value="{DynamicResource MahApps.Brushes.RadioButton.OuterEllipseStrokePressed}" />
+        <Setter Property="mah:RadioButtonHelper.RadioBoxHeight" Value="32" />
+        <Setter Property="mah:RadioButtonHelper.RadioCheckSize" Value="12" />
         <Setter Property="mah:RadioButtonHelper.RadioSize" Value="20" />
         <Setter Property="mah:RadioButtonHelper.RadioStrokeThickness" Value="{DynamicResource RadioButtonBorderThemeThickness}" />
         <Style.Triggers>


### PR DESCRIPTION
The dot inside a radio button sits half a device pixel off the ring around it as soon as the display is scaled.

## What it is

The three ellipses sat in a box that was centred inside the control. With a scale factor the resulting offset lands on half a device pixel, and the ring is drawn half a pixel below the dot it surrounds.

The Windows template puts the ellipses in a box of their own and aligns that box to the top, which keeps the offset on whole pixels. This does the same.

Measured against the XAML UI Controls app, same monitor, same scale, both in the light theme, cut outs magnified eight times:

| | ring | dot | offset |
| --- | --- | --- | --- |
| XAML UI Controls | Y 7..33 | Y 15..25 | -0,5 h, **0 v** |
| MahApps before | Y 8..33 | Y 15..25 | -0,5 h, **0,5 v** |
| MahApps after | Y 7..32 | Y 14..25 | -0,5 h, **0 v** |

The dot was never the problem, the ring was. The half pixel that remains horizontally is the same one the Windows control has.

## New property

`RadioButtonHelper.RadioBoxHeight` carries the height of that box, `18` by default and `32` in the `Win10` style, which is what those two styles were already using. It is a minimum, so a `RadioSize` larger than the box grows the box with it, and the documented example with `RadioSize="26"` keeps working.

The [mahapps.com](https://github.com/MahApps/mahapps.com) page is updated in MahApps/mahapps.com#37.
