### PR TITLE
fix(MetroContentControl): raise TransitionStarted once per transition

### DIFF
--- a/src/MahApps.Metro/Controls/MetroContentControl.cs
+++ b/src/MahApps.Metro/Controls/MetroContentControl.cs
@@ -225,7 +225,9 @@ namespace MahApps.Metro.Controls
         {
             if (sender is Clock clock)
             {
-                if (clock.CurrentState == ClockState.Active)
+                // This runs on every frame while the clock is ticking, so the transition has only
+                // started when the control was not transitioning before.
+                if (clock.CurrentState == ClockState.Active && !this.IsTransitioning)
                 {
                     this.SetValue(IsTransitioningPropertyKey, BooleanBoxes.TrueBox);
                     this.RaiseEvent(new RoutedEventArgs(TransitionStartedEvent));

--- a/src/Mahapps.Metro.Tests/Tests/MetroContentControlTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/MetroContentControlTests.cs
@@ -16,6 +16,8 @@ namespace MahApps.Metro.Tests.Tests
     [TestFixture]
     public class MetroContentControlTests
     {
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
         private MetroContentControlWindow? window;
 
         [OneTimeSetUp]
@@ -32,8 +34,26 @@ namespace MahApps.Metro.Tests.Tests
         }
 
         /// <summary>
-        /// Runs the dispatcher until the condition holds or the time is up. The transition is an animation,
-        /// so the test has to let the dispatcher work while it waits.
+        /// Runs the dispatcher for a while. The transition is an animation, so the test has to let the
+        /// dispatcher work instead of blocking the thread it runs on.
+        /// </summary>
+        private static void Pump(TimeSpan duration)
+        {
+            var frame = new DispatcherFrame();
+            var timer = new DispatcherTimer(duration, DispatcherPriority.Background, (_, _) => frame.Continue = false, Dispatcher.CurrentDispatcher);
+
+            try
+            {
+                Dispatcher.PushFrame(frame);
+            }
+            finally
+            {
+                timer.Stop();
+            }
+        }
+
+        /// <summary>
+        /// Runs the dispatcher until the condition holds, and reports whether it did before the time was up.
         /// </summary>
         private static bool PumpUntil(Func<bool> condition, TimeSpan timeout)
         {
@@ -71,8 +91,15 @@ namespace MahApps.Metro.Tests.Tests
             var started = 0;
             var completed = 0;
 
-            void OnStarted(object? sender, RoutedEventArgs e) => started++;
-            void OnCompleted(object? sender, RoutedEventArgs e) => completed++;
+            void OnStarted(object? sender, RoutedEventArgs e)
+            {
+                started++;
+            }
+
+            void OnCompleted(object? sender, RoutedEventArgs e)
+            {
+                completed++;
+            }
 
             control.TransitionStarted += OnStarted;
             control.TransitionCompleted += OnCompleted;
@@ -82,12 +109,14 @@ namespace MahApps.Metro.Tests.Tests
 
                 // Reload ends the previous storyboard, which raises a completed event right away, so
                 // wait for the new transition to start before waiting for it to finish.
-                PumpUntil(() => started > 0, TimeSpan.FromSeconds(5));
+                Assert.That(PumpUntil(() => started > 0, Timeout), Is.True, "the transition did not start in time");
 
                 // that early completed belongs to the previous storyboard, only count from here on
                 completed = 0;
-                PumpUntil(() => control.IsTransitioning == false && completed > 0, TimeSpan.FromSeconds(5));
-                PumpUntil(() => false, TimeSpan.FromMilliseconds(300));
+                Assert.That(PumpUntil(() => control.IsTransitioning == false && completed > 0, Timeout), Is.True, "the transition did not finish in time");
+
+                // the clock keeps ticking for a moment after the storyboard completed
+                Pump(TimeSpan.FromMilliseconds(300));
             }
             finally
             {
@@ -105,11 +134,14 @@ namespace MahApps.Metro.Tests.Tests
 
             var control = this.window.TheMetroContentControl;
 
-            PumpUntil(() => control.IsTransitioning == false, TimeSpan.FromSeconds(5));
+            Assert.That(PumpUntil(() => control.IsTransitioning == false, Timeout), Is.True, "the control should settle before the test starts");
 
             bool? whileStarting = null;
 
-            void OnStarted(object? sender, RoutedEventArgs e) => whileStarting ??= control.IsTransitioning;
+            void OnStarted(object? sender, RoutedEventArgs e)
+            {
+                whileStarting ??= control.IsTransitioning;
+            }
 
             control.TransitionStarted += OnStarted;
             try
@@ -132,8 +164,7 @@ namespace MahApps.Metro.Tests.Tests
 
             var control = this.window.TheMetroContentControl;
 
-            // the control transitions once while it loads, let that one finish first
-            PumpUntil(() => control.IsTransitioning == false, TimeSpan.FromSeconds(5));
+            Assert.That(PumpUntil(() => control.IsTransitioning == false, Timeout), Is.True, "the control should settle before the test starts");
 
             var (started, completed) = RunTransition(control, control.Reload);
 

--- a/src/Mahapps.Metro.Tests/Tests/MetroContentControlTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/MetroContentControlTests.cs
@@ -1,0 +1,144 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class MetroContentControlTests
+    {
+        private MetroContentControlWindow? window;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<MetroContentControlWindow>().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        /// <summary>
+        /// Runs the dispatcher until the condition holds or the time is up. The transition is an animation,
+        /// so the test has to let the dispatcher work while it waits.
+        /// </summary>
+        private static bool PumpUntil(Func<bool> condition, TimeSpan timeout)
+        {
+            var frame = new DispatcherFrame();
+            var timer = new DispatcherTimer(TimeSpan.FromMilliseconds(20),
+                                            DispatcherPriority.Background,
+                                            (_, _) =>
+                                                {
+                                                    if (condition())
+                                                    {
+                                                        frame.Continue = false;
+                                                    }
+                                                },
+                                            Dispatcher.CurrentDispatcher);
+            var deadline = new DispatcherTimer(timeout, DispatcherPriority.Background, (_, _) => frame.Continue = false, Dispatcher.CurrentDispatcher);
+
+            try
+            {
+                Dispatcher.PushFrame(frame);
+            }
+            finally
+            {
+                timer.Stop();
+                deadline.Stop();
+            }
+
+            return condition();
+        }
+
+        /// <summary>
+        /// Triggers a transition and waits for it to finish, counting both events on the way.
+        /// </summary>
+        private static (int started, int completed) RunTransition(MetroContentControl control, Action trigger)
+        {
+            var started = 0;
+            var completed = 0;
+
+            void OnStarted(object? sender, RoutedEventArgs e) => started++;
+            void OnCompleted(object? sender, RoutedEventArgs e) => completed++;
+
+            control.TransitionStarted += OnStarted;
+            control.TransitionCompleted += OnCompleted;
+            try
+            {
+                trigger();
+
+                // Reload ends the previous storyboard, which raises a completed event right away, so
+                // wait for the new transition to start before waiting for it to finish.
+                PumpUntil(() => started > 0, TimeSpan.FromSeconds(5));
+
+                // that early completed belongs to the previous storyboard, only count from here on
+                completed = 0;
+                PumpUntil(() => control.IsTransitioning == false && completed > 0, TimeSpan.FromSeconds(5));
+                PumpUntil(() => false, TimeSpan.FromMilliseconds(300));
+            }
+            finally
+            {
+                control.TransitionStarted -= OnStarted;
+                control.TransitionCompleted -= OnCompleted;
+            }
+
+            return (started, completed);
+        }
+
+        [Test]
+        public void ShouldReportIsTransitioningWhileTheTransitionRuns()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var control = this.window.TheMetroContentControl;
+
+            PumpUntil(() => control.IsTransitioning == false, TimeSpan.FromSeconds(5));
+
+            bool? whileStarting = null;
+
+            void OnStarted(object? sender, RoutedEventArgs e) => whileStarting ??= control.IsTransitioning;
+
+            control.TransitionStarted += OnStarted;
+            try
+            {
+                RunTransition(control, control.Reload);
+            }
+            finally
+            {
+                control.TransitionStarted -= OnStarted;
+            }
+
+            Assert.That(whileStarting, Is.True, "IsTransitioning should already be set when the event is raised");
+            Assert.That(control.IsTransitioning, Is.False, "IsTransitioning should be cleared once the transition is over");
+        }
+
+        [Test]
+        public void ShouldRaiseTransitionStartedOncePerTransition()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var control = this.window.TheMetroContentControl;
+
+            // the control transitions once while it loads, let that one finish first
+            PumpUntil(() => control.IsTransitioning == false, TimeSpan.FromSeconds(5));
+
+            var (started, completed) = RunTransition(control, control.Reload);
+
+            Assert.That(completed, Is.EqualTo(1), "the transition should complete once");
+            Assert.That(started, Is.EqualTo(1), "the transition should start once");
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Views/MetroContentControlWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/MetroContentControlWindow.xaml
@@ -1,0 +1,16 @@
+﻿<tests:TestWindow x:Class="MahApps.Metro.Tests.Views.MetroContentControlWindow"
+                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                  xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:tests="clr-namespace:MahApps.Metro.Tests"
+                  d:DesignHeight="300"
+                  d:DesignWidth="300"
+                  mc:Ignorable="d">
+    <StackPanel>
+        <mah:MetroContentControl x:Name="TheMetroContentControl" Height="60">
+            <TextBlock Text="Content" />
+        </mah:MetroContentControl>
+    </StackPanel>
+</tests:TestWindow>

--- a/src/Mahapps.Metro.Tests/Views/MetroContentControlWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/MetroContentControlWindow.xaml.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MahApps.Metro.Tests.Views
+{
+    public partial class MetroContentControlWindow : TestWindow
+    {
+        public MetroContentControlWindow()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Closes #4583

`TransitionStarted` came out of the `CurrentTimeInvalidated` handler of the storyboard clock, which runs on every frame. The only guard was that the clock is active, and that holds for the whole animation.

| | before | after |
| --- | --- | --- |
| `TransitionStarted` per transition | once per frame | once |
| `IsTransitioning` | written on every frame | written once |

Checking `IsTransitioning` before setting it turns the frame callback into the edge from not transitioning to transitioning, which is what the event is supposed to report. `TransitionCompleted` already behaved that way.

## Tests

New fixture `MetroContentControlTests` with `Views/MetroContentControlWindow.xaml`. It drives a transition through `Reload` and counts both events; before the change it saw 42 started events against one completed. A second test covers `IsTransitioning` set while the transition runs and cleared afterwards, which already held.

One thing worth knowing for anyone touching that fixture: `Reload` ends the running storyboard, so a completed event arrives immediately, before the new transition even starts. The first version of the test waited on that one and passed for the wrong reason. It now waits for the new transition to start, then for it to finish.

## Behaviour change for the release notes

Anyone counting on `TransitionStarted` firing repeatedly, for instance to drive per frame work, gets a single call now. Given the event name and that the docs describe it as the start of the transition, that is unlikely to be relied on, but it is a visible change.
