### PR TITLE
fix(ProgressBar): let Foreground paint the bar

### DIFF
--- a/src/MahApps.Metro/Styles/Controls.ProgressBar.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ProgressBar.xaml
@@ -6,7 +6,7 @@
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray5}" />
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Control.Border}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Highlight}" />
+        <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Progress}" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Maximum" Value="100" />
         <Setter Property="MinHeight" Value="10" />
@@ -23,7 +23,7 @@
                             <Grid x:Name="IndeterminateRoot" Visibility="Collapsed">
                                 <Rectangle x:Name="IndeterminateSolidFill"
                                            Margin="{TemplateBinding BorderThickness}"
-                                           Fill="{DynamicResource MahApps.Brushes.Progress}"
+                                           Fill="{TemplateBinding Foreground}"
                                            Opacity="1"
                                            RenderTransformOrigin="0.5,0.5"
                                            StrokeThickness="0" />
@@ -51,7 +51,7 @@
                                 <Border x:Name="PART_Indicator"
                                         Margin="-1"
                                         HorizontalAlignment="Left"
-                                        Background="{DynamicResource MahApps.Brushes.Progress}">
+                                        Background="{TemplateBinding Foreground}">
                                     <Rectangle x:Name="GradientFill"
                                                Opacity="0.7"
                                                Visibility="Collapsed">

--- a/src/Mahapps.Metro.Tests/Tests/ProgressBarTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ProgressBarTests.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class ProgressBarTests
+    {
+        private ProgressBarWindow? window;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<ProgressBarWindow>().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        private static Color ColorOf(Brush? brush)
+        {
+            Assert.That(brush, Is.InstanceOf<SolidColorBrush>(), "the test sets a solid colour, so this should be one");
+
+            return ((SolidColorBrush)brush!).Color;
+        }
+
+        [Test]
+        public void ForegroundShouldPaintTheIndicator()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var progressBar = this.window.TheColouredProgressBar;
+            progressBar.UpdateLayout();
+
+            var indicator = progressBar.FindChild<Border>("PART_Indicator");
+            Assert.That(indicator, Is.Not.Null, "the template should carry the indicator");
+            Assert.That(ColorOf(indicator!.Background), Is.EqualTo(Colors.Red), "the indicator should be painted with Foreground");
+        }
+
+        [Test]
+        public void ForegroundShouldPaintTheIndeterminateFill()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var progressBar = this.window.TheIndeterminateProgressBar;
+            progressBar.UpdateLayout();
+
+            var fill = progressBar.FindChild<Rectangle>("IndeterminateSolidFill");
+            Assert.That(fill, Is.Not.Null, "the template should carry the indeterminate fill");
+            Assert.That(ColorOf(fill!.Fill), Is.EqualTo(Colors.Blue), "the stripes should run over Foreground as well");
+        }
+
+        [Test]
+        public void ProgressBarWithoutAForegroundShouldKeepTheProgressBrush()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var progressBar = this.window.TheProgressBar;
+            progressBar.UpdateLayout();
+
+            var progressBrush = progressBar.TryFindResource("MahApps.Brushes.Progress") as Brush;
+            Assert.That(progressBrush, Is.Not.Null, "the theme should carry the progress brush");
+
+            var indicator = progressBar.FindChild<Border>("PART_Indicator");
+            Assert.That(indicator, Is.Not.Null);
+            Assert.That(indicator!.Background, Is.SameAs(progressBrush), "leaving Foreground alone should keep the look it always had");
+
+            var fill = this.window.TheDefaultIndeterminateProgressBar.FindChild<Rectangle>("IndeterminateSolidFill");
+            Assert.That(fill, Is.Not.Null);
+            Assert.That(fill!.Fill, Is.SameAs(progressBrush), "the same goes for the stripes");
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Views/ProgressBarWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/ProgressBarWindow.xaml
@@ -1,0 +1,31 @@
+﻿<tests:TestWindow x:Class="MahApps.Metro.Tests.Views.ProgressBarWindow"
+                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:tests="clr-namespace:MahApps.Metro.Tests"
+                  Width="400"
+                  d:DesignHeight="300"
+                  d:DesignWidth="400"
+                  mc:Ignorable="d">
+    <StackPanel>
+        <ProgressBar x:Name="TheProgressBar"
+                     Width="200"
+                     Height="12"
+                     Value="70" />
+        <ProgressBar x:Name="TheColouredProgressBar"
+                     Width="200"
+                     Height="12"
+                     Foreground="Red"
+                     Value="70" />
+        <ProgressBar x:Name="TheDefaultIndeterminateProgressBar"
+                     Width="200"
+                     Height="12"
+                     IsIndeterminate="True" />
+        <ProgressBar x:Name="TheIndeterminateProgressBar"
+                     Width="200"
+                     Height="12"
+                     Foreground="Blue"
+                     IsIndeterminate="True" />
+    </StackPanel>
+</tests:TestWindow>

--- a/src/Mahapps.Metro.Tests/Views/ProgressBarWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/ProgressBarWindow.xaml.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MahApps.Metro.Tests.Views
+{
+    public partial class ProgressBarWindow : TestWindow
+    {
+        public ProgressBarWindow()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Closes #4579

`ProgressBar.Foreground` had no effect. The template filled the determinate indicator and the indeterminate stripes from `{DynamicResource MahApps.Brushes.Progress}`, so every `Foreground` value was ignored, the style's own setter included. WPF's template binds it, and so does MahApps' own `MetroProgressBar`.

Both places are template bindings now, and the brush moved into the `Foreground` setter of the style.

That last part matters more than it looks: the setter used to be `MahApps.Brushes.Highlight`, and the two are not the same brush. `MahApps.Brushes.Progress` is a `LinearGradientBrush` from `MahApps.Colors.Highlight` to `MahApps.Colors.Accent3`, so keeping the old setter would have turned every bar flat.

Nothing changes for anyone recolouring a bar the way it had to be done before. Putting a `MahApps.Brushes.Progress` of your own into the resources of a bar or an ancestor still works, because the setter looks the key up as a `DynamicResource` as well.

### Tests

New `ProgressBarWindow` with five bars, three tests, the first two red before the change:

- `Foreground` paints `PART_Indicator`
- `Foreground` paints `IndeterminateSolidFill`
- a bar that sets no `Foreground` keeps the very brush instance `MahApps.Brushes.Progress` resolves to, determinate and indeterminate alike, so the default look cannot drift

### Documentation

The [ProgressBar style page](https://github.com/MahApps/mahapps.com) carried the dead `Foreground` as an open defect and the `MetroProgressBar` comparison table repeated it. Both now separate a released version from `develop`.
