### PR TITLE
fix(Dialogs): tell a dialog which window is showing it

### DIFF
--- a/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -295,6 +295,7 @@ namespace MahApps.Metro.Controls.Dialogs
         {
             AccessKeyHelper.SetIsAccessKeyScope(this, true);
 
+            this.owningWindowFromConstructor = owningWindow;
             this.OwningWindow = owningWindow;
             this.DialogSettings = this.ConfigureSettings(settings ?? owningWindow?.MetroDialogOptions ?? new MetroDialogSettings());
 
@@ -484,8 +485,14 @@ namespace MahApps.Metro.Controls.Dialogs
         }
 
         /// <summary>
-        /// Gets the window this dialog belongs to. It is the window that was handed to the constructor
-        /// until the dialog is shown, and from then on the window that shows it.
+        /// The window the constructor was given, if any. It is what <see cref="OwningWindow"/> falls back
+        /// to once the dialog is not shown any more.
+        /// </summary>
+        private MetroWindow? owningWindowFromConstructor;
+
+        /// <summary>
+        /// Gets the window this dialog belongs to. While the dialog is shown that is the window showing
+        /// it, otherwise the one handed to the constructor, if there was one.
         /// </summary>
         protected MetroWindow? OwningWindow { get; private set; }
 
@@ -496,6 +503,15 @@ namespace MahApps.Metro.Controls.Dialogs
         internal void SetOwningWindow(MetroWindow owningWindow)
         {
             this.OwningWindow = owningWindow;
+        }
+
+        /// <summary>
+        /// Called while the dialog is removed from a window. A dialog that is not shown any more should
+        /// not hold on to a window it was never given, so this falls back to the one of the constructor.
+        /// </summary>
+        internal void ResetOwningWindow()
+        {
+            this.OwningWindow = this.owningWindowFromConstructor;
         }
 
         /// <summary>

--- a/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -484,9 +484,19 @@ namespace MahApps.Metro.Controls.Dialogs
         }
 
         /// <summary>
-        /// Gets the window that owns the current Dialog IF AND ONLY IF the dialog is shown inside of a window.
+        /// Gets the window this dialog belongs to. It is the window that was handed to the constructor
+        /// until the dialog is shown, and from then on the window that shows it.
         /// </summary>
         protected MetroWindow? OwningWindow { get; private set; }
+
+        /// <summary>
+        /// Tells the dialog which window is showing it. Called while the dialog is added to a window, so
+        /// that a dialog the caller created without one can still reach it.
+        /// </summary>
+        internal void SetOwningWindow(MetroWindow owningWindow)
+        {
+            this.OwningWindow = owningWindow;
+        }
 
         /// <summary>
         /// Waits until this dialog gets unloaded.

--- a/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -394,6 +394,8 @@ namespace MahApps.Metro.Controls.Dialogs
 
         private static SizeChangedEventHandler SetupAndAddDialog(MetroWindow window, BaseMetroDialog dialog)
         {
+            dialog.SetOwningWindow(window);
+
             dialog.SetValue(Panel.ZIndexProperty, (int)(window.overlayBox?.GetValue(Panel.ZIndexProperty) ?? 0) + 1);
 
             var fixedMinHeight = dialog.MinHeight > 0;

--- a/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -491,6 +491,8 @@ namespace MahApps.Metro.Controls.Dialogs
             }
 
             window.SetValue(MetroWindow.IsAnyDialogOpenPropertyKey, BooleanBoxes.Box(window.metroActiveDialogContainer.Children.Count > 0));
+
+            dialog.ResetOwningWindow();
         }
 
         private static MetroWindow CreateExternalWindow(Window? windowOwner = null)

--- a/src/Mahapps.Metro.Tests/Tests/DialogOwningWindowTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DialogOwningWindowTests.cs
@@ -84,6 +84,44 @@ namespace MahApps.Metro.Tests.Tests
         }
 
         [Test]
