### PR TITLE
fix(RangeSlider): document what MinRangeWidth really is

### DIFF
--- a/src/MahApps.Metro/Controls/RangeSlider.cs
+++ b/src/MahApps.Metro/Controls/RangeSlider.cs
@@ -326,8 +326,15 @@ namespace MahApps.Metro.Controls
                                           new FrameworkPropertyMetadata(0d, MinRangeChanged, CoerceMinRange), IsValidMinRange);
 
         /// <summary>
-        /// Get/sets the minimum range that can be selected.
+        /// Get/sets the smallest distance there may be between <see cref="LowerValue"/> and
+        /// <see cref="UpperValue"/>, in the units of <see cref="RangeBase.Minimum"/> and
+        /// <see cref="RangeBase.Maximum"/>. Raising it pushes the two values apart.
+        /// Defaults to 0, which lets them meet.
         /// </summary>
+        /// <remarks>
+        /// This is about the values. For the smallest width the selected range may be drawn with,
+        /// see <see cref="MinRangeWidth"/>.
+        /// </remarks>
         [Bindable(true)]
         [Category("Common")]
         public double MinRange
@@ -383,8 +390,16 @@ namespace MahApps.Metro.Controls
                                           new FrameworkPropertyMetadata(30d, MinRangeWidthChanged, CoerceMinRangeWidth), IsValidMinRange);
 
         /// <summary>
-        /// Get/sets the minimal distance between two thumbs.
+        /// Get/sets the smallest width, in device-independent pixels, that the middle thumb between
+        /// the two other thumbs may be drawn with. It is coerced to at most half of the track.
+        /// Defaults to 30, so even an empty range stays visible and can be grabbed.
         /// </summary>
+        /// <remarks>
+        /// This is about the drawing, not about the values: <see cref="LowerValue"/> and
+        /// <see cref="UpperValue"/> can still be equal while the thumbs stay this far apart, and the
+        /// width is taken off the track before the values are mapped onto it. For the smallest
+        /// distance between the values, see <see cref="MinRange"/>.
+        /// </remarks>
         [Bindable(true)]
         [Category("Common")]
         public double MinRangeWidth

