### PR TITLE
feat(MetroWindow): add a window placement store that writes a file

### DIFF
--- a/src/MahApps.Metro/Controls/WindowPlacementFileSettings.cs
+++ b/src/MahApps.Metro/Controls/WindowPlacementFileSettings.cs
@@ -1,0 +1,180 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Windows;
+using System.Xml.Serialization;
+
+namespace MahApps.Metro.Controls
+{
+    /// <summary>
+    /// Keeps the placement of a window in a file of its own instead of the application settings.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The default store, which builds on <see cref="System.Configuration.ApplicationSettingsBase"/>, fails
+    /// to save on some runtimes and setups, for example .NET 9 before 9.0.3 when the application runs from a
+    /// network location. This store has no such dependency, and it is useful wherever the placement should
+    /// live somewhere the application controls.
+    /// </para>
+    /// <para>
+    /// It is not used unless a caller asks for it:
+    /// <code>
+    /// this.WindowPlacementSettings = WindowPlacementFileSettings.ForWindow(this);
+    /// </code>
+    /// </para>
+    /// </remarks>
+    public class WindowPlacementFileSettings : IWindowPlacementSettings
+    {
+        private static readonly XmlSerializer Serializer = new(typeof(StoredPlacement));
+
+        /// <summary>
+        /// Initializes a new instance which reads and writes the given file.
+        /// </summary>
+        /// <param name="filePath">The file to keep the placement in. Its directory is created when saving.</param>
+        public WindowPlacementFileSettings(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                throw new ArgumentException("The file path must not be empty.", nameof(filePath));
+            }
+
+            this.FilePath = filePath;
+        }
+
+        /// <summary>
+        /// Gets the file the placement is kept in.
+        /// </summary>
+        public string FilePath { get; }
+
+        /// <inheritdoc />
+        public WindowPlacementSetting? Placement { get; set; }
+
+        /// <inheritdoc />
+        public bool UpgradeSettings { get; set; }
+
+        /// <summary>
+        /// Creates a store for the given window under the local application data of the current user.
+        /// </summary>
+        /// <param name="window">The window whose type names the file.</param>
+        public static WindowPlacementFileSettings ForWindow(Window window)
+        {
+            if (window is null)
+            {
+                throw new ArgumentNullException(nameof(window));
+            }
+
+            var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var application = Assembly.GetEntryAssembly()?.GetName().Name ?? "MahApps.Metro";
+            var name = window.GetType().FullName ?? window.GetType().Name;
+
+            return new WindowPlacementFileSettings(Path.Combine(root, application, "WindowPlacement", $"{name}.xml"));
+        }
+
+        /// <inheritdoc />
+        public void Reload()
+        {
+            if (!File.Exists(this.FilePath))
+            {
+                // no file yet is the normal first start
+                this.Placement = null;
+                return;
+            }
+
+            using var stream = File.OpenRead(this.FilePath);
+            var stored = (StoredPlacement?)Serializer.Deserialize(stream);
+
+            this.Placement = stored?.ToSetting();
+        }
+
+        /// <inheritdoc />
+        public void Save()
+        {
+            if (this.Placement is null)
+            {
+                return;
+            }
+
+            var directory = Path.GetDirectoryName(this.FilePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory!);
+            }
+
+            using var stream = File.Create(this.FilePath);
+            Serializer.Serialize(stream, StoredPlacement.From(this.Placement));
+        }
+
+        /// <inheritdoc />
+        public void Upgrade()
+        {
+            // there is nothing to carry over from an older version of the application
+        }
+
+        /// <inheritdoc />
+        public void Reset()
+        {
+            this.Placement = null;
+
+            if (File.Exists(this.FilePath))
+            {
+                File.Delete(this.FilePath);
+            }
+        }
+
+        /// <summary>
+        /// What actually goes into the file. Plain numbers rather than <see cref="WindowPlacementSetting"/>,
+        /// so the file survives changes to that type and needs no serializer that knows WPF types.
+        /// </summary>
+        public class StoredPlacement
+        {
+            public uint ShowCommand { get; set; }
+
+            public double MinimumX { get; set; }
+
+            public double MinimumY { get; set; }
+
+            public double MaximumX { get; set; }
+
+            public double MaximumY { get; set; }
+
+            public double X { get; set; }
+
+            public double Y { get; set; }
+
+            public double Width { get; set; }
+
+            public double Height { get; set; }
+
+            internal static StoredPlacement From(WindowPlacementSetting placement)
+            {
+                return new StoredPlacement
+                       {
+                           ShowCommand = placement.showCmd,
+                           MinimumX = placement.minPosition.X,
+                           MinimumY = placement.minPosition.Y,
+                           MaximumX = placement.maxPosition.X,
+                           MaximumY = placement.maxPosition.Y,
+                           X = placement.normalPosition.X,
+                           Y = placement.normalPosition.Y,
+                           Width = placement.normalPosition.Width,
+                           Height = placement.normalPosition.Height
+                       };
+            }
+
+            internal WindowPlacementSetting ToSetting()
+            {
+                return new WindowPlacementSetting
+                       {
+                           showCmd = this.ShowCommand,
+                           minPosition = new Point(this.MinimumX, this.MinimumY),
+                           maxPosition = new Point(this.MaximumX, this.MaximumY),
+                           normalPosition = new Rect(this.X, this.Y, this.Width, this.Height)
+                       };
+            }
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/WindowPlacementSettingsTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/WindowPlacementSettingsTests.cs
@@ -1,0 +1,273 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class WindowPlacementSettingsTests
+    {
+        /// <summary>
+        /// A placement store that keeps everything in memory, the way a caller would write one that
+        /// persists somewhere other than the application settings.
+        /// </summary>
+        private sealed class RecordingPlacementSettings : IWindowPlacementSettings
+        {
+            public List<string> Calls { get; } = new();
+
+            public WindowPlacementSetting? Placement { get; set; }
+
+            public bool UpgradeSettings { get; set; }
+
+            public void Reload()
+            {
+                this.Calls.Add(nameof(this.Reload));
+            }
+
+            public void Upgrade()
+            {
+                this.Calls.Add(nameof(this.Upgrade));
+            }
+
+            public void Save()
+            {
+                this.Calls.Add(nameof(this.Save));
+            }
+
+            public void Reset()
+            {
+                this.Calls.Add(nameof(this.Reset));
+            }
+        }
+
+        /// <summary>
+        /// Settings that are broken the way a corrupted configuration file is: reloading throws, and so
+        /// does reading the placement afterwards.
+        /// </summary>
+        private sealed class BrokenPlacementSettings : IWindowPlacementSettings
+        {
+            public WindowPlacementSetting? Placement
+            {
+                get => throw new MahAppsException("the settings file seems to be corrupted");
+                set { }
+            }
+
+            public bool UpgradeSettings { get; set; }
+
+            public void Reload()
+            {
+                throw new MahAppsException("the settings file seems to be corrupted");
+            }
+
+            public void Upgrade()
+            {
+            }
+
+            public void Save()
+            {
+            }
+
+            public void Reset()
+            {
+            }
+        }
+
+        [Test]
+        public void ShouldRoundTripThePlacementThroughAFile()
+        {
+            var file = Path.Combine(Path.GetTempPath(), $"mahapps-placement-{Guid.NewGuid():N}.xml");
+
+            try
+            {
+                var settings = new WindowPlacementFileSettings(file)
+                               {
+                                   Placement = new WindowPlacementSetting
+                                               {
+                                                   showCmd = 3,
+                                                   minPosition = new Point(-1, -2),
+                                                   maxPosition = new Point(-3, -4),
+                                                   normalPosition = new Rect(10, 20, 300, 400)
+                                               }
+                               };
+
+                settings.Save();
+
+                Assert.That(File.Exists(file), Is.True, "the store should write the file it was given");
+
+                var reloaded = new WindowPlacementFileSettings(file);
+                reloaded.Reload();
+
+                Assert.That(reloaded.Placement, Is.Not.Null);
+                Assert.That(reloaded.Placement!.showCmd, Is.EqualTo(3u));
+                Assert.That(reloaded.Placement.minPosition, Is.EqualTo(new Point(-1, -2)));
+                Assert.That(reloaded.Placement.maxPosition, Is.EqualTo(new Point(-3, -4)));
+                Assert.That(reloaded.Placement.normalPosition, Is.EqualTo(new Rect(10, 20, 300, 400)));
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [Test]
+        public void ShouldReportNoPlacementWhenTheFileIsMissing()
+        {
+            var file = Path.Combine(Path.GetTempPath(), $"mahapps-placement-{Guid.NewGuid():N}.xml");
+            var settings = new WindowPlacementFileSettings(file);
+
+            Assert.That(() => settings.Reload(), Throws.Nothing, "a missing file is the normal first start, not an error");
+            Assert.That(settings.Placement, Is.Null);
+        }
+
+        [Test]
+        public void ShouldForgetThePlacementOnReset()
+        {
+            var file = Path.Combine(Path.GetTempPath(), $"mahapps-placement-{Guid.NewGuid():N}.xml");
+
+            try
+            {
+                var settings = new WindowPlacementFileSettings(file)
+                               {
+                                   Placement = new WindowPlacementSetting { normalPosition = new Rect(1, 2, 3, 4) }
+                               };
+                settings.Save();
+
+                settings.Reset();
+
+                Assert.That(settings.Placement, Is.Null, "reset should drop the placement");
+                Assert.That(File.Exists(file), Is.False, "reset should remove the file");
+            }
+            finally
+            {
+                if (File.Exists(file))
+                {
+                    File.Delete(file);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldSaveTheWindowPlacementIntoTheFile()
+        {
+            var file = Path.Combine(Path.GetTempPath(), $"mahapps-placement-{Guid.NewGuid():N}.xml");
+            var settings = new WindowPlacementFileSettings(file);
+
+            var window = new TestWindow
+                         {
+                             Width = 800,
+                             Height = 600,
+                             ShowInTaskbar = false,
+                             Left = int.MinValue,
+                             Top = int.MinValue
+                         };
+            window.SetCurrentValue(MetroWindow.SaveWindowPositionProperty, true);
+            window.SetCurrentValue(MetroWindow.WindowPlacementSettingsProperty, settings);
+
+            try
+            {
+                window.Show();
+                window.Close();
+
+                Assert.That(File.Exists(file), Is.True, "closing the window should have written the placement");
+
+                var reloaded = new WindowPlacementFileSettings(file);
+                reloaded.Reload();
+                Assert.That(reloaded.Placement, Is.Not.Null);
+                Assert.That(reloaded.Placement!.normalPosition.IsEmpty, Is.False);
+            }
+            finally
+            {
+                if (File.Exists(file))
+                {
+                    File.Delete(file);
+                }
+            }
+        }
+
+        [Test]
+        public void ShouldOpenTheWindowWhenTheSettingsAreBroken()
+        {
+            var window = new TestWindow
+                         {
+                             Width = 800,
+                             Height = 600,
+                             ShowInTaskbar = false,
+                             Left = int.MinValue,
+                             Top = int.MinValue
+                         };
+            window.SetCurrentValue(MetroWindow.SaveWindowPositionProperty, true);
+            window.SetCurrentValue(MetroWindow.WindowPlacementSettingsProperty, new BrokenPlacementSettings());
+
+            try
+            {
+                Assert.That(() => window.Show(), Throws.Nothing, "a broken settings store must not stop the window from opening");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task ShouldSaveThePlacementThroughSettingsOfTheCaller()
+        {
+            var settings = new RecordingPlacementSettings();
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>().ConfigureAwait(false);
+
+            window.SetCurrentValue(MetroWindow.SaveWindowPositionProperty, true);
+            window.SetCurrentValue(MetroWindow.WindowPlacementSettingsProperty, settings);
+
+            window.Close();
+
+            Assert.That(settings.Calls, Does.Contain("Save"), "the behavior should save through the settings of the caller");
+            Assert.That(settings.Placement, Is.Not.Null, "the placement should have been handed to the settings");
+            Assert.That(settings.Placement!.normalPosition.IsEmpty, Is.False, "the placement should carry the bounds of the window");
+        }
+
+        [Test]
+        public void ShouldReadThePlacementFromSettingsOfTheCaller()
+        {
+            var settings = new RecordingPlacementSettings
+                           {
+                               Placement = new WindowPlacementSetting
+                                           {
+                                               showCmd = 1,
+                                               normalPosition = new Rect(120, 130, 400, 300)
+                                           }
+                           };
+
+            var window = new TestWindow
+                         {
+                             Width = 800,
+                             Height = 600,
+                             ShowInTaskbar = false,
+                             Left = int.MinValue,
+                             Top = int.MinValue
+                         };
+            window.SetCurrentValue(MetroWindow.SaveWindowPositionProperty, true);
+            window.SetCurrentValue(MetroWindow.WindowPlacementSettingsProperty, settings);
+
+            try
+            {
+                window.Show();
+
+                Assert.That(settings.Calls, Does.Contain("Reload"), "the behavior should read through the settings of the caller");
+                Assert.That(window.RestoreBounds.Width, Is.EqualTo(400).Within(1), "the window should take the width from the settings");
+                Assert.That(window.RestoreBounds.Height, Is.EqualTo(300).Within(1), "the window should take the height from the settings");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/WindowPlacementSettingsTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/WindowPlacementSettingsTests.cs
@@ -55,10 +55,16 @@ namespace MahApps.Metro.Tests.Tests
         /// </summary>
         private sealed class BrokenPlacementSettings : IWindowPlacementSettings
         {
+            /// <summary>
+            /// Gets the placement the behavior handed over on the way out. Reading <see cref="Placement"/>
+            /// throws, so this is how a test sees what was written.
+            /// </summary>
+            public WindowPlacementSetting? Written { get; private set; }
+
             public WindowPlacementSetting? Placement
             {
                 get => throw new MahAppsException("the settings file seems to be corrupted");
-                set { }
+                set => this.Written = value;
             }
 
             public bool UpgradeSettings { get; set; }
@@ -70,14 +76,17 @@ namespace MahApps.Metro.Tests.Tests
 
             public void Upgrade()
             {
+                // a store this broken has nothing to carry over
             }
 
             public void Save()
             {
+                // writing works, it is reading that is broken here
             }
 
             public void Reset()
             {
+                // there is no state to drop
             }
         }
 
@@ -196,6 +205,7 @@ namespace MahApps.Metro.Tests.Tests
         [Test]
         public void ShouldOpenTheWindowWhenTheSettingsAreBroken()
         {
+            var settings = new BrokenPlacementSettings();
             var window = new TestWindow
                          {
                              Width = 800,
@@ -205,7 +215,7 @@ namespace MahApps.Metro.Tests.Tests
                              Top = int.MinValue
                          };
             window.SetCurrentValue(MetroWindow.SaveWindowPositionProperty, true);
-            window.SetCurrentValue(MetroWindow.WindowPlacementSettingsProperty, new BrokenPlacementSettings());
+            window.SetCurrentValue(MetroWindow.WindowPlacementSettingsProperty, settings);
 
             try
             {
@@ -215,6 +225,8 @@ namespace MahApps.Metro.Tests.Tests
             {
                 window.Close();
             }
+
+            Assert.That(settings.Written, Is.Not.Null, "the placement should still be written on the way out");
         }
 
         [Test]


### PR DESCRIPTION
Relates to #4541 and replaces the approach in #4567.

## Why

The default placement store builds on `ApplicationSettingsBase`, so it depends on the configuration system. That store does fail: on .NET 9 before 9.0.3, saving throws when the application runs from a network location ([dotnet/runtime#112410](https://github.com/dotnet/runtime/issues/112410)), and the window position is silently lost.

`MetroWindow.WindowPlacementSettings` has always taken any `IWindowPlacementSettings`, and `GetWindowPlacementSettings()` is virtual, so callers could already keep the placement elsewhere. What was missing is something to reach for, and a page that says so.

## What this adds

`WindowPlacementFileSettings`, a store that writes a file. Nothing changes for anyone who does not ask for it:

```csharp
this.WindowPlacementSettings = WindowPlacementFileSettings.ForWindow(this);
```

`ForWindow` puts the file under the local application data of the current user; the constructor takes any path instead.

Two decisions worth flagging for review:

- It serialises through `XmlSerializer`, not `System.Text.Json`. net462 has no `System.Text.Json`, and a store that only exists on some target frameworks would be worse than none.
- It writes plain numbers rather than `WindowPlacementSetting` itself, so the file survives changes to that type and the serializer needs to know no WPF types.

## Tests

Four cover the store: the round trip through a file, a missing file as the normal first start, `Reset` removing it, and a window writing its placement on close.

Three cover the extension point itself, which had none: the behavior saves through settings supplied by the caller, reads through them, and a store that throws does not stop the window from opening. That last one is the property #4567 breaks, so it is worth having either way.

The [mahapps.com](https://github.com/MahApps/mahapps.com) page is updated in MahApps/mahapps.com#38.