+        public async Task OwningWindowShouldBeLetGoWhenTheDialogIsHidden()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            var dialog = new OwningWindowProbeDialog();
+
+            try
+            {
+                await window.ShowMetroDialogAsync(dialog);
+                await window.HideMetroDialogAsync(dialog);
+
+                Assert.That(dialog.Owner, Is.Null, "a dialog that is not shown any more should not hold on to the window");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task OwningWindowShouldFallBackToTheOneFromTheConstructor()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            var dialog = new OwningWindowProbeDialog(window, null);
+
+            try
+            {
+                await window.ShowMetroDialogAsync(dialog);
+                await window.HideMetroDialogAsync(dialog);
+
+                Assert.That(dialog.Owner, Is.SameAs(window), "what the caller handed to the constructor is not ours to drop");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
         public async Task ADialogDeclaredInXamlShouldGetItsWindowToo()
         {
             var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();

--- a/src/Mahapps.Metro.Tests/Tests/DialogOwningWindowTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DialogOwningWindowTests.cs
@@ -14,34 +14,11 @@ namespace MahApps.Metro.Tests.Tests
     [TestFixture]
     public class DialogOwningWindowTests
     {
-        /// <summary>
-        /// A dialog the way a caller writes one: it reaches its window through <see cref="BaseMetroDialog.OwningWindow"/>,
-        /// which is protected and therefore only available from within a dialog of your own.
-        /// </summary>
-        private class ProbeDialog : CustomDialog
-        {
-            public ProbeDialog()
-            {
-            }
-
-            public ProbeDialog(MetroWindow? owningWindow, MetroDialogSettings? settings)
-                : base(owningWindow, settings)
-            {
-            }
-
-            public MetroWindow? Owner => this.OwningWindow;
-
-            public Task CloseItselfAsync()
-            {
-                return this.OwningWindow!.HideMetroDialogAsync(this);
-            }
-        }
-
         [Test]
         public async Task OwningWindowShouldBeTheWindowThatShowsTheDialog()
         {
             var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
-            var dialog = new ProbeDialog();
+            var dialog = new OwningWindowProbeDialog();
 
             Assert.That(dialog.Owner, Is.Null, "a dialog nobody has shown yet has no window");
 
@@ -64,7 +41,7 @@ namespace MahApps.Metro.Tests.Tests
         {
             var first = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
             var second = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
-            var dialog = new ProbeDialog();
+            var dialog = new OwningWindowProbeDialog();
 
             try
             {
@@ -88,7 +65,7 @@ namespace MahApps.Metro.Tests.Tests
         public async Task OwningWindowShouldStillComeFromTheConstructor()
         {
             var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
-            var dialog = new ProbeDialog(window, null);
+            var dialog = new OwningWindowProbeDialog(window, null);
 
             try
             {
@@ -107,10 +84,34 @@ namespace MahApps.Metro.Tests.Tests
         }
 
         [Test]
+        public async Task ADialogDeclaredInXamlShouldGetItsWindowToo()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            var dialog = (OwningWindowProbeDialog)window.Resources["ProbeDialog"];
+
+            Assert.That(dialog.Owner, Is.Null, "markup builds the dialog with its parameterless constructor, so it starts without a window");
+
+            try
+            {
+                await window.ShowMetroDialogAsync(dialog);
+
+                Assert.That(dialog.Owner, Is.SameAs(window), "a dialog written in XAML should reach its window like any other");
+
+                await dialog.CloseItselfAsync();
+
+                Assert.That(await window.GetCurrentDialogAsync<OwningWindowProbeDialog>(), Is.Null);
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
         public async Task ADialogShouldBeAbleToCloseItself()
         {
             var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
-            var dialog = new ProbeDialog();
+            var dialog = new OwningWindowProbeDialog();
 
             try
             {
@@ -118,7 +119,7 @@ namespace MahApps.Metro.Tests.Tests
 
                 await dialog.CloseItselfAsync();
 
-                Assert.That(await window.GetCurrentDialogAsync<ProbeDialog>(), Is.Null, "a dialog should be able to close itself through its own window");
+                Assert.That(await window.GetCurrentDialogAsync<OwningWindowProbeDialog>(), Is.Null, "a dialog should be able to close itself through its own window");
             }
             finally
             {

--- a/src/Mahapps.Metro.Tests/Tests/DialogOwningWindowTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DialogOwningWindowTests.cs
@@ -1,0 +1,129 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Controls.Dialogs;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class DialogOwningWindowTests
+    {
+        /// <summary>
+        /// A dialog the way a caller writes one: it reaches its window through <see cref="BaseMetroDialog.OwningWindow"/>,
+        /// which is protected and therefore only available from within a dialog of your own.
+        /// </summary>
+        private class ProbeDialog : CustomDialog
+        {
+            public ProbeDialog()
+            {
+            }
+
+            public ProbeDialog(MetroWindow? owningWindow, MetroDialogSettings? settings)
+                : base(owningWindow, settings)
+            {
+            }
+
+            public MetroWindow? Owner => this.OwningWindow;
+
+            public Task CloseItselfAsync()
+            {
+                return this.OwningWindow!.HideMetroDialogAsync(this);
+            }
+        }
+
+        [Test]
+        public async Task OwningWindowShouldBeTheWindowThatShowsTheDialog()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            var dialog = new ProbeDialog();
+
+            Assert.That(dialog.Owner, Is.Null, "a dialog nobody has shown yet has no window");
+
+            try
+            {
+                await window.ShowMetroDialogAsync(dialog);
+
+                Assert.That(dialog.Owner, Is.SameAs(window), "showing a dialog should tell it which window it is on");
+
+                await window.HideMetroDialogAsync(dialog);
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task OwningWindowShouldFollowTheDialogToAnotherWindow()
+        {
+            var first = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            var second = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            var dialog = new ProbeDialog();
+
+            try
+            {
+                await first.ShowMetroDialogAsync(dialog);
+                await first.HideMetroDialogAsync(dialog);
+
+                await second.ShowMetroDialogAsync(dialog);
+
+                Assert.That(dialog.Owner, Is.SameAs(second), "the window that shows the dialog now is the one it belongs to");
+
+                await second.HideMetroDialogAsync(dialog);
+            }
+            finally
+            {
+                first.Close();
+                second.Close();
+            }
+        }
+
+        [Test]
+        public async Task OwningWindowShouldStillComeFromTheConstructor()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            var dialog = new ProbeDialog(window, null);
+
+            try
+            {
+                Assert.That(dialog.Owner, Is.SameAs(window), "a dialog built with its window knows it before it is shown");
+
+                await window.ShowMetroDialogAsync(dialog);
+
+                Assert.That(dialog.Owner, Is.SameAs(window));
+
+                await window.HideMetroDialogAsync(dialog);
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task ADialogShouldBeAbleToCloseItself()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<DialogWindow>();
+            var dialog = new ProbeDialog();
+
+            try
+            {
+                await window.ShowMetroDialogAsync(dialog);
+
+                await dialog.CloseItselfAsync();
+
+                Assert.That(await window.GetCurrentDialogAsync<ProbeDialog>(), Is.Null, "a dialog should be able to close itself through its own window");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Views/DialogWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/DialogWindow.xaml
@@ -5,6 +5,7 @@
                   xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                   xmlns:tests="clr-namespace:MahApps.Metro.Tests"
+                  xmlns:views="clr-namespace:MahApps.Metro.Tests.Views"
                   d:DesignHeight="300"
                   d:DesignWidth="300"
                   mc:Ignorable="d">
@@ -13,6 +14,9 @@
             <mah:CustomDialog x:Key="CustomDialog" Title="{Binding Path=Title}">
                 <TextBlock x:Name="TheDialogBody" Text="{Binding Path=Text}" />
             </mah:CustomDialog>
+            <views:OwningWindowProbeDialog x:Key="ProbeDialog" Title="Probe">
+                <TextBlock Text="Probe" />
+            </views:OwningWindowProbeDialog>
         </ResourceDictionary>
     </mah:MetroWindow.Resources>
 </tests:TestWindow>

--- a/src/Mahapps.Metro.Tests/Views/OwningWindowProbeDialog.cs
+++ b/src/Mahapps.Metro.Tests/Views/OwningWindowProbeDialog.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Controls.Dialogs;
+
+namespace MahApps.Metro.Tests.Views
+{
+    /// <summary>
+    /// A dialog the way a caller writes one, in code or in XAML. It reaches its window through
+    /// <see cref="BaseMetroDialog.OwningWindow"/>, which is protected and therefore only available
+    /// from within a dialog of your own.
+    /// </summary>
+    public class OwningWindowProbeDialog : CustomDialog
+    {
+        public OwningWindowProbeDialog()
+        {
+        }
+
+        public OwningWindowProbeDialog(MetroWindow? owningWindow, MetroDialogSettings? settings)
+            : base(owningWindow, settings)
+        {
+        }
+
+        public MetroWindow? Owner => this.OwningWindow;
+
+        public Task CloseItselfAsync()
+        {
+            return this.OwningWindow!.HideMetroDialogAsync(this);
+        }
+    }
+}


### PR DESCRIPTION
Closes #4601

`OwningWindow` was only ever filled in by a constructor that was handed the window, although `SetupAndAddDialog(MetroWindow window, BaseMetroDialog dialog)` has both at hand. A dialog the caller created and passed to `ShowMetroDialogAsync` therefore never learned which window was showing it, and could not reach the one thing it needs to close itself.

Adding a dialog to a window sets it now, removing it again lets go of it. Both live where every path goes through: `SetupAndAddDialog` for the one, `RemoveDialog` for the other, so the built-in dialogs take the same route as a custom one.

Letting go falls back to the window the constructor was given rather than to `null`. A dialog built as `new ExportDialog(this)` keeps what the caller gave it, and one built without a window holds nothing once it is hidden, which matters for a dialog in the application resources that outlives the window it was shown on.

### What a caller can write now

```csharp
private async void OnLaterClick(object sender, RoutedEventArgs e)
{
    if (this.OwningWindow is not null)
    {
        await this.OwningWindow.HideMetroDialogAsync(this);
    }
}
```

Until now that needed `this.OwningWindow ?? this.TryFindParent<MetroWindow>()`, the same pair the library keeps in `DetectTheme` for exactly this reason. That fallback stays, for a dialog which is not shown through the manager at all.

### Tests

Seven, in a fixture of their own. Four were red before the change:

- showing a dialog names the window that is showing it
- the dialog follows to another window when that one shows it
- a dialog declared in XAML as a window resource gets one too, which is the ordinary way a `CustomDialog` is written and the case that used to come up empty
- a dialog can close itself through its own window, which failed with a `NullReferenceException` before
- hiding it lets go of the window again
- unless the constructor was given one, which it then falls back to
- a dialog built with its window still knows it before it is shown

The probe dialog lives in `Views` rather than inside the fixture, so that it can be declared in markup as well as in code.

### Also of note

`RequestCloseAsync`, removed in e3e4f5377 and asked about in #4578, went through `OwningWindow` too, so bringing it back would have inherited this gap. Whether it should come back is worth deciding now that it would not.
