### PR TITLE
fix(Dialogs): let the login dialog use the options of the window

### DIFF
--- a/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -27,7 +27,7 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             window.Dispatcher.VerifyAccess();
 
-            settings ??= new LoginDialogSettings();
+            settings ??= new LoginDialogSettings(window.MetroDialogOptions);
 
             await HandleOverlayOnShowAsync(settings, window);
 
@@ -574,7 +574,7 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             var win = CreateModalExternalWindow(window);
 
-            settings ??= new LoginDialogSettings();
+            settings ??= new LoginDialogSettings(window.MetroDialogOptions);
 
             //create the dialog control
             LoginDialog dialog = new LoginDialog(win, settings)

--- a/src/Mahapps.Metro.Tests/Tests/LoginDialogTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/LoginDialogTests.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Controls.Dialogs;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class LoginDialogTests
+    {
+        private static MetroDialogSettings WindowOptions()
+        {
+            return new MetroDialogSettings
+                   {
+                       ColorScheme = MetroDialogColorScheme.Accented,
+                       NegativeButtonText = "No",
+                       DialogTitleFontSize = 42d
+                   };
+        }
+
+        /// <summary>
+        /// The dialog needs a moment to load before it is the current one, so give it that moment.
+        /// </summary>
+        private static async Task<LoginDialog> WaitForLoginDialogAsync(MetroWindow window)
+        {
+            LoginDialog? dialog = null;
+
+            for (var i = 0; i < 100 && dialog is null; i++)
+            {
+                dialog = await window.GetCurrentDialogAsync<LoginDialog>();
+                if (dialog is null)
+                {
+                    await Task.Delay(20);
+                }
+            }
+
+            Assert.That(dialog, Is.Not.Null, "the login dialog should be up");
+
+            return dialog!;
+        }
+
+        [Test]
+        public async Task LoginDialogShouldTakeTheDialogOptionsOfTheWindow()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            window.SetCurrentValue(MetroWindow.MetroDialogOptionsProperty, WindowOptions());
+
+            try
+            {
+                _ = window.ShowLoginAsync("Title", "Message");
+
+                var dialog = await WaitForLoginDialogAsync(window);
+
+                Assert.That(dialog.DialogSettings.ColorScheme, Is.EqualTo(MetroDialogColorScheme.Accented), "the login dialog should look like every other dialog of the window");
+                Assert.That(dialog.DialogSettings.NegativeButtonText, Is.EqualTo("No"));
+                Assert.That(dialog.DialogSettings.DialogTitleFontSize, Is.EqualTo(42d));
+
+                await window.HideMetroDialogAsync(dialog);
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task LoginDialogShouldKeepItsOwnDefaults()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            window.SetCurrentValue(MetroWindow.MetroDialogOptionsProperty, WindowOptions());
+
+            try
+            {
+                _ = window.ShowLoginAsync("Title", "Message");
+
+                var dialog = await WaitForLoginDialogAsync(window);
+
+                Assert.That(dialog.DialogSettings, Is.InstanceOf<LoginDialogSettings>(), "the dialog needs the login settings, not the plain ones");
+                Assert.That(((LoginDialogSettings)dialog.DialogSettings).UsernameWatermark, Is.EqualTo("Username..."), "what only a login dialog has should still come from its own defaults");
+
+                await window.HideMetroDialogAsync(dialog);
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task SettingsPassedInShouldBeatTheDialogOptionsOfTheWindow()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            window.SetCurrentValue(MetroWindow.MetroDialogOptionsProperty, WindowOptions());
+
+            try
+            {
+                _ = window.ShowLoginAsync("Title", "Message", new LoginDialogSettings { NegativeButtonText = "Nope" });
+
+                var dialog = await WaitForLoginDialogAsync(window);
+
+                Assert.That(dialog.DialogSettings.NegativeButtonText, Is.EqualTo("Nope"), "settings handed to the call should still win");
+
+                await window.HideMetroDialogAsync(dialog);
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #4577

Every entry point in `DialogManager` falls back to `MetroDialogOptions` when the caller passes no settings. The two login ones fell back to a fresh `LoginDialogSettings` instead, so a window that sets a colour scheme, button labels or font sizes for all of its dialogs got a login dialog that looked like none of them.

`ShowLoginAsync` and `ShowModalLoginExternal` now build their settings from the options of the window, through the copy constructor `LoginDialogSettings` already has. It is the same line the demo has always written by hand:

```csharp
await this.ShowLoginAsync("Authentication", "Enter your credentials", new LoginDialogSettings(this.MetroDialogOptions));
```

### Tests

Three, of which the first was red:

- a login dialog with no settings of its own takes the colour scheme, the negative button text and the title font size of the window
- what only a login dialog has, the username watermark for one, still comes from its own defaults
- settings handed to the call still beat the options of the window

### One thing that does not change

`AffirmativeButtonText` keeps coming out as `Login`. The copy constructor sets it after copying the base properties, so it wins over a value from the window. That is how it has always behaved for the callers that used the copy constructor themselves, and changing it would move behaviour nobody reported. The documentation says so now.
