### PR TITLE
fix(Dialogs): correct the progress dialog documentation

### DIFF
--- a/src/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/MessageDialog.cs
@@ -13,7 +13,7 @@ using ControlzEx;
 namespace MahApps.Metro.Controls.Dialogs
 {
     /// <summary>
-    /// An internal control that represents a message dialog. Please use MetroWindow.ShowMessage instead!
+    /// An internal control that represents a message dialog. Please use MetroWindow.ShowMessageAsync instead!
     /// </summary>
     [TemplatePart(Name = nameof(PART_AffirmativeButton), Type = typeof(Button))]
     [TemplatePart(Name = nameof(PART_NegativeButton), Type = typeof(Button))]

--- a/src/MahApps.Metro/Controls/Dialogs/ProgressDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/ProgressDialog.cs
@@ -11,7 +11,7 @@ using MahApps.Metro.ValueBoxes;
 namespace MahApps.Metro.Controls.Dialogs
 {
     /// <summary>
-    /// An internal control that represents a message dialog. Please use MetroWindow.ShowMessage instead!
+    /// An internal control that represents a progress dialog. Please use MetroWindow.ShowProgressAsync instead!
     /// </summary>
     [TemplatePart(Name = nameof(PART_ProgressBar), Type = typeof(MetroProgressBar))]
     [TemplatePart(Name = nameof(PART_NegativeButton), Type = typeof(Button))]

--- a/src/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/ProgressDialogController.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -102,7 +102,13 @@ namespace MahApps.Metro.Controls.Dialogs
         /// <summary>
         /// Sets the dialog's progress bar value and sets IsIndeterminate to false.
         /// </summary>
-        /// <param name="value">The percentage to set as the value.</param>
+        /// <param name="value">
+        /// The value to set, somewhere between <see cref="Minimum"/> and <see cref="Maximum"/>. Those are
+        /// 0.0 and 1.0 unless you have changed them, so a quarter of the way through is 0.25 and not 25.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="value"/> is below <see cref="Minimum"/> or above <see cref="Maximum"/>.
+        /// </exception>
         public void SetProgress(double value)
         {
             this.WrappedDialog.Invoke(() =>
@@ -117,7 +123,7 @@ namespace MahApps.Metro.Controls.Dialogs
         }
 
         /// <summary>
-        ///  Gets/Sets the minimum restriction of the progress Value property.
+        /// Gets/Sets the minimum restriction of the progress Value property. Defaults to 0.0.
         /// </summary>
         public double Minimum
         {
@@ -126,7 +132,8 @@ namespace MahApps.Metro.Controls.Dialogs
         }
 
         /// <summary>
-        ///  Gets/Sets the maximum restriction of the progress Value property.
+        /// Gets/Sets the maximum restriction of the progress Value property. Defaults to 1.0. Raise it to
+        /// 100.0 if you would rather hand <see cref="SetProgress"/> a percentage.
         /// </summary>
         public double Maximum
         {

--- a/src/Mahapps.Metro.Tests/Tests/ProgressDialogTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ProgressDialogTests.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using MahApps.Metro.Controls.Dialogs;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// The progress of this dialog runs from 0.0 to 1.0 and not from 0 to 100, which is what the
+    /// documentation of <see cref="ProgressDialogController.SetProgress"/> used to say. These tests
+    /// hold it to the range it really has.
+    /// </summary>
+    [TestFixture]
+    public class ProgressDialogTests
+    {
+        [Test]
+        public async Task ProgressShouldRunFromZeroToOne()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+
+            try
+            {
+                var controller = await window.ShowProgressAsync("Title", "Message");
+
+                Assert.That(controller.Minimum, Is.EqualTo(0d), "the dialog should start at zero");
+                Assert.That(controller.Maximum, Is.EqualTo(1d), "and it should be full at one, not at a hundred");
+
+                await controller.CloseAsync();
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task SetProgressShouldTakeAValueInThatRange()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+
+            try
+            {
+                var controller = await window.ShowProgressAsync("Title", "Message");
+
+                Assert.That(() => controller.SetProgress(0.25d), Throws.Nothing, "a quarter of the way is 0.25");
+
+                await controller.CloseAsync();
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task SetProgressShouldRefuseAPercentage()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+
+            try
+            {
+                var controller = await window.ShowProgressAsync("Title", "Message");
+
+                Assert.That(() => controller.SetProgress(25d), Throws.InstanceOf<ArgumentOutOfRangeException>(), "25 is past the maximum, which is what makes the old wording so misleading");
+
+                await controller.CloseAsync();
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task SetProgressShouldFollowAMaximumOfYourOwn()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+
+            try
+            {
+                var controller = await window.ShowProgressAsync("Title", "Message");
+
+                controller.Maximum = 100d;
+
+                Assert.That(() => controller.SetProgress(25d), Throws.Nothing, "raising Maximum is how a caller gets percentages");
+
+                await controller.CloseAsync();
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #4575
Closes #4576

Two documentation mismatches in the progress dialog, reported together.

**`SetProgress` promised a percentage.** The bar is created with `Minimum="0.0"` and `Maximum="1.0"`, and the method throws for anything outside that, so the call its own comment invited was the one that failed. It now names the range, points at `Minimum` and `Maximum` for callers who would rather hand it percentages after all, and declares the exception it throws.

**`ProgressDialog` carried the class summary of `MessageDialog` word for word.** It named the wrong dialog and sent readers to `MetroWindow.ShowMessage`, which is not a method. Both summaries now name the right type and the right extension, `ShowProgressAsync` and `ShowMessageAsync`.

### Tests

A comment cannot be driven red to green, so the tests pin the behaviour the new wording describes:

- the controller reports 0.0 as its minimum and 1.0 as its maximum
- `SetProgress(0.25)` goes through
- `SetProgress(25)` throws `ArgumentOutOfRangeException`, which is what makes the old wording so misleading
- after `Maximum = 100`, `SetProgress(25)` goes through, so the escape hatch the comment now mentions really is one

### Not in here

The third report of that set, #4578, cannot be fixed on `develop`: `RequestCloseAsync` was removed in e3e4f5377. What is behind it turned out to be a gap of its own and is now #4601.