--- a/src/Mahapps.Metro.Tests/Tests/RangeSliderTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/RangeSliderTests.cs
@@ -1,0 +1,134 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Windows.Controls.Primitives;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// MinRange and MinRangeWidth sound like the same thing and are not: one is a distance between
+    /// the values, the other a width in pixels. These tests hold both of them to what the
+    /// documentation of the two properties says.
+    /// </summary>
+    [TestFixture]
+    public class RangeSliderTests
+    {
+        private RangeSliderWindow? window;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<RangeSliderWindow>().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        private static Thumb GetMiddleThumb(RangeSlider slider)
+        {
+            var thumb = slider.FindChild<Thumb>("PART_MiddleThumb");
+            Assert.That(thumb, Is.Not.Null, "the template should carry a middle thumb");
+
+            return thumb!;
+        }
+
+        [Test]
+        public void MinRangeWidthShouldBeTheMinimumWidthOfTheMiddleThumb()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var slider = this.window.TheRangeSlider;
+            slider.UpdateLayout();
+
+            Assert.That(slider.MinRangeWidth, Is.EqualTo(30d), "the default should be 30");
+            Assert.That(GetMiddleThumb(slider).MinWidth, Is.EqualTo(slider.MinRangeWidth), "the template binds MinRangeWidth to the minimum width of the middle thumb");
+        }
+
+        [Test]
+        public void MinRangeWidthShouldKeepTheThumbsApartWithoutMovingTheValues()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var slider = this.window.TheRangeSlider;
+            slider.UpdateLayout();
+
+            Assert.That(slider.MinRange, Is.EqualTo(0d), "nothing should keep the values apart here");
+            Assert.That(slider.LowerValue, Is.EqualTo(50d));
+            Assert.That(slider.UpperValue, Is.EqualTo(50d), "MinRangeWidth is a width, so it must not move the values");
+            Assert.That(GetMiddleThumb(slider).ActualWidth, Is.EqualTo(slider.MinRangeWidth).Within(0.5), "two equal values still draw a range as wide as MinRangeWidth");
+        }
+
+        [Test]
+        public void MinRangeWidthShouldBeCoercedToHalfOfTheTrack()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var slider = this.window.TheRangeSlider;
+            slider.UpdateLayout();
+
+            var leftThumb = slider.FindChild<Thumb>("PART_LeftThumb");
+            var rightThumb = slider.FindChild<Thumb>("PART_RightThumb");
+            Assert.That(leftThumb, Is.Not.Null);
+            Assert.That(rightThumb, Is.Not.Null);
+
+            var track = slider.ActualWidth - leftThumb!.ActualWidth - rightThumb!.ActualWidth;
+            Assert.That(track, Is.GreaterThan(0), "the slider should be laid out, otherwise this test proves nothing");
+
+            try
+            {
+                slider.SetCurrentValue(RangeSlider.MinRangeWidthProperty, 10000d);
+
+                Assert.That(slider.MinRangeWidth, Is.EqualTo(track / 2).Within(0.5), "a value wider than the track should be cut down to half of it");
+            }
+            finally
+            {
+                slider.ClearValue(RangeSlider.MinRangeWidthProperty);
+            }
+        }
+
+        [Test]
+        public void MinRangeShouldBeTheMinimumDistanceBetweenTheValues()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var slider = this.window.TheMinRangeSlider;
+            slider.UpdateLayout();
+
+            Assert.That(slider.MinRangeWidth, Is.EqualTo(0d), "nothing should keep the thumbs apart here");
+            Assert.That(slider.MinRange, Is.EqualTo(10d));
+            Assert.That(slider.UpperValue - slider.LowerValue, Is.GreaterThanOrEqualTo(slider.MinRange), "two equal values should be pushed apart by MinRange");
+        }
+
+        [Test]
+        public void MinRangeShouldStopTheLowerValueFromReachingTheUpperOne()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var slider = this.window.TheMinRangeSlider;
+            slider.UpdateLayout();
+
+            var upperValue = slider.UpperValue;
+
+            try
+            {
+                slider.SetCurrentValue(RangeSlider.LowerValueProperty, upperValue);
+
+                Assert.That(slider.LowerValue, Is.EqualTo(upperValue - slider.MinRange), "the lower value should stop MinRange short of the upper one");
+            }
+            finally
+            {
+                slider.SetCurrentValue(RangeSlider.LowerValueProperty, 50d);
+            }
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Views/RangeSliderWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/RangeSliderWindow.xaml
@@ -1,0 +1,28 @@
+﻿<tests:TestWindow x:Class="MahApps.Metro.Tests.Views.RangeSliderWindow"
+                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                  xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:tests="clr-namespace:MahApps.Metro.Tests"
+                  Width="400"
+                  d:DesignHeight="300"
+                  d:DesignWidth="400"
+                  mc:Ignorable="d">
+    <StackPanel>
+        <mah:RangeSlider x:Name="TheRangeSlider"
+                         Width="300"
+                         LowerValue="50"
+                         Maximum="100"
+                         Minimum="0"
+                         UpperValue="50" />
+        <mah:RangeSlider x:Name="TheMinRangeSlider"
+                         Width="300"
+                         LowerValue="50"
+                         Maximum="100"
+                         MinRange="10"
+                         MinRangeWidth="0"
+                         Minimum="0"
+                         UpperValue="50" />
+    </StackPanel>
+</tests:TestWindow>

--- a/src/Mahapps.Metro.Tests/Views/RangeSliderWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/RangeSliderWindow.xaml.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MahApps.Metro.Tests.Views
+{
+    public partial class RangeSliderWindow : TestWindow
+    {
+        public RangeSliderWindow()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Closes #4580

The XML comment on `RangeSlider.MinRangeWidth` described `MinRange`, so the two properties read as if they were the same thing, in the API reference and in IntelliSense alike.

They are not. `MinRangeWidth` is a width in device-independent pixels: the template binds it to `MinWidth` and `MinHeight` of the middle thumb, `CoerceMinRangeWidth` cuts it down to half the track, and `ReCalculateSize` subtracts it from the usable width before values are mapped onto pixels. That is why a `RangeSlider` with `LowerValue` and `UpperValue` both at 50 still draws a band thirty pixels wide, and why the thumbs straddle the midpoint instead of sitting on it.

Both comments now say which of the two they are about, name the unit and the default, and point at each other.

### Documentation

The [RangeSlider page](https://github.com/MahApps/mahapps.com) carried the wrong comment as a known defect and now separates a released version from `develop`.
