### PR TITLE
fix(Clipping): clip the content of a template to its border without ClipBorder

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/VSDemo.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleWindows/VSDemo.xaml
@@ -93,6 +93,7 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <GroupBox Grid.Row="0"
@@ -181,9 +182,16 @@
                                 </Expander>
                             </StackPanel>
                         </Expander>
-                        <Button Grid.Row="2"
-                                Margin="20"
+                        <Button x:Name="TestButton1"
+                                Grid.Row="2"
+                                Margin="20 10"
                                 Content="Beam me up..." />
+                        <Button x:Name="TestButton2"
+                                Grid.Row="3"
+                                Margin="20 10"
+                                Padding="4"
+                                mah:ControlsHelper.CornerRadius="4"
+                                Content="...Scotty!" />
                     </Grid>
                 </TabItem>
                 <TabItem Header="Demo">

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/HamburgerMenuRipple/HamburgerMenuRipple.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/HamburgerMenuRipple/HamburgerMenuRipple.xaml
@@ -59,17 +59,23 @@
                             <Grid x:Name="RootGrid"
                                   Background="Transparent"
                                   RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}">
-                                <mah:ClipBorder x:Name="Background"
-                                                Background="{TemplateBinding Background}"
-                                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-
-                                <mah:ClipBorder x:Name="Border"
-                                                BorderBrush="{TemplateBinding BorderBrush}"
-                                                BorderThickness="{TemplateBinding BorderThickness}"
-                                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                                    <Grid>
+                                <Border x:Name="Border"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                    <Grid x:Name="ContentGrid">
+                                        <Grid.Clip>
+                                            <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                            <MultiBinding Converter="{x:Static mah:ClipGeometryConverter.Instance}">
+                                                <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                                <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                                <Binding ElementName="Border" Path="CornerRadius" />
+                                                <Binding ElementName="Border" Path="BorderThickness" />
+                                                <Binding ElementName="Border" Path="Padding" />
+                                            </MultiBinding>
+                                        </Grid.Clip>
                                         <Grid HorizontalAlignment="Left"
                                               VerticalAlignment="Center"
                                               Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:HamburgerMenu}}, Path=ShowSelectionIndicator, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -91,11 +97,11 @@
                                                                Focusable="False"
                                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                     </Grid>
-                                </mah:ClipBorder>
+                                </Border>
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsSelected" Value="True">
-                                    <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedBackgroundBrush), Mode=OneWay}" />
+                                    <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedBackgroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedBorderBrush), Mode=OneWay}" />
                                     <Setter TargetName="ContentPresenter" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedForegroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedForegroundBrush), Mode=OneWay}" />
@@ -106,7 +112,7 @@
                                         <Condition Property="IsSelected" Value="True" />
                                         <Condition Property="Selector.IsSelectionActive" Value="True" />
                                     </MultiTrigger.Conditions>
-                                    <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionBackgroundBrush), Mode=OneWay}" />
+                                    <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionBackgroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionBorderBrush), Mode=OneWay}" />
                                     <Setter TargetName="ContentPresenter" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionForegroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionForegroundBrush), Mode=OneWay}" />
@@ -117,7 +123,7 @@
                                         <Condition Property="IsMouseOver" Value="True" />
                                         <Condition Property="IsSelected" Value="True" />
                                     </MultiTrigger.Conditions>
-                                    <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedBackgroundBrush), Mode=OneWay}" />
+                                    <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedBackgroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedBorderBrush), Mode=OneWay}" />
                                     <Setter TargetName="ContentPresenter" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedForegroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedForegroundBrush), Mode=OneWay}" />
@@ -127,27 +133,27 @@
                                         <Condition Property="IsMouseOver" Value="True" />
                                         <Condition Property="IsSelected" Value="False" />
                                     </MultiTrigger.Conditions>
-                                    <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverBackgroundBrush), Mode=OneWay}" />
+                                    <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverBackgroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverBorderBrush), Mode=OneWay}" />
                                     <Setter TargetName="ContentPresenter" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverForegroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverForegroundBrush), Mode=OneWay}" />
                                 </MultiTrigger>
 
                                 <Trigger Property="mah:ItemHelper.IsMouseLeftButtonPressed" Value="True">
-                                    <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseLeftButtonPressedBackgroundBrush), Mode=OneWay}" />
+                                    <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseLeftButtonPressedBackgroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseLeftButtonPressedBorderBrush), Mode=OneWay}" />
                                     <Setter TargetName="ContentPresenter" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseLeftButtonPressedForegroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseLeftButtonPressedForegroundBrush), Mode=OneWay}" />
                                 </Trigger>
                                 <Trigger Property="mah:ItemHelper.IsMouseRightButtonPressed" Value="True">
-                                    <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseRightButtonPressedBackgroundBrush), Mode=OneWay}" />
+                                    <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseRightButtonPressedBackgroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseRightButtonPressedBorderBrush), Mode=OneWay}" />
                                     <Setter TargetName="ContentPresenter" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseRightButtonPressedForegroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseRightButtonPressedForegroundBrush), Mode=OneWay}" />
                                 </Trigger>
 
                                 <Trigger Property="IsEnabled" Value="False">
-                                    <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledBackgroundBrush), Mode=OneWay}" />
+                                    <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledBackgroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledBorderBrush), Mode=OneWay}" />
                                     <Setter TargetName="ContentPresenter" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledForegroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="RootGrid" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background, Mode=OneWay}" />
@@ -158,7 +164,7 @@
                                         <Condition Property="IsEnabled" Value="False" />
                                         <Condition Property="IsSelected" Value="True" />
                                     </MultiTrigger.Conditions>
-                                    <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedBackgroundBrush), Mode=OneWay}" />
+                                    <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedBackgroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedBorderBrush), Mode=OneWay}" />
                                     <Setter TargetName="ContentPresenter" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedForegroundBrush), Mode=OneWay}" />
                                     <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedForegroundBrush), Mode=OneWay}" />

--- a/src/MahApps.Metro/Controls/ClipBorder.Utils.cs
+++ b/src/MahApps.Metro/Controls/ClipBorder.Utils.cs
@@ -12,6 +12,7 @@ namespace MahApps.Metro.Controls
     /// <summary>
     /// A few very useful extension methods
     /// </summary>
+    [Obsolete("These extensions were written for ClipBorder, which is obsolete as well, and nothing else in the library uses them any more. DoubleUtil.AreClose covers the one comparison that was of general use.")]
     public static class Utils
     {
         #region Double

--- a/src/MahApps.Metro/Controls/ClipBorder.cs
+++ b/src/MahApps.Metro/Controls/ClipBorder.cs
@@ -14,6 +14,7 @@ namespace MahApps.Metro.Controls
     /// Represents a border whose contents are clipped within the bounds
     /// of the border. The border may have rounded corners.
     /// </summary>
+    [Obsolete("Use a Border and clip its content instead: put a Grid inside it and bind the Clip of that grid to ClipGeometryConverter, passing the size of the grid and the corner radius, the border thickness and the padding of the border. That is what the styles in here do, and it keeps every feature of the WPF Border.")]
     public sealed class ClipBorder : Decorator
     {
         #region Fields

--- a/src/MahApps.Metro/Controls/ColorPicker/HSVColor.cs
+++ b/src/MahApps.Metro/Controls/ColorPicker/HSVColor.cs
@@ -133,7 +133,10 @@ namespace MahApps.Metro.Controls
 
         public bool Equals(HSVColor other)
         {
-            return this.Hue.IsCloseTo(other.Hue) && this.A.IsCloseTo(other.A) && this.Saturation.IsCloseTo(other.Saturation) && this.Value.IsCloseTo(other.Value);
+            return DoubleUtil.AreClose(this.Hue, other.Hue)
+                   && DoubleUtil.AreClose(this.A, other.A)
+                   && DoubleUtil.AreClose(this.Saturation, other.Saturation)
+                   && DoubleUtil.AreClose(this.Value, other.Value);
         }
     }
 }

--- a/src/MahApps.Metro/Controls/Helper/ControlsHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ControlsHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
@@ -153,6 +154,8 @@ namespace MahApps.Metro.Controls
             obj.SetValue(FocusBorderBrushProperty, value);
         }
 
+        /// <summary>Identifies the FocusBorderThickness attached property.</summary>
+        [Obsolete("Changing the border thickness on focus makes the control jump, because the content has to move with it. Set FocusBorderBrush instead, which colours the border it already has.")]
         public static readonly DependencyProperty FocusBorderThicknessProperty
             = DependencyProperty.RegisterAttached(
                 "FocusBorderThickness",
@@ -161,8 +164,9 @@ namespace MahApps.Metro.Controls
                 new FrameworkPropertyMetadata(default(Thickness), FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.Inherits));
 
         /// <summary>
-        /// Gets the brush used to draw the focus border.
+        /// Gets the thickness the border is drawn with while the control has the focus.
         /// </summary>
+        [Obsolete("Changing the border thickness on focus makes the control jump, because the content has to move with it. Set FocusBorderBrush instead, which colours the border it already has.")]
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(TextBox))]
         [AttachedPropertyBrowsableForType(typeof(DatePicker))]
@@ -174,8 +178,9 @@ namespace MahApps.Metro.Controls
         }
 
         /// <summary>
-        /// Sets the brush used to draw the focus border.
+        /// Sets the thickness the border is drawn with while the control has the focus.
         /// </summary>
+        [Obsolete("Changing the border thickness on focus makes the control jump, because the content has to move with it. Set FocusBorderBrush instead, which colours the border it already has.")]
         [Category(AppName.MahApps)]
         [AttachedPropertyBrowsableForType(typeof(TextBox))]
         [AttachedPropertyBrowsableForType(typeof(DatePicker))]

--- a/src/MahApps.Metro/Controls/Helper/DoubleUtil.cs
+++ b/src/MahApps.Metro/Controls/Helper/DoubleUtil.cs
@@ -25,10 +25,12 @@ namespace MahApps.Metro.Controls
         /// <param name="value2">The second double to compare.</param>
         public static bool AreClose(double value1, double value2)
         {
-            // Infinities compare equal to themselves, which the epsilon check below cannot do.
-            if (value1 == value2)
+            // The epsilon check below cannot answer for infinities: subtracting one from itself gives
+            // NaN, and every comparison against NaN is false. So they are answered here, on whether
+            // they are the same value, which for two infinities means the same sign.
+            if (double.IsInfinity(value1) || double.IsInfinity(value2))
             {
-                return true;
+                return value1.CompareTo(value2) == 0;
             }
 
             // This computes (|value1-value2| / (|value1| + |value2| + 10.0)) < Epsilon

--- a/src/MahApps.Metro/Controls/Helper/DoubleUtil.cs
+++ b/src/MahApps.Metro/Controls/Helper/DoubleUtil.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MahApps.Metro.Controls
+{
+    /// <summary>
+    /// Comparing two doubles for equality fails on values that only differ by the last bit or two,
+    /// which is what arithmetic on them leaves behind. These comparisons allow for that.
+    /// </summary>
+    public static class DoubleUtil
+    {
+        /// <summary>
+        /// The smallest double where 1.0 + Epsilon is not 1.0 any more.
+        /// </summary>
+        private const double Epsilon = 2.2204460492503131e-016;
+
+        /// <summary>
+        /// Gets whether two doubles are close enough to each other to count as equal. How close that is
+        /// grows with the values themselves, so the comparison holds up at any magnitude.
+        /// </summary>
+        /// <param name="value1">The first double to compare.</param>
+        /// <param name="value2">The second double to compare.</param>
+        public static bool AreClose(double value1, double value2)
+        {
+            // Infinities compare equal to themselves, which the epsilon check below cannot do.
+            if (value1 == value2)
+            {
+                return true;
+            }
+
+            // This computes (|value1-value2| / (|value1| + |value2| + 10.0)) < Epsilon
+            var eps = (Math.Abs(value1) + Math.Abs(value2) + 10.0) * Epsilon;
+            var delta = value1 - value2;
+
+            return -eps < delta && eps > delta;
+        }
+    }
+}

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1295,7 +1295,7 @@ namespace MahApps.Metro.Controls
             {
                 var textRepresentsValue = newValue.HasValue
                                           && this.ValidateText(this.valueTextBox.Text, out var textValue)
-                                          && FormattedValue(textValue, this.StringFormat, this.SpecificCultureInfo).IsCloseTo(newValue.Value);
+                                          && DoubleUtil.AreClose(FormattedValue(textValue, this.StringFormat, this.SpecificCultureInfo), newValue.Value);
 
                 if (!textRepresentsValue)
                 {

--- a/src/MahApps.Metro/Converters/ClipGeometryConverter.cs
+++ b/src/MahApps.Metro/Converters/ClipGeometryConverter.cs
@@ -40,8 +40,8 @@ namespace MahApps.Metro.Converters
             var padding = values.Length > 4 && values[4] is Thickness thicknessPadding ? thicknessPadding : default;
 
             // Half of the border and the whole padding, which is how the WPF Border draws the inner edge
-            // of its own frame and what ClipBorder clips its child to. Taking the whole thickness would
-            // leave a gap between the frame and the content along every rounded corner.
+            // of its own frame. Taking the whole thickness would leave a gap between the frame and the
+            // content along every rounded corner.
             var inset = new Thickness(0.5 * borderThickness.Left + padding.Left,
                                       0.5 * borderThickness.Top + padding.Top,
                                       0.5 * borderThickness.Right + padding.Right,

--- a/src/MahApps.Metro/Converters/ClipGeometryConverter.cs
+++ b/src/MahApps.Metro/Converters/ClipGeometryConverter.cs
@@ -1,0 +1,135 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace MahApps.Metro.Converters
+{
+    public class ClipGeometryConverter : IMultiValueConverter
+    {
+        public static readonly ClipGeometryConverter Instance = new();
+
+        /// <summary>
+        /// Builds the geometry for a <see cref="UIElement.Clip"/> on the content of a border. It takes
+        /// the width and the height of the element carrying the clip, and optionally the corner radius,
+        /// the border thickness and the padding of the border around it.
+        /// </summary>
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Length < 2
+                || values[0] is not double width
+                || values[1] is not double height
+                || width <= 0
+                || height <= 0)
+            {
+                return DependencyProperty.UnsetValue;
+            }
+
+            if (width < 1.0 || height < 1.0)
+            {
+                return Geometry.Empty;
+            }
+
+            var cornerRadius = values.Length > 2 && values[2] is CornerRadius radius ? radius : default;
+            var borderThickness = values.Length > 3 && values[3] is Thickness thickness ? thickness : default;
+            var padding = values.Length > 4 && values[4] is Thickness thicknessPadding ? thicknessPadding : default;
+
+            // Half of the border and the whole padding, which is how the WPF Border draws the inner edge
+            // of its own frame and what ClipBorder clips its child to. Taking the whole thickness would
+            // leave a gap between the frame and the content along every rounded corner.
+            var inset = new Thickness(0.5 * borderThickness.Left + padding.Left,
+                                      0.5 * borderThickness.Top + padding.Top,
+                                      0.5 * borderThickness.Right + padding.Right,
+                                      0.5 * borderThickness.Bottom + padding.Bottom);
+
+            var geometry = GetRoundRectangle(new Rect(0, 0, width, height), inset, cornerRadius);
+            geometry.Freeze();
+
+            return geometry;
+        }
+
+        public object?[]? ConvertBack(object? value, Type[] targetTypes, object? parameter, CultureInfo culture)
+            => throw new NotImplementedException();
+
+        // Started from https://wpfspark.wordpress.com/2011/06/08/clipborder-a-wpf-border-that-clips/
+        private static Geometry GetRoundRectangle(Rect baseRect, Thickness inset, CornerRadius cornerRadius)
+        {
+            // The clip sits on the content of the border, so every corner loses what the frame takes away
+            // from it on the two sides that meet there. A corner is an ellipse rather than a circle
+            // whenever those two differ.
+            var topLeftRect = CornerRect(cornerRadius.TopLeft - inset.Left, cornerRadius.TopLeft - inset.Top);
+            var topRightRect = CornerRect(cornerRadius.TopRight - inset.Right, cornerRadius.TopRight - inset.Top);
+            var bottomRightRect = CornerRect(cornerRadius.BottomRight - inset.Right, cornerRadius.BottomRight - inset.Bottom);
+            var bottomLeftRect = CornerRect(cornerRadius.BottomLeft - inset.Left, cornerRadius.BottomLeft - inset.Bottom);
+
+            // Put each of them in its own corner of the rectangle. Size first, then position, so that a
+            // corner which was cut back to nothing still sits on the edge instead of beyond it.
+            topLeftRect.Location = baseRect.TopLeft;
+            topRightRect.Location = new Point(baseRect.Right - topRightRect.Width, baseRect.Top);
+            bottomRightRect.Location = new Point(baseRect.Right - bottomRightRect.Width, baseRect.Bottom - bottomRightRect.Height);
+            bottomLeftRect.Location = new Point(baseRect.Left, baseRect.Bottom - bottomLeftRect.Height);
+
+            // Two corners sharing a side can ask for more than the side has. Then they share it in
+            // proportion instead of overlapping.
+            if (topLeftRect.Right > topRightRect.Left)
+            {
+                var newWidth = topLeftRect.Width / (topLeftRect.Width + topRightRect.Width) * baseRect.Width;
+                topLeftRect = new Rect(topLeftRect.Location, new Size(newWidth, topLeftRect.Height));
+                topRightRect = new Rect(new Point(baseRect.Left + newWidth, topRightRect.Top),
+                                        new Size(Math.Max(0.0, baseRect.Width - newWidth), topRightRect.Height));
+            }
+
+            if (topRightRect.Bottom > bottomRightRect.Top)
+            {
+                var newHeight = topRightRect.Height / (topRightRect.Height + bottomRightRect.Height) * baseRect.Height;
+                topRightRect = new Rect(topRightRect.Location, new Size(topRightRect.Width, newHeight));
+                bottomRightRect = new Rect(new Point(bottomRightRect.Left, baseRect.Top + newHeight),
+                                           new Size(bottomRightRect.Width, Math.Max(0.0, baseRect.Height - newHeight)));
+            }
+
+            if (bottomRightRect.Left < bottomLeftRect.Right)
+            {
+                var newWidth = bottomLeftRect.Width / (bottomLeftRect.Width + bottomRightRect.Width) * baseRect.Width;
+                bottomLeftRect = new Rect(bottomLeftRect.Location, new Size(newWidth, bottomLeftRect.Height));
+                bottomRightRect = new Rect(new Point(baseRect.Left + newWidth, bottomRightRect.Top),
+                                           new Size(Math.Max(0.0, baseRect.Width - newWidth), bottomRightRect.Height));
+            }
+
+            if (bottomLeftRect.Top < topLeftRect.Bottom)
+            {
+                var newHeight = topLeftRect.Height / (topLeftRect.Height + bottomLeftRect.Height) * baseRect.Height;
+                topLeftRect = new Rect(topLeftRect.Location, new Size(topLeftRect.Width, newHeight));
+                bottomLeftRect = new Rect(new Point(bottomLeftRect.Left, baseRect.Top + newHeight),
+                                          new Size(bottomLeftRect.Width, Math.Max(0.0, baseRect.Height - newHeight)));
+            }
+
+            StreamGeometry roundedRectGeometry = new();
+
+            using (var context = roundedRectGeometry.Open())
+            {
+                // Begin from the bottom of the top left arc and proceed clockwise
+                context.BeginFigure(topLeftRect.BottomLeft, true, true);
+
+                context.ArcTo(topLeftRect.TopRight, topLeftRect.Size, 0, false, SweepDirection.Clockwise, true, true);
+                context.LineTo(topRightRect.TopLeft, true, true);
+                context.ArcTo(topRightRect.BottomRight, topRightRect.Size, 0, false, SweepDirection.Clockwise, true, true);
+                context.LineTo(bottomRightRect.TopRight, true, true);
+                context.ArcTo(bottomRightRect.BottomLeft, bottomRightRect.Size, 0, false, SweepDirection.Clockwise, true, true);
+                context.LineTo(bottomLeftRect.BottomRight, true, true);
+                context.ArcTo(bottomLeftRect.TopLeft, bottomLeftRect.Size, 0, false, SweepDirection.Clockwise, true, true);
+            }
+
+            return roundedRectGeometry;
+        }
+
+        private static Rect CornerRect(double width, double height)
+        {
+            return new Rect(0, 0, Math.Max(0.0, width), Math.Max(0.0, height));
+        }
+    }
+}

--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -646,7 +646,6 @@
                         </Trigger>
                         <Trigger Property="IsKeyboardFocusWithin" Value="True">
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderBrush), Mode=OneWay}" />
-                            <Setter TargetName="Border" Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderThickness), Mode=OneWay}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.7" />
@@ -659,7 +658,6 @@
         <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{DynamicResource MahApps.CharacterCasing.Button}" />
         <Setter Property="mah:ControlsHelper.CornerRadius" Value="3" />
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.Border.Focus}" />
-        <Setter Property="mah:ControlsHelper.FocusBorderThickness" Value="1" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.Border.MouseOver}" />
     </Style>
 

--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -659,7 +659,7 @@
         <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{DynamicResource MahApps.CharacterCasing.Button}" />
         <Setter Property="mah:ControlsHelper.CornerRadius" Value="3" />
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.Border.Focus}" />
-        <Setter Property="mah:ControlsHelper.FocusBorderThickness" Value="2" />
+        <Setter Property="mah:ControlsHelper.FocusBorderThickness" Value="1" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.Border.MouseOver}" />
     </Style>
 

--- a/src/MahApps.Metro/Styles/Controls.Buttons.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Buttons.xaml
@@ -32,25 +32,37 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
-                    <mah:ClipBorder x:Name="Border"
-                                    Margin="0"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <mah:ContentControlEx x:Name="PART_ContentPresenter"
-                                              Padding="{TemplateBinding Padding}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              Content="{TemplateBinding Content}"
-                                              ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                              ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                              RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                    </mah:ClipBorder>
+                    <Border x:Name="Border"
+                            Margin="0"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <mah:ContentControlEx x:Name="PART_ContentPresenter"
+                                                  Padding="{TemplateBinding Padding}"
+                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Content="{TemplateBinding Content}"
+                                                  ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                  ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                  RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -87,28 +99,40 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
                     <Grid SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <mah:ClipBorder x:Name="Background"
-                                        Background="{TemplateBinding Background}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Border x:Name="Background"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
-                        <mah:ClipBorder x:Name="Border"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                            <mah:ContentControlEx x:Name="PART_ContentPresenter"
-                                                  Padding="{TemplateBinding Padding}"
-                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  Content="{TemplateBinding Content}"
-                                                  ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                                  ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                  RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </mah:ClipBorder>
+                        <Border x:Name="Border"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
+                                <mah:ContentControlEx x:Name="PART_ContentPresenter"
+                                                      Padding="{TemplateBinding Padding}"
+                                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                      Content="{TemplateBinding Content}"
+                                                      ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                      ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                      ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                      RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </Border>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
@@ -199,25 +223,37 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
-                    <mah:ClipBorder x:Name="Border"
-                                    Margin="0"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <mah:ContentControlEx x:Name="PART_ContentPresenter"
-                                              Padding="{TemplateBinding Padding}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              Content="{TemplateBinding Content}"
-                                              ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                              ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                              RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                    </mah:ClipBorder>
+                    <Border x:Name="Border"
+                            Margin="0"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <mah:ContentControlEx x:Name="PART_ContentPresenter"
+                                                  Padding="{TemplateBinding Padding}"
+                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Content="{TemplateBinding Content}"
+                                                  ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                  ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                  RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -563,30 +599,42 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
                     <Grid>
-                        <mah:ClipBorder x:Name="Border"
-                                        Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <mah:ClipBorder x:Name="DisabledVisualElement"
-                                        Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        IsHitTestVisible="False"
-                                        Opacity="0"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <mah:ContentControlEx x:Name="PART_ContentPresenter"
-                                              Margin="{TemplateBinding BorderThickness}"
-                                              Padding="{TemplateBinding Padding}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              Content="{TemplateBinding Content}"
-                                              ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                              ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                              RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
+                                <mah:ContentControlEx x:Name="PART_ContentPresenter"
+                                                      Padding="{TemplateBinding Padding}"
+                                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                      Content="{TemplateBinding Content}"
+                                                      ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                      ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                      ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                      RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </Border>
+                        <Border x:Name="DisabledVisualElement"
+                                Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                IsHitTestVisible="False"
+                                Opacity="0"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
@@ -602,7 +650,7 @@
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.7" />
-                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="0.3" />
+                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="0.4" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -629,31 +677,42 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
                     <Grid>
-                        <mah:ClipBorder x:Name="Background"
-                                        Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <Grid Margin="{TemplateBinding BorderThickness}">
-                            <mah:ContentControlEx x:Name="PART_ContentPresenter"
-                                                  Padding="{TemplateBinding Padding}"
-                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  Content="{TemplateBinding Content}"
-                                                  ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                                  ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                  RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </Grid>
-                        <mah:ClipBorder x:Name="DisabledVisualElement"
-                                        Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        IsHitTestVisible="False"
-                                        Opacity="0"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
+                                <mah:ContentControlEx x:Name="PART_ContentPresenter"
+                                                      Padding="{TemplateBinding Padding}"
+                                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                      Content="{TemplateBinding Content}"
+                                                      ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                      ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                      ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                      RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </Border>
+                        <Border x:Name="DisabledVisualElement"
+                                Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                IsHitTestVisible="False"
+                                Opacity="0"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
 
                     <ControlTemplate.Triggers>
@@ -667,7 +726,7 @@
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.7" />
-                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="0.3" />
+                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="0.4" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -685,34 +744,45 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
                     <Grid>
-                        <mah:ClipBorder x:Name="Background"
-                                        Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <mah:ClipBorder x:Name="DisabledVisualElement"
-                                        Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        IsHitTestVisible="False"
-                                        Opacity="0"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <Grid Margin="{TemplateBinding BorderThickness}">
-                            <Rectangle x:Name="MouseOverRectangle"
-                                       Fill="{DynamicResource MahApps.Brushes.Button.AccentedSquare.Background.MouseOver}"
-                                       Opacity="0" />
-                            <mah:ContentControlEx x:Name="PART_ContentPresenter"
-                                                  Padding="{TemplateBinding Padding}"
-                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  Content="{TemplateBinding Content}"
-                                                  ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                                  ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                  RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </Grid>
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
+                                <Rectangle x:Name="MouseOverRectangle"
+                                           Fill="{DynamicResource MahApps.Brushes.Button.AccentedSquare.Background.MouseOver}"
+                                           Opacity="0" />
+                                <mah:ContentControlEx x:Name="PART_ContentPresenter"
+                                                      Padding="{TemplateBinding Padding}"
+                                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                      Content="{TemplateBinding Content}"
+                                                      ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                      ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                      ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                      RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </Border>
+                        <Border x:Name="DisabledVisualElement"
+                                Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                IsHitTestVisible="False"
+                                Opacity="0"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
 
                     <ControlTemplate.Triggers>
@@ -743,30 +813,43 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
-                    <Grid Background="{TemplateBinding Background}">
-                        <mah:ClipBorder x:Name="Background"
-                                        Background="{x:Null}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <mah:ClipBorder x:Name="DisabledVisualElement"
-                                        Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        IsHitTestVisible="False"
-                                        Opacity="0"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <mah:ContentControlEx x:Name="PART_ContentPresenter"
-                                              Padding="{TemplateBinding Padding}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              Content="{TemplateBinding Content}"
-                                              ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                              ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                              RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                    <Grid>
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
+                                <mah:ContentControlEx x:Name="PART_ContentPresenter"
+                                                      Padding="{TemplateBinding Padding}"
+                                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                      Content="{TemplateBinding Content}"
+                                                      ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                      ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                      ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                      RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </Border>
+                        <Border x:Name="DisabledVisualElement"
+                                Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                IsHitTestVisible="False"
+                                Opacity="0"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
 
                     <ControlTemplate.Triggers>
@@ -883,30 +966,42 @@
             <Setter.Value>
                 <ControlTemplate TargetType="ToggleButton">
                     <Grid>
-                        <mah:ClipBorder x:Name="Border"
-                                        Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <mah:ClipBorder x:Name="DisabledVisualElement"
-                                        Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        IsHitTestVisible="False"
-                                        Opacity="0"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <mah:ContentControlEx x:Name="PART_ContentPresenter"
-                                              Margin="{TemplateBinding BorderThickness}"
-                                              Padding="{TemplateBinding Padding}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              Content="{TemplateBinding Content}"
-                                              ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                              ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                              RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
+                                <mah:ContentControlEx x:Name="PART_ContentPresenter"
+                                                      Padding="{TemplateBinding Padding}"
+                                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                      Content="{TemplateBinding Content}"
+                                                      ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                      ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                      ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                      RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </Border>
+                        <Border x:Name="DisabledVisualElement"
+                                Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                IsHitTestVisible="False"
+                                Opacity="0"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="True">
@@ -966,18 +1061,30 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
-                    <mah:ClipBorder x:Name="Border"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <ContentPresenter x:Name="PART_ContentPresenter"
-                                          Margin="{TemplateBinding Padding}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}" />
-                    </mah:ClipBorder>
+                    <Border x:Name="Border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <ContentPresenter x:Name="PART_ContentPresenter"
+                                              Margin="{TemplateBinding Padding}"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}" />
+                        </Grid>
+                    </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsKeyboardFocused" Value="True">
                             <Setter TargetName="Border" Property="BorderBrush" Value="Transparent" />

--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -416,18 +416,30 @@
                                Placement="Bottom"
                                PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
                             <Grid MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}" MaxHeight="{Binding MaxDropDownHeight, RelativeSource={RelativeSource TemplatedParent}}">
-                                <mah:ClipBorder x:Name="PopupBorder"
-                                                Height="Auto"
-                                                HorizontalAlignment="Stretch"
-                                                Background="{DynamicResource MahApps.Brushes.ThemeBackground}"
-                                                BorderBrush="{DynamicResource MahApps.Brushes.ComboBox.PopupBorder}"
-                                                BorderThickness="{DynamicResource ComboBoxPopupBorderThemeThickness}"
-                                                CornerRadius="{DynamicResource ComboBoxPopupBorderThemeCornerRadius}"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                                    <ScrollViewer Padding="{DynamicResource ComboBoxPopupBorderThemePadding}" BorderThickness="0">
-                                        <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained" />
-                                    </ScrollViewer>
-                                </mah:ClipBorder>
+                                <Border x:Name="PopupBorder"
+                                        Height="Auto"
+                                        HorizontalAlignment="Stretch"
+                                        Background="{DynamicResource MahApps.Brushes.ComboBox.PopupBackground}"
+                                        BorderBrush="{DynamicResource MahApps.Brushes.ComboBox.PopupBorder}"
+                                        BorderThickness="{DynamicResource ComboBoxPopupBorderThemeThickness}"
+                                        CornerRadius="{DynamicResource ComboBoxPopupBorderThemeCornerRadius}"
+                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                    <Grid x:Name="ContentGrid">
+                                        <Grid.Clip>
+                                            <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                            <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                                <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                                <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                                <Binding ElementName="PopupBorder" Path="CornerRadius" />
+                                                <Binding ElementName="PopupBorder" Path="BorderThickness" />
+                                                <Binding ElementName="PopupBorder" Path="Padding" />
+                                            </MultiBinding>
+                                        </Grid.Clip>
+                                        <ScrollViewer Padding="{DynamicResource ComboBoxPopupBorderThemePadding}" BorderThickness="0">
+                                            <ItemsPresenter x:Name="ItemsPresenter" KeyboardNavigation.DirectionalNavigation="Contained" />
+                                        </ScrollViewer>
+                                    </Grid>
+                                </Border>
                             </Grid>
                         </Popup>
                         <VisualStateManager.VisualStateGroups>
@@ -618,22 +630,34 @@
                           Background="Transparent"
                           RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <mah:ClipBorder x:Name="Background"
-                                        Background="{TemplateBinding Background}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Border x:Name="Background"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
-                        <mah:ClipBorder x:Name="Border"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                            <ContentPresenter x:Name="ContentPresenter"
-                                              Margin="{TemplateBinding Padding}"
-                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </mah:ClipBorder>
+                        <Border x:Name="Border"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
+                                <ContentPresenter x:Name="ContentPresenter"
+                                                  Margin="{TemplateBinding Padding}"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="True">

--- a/src/MahApps.Metro/Styles/Controls.ContextMenu.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ContextMenu.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <Style x:Key="MahApps.Styles.ContextMenu" TargetType="{x:Type ContextMenu}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.ContextMenu.Background}" />
@@ -21,27 +22,35 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ContextMenu}">
-                    <mah:ClipBorder x:Name="Border"
-                                    Width="{TemplateBinding Width}"
-                                    Height="{TemplateBinding Height}"
-                                    Padding="{TemplateBinding Padding}"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-
-                        <ScrollViewer x:Name="SubMenuScrollViewer"
-                                      CanContentScroll="True"
-                                      Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
-                            <ItemsPresenter x:Name="ItemsPresenter"
-                                            Margin="0"
-                                            Grid.IsSharedSizeScope="True"
-                                            KeyboardNavigation.DirectionalNavigation="Cycle"
-                                            KeyboardNavigation.TabNavigation="Cycle"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </ScrollViewer>
-                    </mah:ClipBorder>
+                    <Border x:Name="Border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <ScrollViewer x:Name="SubMenuScrollViewer"
+                                          CanContentScroll="True"
+                                          Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                                <ItemsPresenter x:Name="ItemsPresenter"
+                                                Margin="{TemplateBinding Padding}"
+                                                Grid.IsSharedSizeScope="True"
+                                                KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                KeyboardNavigation.TabNavigation="Cycle"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </ScrollViewer>
+                        </Grid>
+                    </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="HasDropShadow" Value="True">
                             <Setter TargetName="Border" Property="Effect" Value="{DynamicResource MahApps.DropShadowEffect.Menu}" />

--- a/src/MahApps.Metro/Styles/Controls.ListBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ListBox.xaml
@@ -24,16 +24,28 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <ScrollViewer Padding="{TemplateBinding Padding}"
-                                      mah:ScrollViewerHelper.BubbleUpScrollEventToParentScrollviewer="{TemplateBinding mah:ScrollViewerHelper.BubbleUpScrollEventToParentScrollviewer}"
-                                      mah:ScrollViewerHelper.IsHorizontalScrollWheelEnabled="{TemplateBinding mah:ScrollViewerHelper.IsHorizontalScrollWheelEnabled}"
-                                      CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
-                                      Focusable="False"
-                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </ScrollViewer>
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <ScrollViewer Padding="{TemplateBinding Padding}"
+                                          mah:ScrollViewerHelper.BubbleUpScrollEventToParentScrollviewer="{TemplateBinding mah:ScrollViewerHelper.BubbleUpScrollEventToParentScrollviewer}"
+                                          mah:ScrollViewerHelper.IsHorizontalScrollWheelEnabled="{TemplateBinding mah:ScrollViewerHelper.IsHorizontalScrollWheelEnabled}"
+                                          CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
+                                          Focusable="False"
+                                          HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                                <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </ScrollViewer>
+                        </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <MultiTrigger>

--- a/src/MahApps.Metro/Styles/Controls.ListBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ListBox.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <Style x:Key="MahApps.Styles.ListBox" TargetType="{x:Type ListBox}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.ThemeBackground}" />
@@ -93,22 +94,34 @@
                           Background="Transparent"
                           RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <mah:ClipBorder x:Name="Background"
-                                        Background="{TemplateBinding Background}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Border x:Name="Background"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
-                        <mah:ClipBorder x:Name="Border"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                            <ContentPresenter x:Name="ContentPresenter"
-                                              Margin="{TemplateBinding Padding}"
-                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </mah:ClipBorder>
+                        <Border x:Name="Border"
+                                Padding="{TemplateBinding Padding}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
+                                <ContentPresenter x:Name="ContentPresenter"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="True">

--- a/src/MahApps.Metro/Styles/Controls.ListView.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ListView.xaml
@@ -113,15 +113,27 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <ScrollViewer Padding="{TemplateBinding Padding}"
-                                      CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
-                                      Focusable="False"
-                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                      Style="{DynamicResource MahApps.Styles.ScrollViewer.GridView}"
-                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                            <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </ScrollViewer>
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <ScrollViewer Padding="{TemplateBinding Padding}"
+                                          CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
+                                          Focusable="False"
+                                          HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          Style="{DynamicResource MahApps.Styles.ScrollViewer.GridView}"
+                                          VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                                <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </ScrollViewer>
+                        </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <MultiTrigger>

--- a/src/MahApps.Metro/Styles/Controls.ListView.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ListView.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <Style x:Key="MahApps.Styles.ScrollViewer.GridView"
            BasedOn="{StaticResource {x:Static GridView.GridViewScrollViewerStyleKey}}"
@@ -166,28 +167,38 @@
                           Background="Transparent"
                           RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <mah:ClipBorder x:Name="Background"
-                                        Background="{TemplateBinding Background}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Border x:Name="Background"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
-                        <mah:ClipBorder x:Name="Border"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                            <Grid>
+                        <Border x:Name="Border"
+                                Padding="{TemplateBinding Padding}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
                                 <GridViewRowPresenter x:Name="PART_RowPresenter"
                                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                 <ContentPresenter x:Name="PART_ContentPresenter"
-                                                  Margin="{TemplateBinding Padding}"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                   Visibility="Collapsed" />
                             </Grid>
-                        </mah:ClipBorder>
+                        </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="GridView.ColumnCollection" Value="{x:Null}">
@@ -301,28 +312,38 @@
                           Background="Transparent"
                           RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <mah:ClipBorder x:Name="Background"
-                                        Background="{TemplateBinding Background}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Border x:Name="Background"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
-                        <mah:ClipBorder x:Name="Border"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                            <Grid>
+                        <Border x:Name="Border"
+                                Padding="{TemplateBinding Padding}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
                                 <GridViewRowPresenter x:Name="PART_RowPresenter"
                                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                 <ContentPresenter x:Name="PART_ContentPresenter"
-                                                  Margin="{TemplateBinding Padding}"
                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                   Visibility="Collapsed" />
                             </Grid>
-                        </mah:ClipBorder>
+                        </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="GridView.ColumnCollection" Value="{x:Null}">

--- a/src/MahApps.Metro/Styles/Controls.Menu.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Menu.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <Style x:Key="MahApps.Styles.Menu" TargetType="{x:Type Menu}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Menu.Background}" />
@@ -14,15 +15,26 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Menu}">
-                    <mah:ClipBorder Width="{TemplateBinding Width}"
-                                    Height="{TemplateBinding Height}"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <ItemsPresenter Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                    </mah:ClipBorder>
+                    <Border x:Name="Border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <ItemsPresenter Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/MahApps.Metro/Styles/Controls.MenuItem.xaml
+++ b/src/MahApps.Metro/Styles/Controls.MenuItem.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <MenuScrollingVisibilityConverter x:Key="MenuScrollingVisibilityConverter" />
 
@@ -228,23 +229,35 @@
                    Placement="Bottom"
                    PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}"
                    VerticalOffset="-2">
-                <mah:ClipBorder x:Name="Border"
-                                Background="{DynamicResource MahApps.Brushes.SubMenu.Background}"
-                                BorderBrush="{DynamicResource MahApps.Brushes.SubMenu.Border}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                    <ScrollViewer x:Name="SubMenuScrollViewer"
-                                  CanContentScroll="True"
-                                  Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
-                        <ItemsPresenter x:Name="ItemsPresenter"
-                                        Margin="0"
-                                        Grid.IsSharedSizeScope="True"
-                                        KeyboardNavigation.DirectionalNavigation="Cycle"
-                                        KeyboardNavigation.TabNavigation="Cycle"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                    </ScrollViewer>
-                </mah:ClipBorder>
+                <Border x:Name="Border"
+                        Background="{DynamicResource MahApps.Brushes.SubMenu.Background}"
+                        BorderBrush="{DynamicResource MahApps.Brushes.SubMenu.Border}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                    <Grid x:Name="ContentGrid">
+                        <Grid.Clip>
+                            <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                            <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                <Binding ElementName="Border" Path="CornerRadius" />
+                                <Binding ElementName="Border" Path="BorderThickness" />
+                                <Binding ElementName="Border" Path="Padding" />
+                            </MultiBinding>
+                        </Grid.Clip>
+                        <ScrollViewer x:Name="SubMenuScrollViewer"
+                                      CanContentScroll="True"
+                                      Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                            <ItemsPresenter x:Name="ItemsPresenter"
+                                            Margin="0"
+                                            Grid.IsSharedSizeScope="True"
+                                            KeyboardNavigation.DirectionalNavigation="Cycle"
+                                            KeyboardNavigation.TabNavigation="Cycle"
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </ScrollViewer>
+                    </Grid>
+                </Border>
             </Popup>
         </Grid>
         <ControlTemplate.Triggers>
@@ -384,23 +397,35 @@
                        Placement="Right"
                        PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}"
                        VerticalOffset="-3">
-                    <mah:ClipBorder x:Name="Border"
-                                    Background="{DynamicResource MahApps.Brushes.SubMenu.Background}"
-                                    BorderBrush="{DynamicResource MahApps.Brushes.SubMenu.Border}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <ScrollViewer x:Name="SubMenuScrollViewer"
-                                      CanContentScroll="True"
-                                      Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
-                            <ItemsPresenter x:Name="ItemsPresenter"
-                                            Margin="0"
-                                            Grid.IsSharedSizeScope="True"
-                                            KeyboardNavigation.DirectionalNavigation="Cycle"
-                                            KeyboardNavigation.TabNavigation="Cycle"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </ScrollViewer>
-                    </mah:ClipBorder>
+                    <Border x:Name="Border"
+                            Background="{DynamicResource MahApps.Brushes.SubMenu.Background}"
+                            BorderBrush="{DynamicResource MahApps.Brushes.SubMenu.Border}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <ScrollViewer x:Name="SubMenuScrollViewer"
+                                          CanContentScroll="True"
+                                          Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                                <ItemsPresenter x:Name="ItemsPresenter"
+                                                Margin="0"
+                                                Grid.IsSharedSizeScope="True"
+                                                KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                KeyboardNavigation.TabNavigation="Cycle"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </ScrollViewer>
+                        </Grid>
+                    </Border>
                 </Popup>
             </Grid>
         </Grid>

--- a/src/MahApps.Metro/Styles/Controls.TreeView.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TreeView.xaml
@@ -84,37 +84,50 @@
                               Background="Transparent"
                               RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}"
                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                            <mah:ClipBorder x:Name="Background"
-                                            Background="{TemplateBinding Background}"
-                                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <Border x:Name="Background"
+                                    Background="{TemplateBinding Background}"
+                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
-                            <mah:ClipBorder x:Name="Border"
-                                            Padding="{TemplateBinding Padding}"
-                                            BorderBrush="{TemplateBinding BorderBrush}"
-                                            BorderThickness="{TemplateBinding BorderThickness}"
-                                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                                <Grid Margin="{Binding Converter={StaticResource LengthConverter}, RelativeSource={x:Static RelativeSource.TemplatedParent}}"
-                                      VerticalAlignment="Stretch"
-                                      Background="Transparent">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" />
-                                        <ColumnDefinition Width="*" />
-                                    </Grid.ColumnDefinitions>
-                                    <ToggleButton x:Name="Expander"
-                                                  Grid.Column="0"
-                                                  ClickMode="Press"
-                                                  IsChecked="{Binding Path=IsExpanded, RelativeSource={x:Static RelativeSource.TemplatedParent}, Mode=TwoWay}"
-                                                  Style="{TemplateBinding mah:TreeViewItemHelper.ToggleButtonStyle}" />
-                                    <ContentPresenter x:Name="PART_Header"
-                                                      Grid.Column="1"
-                                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                      ContentSource="Header"
-                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <Border x:Name="Border"
+                                    Padding="{TemplateBinding Padding}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                <Grid x:Name="ContentGrid">
+                                    <Grid.Clip>
+                                        <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over. It sits on the whole inside of the border rather than on the indented header, which starts somewhere in the middle of the item and has no corners of its own.  -->
+                                        <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                            <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                            <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                            <Binding ElementName="Border" Path="CornerRadius" />
+                                            <Binding ElementName="Border" Path="BorderThickness" />
+                                            <Binding ElementName="Border" Path="Padding" />
+                                        </MultiBinding>
+                                    </Grid.Clip>
+                                    <Grid x:Name="HeaderGrid"
+                                          Margin="{Binding Converter={StaticResource LengthConverter}, RelativeSource={x:Static RelativeSource.TemplatedParent}}"
+                                          VerticalAlignment="Stretch"
+                                          Background="Transparent">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <ToggleButton x:Name="Expander"
+                                                      Grid.Column="0"
+                                                      ClickMode="Press"
+                                                      IsChecked="{Binding Path=IsExpanded, RelativeSource={x:Static RelativeSource.TemplatedParent}, Mode=TwoWay}"
+                                                      Style="{TemplateBinding mah:TreeViewItemHelper.ToggleButtonStyle}" />
+                                        <ContentPresenter x:Name="PART_Header"
+                                                          Grid.Column="1"
+                                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                          ContentSource="Header"
+                                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                    </Grid>
                                 </Grid>
-                            </mah:ClipBorder>
+                            </Border>
                         </Grid>
 
                         <ItemsPresenter x:Name="ItemsHost" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />

--- a/src/MahApps.Metro/Styles/Controls.TreeView.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TreeView.xaml
@@ -257,15 +257,27 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <ScrollViewer x:Name="TreeViewScrollViewer"
-                                      Padding="{TemplateBinding Padding}"
-                                      CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
-                                      Focusable="False"
-                                      HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                      VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
-                            <ItemsPresenter />
-                        </ScrollViewer>
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <ScrollViewer x:Name="TreeViewScrollViewer"
+                                          Padding="{TemplateBinding Padding}"
+                                          CanContentScroll="{TemplateBinding ScrollViewer.CanContentScroll}"
+                                          Focusable="False"
+                                          HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                                <ItemsPresenter />
+                            </ScrollViewer>
+                        </Grid>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/MahApps.Metro/Styles/Themes/Theme.Template.xaml
+++ b/src/MahApps.Metro/Styles/Themes/Theme.Template.xaml
@@ -119,6 +119,7 @@
 
     <SolidColorBrush x:Key="MahApps.Brushes.ComboBox.Border.MouseOver" Color="{StaticResource MahApps.Colors.Gray2}" options:Freeze="True" />
     <SolidColorBrush x:Key="MahApps.Brushes.ComboBox.Border.Focus" Color="{StaticResource MahApps.Colors.ThemeForeground}" options:Freeze="True" />
+    <SolidColorBrush x:Key="MahApps.Brushes.ComboBox.PopupBackground" Color="{StaticResource MahApps.Colors.ThemeBackground}" options:Freeze="True" />
     <SolidColorBrush x:Key="MahApps.Brushes.ComboBox.PopupBorder" Color="{StaticResource MahApps.Colors.Gray4}" options:Freeze="True" />
 
     <SolidColorBrush x:Key="MahApps.Brushes.CheckBox" Color="{StaticResource MahApps.Colors.Gray5}" options:Freeze="True" />

--- a/src/MahApps.Metro/Styles/VS/Button.xaml
+++ b/src/MahApps.Metro/Styles/VS/Button.xaml
@@ -1,26 +1,43 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <Style x:Key="MahApps.Styles.Button.VisualStudio" TargetType="Button">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Background.Normal}" />
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Border.Normal}" />
+        <Setter Property="BorderThickness" Value="1" />
         <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Foreground}" />
-        <Setter Property="Height" Value="23" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="MinHeight" Value="24" />
         <Setter Property="Padding" Value="1" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
-                    <mah:ClipBorder Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="1"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    SnapsToDevicePixels="True">
-                        <ContentPresenter Margin="{TemplateBinding Padding}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-                    </mah:ClipBorder>
+                    <Border x:Name="Border"
+                            Padding="{TemplateBinding Padding}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <ContentPresenter x:Name="PART_ContentPresenter"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                        </Grid>
+                    </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.BackgroundHighlighted}" />

--- a/src/MahApps.Metro/Styles/VS/ContextMenu.xaml
+++ b/src/MahApps.Metro/Styles/VS/ContextMenu.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <Style x:Key="MahApps.Styles.ContextMenu.VisualStudio" TargetType="{x:Type ContextMenu}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.ContextMenu.Background}" />
@@ -22,27 +23,35 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ContextMenu}">
-                    <mah:ClipBorder x:Name="Border"
-                                    Width="{TemplateBinding Width}"
-                                    Height="{TemplateBinding Height}"
-                                    Padding="{TemplateBinding Padding}"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-
-                        <ScrollViewer x:Name="SubMenuScrollViewer"
-                                      CanContentScroll="True"
-                                      Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
-                            <ItemsPresenter x:Name="ItemsPresenter"
-                                            Margin="0"
-                                            Grid.IsSharedSizeScope="True"
-                                            KeyboardNavigation.DirectionalNavigation="Cycle"
-                                            KeyboardNavigation.TabNavigation="Cycle"
-                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </ScrollViewer>
-                    </mah:ClipBorder>
+                    <Border x:Name="Border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <ScrollViewer x:Name="SubMenuScrollViewer"
+                                          CanContentScroll="True"
+                                          Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                                <ItemsPresenter x:Name="ItemsPresenter"
+                                                Margin="{TemplateBinding Padding}"
+                                                Grid.IsSharedSizeScope="True"
+                                                KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                KeyboardNavigation.TabNavigation="Cycle"
+                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </ScrollViewer>
+                        </Grid>
+                    </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="HasDropShadow" Value="True">
                             <Setter TargetName="Border" Property="Effect" Value="{DynamicResource MahApps.DropShadowEffect.Menu.VisualStudio}" />

--- a/src/MahApps.Metro/Styles/VS/Menu.xaml
+++ b/src/MahApps.Metro/Styles/VS/Menu.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <Style x:Key="MahApps.Styles.Menu.VisualStudio" TargetType="{x:Type Menu}">
         <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.LightBackground}" />
@@ -10,15 +11,26 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Menu}">
-                    <mah:ClipBorder Width="{TemplateBinding Width}"
-                                    Height="{TemplateBinding Height}"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <ItemsPresenter Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                    </mah:ClipBorder>
+                    <Border x:Name="Border"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <ItemsPresenter Margin="{TemplateBinding Padding}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Grid>
+                    </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/MahApps.Metro/Styles/VS/MenuItem.xaml
+++ b/src/MahApps.Metro/Styles/VS/MenuItem.xaml
@@ -27,6 +27,7 @@
         <Setter Property="Foreground" Value="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type MenuBase}}}" />
         <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
         <Setter Property="ScrollViewer.PanningMode" Value="Both" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
@@ -37,8 +38,18 @@
                             BorderBrush="Transparent"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                            SnapsToDevicePixels="False">
-                        <Grid x:Name="Grid">
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition x:Name="Col0"
                                                   Width="Auto"
@@ -99,15 +110,24 @@
                                 <Grid Margin="0 0 5 5">
                                     <!--  Border 2  -->
                                     <Border x:Name="SubMenuBorder"
+                                            Padding="2"
                                             Background="{DynamicResource MahApps.Brushes.SubmenuItem.Background}"
                                             BorderBrush="{DynamicResource MahApps.Brushes.MenuSeparator.Border}"
                                             BorderThickness="{TemplateBinding BorderThickness}"
                                             CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                                             Effect="{DynamicResource MahApps.DropShadowEffect.Menu.VisualStudio}"
-                                            SnapsToDevicePixels="True">
-                                        <Grid x:Name="SubMenu"
-                                              Margin="2"
-                                              Grid.IsSharedSizeScope="True">
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                        <Grid x:Name="SubMenu" Grid.IsSharedSizeScope="True">
+                                            <Grid.Clip>
+                                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                                    <Binding ElementName="SubMenu" Path="ActualWidth" />
+                                                    <Binding ElementName="SubMenu" Path="ActualHeight" />
+                                                    <Binding ElementName="SubMenuBorder" Path="CornerRadius" />
+                                                    <Binding ElementName="SubMenuBorder" Path="BorderThickness" />
+                                                    <Binding ElementName="SubMenuBorder" Path="Padding" />
+                                                </MultiBinding>
+                                            </Grid.Clip>
                                             <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Cycle" />
                                         </Grid>
                                     </Border>
@@ -121,7 +141,7 @@
                                             Background="{DynamicResource MahApps.Brushes.SubmenuItem.Background}"
                                             BorderBrush="{DynamicResource MahApps.Brushes.SubmenuItem.Background}"
                                             BorderThickness="{TemplateBinding BorderThickness}"
-                                            SnapsToDevicePixels="False" />
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                 </Grid>
                             </Popup>
                         </Grid>
@@ -136,7 +156,7 @@
                             <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
                             <Setter TargetName="SubMenu" Property="Margin" Value="2 3 2 2" />
                             <Setter TargetName="SubMenuPopup" Property="Placement" Value="Bottom" />
-                            <Setter TargetName="TransitionBorder" Property="Width" Value="{Binding ActualWidth, ElementName=Grid}" />
+                            <Setter TargetName="TransitionBorder" Property="Width" Value="{Binding ActualWidth, ElementName=ContentGrid}" />
                         </Trigger>
                         <Trigger Property="Role" Value="TopLevelItem">
                             <Setter Property="Padding" Value="6 2 6 2" />

--- a/src/MahApps.Metro/Themes/ColorPicker/ColorEyeDropper.xaml
+++ b/src/MahApps.Metro/Themes/ColorPicker/ColorEyeDropper.xaml
@@ -79,30 +79,42 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
                     <Grid>
-                        <mah:ClipBorder x:Name="Border"
-                                        Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <mah:ClipBorder x:Name="DisabledVisualElement"
-                                        Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        IsHitTestVisible="False"
-                                        Opacity="0"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        <mah:ContentControlEx x:Name="PART_ContentPresenter"
-                                              Margin="{TemplateBinding BorderThickness}"
-                                              Padding="{TemplateBinding Padding}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              Content="{TemplateBinding Content}"
-                                              ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                              ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                              RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Border x:Name="Border"
+                                Padding="{TemplateBinding Padding}"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
+                                <mah:ContentControlEx x:Name="PART_ContentPresenter"
+                                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                      Content="{TemplateBinding Content}"
+                                                      ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                      ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                      ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                      RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </Border>
+                        <Border x:Name="DisabledVisualElement"
+                                Background="{DynamicResource MahApps.Brushes.Control.Disabled}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                IsHitTestVisible="False"
+                                Opacity="0"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
@@ -118,7 +130,7 @@
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.7" />
-                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="0.3" />
+                            <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="0.4" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -127,7 +139,7 @@
         <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{DynamicResource MahApps.CharacterCasing.ColorEyeDropper}" />
         <Setter Property="mah:ControlsHelper.CornerRadius" Value="3" />
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.Border.Focus}" />
-        <Setter Property="mah:ControlsHelper.FocusBorderThickness" Value="2" />
+        <Setter Property="mah:ControlsHelper.FocusBorderThickness" Value="1" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.Border.MouseOver}" />
         <Style.Triggers>
             <Trigger Property="Content" Value="{x:Null}">

--- a/src/MahApps.Metro/Themes/ColorPicker/ColorEyeDropper.xaml
+++ b/src/MahApps.Metro/Themes/ColorPicker/ColorEyeDropper.xaml
@@ -126,7 +126,6 @@
                         </Trigger>
                         <Trigger Property="IsKeyboardFocusWithin" Value="True">
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderBrush), Mode=OneWay}" />
-                            <Setter TargetName="Border" Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.FocusBorderThickness), Mode=OneWay}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter TargetName="DisabledVisualElement" Property="Opacity" Value="0.7" />
@@ -139,7 +138,6 @@
         <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{DynamicResource MahApps.CharacterCasing.ColorEyeDropper}" />
         <Setter Property="mah:ControlsHelper.CornerRadius" Value="3" />
         <Setter Property="mah:ControlsHelper.FocusBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.Border.Focus}" />
-        <Setter Property="mah:ControlsHelper.FocusBorderThickness" Value="1" />
         <Setter Property="mah:ControlsHelper.MouseOverBorderBrush" Value="{DynamicResource MahApps.Brushes.Button.Border.MouseOver}" />
         <Style.Triggers>
             <Trigger Property="Content" Value="{x:Null}">
@@ -164,7 +162,6 @@
            BasedOn="{StaticResource MahApps.Styles.ColorEyeDropper}"
            TargetType="{x:Type mah:ColorEyeDropper}">
         <Setter Property="mah:ControlsHelper.CornerRadius" Value="0" />
-        <Setter Property="mah:ControlsHelper.FocusBorderThickness" Value="1" />
     </Style>
 
 </ResourceDictionary>

--- a/src/MahApps.Metro/Themes/DateTimePicker.xaml
+++ b/src/MahApps.Metro/Themes/DateTimePicker.xaml
@@ -130,261 +130,284 @@
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-
-                        <Grid x:Name="PART_InnerGrid" Margin="{TemplateBinding BorderThickness}">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition x:Name="TextColumn" Width="*" />
-                                <ColumnDefinition x:Name="ClearButtonColumn" Width="Auto" />
-                                <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition x:Name="ButtonRow" Height="*" />
-                            </Grid.RowDefinitions>
-
-                            <DatePickerTextBox x:Name="PART_TextBox"
-                                               Grid.Row="1"
-                                               Grid.Column="0"
-                                               Margin="0"
-                                               Padding="{TemplateBinding Padding}"
-                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                               mah:TextBoxHelper.Watermark="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.Watermark), Mode=OneWay}"
-                                               mah:TextBoxHelper.WatermarkAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
-                                               mah:TextBoxHelper.WatermarkTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}"
-                                               CaretBrush="{DynamicResource MahApps.Brushes.ThemeForeground}"
-                                               ContextMenu="{TemplateBinding ContextMenu}"
-                                               Focusable="{TemplateBinding Focusable}"
-                                               FontFamily="{TemplateBinding FontFamily}"
-                                               FontSize="{TemplateBinding FontSize}"
-                                               Foreground="{TemplateBinding Foreground}"
-                                               IsReadOnly="{Binding Path=IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}"
-                                               SelectionBrush="{DynamicResource MahApps.Brushes.Highlight}"
-                                               Style="{DynamicResource MahApps.Styles.DatePickerTextBox.TimePickerBase}">
-                                <i:Interaction.Behaviors>
-                                    <behaviors:DatePickerTextBoxBehavior />
-                                </i:Interaction.Behaviors>
-                            </DatePickerTextBox>
-
-                            <ContentControl x:Name="PART_FloatingMessageContainer"
-                                            Grid.Row="0"
-                                            Grid.Column="0"
-                                            Margin="4 0"
-                                            Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
-                                <ContentControl.Height>
-                                    <MultiBinding Converter="{mahConverters:MathMultiplyConverter}" FallbackValue="0">
-                                        <Binding ElementName="PART_FloatingMessage"
-                                                 Mode="OneWay"
-                                                 Path="ActualHeight" />
-                                        <Binding ElementName="PART_FloatingMessageContainer"
-                                                 Mode="OneWay"
-                                                 Path="Opacity" />
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="PART_InnerGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="PART_InnerGrid" Path="ActualWidth" />
+                                        <Binding ElementName="PART_InnerGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Base" Path="CornerRadius" />
+                                        <Binding ElementName="Base" Path="BorderThickness" />
+                                        <Binding ElementName="Base" Path="Padding" />
                                     </MultiBinding>
-                                </ContentControl.Height>
-                                <TextBlock x:Name="PART_FloatingMessage"
-                                           HorizontalAlignment="Stretch"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                           Foreground="{TemplateBinding Foreground}"
-                                           Style="{DynamicResource MahApps.Styles.TextBlock.AutoCollapsing}"
-                                           Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
-                                           TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
-                                           TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}">
-                                    <TextBlock.RenderTransform>
-                                        <TranslateTransform x:Name="FloatingMessageTransform">
-                                            <TranslateTransform.Y>
-                                                <MultiBinding Converter="{mahConverters:MathSubtractConverter}" FallbackValue="0">
-                                                    <Binding ElementName="PART_FloatingMessage"
-                                                             Mode="OneWay"
-                                                             Path="ActualHeight" />
-                                                    <Binding ElementName="PART_FloatingMessageContainer"
-                                                             Mode="OneWay"
-                                                             Path="ActualHeight" />
-                                                </MultiBinding>
-                                            </TranslateTransform.Y>
-                                        </TranslateTransform>
-                                    </TextBlock.RenderTransform>
-                                </TextBlock>
-                            </ContentControl>
+                                </Grid.Clip>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition x:Name="TextColumn" Width="*" />
+                                    <ColumnDefinition x:Name="ClearButtonColumn" Width="Auto" />
+                                    <ColumnDefinition x:Name="ButtonColumn" Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition x:Name="ButtonRow" Height="*" />
+                                </Grid.RowDefinitions>
 
-                            <Button x:Name="PART_ClearText"
-                                    Grid.Row="0"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="1"
-                                    Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                    Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
-                                    CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
-                                    CommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
-                                    Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
-                                    ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
-                                    Focusable="False"
-                                    FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
-                                    FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
-                                    IsTabStop="False"
-                                    Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
-                                    Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
-                                    Visibility="Visible" />
+                                <DatePickerTextBox x:Name="PART_TextBox"
+                                                   Grid.Row="1"
+                                                   Grid.Column="0"
+                                                   Margin="0"
+                                                   Padding="{TemplateBinding Padding}"
+                                                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                   mah:TextBoxHelper.Watermark="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:TextBoxHelper.Watermark), Mode=OneWay}"
+                                                   mah:TextBoxHelper.WatermarkAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
+                                                   mah:TextBoxHelper.WatermarkTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}"
+                                                   CaretBrush="{DynamicResource MahApps.Brushes.ThemeForeground}"
+                                                   ContextMenu="{TemplateBinding ContextMenu}"
+                                                   Focusable="{TemplateBinding Focusable}"
+                                                   FontFamily="{TemplateBinding FontFamily}"
+                                                   FontSize="{TemplateBinding FontSize}"
+                                                   Foreground="{TemplateBinding Foreground}"
+                                                   IsReadOnly="{Binding Path=IsReadOnly, RelativeSource={RelativeSource TemplatedParent}}"
+                                                   SelectionBrush="{DynamicResource MahApps.Brushes.Highlight}"
+                                                   Style="{DynamicResource MahApps.Styles.DatePickerTextBox.TimePickerBase}">
+                                    <i:Interaction.Behaviors>
+                                        <behaviors:DatePickerTextBoxBehavior />
+                                    </i:Interaction.Behaviors>
+                                </DatePickerTextBox>
 
-                            <Button x:Name="PART_Button"
-                                    Grid.Row="0"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="2"
-                                    Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
-                                    Content="{TemplateBinding mah:DatePickerHelper.DropDownButtonContent}"
-                                    ContentTemplate="{TemplateBinding mah:DatePickerHelper.DropDownButtonContentTemplate}"
-                                    Focusable="False"
-                                    FontFamily="{TemplateBinding mah:DatePickerHelper.DropDownButtonFontFamily}"
-                                    FontSize="{TemplateBinding mah:DatePickerHelper.DropDownButtonFontSize}"
-                                    IsTabStop="False"
-                                    Style="{DynamicResource MahApps.Styles.Button.Chromeless}" />
-
-                            <controlzex:PopupEx x:Name="PART_Popup"
-                                                Grid.Row="1"
+                                <ContentControl x:Name="PART_FloatingMessageContainer"
+                                                Grid.Row="0"
                                                 Grid.Column="0"
-                                                Grid.ColumnSpan="2"
-                                                AllowsTransparency="True"
-                                                Focusable="False"
-                                                Placement="Bottom"
-                                                PlacementTarget="{Binding ElementName=PART_Root}"
-                                                PopupAnimation="Fade"
-                                                StaysOpen="False">
-                                <mah:ClipBorder x:Name="PART_PopupBorder"
-                                                Background="{DynamicResource MahApps.Brushes.Control.Background}"
-                                                BorderBrush="{DynamicResource MahApps.Brushes.Control.Border}"
-                                                BorderThickness="1"
-                                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}">
-                                    <StackPanel x:Name="PART_PopupContainer" Background="Transparent">
-                                        <ContentPresenter x:Name="PART_Calendar"
-                                                          Margin="2 0"
-                                                          Focusable="False"
-                                                          Visibility="Collapsed" />
-                                        <Grid VerticalAlignment="Center">
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto" />
-                                                <RowDefinition Height="*" />
-                                            </Grid.RowDefinitions>
-                                            <Border x:Name="PART_Clock"
-                                                    Grid.Row="0"
-                                                    Width="120"
-                                                    Height="120"
-                                                    Margin="0 5 5 0"
-                                                    HorizontalAlignment="Center"
-                                                    BorderBrush="{DynamicResource MahApps.Brushes.Accent}"
-                                                    BorderThickness="2"
-                                                    CornerRadius="75">
-                                                <Canvas HorizontalAlignment="Center">
-                                                    <ItemsControl Focusable="False"
-                                                                  IsTabStop="False"
-                                                                  ItemTemplate="{StaticResource MahApps.Templates.DateTimePicker.FiveMinuteIndicator}"
-                                                                  ItemsSource="{StaticResource FiveMinuteKeys}">
-                                                        <ItemsControl.ItemsPanel>
-                                                            <ItemsPanelTemplate>
-                                                                <Canvas IsItemsHost="True" />
-                                                            </ItemsPanelTemplate>
-                                                        </ItemsControl.ItemsPanel>
-                                                    </ItemsControl>
-                                                    <ItemsControl Focusable="False"
-                                                                  IsTabStop="False"
-                                                                  ItemTemplate="{StaticResource MahApps.Templates.DateTimePicker.MinuteIndicator}"
-                                                                  ItemsSource="{StaticResource MinuteKeys}">
-                                                        <ItemsControl.ItemsPanel>
-                                                            <ItemsPanelTemplate>
-                                                                <Canvas IsItemsHost="True" />
-                                                            </ItemsPanelTemplate>
-                                                        </ItemsControl.ItemsPanel>
-                                                    </ItemsControl>
-                                                    <Rectangle x:Name="PART_MinuteHand"
-                                                               Canvas.Top="6"
-                                                               Width="2"
-                                                               Height="51"
-                                                               HorizontalAlignment="Center"
-                                                               Fill="{DynamicResource MahApps.Brushes.ThemeForeground}"
-                                                               RenderTransformOrigin=".5,1">
-                                                        <Rectangle.RenderTransform>
-                                                            <RotateTransform Angle="{Binding Path=SelectedDateTime, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource ClockDegreeConverter}, ConverterParameter='m', Mode=OneWay}" />
-                                                        </Rectangle.RenderTransform>
-                                                    </Rectangle>
-                                                    <Rectangle x:Name="PART_HourHand"
-                                                               Canvas.Top="27"
-                                                               Width="2"
-                                                               Height="30"
-                                                               HorizontalAlignment="Center"
-                                                               Fill="{DynamicResource MahApps.Brushes.ThemeForeground}"
-                                                               RenderTransformOrigin=".5,1">
-                                                        <Rectangle.RenderTransform>
-                                                            <RotateTransform Angle="{Binding Path=SelectedDateTime, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HourDegreeConverter}, ConverterParameter='h', Mode=OneWay}" />
-                                                        </Rectangle.RenderTransform>
-                                                    </Rectangle>
-                                                    <Ellipse Canvas.Left="-2"
-                                                             Canvas.Top="54"
-                                                             Width="6"
-                                                             Height="6"
-                                                             Fill="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                                                    <Rectangle x:Name="PART_SecondHand"
-                                                               Canvas.Left="0.75"
-                                                               Canvas.Top="6"
-                                                               Width="1"
-                                                               Height="61"
-                                                               Margin="0 5 0 0"
-                                                               HorizontalAlignment="Center"
-                                                               Fill="{DynamicResource MahApps.Brushes.ThemeForeground}"
-                                                               Opacity=".25"
-                                                               RenderTransformOrigin=".5,.75">
-                                                        <Rectangle.RenderTransform>
-                                                            <RotateTransform Angle="{Binding Path=SelectedDateTime, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource ClockDegreeConverter}, ConverterParameter='s', Mode=OneWay}" />
-                                                        </Rectangle.RenderTransform>
-                                                    </Rectangle>
-                                                </Canvas>
-                                            </Border>
-                                            <Grid x:Name="PART_ClockPartSelectorsHolder"
-                                                  Grid.Row="1"
-                                                  Margin="5"
-                                                  HorizontalAlignment="Center"
-                                                  VerticalAlignment="Center">
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="Auto" />
-                                                    <ColumnDefinition Width="Auto" />
-                                                </Grid.ColumnDefinitions>
-                                                <ComboBox x:Name="PART_HourPicker"
-                                                          Grid.Column="0"
-                                                          FontFamily="{TemplateBinding FontFamily}"
-                                                          FontSize="{TemplateBinding FontSize}"
-                                                          ItemStringFormat="{TemplateBinding HoursItemStringFormat}"
-                                                          ItemsSource="{TemplateBinding SourceHours}" />
-                                                <Label x:Name="PART_HourMinuteColon"
-                                                       Grid.Column="1"
-                                                       Content=":"
-                                                       Visibility="Collapsed" />
-                                                <ComboBox x:Name="PART_MinutePicker"
-                                                          Grid.Column="2"
-                                                          FontFamily="{TemplateBinding FontFamily}"
-                                                          FontSize="{TemplateBinding FontSize}"
-                                                          ItemStringFormat="{TemplateBinding MinutesItemStringFormat}"
-                                                          ItemsSource="{TemplateBinding SourceMinutes}" />
-                                                <Label x:Name="PART_MinuteSecondColon"
-                                                       Grid.Column="3"
-                                                       Content=":"
-                                                       Visibility="Collapsed" />
-                                                <ComboBox x:Name="PART_SecondPicker"
-                                                          Grid.Column="4"
-                                                          FontFamily="{TemplateBinding FontFamily}"
-                                                          FontSize="{TemplateBinding FontSize}"
-                                                          ItemStringFormat="{TemplateBinding SecondsItemStringFormat}"
-                                                          ItemsSource="{TemplateBinding SourceSeconds}" />
-                                                <ComboBox x:Name="PART_AmPmSwitcher"
-                                                          Grid.Column="5"
-                                                          FontFamily="{TemplateBinding FontFamily}"
-                                                          FontSize="{TemplateBinding FontSize}" />
-                                            </Grid>
+                                                Margin="4 0"
+                                                Style="{DynamicResource MahApps.Styles.ContentControl.FloatingMessageContainer}">
+                                    <ContentControl.Height>
+                                        <MultiBinding Converter="{mahConverters:MathMultiplyConverter}" FallbackValue="0">
+                                            <Binding ElementName="PART_FloatingMessage"
+                                                     Mode="OneWay"
+                                                     Path="ActualHeight" />
+                                            <Binding ElementName="PART_FloatingMessageContainer"
+                                                     Mode="OneWay"
+                                                     Path="Opacity" />
+                                        </MultiBinding>
+                                    </ContentControl.Height>
+                                    <TextBlock x:Name="PART_FloatingMessage"
+                                               HorizontalAlignment="Stretch"
+                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                               Foreground="{TemplateBinding Foreground}"
+                                               Style="{DynamicResource MahApps.Styles.TextBlock.AutoCollapsing}"
+                                               Text="{TemplateBinding mah:TextBoxHelper.Watermark}"
+                                               TextAlignment="{TemplateBinding mah:TextBoxHelper.WatermarkAlignment}"
+                                               TextTrimming="{TemplateBinding mah:TextBoxHelper.WatermarkTrimming}">
+                                        <TextBlock.RenderTransform>
+                                            <TranslateTransform x:Name="FloatingMessageTransform">
+                                                <TranslateTransform.Y>
+                                                    <MultiBinding Converter="{mahConverters:MathSubtractConverter}" FallbackValue="0">
+                                                        <Binding ElementName="PART_FloatingMessage"
+                                                                 Mode="OneWay"
+                                                                 Path="ActualHeight" />
+                                                        <Binding ElementName="PART_FloatingMessageContainer"
+                                                                 Mode="OneWay"
+                                                                 Path="ActualHeight" />
+                                                    </MultiBinding>
+                                                </TranslateTransform.Y>
+                                            </TranslateTransform>
+                                        </TextBlock.RenderTransform>
+                                    </TextBlock>
+                                </ContentControl>
+
+                                <Button x:Name="PART_ClearText"
+                                        Grid.Row="0"
+                                        Grid.RowSpan="2"
+                                        Grid.Column="1"
+                                        Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
+                                        Command="{TemplateBinding mah:TextBoxHelper.ButtonCommand}"
+                                        CommandParameter="{TemplateBinding mah:TextBoxHelper.ButtonCommandParameter}"
+                                        CommandTarget="{TemplateBinding mah:TextBoxHelper.ButtonCommandTarget}"
+                                        Content="{TemplateBinding mah:TextBoxHelper.ButtonContent}"
+                                        ContentTemplate="{TemplateBinding mah:TextBoxHelper.ButtonContentTemplate}"
+                                        Focusable="False"
+                                        FontFamily="{TemplateBinding mah:TextBoxHelper.ButtonFontFamily}"
+                                        FontSize="{TemplateBinding mah:TextBoxHelper.ButtonFontSize}"
+                                        IsTabStop="False"
+                                        Style="{DynamicResource MahApps.Styles.Button.Chromeless}"
+                                        Template="{TemplateBinding mah:TextBoxHelper.ButtonTemplate}"
+                                        Visibility="Visible" />
+
+                                <Button x:Name="PART_Button"
+                                        Grid.Row="0"
+                                        Grid.RowSpan="2"
+                                        Grid.Column="2"
+                                        Width="{TemplateBinding mah:TextBoxHelper.ButtonWidth}"
+                                        Content="{TemplateBinding mah:DatePickerHelper.DropDownButtonContent}"
+                                        ContentTemplate="{TemplateBinding mah:DatePickerHelper.DropDownButtonContentTemplate}"
+                                        Focusable="False"
+                                        FontFamily="{TemplateBinding mah:DatePickerHelper.DropDownButtonFontFamily}"
+                                        FontSize="{TemplateBinding mah:DatePickerHelper.DropDownButtonFontSize}"
+                                        IsTabStop="False"
+                                        Style="{DynamicResource MahApps.Styles.Button.Chromeless}" />
+
+                                <controlzex:PopupEx x:Name="PART_Popup"
+                                                    Grid.Row="1"
+                                                    Grid.Column="0"
+                                                    Grid.ColumnSpan="2"
+                                                    AllowsTransparency="True"
+                                                    Focusable="False"
+                                                    Placement="Bottom"
+                                                    PlacementTarget="{Binding ElementName=PART_Root}"
+                                                    PopupAnimation="Fade"
+                                                    StaysOpen="False">
+                                    <Border x:Name="PART_PopupBorder"
+                                            Background="{DynamicResource MahApps.Brushes.Control.Background}"
+                                            BorderBrush="{DynamicResource MahApps.Brushes.Control.Border}"
+                                            BorderThickness="1"
+                                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                        <Grid x:Name="ContentGrid">
+                                            <Grid.Clip>
+                                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                                    <Binding ElementName="PART_PopupBorder" Path="CornerRadius" />
+                                                    <Binding ElementName="PART_PopupBorder" Path="BorderThickness" />
+                                                    <Binding ElementName="PART_PopupBorder" Path="Padding" />
+                                                </MultiBinding>
+                                            </Grid.Clip>
+                                            <StackPanel x:Name="PART_PopupContainer" Background="Transparent">
+                                                <ContentPresenter x:Name="PART_Calendar"
+                                                                  Margin="2 0"
+                                                                  Focusable="False"
+                                                                  Visibility="Collapsed" />
+                                                <Grid VerticalAlignment="Center">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto" />
+                                                        <RowDefinition Height="*" />
+                                                    </Grid.RowDefinitions>
+                                                    <Border x:Name="PART_Clock"
+                                                            Grid.Row="0"
+                                                            Width="120"
+                                                            Height="120"
+                                                            Margin="0 5 5 0"
+                                                            HorizontalAlignment="Center"
+                                                            BorderBrush="{DynamicResource MahApps.Brushes.Accent}"
+                                                            BorderThickness="2"
+                                                            CornerRadius="75">
+                                                        <Canvas HorizontalAlignment="Center">
+                                                            <ItemsControl Focusable="False"
+                                                                          IsTabStop="False"
+                                                                          ItemTemplate="{StaticResource MahApps.Templates.DateTimePicker.FiveMinuteIndicator}"
+                                                                          ItemsSource="{StaticResource FiveMinuteKeys}">
+                                                                <ItemsControl.ItemsPanel>
+                                                                    <ItemsPanelTemplate>
+                                                                        <Canvas IsItemsHost="True" />
+                                                                    </ItemsPanelTemplate>
+                                                                </ItemsControl.ItemsPanel>
+                                                            </ItemsControl>
+                                                            <ItemsControl Focusable="False"
+                                                                          IsTabStop="False"
+                                                                          ItemTemplate="{StaticResource MahApps.Templates.DateTimePicker.MinuteIndicator}"
+                                                                          ItemsSource="{StaticResource MinuteKeys}">
+                                                                <ItemsControl.ItemsPanel>
+                                                                    <ItemsPanelTemplate>
+                                                                        <Canvas IsItemsHost="True" />
+                                                                    </ItemsPanelTemplate>
+                                                                </ItemsControl.ItemsPanel>
+                                                            </ItemsControl>
+                                                            <Rectangle x:Name="PART_MinuteHand"
+                                                                       Canvas.Top="6"
+                                                                       Width="2"
+                                                                       Height="51"
+                                                                       HorizontalAlignment="Center"
+                                                                       Fill="{DynamicResource MahApps.Brushes.ThemeForeground}"
+                                                                       RenderTransformOrigin=".5,1">
+                                                                <Rectangle.RenderTransform>
+                                                                    <RotateTransform Angle="{Binding Path=SelectedDateTime, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource ClockDegreeConverter}, ConverterParameter='m', Mode=OneWay}" />
+                                                                </Rectangle.RenderTransform>
+                                                            </Rectangle>
+                                                            <Rectangle x:Name="PART_HourHand"
+                                                                       Canvas.Top="27"
+                                                                       Width="2"
+                                                                       Height="30"
+                                                                       HorizontalAlignment="Center"
+                                                                       Fill="{DynamicResource MahApps.Brushes.ThemeForeground}"
+                                                                       RenderTransformOrigin=".5,1">
+                                                                <Rectangle.RenderTransform>
+                                                                    <RotateTransform Angle="{Binding Path=SelectedDateTime, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource HourDegreeConverter}, ConverterParameter='h', Mode=OneWay}" />
+                                                                </Rectangle.RenderTransform>
+                                                            </Rectangle>
+                                                            <Ellipse Canvas.Left="-2"
+                                                                     Canvas.Top="54"
+                                                                     Width="6"
+                                                                     Height="6"
+                                                                     Fill="{DynamicResource MahApps.Brushes.ThemeForeground}" />
+                                                            <Rectangle x:Name="PART_SecondHand"
+                                                                       Canvas.Left="0.75"
+                                                                       Canvas.Top="6"
+                                                                       Width="1"
+                                                                       Height="61"
+                                                                       Margin="0 5 0 0"
+                                                                       HorizontalAlignment="Center"
+                                                                       Fill="{DynamicResource MahApps.Brushes.ThemeForeground}"
+                                                                       Opacity=".25"
+                                                                       RenderTransformOrigin=".5,.75">
+                                                                <Rectangle.RenderTransform>
+                                                                    <RotateTransform Angle="{Binding Path=SelectedDateTime, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource ClockDegreeConverter}, ConverterParameter='s', Mode=OneWay}" />
+                                                                </Rectangle.RenderTransform>
+                                                            </Rectangle>
+                                                        </Canvas>
+                                                    </Border>
+                                                    <Grid x:Name="PART_ClockPartSelectorsHolder"
+                                                          Grid.Row="1"
+                                                          Margin="5"
+                                                          HorizontalAlignment="Center"
+                                                          VerticalAlignment="Center">
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="Auto" />
+                                                            <ColumnDefinition Width="Auto" />
+                                                            <ColumnDefinition Width="Auto" />
+                                                            <ColumnDefinition Width="Auto" />
+                                                            <ColumnDefinition Width="Auto" />
+                                                            <ColumnDefinition Width="Auto" />
+                                                        </Grid.ColumnDefinitions>
+                                                        <ComboBox x:Name="PART_HourPicker"
+                                                                  Grid.Column="0"
+                                                                  FontFamily="{TemplateBinding FontFamily}"
+                                                                  FontSize="{TemplateBinding FontSize}"
+                                                                  ItemStringFormat="{TemplateBinding HoursItemStringFormat}"
+                                                                  ItemsSource="{TemplateBinding SourceHours}" />
+                                                        <Label x:Name="PART_HourMinuteColon"
+                                                               Grid.Column="1"
+                                                               Content=":"
+                                                               Visibility="Collapsed" />
+                                                        <ComboBox x:Name="PART_MinutePicker"
+                                                                  Grid.Column="2"
+                                                                  FontFamily="{TemplateBinding FontFamily}"
+                                                                  FontSize="{TemplateBinding FontSize}"
+                                                                  ItemStringFormat="{TemplateBinding MinutesItemStringFormat}"
+                                                                  ItemsSource="{TemplateBinding SourceMinutes}" />
+                                                        <Label x:Name="PART_MinuteSecondColon"
+                                                               Grid.Column="3"
+                                                               Content=":"
+                                                               Visibility="Collapsed" />
+                                                        <ComboBox x:Name="PART_SecondPicker"
+                                                                  Grid.Column="4"
+                                                                  FontFamily="{TemplateBinding FontFamily}"
+                                                                  FontSize="{TemplateBinding FontSize}"
+                                                                  ItemStringFormat="{TemplateBinding SecondsItemStringFormat}"
+                                                                  ItemsSource="{TemplateBinding SourceSeconds}" />
+                                                        <ComboBox x:Name="PART_AmPmSwitcher"
+                                                                  Grid.Column="5"
+                                                                  FontFamily="{TemplateBinding FontFamily}"
+                                                                  FontSize="{TemplateBinding FontSize}" />
+                                                    </Grid>
+                                                </Grid>
+                                            </StackPanel>
                                         </Grid>
-                                    </StackPanel>
-                                </mah:ClipBorder>
-                            </controlzex:PopupEx>
-                        </Grid>
+                                    </Border>
+                                </controlzex:PopupEx>
+                            </Grid>
+                        </Border>
 
                         <Border x:Name="DisabledVisualElement"
                                 Background="{DynamicResource MahApps.Brushes.Control.Disabled}"

--- a/src/MahApps.Metro/Themes/DropDownButton.xaml
+++ b/src/MahApps.Metro/Themes/DropDownButton.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <Style x:Key="MahApps.Styles.DropDownButton.FocusVisualStyle">
         <Setter Property="Control.Template">
@@ -44,9 +45,17 @@
                             CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                             UseLayoutRounding="True">
-                        <mah:ClipBorder x:Name="PART_ClipBorder"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="PART_Border" Path="CornerRadius" />
+                                    <Binding ElementName="PART_Border" Path="BorderThickness" />
+                                    <Binding ElementName="PART_Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
                             <Button x:Name="PART_Button"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Stretch"
@@ -120,7 +129,7 @@
                                                  UseLayoutRounding="False" />
                                 </Button.ContextMenu>
                             </Button>
-                        </mah:ClipBorder>
+                        </Grid>
                     </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="Content" Value="{x:Null}">

--- a/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
+++ b/src/MahApps.Metro/Themes/HamburgerMenuTemplate.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
                     xmlns:system="clr-namespace:System;assembly=mscorlib"
@@ -205,17 +206,23 @@
                           Background="Transparent"
                           RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <mah:ClipBorder x:Name="Background"
-                                        Background="{TemplateBinding Background}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-
-                        <mah:ClipBorder x:Name="Border"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                            <Grid>
+                        <Border x:Name="Border"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
                                 <Grid HorizontalAlignment="Left"
                                       VerticalAlignment="Center"
                                       Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type mah:HamburgerMenu}}, Path=ShowSelectionIndicator, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -232,11 +239,11 @@
                                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                             </Grid>
-                        </mah:ClipBorder>
+                        </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedBackgroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedBackgroundBrush), Mode=OneWay}" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedBorderBrush), Mode=OneWay}" />
                             <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedForegroundBrush), Mode=OneWay}" />
                             <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.SelectedForegroundBrush), Mode=OneWay}" />
@@ -247,7 +254,7 @@
                                 <Condition Property="IsSelected" Value="True" />
                                 <Condition Property="Selector.IsSelectionActive" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionBackgroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionBackgroundBrush), Mode=OneWay}" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionBorderBrush), Mode=OneWay}" />
                             <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionForegroundBrush), Mode=OneWay}" />
                             <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.ActiveSelectionForegroundBrush), Mode=OneWay}" />
@@ -258,7 +265,7 @@
                                 <Condition Property="IsMouseOver" Value="True" />
                                 <Condition Property="IsSelected" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedBackgroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedBackgroundBrush), Mode=OneWay}" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedBorderBrush), Mode=OneWay}" />
                             <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedForegroundBrush), Mode=OneWay}" />
                             <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverSelectedForegroundBrush), Mode=OneWay}" />
@@ -268,27 +275,27 @@
                                 <Condition Property="IsMouseOver" Value="True" />
                                 <Condition Property="IsSelected" Value="False" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverBackgroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverBackgroundBrush), Mode=OneWay}" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverBorderBrush), Mode=OneWay}" />
                             <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverForegroundBrush), Mode=OneWay}" />
                             <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.HoverForegroundBrush), Mode=OneWay}" />
                         </MultiTrigger>
 
                         <Trigger Property="mah:ItemHelper.IsMouseLeftButtonPressed" Value="True">
-                            <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseLeftButtonPressedBackgroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseLeftButtonPressedBackgroundBrush), Mode=OneWay}" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseLeftButtonPressedBorderBrush), Mode=OneWay}" />
                             <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseLeftButtonPressedForegroundBrush), Mode=OneWay}" />
                             <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseLeftButtonPressedForegroundBrush), Mode=OneWay}" />
                         </Trigger>
                         <Trigger Property="mah:ItemHelper.IsMouseRightButtonPressed" Value="True">
-                            <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseRightButtonPressedBackgroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseRightButtonPressedBackgroundBrush), Mode=OneWay}" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseRightButtonPressedBorderBrush), Mode=OneWay}" />
                             <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseRightButtonPressedForegroundBrush), Mode=OneWay}" />
                             <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.MouseRightButtonPressedForegroundBrush), Mode=OneWay}" />
                         </Trigger>
 
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ItemHelper.DisabledBackgroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledBackgroundBrush), Mode=OneWay}" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledBorderBrush), Mode=OneWay}" />
                             <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledForegroundBrush), Mode=OneWay}" />
                             <Setter TargetName="RootGrid" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background, Mode=OneWay}" />
@@ -299,7 +306,7 @@
                                 <Condition Property="IsEnabled" Value="False" />
                                 <Condition Property="IsSelected" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="Background" Property="Background" Value="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ItemHelper.DisabledSelectedBackgroundBrush), Mode=OneWay}" />
+                            <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedBackgroundBrush), Mode=OneWay}" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedBorderBrush), Mode=OneWay}" />
                             <Setter TargetName="ContentPresenter" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedForegroundBrush), Mode=OneWay}" />
                             <Setter TargetName="SelectionIndicator" Property="Fill" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ItemHelper.DisabledSelectedForegroundBrush), Mode=OneWay}" />

--- a/src/MahApps.Metro/Themes/MetroWindow.xaml
+++ b/src/MahApps.Metro/Themes/MetroWindow.xaml
@@ -14,19 +14,29 @@
     <mahConverters:ThicknessToDoubleConverter x:Key="ThicknessToDoubleConverter" />
 
     <ControlTemplate x:Key="MahApps.Templates.MetroWindow" TargetType="{x:Type mah:MetroWindow}">
-        <mah:ClipBorder x:Name="PART_Border"
-                        Margin="{TemplateBinding Padding}"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{Binding Path=GlowColor, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static mahConverters:ColorToSolidColorBrushConverter.DefaultInstance}}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                        UseLayoutRounding="True">
+        <Border x:Name="PART_Border"
+                Margin="{TemplateBinding Padding}"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{Binding Path=GlowColor, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static mahConverters:ColorToSolidColorBrushConverter.DefaultInstance}}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                UseLayoutRounding="True">
             <AdornerDecorator UseLayoutRounding="False">
-                <Grid Background="{x:Null}"
+                <Grid x:Name="ContentGrid"
                       LayoutTransform="{Binding LayoutTransform, RelativeSource={RelativeSource TemplatedParent}}"
                       RenderTransform="{Binding RenderTransform, RelativeSource={RelativeSource TemplatedParent}}"
                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                       UseLayoutRounding="False">
+                    <Grid.Clip>
+                        <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                        <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                            <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                            <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                            <Binding ElementName="PART_Border" Path="CornerRadius" />
+                            <Binding ElementName="PART_Border" Path="BorderThickness" />
+                            <Binding ElementName="PART_Border" Path="Padding" />
+                        </MultiBinding>
+                    </Grid.Clip>
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <!--  icon  -->
@@ -205,7 +215,7 @@
                                 Visibility="Collapsed" />
                 </Grid>
             </AdornerDecorator>
-        </mah:ClipBorder>
+        </Border>
 
         <ControlTemplate.Triggers>
             <Trigger Property="ShowDialogsOverTitleBar" Value="False">
@@ -260,19 +270,29 @@
     </ControlTemplate>
 
     <ControlTemplate x:Key="MahApps.Templates.MetroWindow.Center" TargetType="{x:Type mah:MetroWindow}">
-        <mah:ClipBorder x:Name="PART_Border"
-                        Margin="{TemplateBinding Padding}"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{Binding Path=GlowColor, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static mahConverters:ColorToSolidColorBrushConverter.DefaultInstance}}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                        UseLayoutRounding="True">
+        <Border x:Name="PART_Border"
+                Margin="{TemplateBinding Padding}"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{Binding Path=GlowColor, Mode=OneWay, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static mahConverters:ColorToSolidColorBrushConverter.DefaultInstance}}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                UseLayoutRounding="True">
             <AdornerDecorator UseLayoutRounding="False">
-                <Grid Background="{x:Null}"
+                <Grid x:Name="ContentGrid"
                       LayoutTransform="{Binding LayoutTransform, RelativeSource={RelativeSource TemplatedParent}}"
                       RenderTransform="{Binding RenderTransform, RelativeSource={RelativeSource TemplatedParent}}"
                       SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                       UseLayoutRounding="True">
+                    <Grid.Clip>
+                        <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                        <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                            <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                            <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                            <Binding ElementName="PART_Border" Path="CornerRadius" />
+                            <Binding ElementName="PART_Border" Path="BorderThickness" />
+                            <Binding ElementName="PART_Border" Path="Padding" />
+                        </MultiBinding>
+                    </Grid.Clip>
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <!--  icon  -->
@@ -458,7 +478,7 @@
                                 Visibility="Collapsed" />
                 </Grid>
             </AdornerDecorator>
-        </mah:ClipBorder>
+        </Border>
 
         <ControlTemplate.Resources>
             <Storyboard x:Key="OverlayFastSemiFadeIn"

--- a/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
+++ b/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
@@ -51,31 +51,43 @@
                           Background="Transparent"
                           RenderOptions.ClearTypeHint="{TemplateBinding RenderOptions.ClearTypeHint}"
                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <mah:ClipBorder x:Name="Background"
-                                        Background="{TemplateBinding Background}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        <Border x:Name="Background"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
-                        <mah:ClipBorder x:Name="Border"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                            <CheckBox x:Name="ContentPresenter"
-                                      Margin="{TemplateBinding Padding}"
-                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                      mah:CheckBoxHelper.ForegroundIndeterminatePressed="{TemplateBinding Foreground}"
-                                      mah:CheckBoxHelper.ForegroundUnchecked="{TemplateBinding Foreground}"
-                                      mah:CheckBoxHelper.ForegroundUncheckedPressed="{TemplateBinding Foreground}"
-                                      Content="{TemplateBinding Content}"
-                                      ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                      ContentTemplate="{TemplateBinding ContentTemplate}"
-                                      ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                      IsChecked="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=IsSelected, Mode=TwoWay}"
-                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                      Style="{DynamicResource MahApps.Styles.CheckBox.MultiSelectionComboBoxItem}" />
-                        </mah:ClipBorder>
+                        <Border x:Name="Border"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Grid x:Name="ContentGrid">
+                                <Grid.Clip>
+                                    <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                    <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                        <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                        <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                        <Binding ElementName="Border" Path="CornerRadius" />
+                                        <Binding ElementName="Border" Path="BorderThickness" />
+                                        <Binding ElementName="Border" Path="Padding" />
+                                    </MultiBinding>
+                                </Grid.Clip>
+                                <CheckBox x:Name="ContentPresenter"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          mah:CheckBoxHelper.ForegroundIndeterminatePressed="{TemplateBinding Foreground}"
+                                          mah:CheckBoxHelper.ForegroundUnchecked="{TemplateBinding Foreground}"
+                                          mah:CheckBoxHelper.ForegroundUncheckedPressed="{TemplateBinding Foreground}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                          IsChecked="{Binding RelativeSource={RelativeSource Mode=TemplatedParent}, Path=IsSelected, Mode=TwoWay}"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                          Style="{DynamicResource MahApps.Styles.CheckBox.MultiSelectionComboBoxItem}" />
+                            </Grid>
+                        </Border>
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsSelected" Value="True">
@@ -436,15 +448,25 @@
                                PlacementTarget="{Binding ElementName=PART_DropDownToggle}"
                                PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}">
                             <Grid MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}" MaxHeight="{Binding MaxDropDownHeight, RelativeSource={RelativeSource TemplatedParent}}">
-                                <mah:ClipBorder x:Name="PopupBorder"
-                                                Height="Auto"
-                                                HorizontalAlignment="Stretch"
-                                                Background="{DynamicResource MahApps.Brushes.ThemeBackground}"
-                                                BorderBrush="{DynamicResource MahApps.Brushes.ComboBox.PopupBorder}"
-                                                BorderThickness="{DynamicResource ComboBoxPopupBorderThemeThickness}"
-                                                CornerRadius="{DynamicResource ComboBoxPopupBorderThemeCornerRadius}"
-                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                                    <Grid>
+                                <Border x:Name="PopupBorder"
+                                        Height="Auto"
+                                        HorizontalAlignment="Stretch"
+                                        Background="{DynamicResource MahApps.Brushes.ThemeBackground}"
+                                        BorderBrush="{DynamicResource MahApps.Brushes.ComboBox.PopupBorder}"
+                                        BorderThickness="{DynamicResource ComboBoxPopupBorderThemeThickness}"
+                                        CornerRadius="{DynamicResource ComboBoxPopupBorderThemeCornerRadius}"
+                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                    <Grid x:Name="ContentGrid">
+                                        <Grid.Clip>
+                                            <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                            <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                                <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                                <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                                <Binding ElementName="PopupBorder" Path="CornerRadius" />
+                                                <Binding ElementName="PopupBorder" Path="BorderThickness" />
+                                                <Binding ElementName="PopupBorder" Path="Padding" />
+                                            </MultiBinding>
+                                        </Grid.Clip>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="*" />
@@ -491,7 +513,7 @@
                                                         ContentTemplate="{TemplateBinding DisabledPopupOverlayContentTemplate}"
                                                         Visibility="Collapsed" />
                                     </Grid>
-                                </mah:ClipBorder>
+                                </Border>
                             </Grid>
                         </Popup>
                         <VisualStateManager.VisualStateGroups>

--- a/src/MahApps.Metro/Themes/NumericUpDown.xaml
+++ b/src/MahApps.Metro/Themes/NumericUpDown.xaml
@@ -1,6 +1,7 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.Shared.xaml" />
@@ -22,25 +23,37 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
-                    <mah:ClipBorder x:Name="Border"
-                                    Margin="0"
-                                    Background="{TemplateBinding Background}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="{TemplateBinding BorderThickness}"
-                                    CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                    SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                        <mah:ContentControlEx x:Name="PART_ContentPresenter"
-                                              Padding="{TemplateBinding Padding}"
-                                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              Content="{TemplateBinding Content}"
-                                              ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                              ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                              ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                              RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                    </mah:ClipBorder>
+                    <Border x:Name="Border"
+                            Margin="0"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="Border" Path="CornerRadius" />
+                                    <Binding ElementName="Border" Path="BorderThickness" />
+                                    <Binding ElementName="Border" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
+                            <mah:ContentControlEx x:Name="PART_ContentPresenter"
+                                                  Padding="{TemplateBinding Padding}"
+                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Content="{TemplateBinding Content}"
+                                                  ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                  ContentStringFormat="{TemplateBinding ContentStringFormat}"
+                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
+                                                  RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Grid>
+                    </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="PART_ContentPresenter" Property="Opacity" Value="1" />

--- a/src/MahApps.Metro/Themes/SplitButton.xaml
+++ b/src/MahApps.Metro/Themes/SplitButton.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <ControlTemplate x:Key="MahApps.Templates.SplitButton.Horizontal" TargetType="{x:Type mah:SplitButton}">
         <Grid UseLayoutRounding="True">
@@ -10,73 +11,79 @@
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                <mah:ClipBorder x:Name="PART_ClipBorder"
-                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                    <Grid x:Name="PART_Container"
-                          HorizontalAlignment="Stretch"
-                          VerticalAlignment="Stretch">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <Button x:Name="PART_Button"
-                                Grid.Column="0"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                HorizontalContentAlignment="Stretch"
-                                VerticalContentAlignment="Stretch"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                FocusVisualStyle="{TemplateBinding FocusVisualStyle}"
-                                Foreground="{TemplateBinding Foreground}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                Style="{TemplateBinding ButtonStyle}">
-                            <StackPanel HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                        Orientation="Horizontal">
-                                <ContentPresenter HorizontalAlignment="Center"
+                <Grid x:Name="PART_Container"
+                      HorizontalAlignment="Stretch"
+                      VerticalAlignment="Stretch">
+                    <Grid.Clip>
+                        <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                        <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                            <Binding ElementName="PART_Container" Path="ActualWidth" />
+                            <Binding ElementName="PART_Container" Path="ActualHeight" />
+                            <Binding ElementName="PART_Border" Path="CornerRadius" />
+                            <Binding ElementName="PART_Border" Path="BorderThickness" />
+                            <Binding ElementName="PART_Border" Path="Padding" />
+                        </MultiBinding>
+                    </Grid.Clip>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <Button x:Name="PART_Button"
+                            Grid.Column="0"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch"
+                            VerticalContentAlignment="Stretch"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            FocusVisualStyle="{TemplateBinding FocusVisualStyle}"
+                            Foreground="{TemplateBinding Foreground}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            Style="{TemplateBinding ButtonStyle}">
+                        <StackPanel HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    Orientation="Horizontal">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              Content="{TemplateBinding Icon}"
+                                              ContentTemplate="{TemplateBinding IconTemplate}"
+                                              Focusable="False"
+                                              RecognizesAccessKey="True"
+                                              UseLayoutRounding="False" />
+                            <mah:ContentControlEx x:Name="PART_ButtonContent"
+                                                  Padding="{TemplateBinding Padding}"
+                                                  HorizontalAlignment="Center"
                                                   VerticalAlignment="Center"
-                                                  Content="{TemplateBinding Icon}"
-                                                  ContentTemplate="{TemplateBinding IconTemplate}"
-                                                  Focusable="False"
-                                                  RecognizesAccessKey="True"
+                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Content="{TemplateBinding SelectionBoxItem}"
+                                                  ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                  ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                                                  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                  ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                                  IsHitTestVisible="False"
+                                                  RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                   UseLayoutRounding="False" />
-                                <mah:ContentControlEx x:Name="PART_ButtonContent"
-                                                      Padding="{TemplateBinding Padding}"
-                                                      HorizontalAlignment="Center"
-                                                      VerticalAlignment="Center"
-                                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                      Content="{TemplateBinding SelectionBoxItem}"
-                                                      ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                                      ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
-                                                      ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
-                                                      ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                                      IsHitTestVisible="False"
-                                                      RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                      UseLayoutRounding="False" />
-                            </StackPanel>
-                        </Button>
-                        <Button x:Name="PART_Expander"
-                                Grid.Column="1"
-                                Width="20"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                FocusVisualStyle="{TemplateBinding FocusVisualStyle}"
-                                Foreground="{TemplateBinding ArrowBrush}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                Style="{TemplateBinding ButtonArrowStyle}">
-                            <!--  Material - ChevronDown  -->
-                            <mah:PathIcon Width="9"
-                                          Height="9"
-                                          HorizontalAlignment="Center"
-                                          VerticalAlignment="Center"
-                                          Data="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
-                        </Button>
-                    </Grid>
-                </mah:ClipBorder>
+                        </StackPanel>
+                    </Button>
+                    <Button x:Name="PART_Expander"
+                            Grid.Column="1"
+                            Width="20"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            FocusVisualStyle="{TemplateBinding FocusVisualStyle}"
+                            Foreground="{TemplateBinding ArrowBrush}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            Style="{TemplateBinding ButtonArrowStyle}">
+                        <!--  Material - ChevronDown  -->
+                        <mah:PathIcon Width="9"
+                                      Height="9"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Data="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
+                    </Button>
+                </Grid>
             </Border>
             <Popup x:Name="PART_Popup"
                    AllowsTransparency="True"
@@ -136,73 +143,79 @@
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                <mah:ClipBorder x:Name="PART_ClipBorder"
-                                CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                    <Grid x:Name="PART_Container"
-                          HorizontalAlignment="Stretch"
-                          VerticalAlignment="Stretch">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="*" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <Button x:Name="PART_Button"
-                                Grid.Row="0"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                HorizontalContentAlignment="Stretch"
-                                VerticalContentAlignment="Stretch"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                FocusVisualStyle="{TemplateBinding FocusVisualStyle}"
-                                Foreground="{TemplateBinding Foreground}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                Style="{TemplateBinding ButtonStyle}">
-                            <StackPanel HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                        Orientation="Vertical">
-                                <ContentPresenter HorizontalAlignment="Center"
+                <Grid x:Name="PART_Container"
+                      HorizontalAlignment="Stretch"
+                      VerticalAlignment="Stretch">
+                    <Grid.Clip>
+                        <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                        <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                            <Binding ElementName="PART_Container" Path="ActualWidth" />
+                            <Binding ElementName="PART_Container" Path="ActualHeight" />
+                            <Binding ElementName="PART_Border" Path="CornerRadius" />
+                            <Binding ElementName="PART_Border" Path="BorderThickness" />
+                            <Binding ElementName="PART_Border" Path="Padding" />
+                        </MultiBinding>
+                    </Grid.Clip>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Button x:Name="PART_Button"
+                            Grid.Row="0"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch"
+                            VerticalContentAlignment="Stretch"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            FocusVisualStyle="{TemplateBinding FocusVisualStyle}"
+                            Foreground="{TemplateBinding Foreground}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            Style="{TemplateBinding ButtonStyle}">
+                        <StackPanel HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    Orientation="Vertical">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              Content="{TemplateBinding Icon}"
+                                              ContentTemplate="{TemplateBinding IconTemplate}"
+                                              Focusable="False"
+                                              RecognizesAccessKey="True"
+                                              UseLayoutRounding="False" />
+                            <mah:ContentControlEx x:Name="PART_ButtonContent"
+                                                  Padding="{TemplateBinding Padding}"
+                                                  HorizontalAlignment="Center"
                                                   VerticalAlignment="Center"
-                                                  Content="{TemplateBinding Icon}"
-                                                  ContentTemplate="{TemplateBinding IconTemplate}"
-                                                  Focusable="False"
-                                                  RecognizesAccessKey="True"
+                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Content="{TemplateBinding SelectionBoxItem}"
+                                                  ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                  ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
+                                                  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                  ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                                  IsHitTestVisible="False"
+                                                  RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                   UseLayoutRounding="False" />
-                                <mah:ContentControlEx x:Name="PART_ButtonContent"
-                                                      Padding="{TemplateBinding Padding}"
-                                                      HorizontalAlignment="Center"
-                                                      VerticalAlignment="Center"
-                                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                      Content="{TemplateBinding SelectionBoxItem}"
-                                                      ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                                      ContentStringFormat="{TemplateBinding SelectionBoxItemStringFormat}"
-                                                      ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
-                                                      ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                                                      IsHitTestVisible="False"
-                                                      RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                      UseLayoutRounding="False" />
-                            </StackPanel>
-                        </Button>
-                        <Button x:Name="PART_Expander"
-                                Grid.Row="1"
-                                Height="20"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                FocusVisualStyle="{TemplateBinding FocusVisualStyle}"
-                                Foreground="{TemplateBinding ArrowBrush}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                Style="{TemplateBinding ButtonArrowStyle}">
-                            <!--  Material - ChevronDown  -->
-                            <mah:PathIcon Width="9"
-                                          Height="9"
-                                          HorizontalAlignment="Center"
-                                          VerticalAlignment="Center"
-                                          Data="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
-                        </Button>
-                    </Grid>
-                </mah:ClipBorder>
+                        </StackPanel>
+                    </Button>
+                    <Button x:Name="PART_Expander"
+                            Grid.Row="1"
+                            Height="20"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            FocusVisualStyle="{TemplateBinding FocusVisualStyle}"
+                            Foreground="{TemplateBinding ArrowBrush}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            Style="{TemplateBinding ButtonArrowStyle}">
+                        <!--  Material - ChevronDown  -->
+                        <mah:PathIcon Width="9"
+                                      Height="9"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Data="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
+                    </Button>
+                </Grid>
             </Border>
             <Popup x:Name="PART_Popup"
                    AllowsTransparency="True"

--- a/src/MahApps.Metro/Themes/Underline.xaml
+++ b/src/MahApps.Metro/Themes/Underline.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <Style TargetType="{x:Type mah:Underline}">
         <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Gray}" />
@@ -18,15 +19,24 @@
                             VerticalAlignment="{TemplateBinding VerticalAlignment}"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
+                            CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}"
                             SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                             UseLayoutRounding="{TemplateBinding UseLayoutRounding}">
-                        <mah:ClipBorder Background="{TemplateBinding Background}"
-                                        BorderThickness="0"
-                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                        <Grid x:Name="ContentGrid">
+                            <Grid.Clip>
+                                <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                    <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                    <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                    <Binding ElementName="PART_UnderlineBorder" Path="CornerRadius" />
+                                    <Binding ElementName="PART_UnderlineBorder" Path="BorderThickness" />
+                                    <Binding ElementName="PART_UnderlineBorder" Path="Padding" />
+                                </MultiBinding>
+                            </Grid.Clip>
                             <ContentPresenter Margin="{TemplateBinding Padding}"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                               UseLayoutRounding="False" />
-                        </mah:ClipBorder>
+                        </Grid>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/Mahapps.Metro.Tests/TestHelpers/ClipAssert.cs
+++ b/src/Mahapps.Metro.Tests/TestHelpers/ClipAssert.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using MahApps.Metro.Controls;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.TestHelpers
+{
+    /// <summary>
+    /// What every template that rounds its corners has to hold up: a clip lives in the coordinates of
+    /// the element carrying it, so the geometry has to match that element and not the border around it.
+    /// </summary>
+    public static class ClipAssert
+    {
+        /// <summary>
+        /// Reaches the grid a template puts its clip on.
+        /// </summary>
+        public static Grid ContentGrid(FrameworkElement root, string name = "ContentGrid")
+        {
+            var grid = root.FindChild<Grid>(name);
+            Assert.That(grid, Is.Not.Null, $"the template should carry the grid named {name} that the clip sits on");
+
+            return grid!;
+        }
+
+        /// <summary>
+        /// The clip covers the element exactly. Anything wider or taller leaves it unclipped along that
+        /// edge, which is what a geometry built from the size of the surrounding border does.
+        /// </summary>
+        public static void CoversElement(FrameworkElement element, string what)
+        {
+            Assert.That(element.ActualWidth, Is.GreaterThan(0), $"the {what} should be laid out, otherwise this test proves nothing");
+            Assert.That(element.Clip, Is.Not.Null, $"the {what} should be clipped");
+
+            Assert.That(element.Clip!.Bounds.Width, Is.EqualTo(element.ActualWidth).Within(0.001), $"a wider clip leaves the {what} unclipped on the right");
+            Assert.That(element.Clip.Bounds.Height, Is.EqualTo(element.ActualHeight).Within(0.001), $"a taller clip leaves the {what} unclipped at the bottom");
+            Assert.That(element.Clip.Bounds.X, Is.EqualTo(0).Within(0.001), $"the clip of the {what} should start at its left edge");
+            Assert.That(element.Clip.Bounds.Y, Is.EqualTo(0).Within(0.001), $"the clip of the {what} should start at its top edge");
+        }
+
+        /// <summary>
+        /// All four corners are cut and the middle survives.
+        /// </summary>
+        public static void CutsEveryCorner(FrameworkElement element, string what)
+        {
+            Assert.That(element.Clip, Is.Not.Null, $"the {what} should be clipped");
+
+            var clip = element.Clip!;
+            var width = element.ActualWidth;
+            var height = element.ActualHeight;
+
+            Assert.That(clip.FillContains(new Point(width / 2, height / 2)), Is.True, $"the middle of the {what} belongs to the clip");
+            Assert.That(clip.FillContains(new Point(1, 1)), Is.False, $"top left of the {what} should be cut");
+            Assert.That(clip.FillContains(new Point(width - 1, 1)), Is.False, $"top right of the {what} should be cut");
+            Assert.That(clip.FillContains(new Point(width - 1, height - 1)), Is.False, $"bottom right of the {what} should be cut");
+            Assert.That(clip.FillContains(new Point(1, height - 1)), Is.False, $"bottom left of the {what} should be cut");
+        }
+
+        /// <summary>
+        /// Nothing is cut, which is what a corner radius of zero has to give.
+        /// </summary>
+        public static void KeepsEveryCorner(FrameworkElement element, string what)
+        {
+            Assert.That(element.Clip, Is.Not.Null, $"the {what} should still be clipped, just not rounded");
+
+            var clip = element.Clip!;
+
+            Assert.That(clip.FillContains(new Point(0.5, 0.5)), Is.True, $"square corners of the {what} belong to the clip");
+            Assert.That(clip.FillContains(new Point(element.ActualWidth - 0.5, element.ActualHeight - 0.5)), Is.True, $"and so does the far corner of the {what}");
+        }
+
+        /// <summary>
+        /// Lets the dispatcher work, which the templates need before anything has a size.
+        /// </summary>
+        public static void Pump(int milliseconds = 300)
+        {
+            var frame = new DispatcherFrame();
+            var timer = new DispatcherTimer(TimeSpan.FromMilliseconds(milliseconds), DispatcherPriority.Background, (_, _) => frame.Continue = false, Dispatcher.CurrentDispatcher);
+
+            try
+            {
+                Dispatcher.PushFrame(frame);
+            }
+            finally
+            {
+                timer.Stop();
+            }
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/ButtonClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ButtonClipTests.cs
@@ -1,0 +1,127 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// Every button style that rounds its corners clips its content to them. A clip lives in the
+    /// coordinates of the element carrying it, so the geometry has to match that element and not the
+    /// border around it.
+    /// </summary>
+    [TestFixture]
+    public class ButtonClipTests
+    {
+        private static readonly object[] ClippedStyles =
+            {
+                new object[] { "MahApps.Styles.Button", false },
+                new object[] { "MahApps.Styles.Button.Flat", false },
+                new object[] { "MahApps.Styles.Button.Win10", false },
+                new object[] { "MahApps.Styles.Button.Square", false },
+                new object[] { "MahApps.Styles.Button.Square.Accent", false },
+                new object[] { "MahApps.Styles.Button.Square.Highlight", false },
+                new object[] { "MahApps.Styles.Button.DropDown", false },
+                new object[] { "MahApps.Styles.ToggleButton", true },
+                new object[] { "MahApps.Styles.ToggleButton.Flat", true }
+            };
+
+        private TestWindow? window;
+        private ResourceDictionary? dictionary;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>().ConfigureAwait(false);
+            this.dictionary = new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Controls.Buttons.xaml", UriKind.Absolute) };
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        private ContentControl ShowButton(string styleKey, bool isToggleButton)
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            ContentControl button = isToggleButton ? new ToggleButton() : new Button();
+            button.Width = 200;
+            button.Height = 48;
+            button.Content = "Beam me up...";
+            button.SetValue(FrameworkElement.StyleProperty, this.dictionary![styleKey]);
+            ControlsHelper.SetCornerRadius(button, new CornerRadius(12));
+
+            this.window!.Content = button;
+            this.window.UpdateLayout();
+            button.UpdateLayout();
+
+            return button;
+        }
+
+        [TestCaseSource(nameof(ClippedStyles))]
+        public void TheClipShouldCoverTheGridItSitsOn(string styleKey, bool isToggleButton)
+        {
+            var button = this.ShowButton(styleKey, isToggleButton);
+
+            var grid = button.FindChild<Grid>("ContentGrid");
+            Assert.That(grid, Is.Not.Null, "the template should carry the grid the clip sits on");
+            Assert.That(grid!.ActualWidth, Is.GreaterThan(0), "the button should be laid out, otherwise this test proves nothing");
+            Assert.That(grid.Clip, Is.Not.Null, "the content should be clipped");
+
+            Assert.That(grid.Clip!.Bounds.Width, Is.EqualTo(grid.ActualWidth).Within(0.001), "a wider clip leaves the content unclipped on the right");
+            Assert.That(grid.Clip.Bounds.Height, Is.EqualTo(grid.ActualHeight).Within(0.001), "a taller clip leaves it unclipped at the bottom");
+            Assert.That(grid.Clip.Bounds.X, Is.EqualTo(0).Within(0.001));
+            Assert.That(grid.Clip.Bounds.Y, Is.EqualTo(0).Within(0.001));
+        }
+
+        [TestCaseSource(nameof(ClippedStyles))]
+        public void TheClipShouldCutEveryCorner(string styleKey, bool isToggleButton)
+        {
+            var button = this.ShowButton(styleKey, isToggleButton);
+
+            var grid = button.FindChild<Grid>("ContentGrid");
+            Assert.That(grid, Is.Not.Null);
+
+            var clip = grid!.Clip;
+            Assert.That(clip, Is.Not.Null);
+
+            var width = grid.ActualWidth;
+            var height = grid.ActualHeight;
+
+            Assert.That(clip!.FillContains(new Point(width / 2, height / 2)), Is.True, "the middle belongs to the clip");
+            Assert.That(clip.FillContains(new Point(1, 1)), Is.False, "top left should be cut");
+            Assert.That(clip.FillContains(new Point(width - 1, 1)), Is.False, "top right should be cut");
+            Assert.That(clip.FillContains(new Point(width - 1, height - 1)), Is.False, "bottom right should be cut");
+            Assert.That(clip.FillContains(new Point(1, height - 1)), Is.False, "bottom left should be cut");
+        }
+
+        [TestCaseSource(nameof(ClippedStyles))]
+        public void WithoutACornerRadiusTheClipShouldKeepTheWholeRectangle(string styleKey, bool isToggleButton)
+        {
+            var button = this.ShowButton(styleKey, isToggleButton);
+
+            // Some of these styles carry a corner radius of their own, so clearing the local value is
+            // not the same as asking for square corners.
+            ControlsHelper.SetCornerRadius(button, new CornerRadius(0));
+            button.UpdateLayout();
+
+            var grid = button.FindChild<Grid>("ContentGrid");
+            Assert.That(grid, Is.Not.Null);
+            Assert.That(grid!.Clip, Is.Not.Null);
+
+            Assert.That(grid.Clip!.FillContains(new Point(0.5, 0.5)), Is.True, "square corners belong to the clip");
+            Assert.That(grid.Clip.FillContains(new Point(grid.ActualWidth - 0.5, grid.ActualHeight - 0.5)), Is.True);
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/ButtonClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ButtonClipTests.cs
@@ -74,15 +74,7 @@ namespace MahApps.Metro.Tests.Tests
         {
             var button = this.ShowButton(styleKey, isToggleButton);
 
-            var grid = button.FindChild<Grid>("ContentGrid");
-            Assert.That(grid, Is.Not.Null, "the template should carry the grid the clip sits on");
-            Assert.That(grid!.ActualWidth, Is.GreaterThan(0), "the button should be laid out, otherwise this test proves nothing");
-            Assert.That(grid.Clip, Is.Not.Null, "the content should be clipped");
-
-            Assert.That(grid.Clip!.Bounds.Width, Is.EqualTo(grid.ActualWidth).Within(0.001), "a wider clip leaves the content unclipped on the right");
-            Assert.That(grid.Clip.Bounds.Height, Is.EqualTo(grid.ActualHeight).Within(0.001), "a taller clip leaves it unclipped at the bottom");
-            Assert.That(grid.Clip.Bounds.X, Is.EqualTo(0).Within(0.001));
-            Assert.That(grid.Clip.Bounds.Y, Is.EqualTo(0).Within(0.001));
+            ClipAssert.CoversElement(ClipAssert.ContentGrid(button), "button");
         }
 
         [TestCaseSource(nameof(ClippedStyles))]
@@ -90,20 +82,7 @@ namespace MahApps.Metro.Tests.Tests
         {
             var button = this.ShowButton(styleKey, isToggleButton);
 
-            var grid = button.FindChild<Grid>("ContentGrid");
-            Assert.That(grid, Is.Not.Null);
-
-            var clip = grid!.Clip;
-            Assert.That(clip, Is.Not.Null);
-
-            var width = grid.ActualWidth;
-            var height = grid.ActualHeight;
-
-            Assert.That(clip!.FillContains(new Point(width / 2, height / 2)), Is.True, "the middle belongs to the clip");
-            Assert.That(clip.FillContains(new Point(1, 1)), Is.False, "top left should be cut");
-            Assert.That(clip.FillContains(new Point(width - 1, 1)), Is.False, "top right should be cut");
-            Assert.That(clip.FillContains(new Point(width - 1, height - 1)), Is.False, "bottom right should be cut");
-            Assert.That(clip.FillContains(new Point(1, height - 1)), Is.False, "bottom left should be cut");
+            ClipAssert.CutsEveryCorner(ClipAssert.ContentGrid(button), "button");
         }
 
         [TestCaseSource(nameof(ClippedStyles))]
@@ -116,12 +95,7 @@ namespace MahApps.Metro.Tests.Tests
             ControlsHelper.SetCornerRadius(button, new CornerRadius(0));
             button.UpdateLayout();
 
-            var grid = button.FindChild<Grid>("ContentGrid");
-            Assert.That(grid, Is.Not.Null);
-            Assert.That(grid!.Clip, Is.Not.Null);
-
-            Assert.That(grid.Clip!.FillContains(new Point(0.5, 0.5)), Is.True, "square corners belong to the clip");
-            Assert.That(grid.Clip.FillContains(new Point(grid.ActualWidth - 0.5, grid.ActualHeight - 0.5)), Is.True);
+            ClipAssert.KeepsEveryCorner(ClipAssert.ContentGrid(button), "button");
         }
     }
 }

--- a/src/Mahapps.Metro.Tests/Tests/ButtonClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ButtonClipTests.cs
@@ -86,6 +86,21 @@ namespace MahApps.Metro.Tests.Tests
         }
 
         [TestCaseSource(nameof(ClippedStyles))]
+        public void TheCornersOutsideTheRoundingShouldNotBeClickable(string styleKey, bool isToggleButton)
+        {
+            var button = this.ShowButton(styleKey, isToggleButton);
+            ControlsHelper.SetCornerRadius(button, new CornerRadius(20));
+            button.UpdateLayout();
+
+            // A rounded button should not answer to a click in the corner of its bounding box, which is
+            // why ClipBorder was put into these templates in the first place (#3876). A Border hit tests
+            // against the background it draws, so the rounding is kept without it.
+            Assert.That(button.InputHitTest(new Point(2, 2)), Is.Null, "the top left corner sits outside the rounding");
+            Assert.That(button.InputHitTest(new Point(button.ActualWidth - 2, button.ActualHeight - 2)), Is.Null, "and so does the bottom right one");
+            Assert.That(button.InputHitTest(new Point(button.ActualWidth / 2, button.ActualHeight / 2)), Is.Not.Null, "while the middle of the button answers as it should");
+        }
+
+        [TestCaseSource(nameof(ClippedStyles))]
         public void WithoutACornerRadiusTheClipShouldKeepTheWholeRectangle(string styleKey, bool isToggleButton)
         {
             var button = this.ShowButton(styleKey, isToggleButton);

--- a/src/Mahapps.Metro.Tests/Tests/ClipGeometryConverterTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ClipGeometryConverterTests.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Windows;
+using System.Windows.Media;
+using MahApps.Metro.Converters;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// The geometry this converter builds is used as a <see cref="UIElement.Clip"/>, which lives in the
+    /// coordinates of the element it sits on. So it has to describe the area inside the border, not the
+    /// border itself.
+    /// </summary>
+    [TestFixture]
+    public class ClipGeometryConverterTests
+    {
+        private static Geometry Convert(double width, double height, CornerRadius cornerRadius, Thickness borderThickness, Thickness? padding = null)
+        {
+            object[] values = padding is null
+                ? new object[] { width, height, cornerRadius, borderThickness }
+                : new object[] { width, height, cornerRadius, borderThickness, padding.Value };
+
+            var result = ClipGeometryConverter.Instance.Convert(values, typeof(Geometry), null!, CultureInfo.InvariantCulture);
+
+            Assert.That(result, Is.InstanceOf<Geometry>(), "the converter should hand back a geometry");
+
+            return (Geometry)result;
+        }
+
+        [Test]
+        public void TheGeometryShouldCoverTheGivenSize()
+        {
+            var geometry = Convert(200, 45, new CornerRadius(22), new Thickness(2));
+
+            Assert.That(geometry.Bounds.Width, Is.EqualTo(200).Within(0.001), "anything wider would leave the element unclipped on the right");
+            Assert.That(geometry.Bounds.Height, Is.EqualTo(45).Within(0.001), "anything taller would leave it unclipped at the bottom");
+            Assert.That(geometry.Bounds.X, Is.EqualTo(0).Within(0.001));
+            Assert.That(geometry.Bounds.Y, Is.EqualTo(0).Within(0.001));
+        }
+
+        [Test]
+        public void EveryCornerShouldBeRounded()
+        {
+            var geometry = Convert(200, 45, new CornerRadius(22), new Thickness(2));
+
+            Assert.That(geometry.FillContains(new Point(100, 22)), Is.True, "the middle belongs to the clip");
+
+            Assert.That(geometry.FillContains(new Point(1, 1)), Is.False, "top left should be cut");
+            Assert.That(geometry.FillContains(new Point(199, 1)), Is.False, "top right should be cut");
+            Assert.That(geometry.FillContains(new Point(199, 44)), Is.False, "bottom right should be cut");
+            Assert.That(geometry.FillContains(new Point(1, 44)), Is.False, "bottom left should be cut");
+        }
+
+        [Test]
+        public void TheRadiusShouldLoseHalfTheBorderThickness()
+        {
+            // A corner radius of 22 with a border of 8 leaves 18 on the inside, which is how the WPF
+            // Border draws its own inner edge and what ClipBorder clips its child to. Taking the whole
+            // thickness would leave 14 and cut a visible gap between the border and the content, and
+            // the two points below tell those apart.
+            var geometry = Convert(200, 45, new CornerRadius(22), new Thickness(8));
+
+            Assert.That(geometry.FillContains(new Point(5.5, 5.5)), Is.True, "the inner radius should be 18");
+            Assert.That(geometry.FillContains(new Point(4.5, 4.5)), Is.False, "and not any smaller than that");
+        }
+
+        [Test]
+        public void PaddingShouldCountWholeTowardsTheInside()
+        {
+            // Half of the border of 8 and the whole padding of 4 take 8 off the radius of 22, so the
+            // corner is a radius of 14 here.
+            var geometry = Convert(200, 45, new CornerRadius(22), new Thickness(8), new Thickness(4));
+
+            Assert.That(geometry.FillContains(new Point(4.7, 4.7)), Is.True, "the padding pushes the content further in");
+            Assert.That(geometry.FillContains(new Point(3.5, 3.5)), Is.False);
+        }
+
+        [Test]
+        public void OneThickSideShouldNotReshapeTheOppositeCorner()
+        {
+            // Only the right side is thick, so the top left corner keeps its radius of 10 and stays a
+            // circle. Reading the wrong side would flatten it into an ellipse, and the point below is
+            // inside the circle and outside that ellipse.
+            var geometry = Convert(200, 45, new CornerRadius(10), new Thickness(0, 0, 10, 0));
+
+            Assert.That(geometry.FillContains(new Point(2, 9)), Is.True, "the top left corner should not care how thick the right side is");
+        }
+
+        [Test]
+        public void CornersAskingForMoreThanThereIsShouldShareTheSide()
+        {
+            // Two radii of 30 on a side of 40 do not fit, so they end up with 20 each instead of
+            // overlapping into a shape that folds back on itself.
+            var geometry = Convert(40, 40, new CornerRadius(30), new Thickness(0));
+
+            Assert.That(geometry.Bounds.Width, Is.EqualTo(40).Within(0.001));
+            Assert.That(geometry.Bounds.Height, Is.EqualTo(40).Within(0.001));
+            Assert.That(geometry.FillContains(new Point(20, 20)), Is.True, "the middle should survive");
+            Assert.That(geometry.FillContains(new Point(1, 1)), Is.False, "the corners should still be cut");
+            Assert.That(geometry.FillContains(new Point(39, 39)), Is.False);
+        }
+
+        [Test]
+        public void ACornerRadiusOfZeroShouldGiveTheWholeRectangle()
+        {
+            var geometry = Convert(200, 45, new CornerRadius(0), new Thickness(2));
+
+            Assert.That(geometry.FillContains(new Point(0.5, 0.5)), Is.True, "square corners belong to the clip");
+            Assert.That(geometry.FillContains(new Point(199.5, 44.5)), Is.True);
+            Assert.That(geometry.Bounds.Width, Is.EqualTo(200).Within(0.001));
+            Assert.That(geometry.Bounds.Height, Is.EqualTo(45).Within(0.001));
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/ClipGeometryConverterTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ClipGeometryConverterTests.cs
@@ -59,9 +59,8 @@ namespace MahApps.Metro.Tests.Tests
         public void TheRadiusShouldLoseHalfTheBorderThickness()
         {
             // A corner radius of 22 with a border of 8 leaves 18 on the inside, which is how the WPF
-            // Border draws its own inner edge and what ClipBorder clips its child to. Taking the whole
-            // thickness would leave 14 and cut a visible gap between the border and the content, and
-            // the two points below tell those apart.
+            // Border draws its own inner edge. Taking the whole thickness would leave 14 and cut a
+            // visible gap between the border and the content, and the two points below tell those apart.
             var geometry = Convert(200, 45, new CornerRadius(22), new Thickness(8));
 
             Assert.That(geometry.FillContains(new Point(5.5, 5.5)), Is.True, "the inner radius should be 18");

--- a/src/Mahapps.Metro.Tests/Tests/ComboBoxClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ComboBoxClipTests.cs
@@ -9,7 +9,6 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Media;
-using System.Windows.Threading;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Tests.TestHelpers;
 using NUnit.Framework;
@@ -41,24 +40,6 @@ namespace MahApps.Metro.Tests.Tests
             this.window = null;
         }
 
-        /// <summary>
-        /// Lets the dispatcher work, which the drop down needs before it has a size.
-        /// </summary>
-        private static void Pump()
-        {
-            var frame = new DispatcherFrame();
-            var timer = new DispatcherTimer(TimeSpan.FromMilliseconds(300), DispatcherPriority.Background, (_, _) => frame.Continue = false, Dispatcher.CurrentDispatcher);
-
-            try
-            {
-                Dispatcher.PushFrame(frame);
-            }
-            finally
-            {
-                timer.Stop();
-            }
-        }
-
         private ComboBox ShowComboBox()
         {
             Assert.That(this.window, Is.Not.Null);
@@ -74,7 +55,7 @@ namespace MahApps.Metro.Tests.Tests
             comboBox.UpdateLayout();
 
             // Let the box finish loading before a test reaches into its template.
-            Pump();
+            ClipAssert.Pump();
             Assert.That(comboBox.IsLoaded, Is.True, "the box should be loaded before a test looks at it");
 
             return comboBox;
@@ -118,38 +99,12 @@ namespace MahApps.Metro.Tests.Tests
             this.window!.Content = host;
             this.window.UpdateLayout();
             host.UpdateLayout();
-            Pump();
+            ClipAssert.Pump();
 
             var border = content!.FindChild<Border>("PopupBorder") ?? content as Border;
             Assert.That(border, Is.Not.Null, "the drop down should sit in a border");
 
             return border!;
-        }
-
-        private static void AssertClipCoversElement(FrameworkElement element, string what)
-        {
-            Assert.That(element.ActualWidth, Is.GreaterThan(0), $"the {what} should be laid out, otherwise this test proves nothing");
-            Assert.That(element.Clip, Is.Not.Null, $"the {what} should be clipped");
-
-            Assert.That(element.Clip!.Bounds.Width, Is.EqualTo(element.ActualWidth).Within(0.001), $"a wider clip leaves the {what} unclipped on the right");
-            Assert.That(element.Clip.Bounds.Height, Is.EqualTo(element.ActualHeight).Within(0.001), $"a taller clip leaves the {what} unclipped at the bottom");
-            Assert.That(element.Clip.Bounds.X, Is.EqualTo(0).Within(0.001));
-            Assert.That(element.Clip.Bounds.Y, Is.EqualTo(0).Within(0.001));
-        }
-
-        private static void AssertEveryCornerIsCut(FrameworkElement element, string what)
-        {
-            var clip = element.Clip;
-            Assert.That(clip, Is.Not.Null);
-
-            var width = element.ActualWidth;
-            var height = element.ActualHeight;
-
-            Assert.That(clip!.FillContains(new Point(width / 2, height / 2)), Is.True, $"the middle of the {what} belongs to the clip");
-            Assert.That(clip.FillContains(new Point(1, 1)), Is.False, $"top left of the {what} should be cut");
-            Assert.That(clip.FillContains(new Point(width - 1, 1)), Is.False, $"top right of the {what} should be cut");
-            Assert.That(clip.FillContains(new Point(width - 1, height - 1)), Is.False, $"bottom right of the {what} should be cut");
-            Assert.That(clip.FillContains(new Point(1, height - 1)), Is.False, $"bottom left of the {what} should be cut");
         }
 
         [Test]
@@ -176,10 +131,9 @@ namespace MahApps.Metro.Tests.Tests
             var comboBox = this.ShowComboBox();
             var popupBorder = this.ShowDropDownContent(comboBox);
 
-            var grid = popupBorder.FindChild<Grid>("ContentGrid");
-            Assert.That(grid, Is.Not.Null, "the drop down should carry the grid the clip sits on");
+            var grid = ClipAssert.ContentGrid(popupBorder);
 
-            AssertClipCoversElement(grid!, "drop down");
+            ClipAssert.CoversElement(grid, "drop down");
         }
 
         [Test]
@@ -198,11 +152,10 @@ namespace MahApps.Metro.Tests.Tests
         {
             var item = this.ShowItem();
 
-            var grid = item.FindChild<Grid>("ContentGrid");
-            Assert.That(grid, Is.Not.Null, "the item template should carry the grid the clip sits on");
+            var grid = ClipAssert.ContentGrid(item);
 
-            AssertClipCoversElement(grid!, "item");
-            AssertEveryCornerIsCut(grid!, "item");
+            ClipAssert.CoversElement(grid, "item");
+            ClipAssert.CutsEveryCorner(grid, "item");
         }
 
         [Test]
@@ -213,12 +166,7 @@ namespace MahApps.Metro.Tests.Tests
             ControlsHelper.SetCornerRadius(item, new CornerRadius(0));
             item.UpdateLayout();
 
-            var grid = item.FindChild<Grid>("ContentGrid");
-            Assert.That(grid, Is.Not.Null);
-            Assert.That(grid!.Clip, Is.Not.Null);
-
-            Assert.That(grid.Clip!.FillContains(new Point(0.5, 0.5)), Is.True, "square corners belong to the clip");
-            Assert.That(grid.Clip.FillContains(new Point(grid.ActualWidth - 0.5, grid.ActualHeight - 0.5)), Is.True);
+            ClipAssert.KeepsEveryCorner(ClipAssert.ContentGrid(item), "item");
         }
     }
 }

--- a/src/Mahapps.Metro.Tests/Tests/ComboBoxClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ComboBoxClipTests.cs
@@ -1,0 +1,224 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Threading;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// The combo box rounds the box, the drop down around the list and every item in it. A clip lives in
+    /// the coordinates of the element carrying it, so each geometry has to match that element rather
+    /// than the border around it.
+    /// </summary>
+    [TestFixture]
+    public class ComboBoxClipTests
+    {
+        private TestWindow? window;
+        private ResourceDictionary? dictionary;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>().ConfigureAwait(false);
+            this.dictionary = new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Controls.ComboBox.xaml", UriKind.Absolute) };
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        /// <summary>
+        /// Lets the dispatcher work, which the drop down needs before it has a size.
+        /// </summary>
+        private static void Pump()
+        {
+            var frame = new DispatcherFrame();
+            var timer = new DispatcherTimer(TimeSpan.FromMilliseconds(300), DispatcherPriority.Background, (_, _) => frame.Continue = false, Dispatcher.CurrentDispatcher);
+
+            try
+            {
+                Dispatcher.PushFrame(frame);
+            }
+            finally
+            {
+                timer.Stop();
+            }
+        }
+
+        private ComboBox ShowComboBox()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var comboBox = new ComboBox { Width = 200, Height = 32 };
+            comboBox.SetValue(FrameworkElement.StyleProperty, this.dictionary!["MahApps.Styles.ComboBox"]);
+            comboBox.Items.Add("Beam me up...");
+            comboBox.Items.Add("Warp nine");
+            ControlsHelper.SetCornerRadius(comboBox, new CornerRadius(12));
+
+            this.window!.Content = comboBox;
+            this.window.UpdateLayout();
+            comboBox.UpdateLayout();
+
+            // Let the box finish loading before a test reaches into its template.
+            Pump();
+            Assert.That(comboBox.IsLoaded, Is.True, "the box should be loaded before a test looks at it");
+
+            return comboBox;
+        }
+
+        private ComboBoxItem ShowItem()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var item = new ComboBoxItem { Width = 200, Height = 32, Content = "Beam me up..." };
+            item.SetValue(FrameworkElement.StyleProperty, this.dictionary!["MahApps.Styles.ComboBoxItem"]);
+            ControlsHelper.SetCornerRadius(item, new CornerRadius(8));
+
+            this.window!.Content = item;
+            this.window.UpdateLayout();
+            item.UpdateLayout();
+
+            return item;
+        }
+
+        /// <summary>
+        /// Takes the content of the drop down out of its popup and lays it out in the window instead.
+        /// Opening the popup for real is not something a test can rely on: the box only opens while it
+        /// holds the mouse capture, and a popup closes again when its window loses activation, which
+        /// happens all the time while four test hosts share one desktop. The geometry inside is the same
+        /// either way, and the element names the clip binds to travel with it.
+        /// </summary>
+        private Border ShowDropDownContent(ComboBox comboBox)
+        {
+            var popup = comboBox.FindChild<Popup>("PART_Popup");
+            Assert.That(popup, Is.Not.Null, "the template should carry the popup");
+
+            var content = popup!.Child as FrameworkElement;
+            Assert.That(content, Is.Not.Null, "the popup should carry its content");
+
+            popup.Child = null;
+
+            var host = new Grid { Width = 200 };
+            host.Children.Add(content);
+
+            this.window!.Content = host;
+            this.window.UpdateLayout();
+            host.UpdateLayout();
+            Pump();
+
+            var border = content!.FindChild<Border>("PopupBorder") ?? content as Border;
+            Assert.That(border, Is.Not.Null, "the drop down should sit in a border");
+
+            return border!;
+        }
+
+        private static void AssertClipCoversElement(FrameworkElement element, string what)
+        {
+            Assert.That(element.ActualWidth, Is.GreaterThan(0), $"the {what} should be laid out, otherwise this test proves nothing");
+            Assert.That(element.Clip, Is.Not.Null, $"the {what} should be clipped");
+
+            Assert.That(element.Clip!.Bounds.Width, Is.EqualTo(element.ActualWidth).Within(0.001), $"a wider clip leaves the {what} unclipped on the right");
+            Assert.That(element.Clip.Bounds.Height, Is.EqualTo(element.ActualHeight).Within(0.001), $"a taller clip leaves the {what} unclipped at the bottom");
+            Assert.That(element.Clip.Bounds.X, Is.EqualTo(0).Within(0.001));
+            Assert.That(element.Clip.Bounds.Y, Is.EqualTo(0).Within(0.001));
+        }
+
+        private static void AssertEveryCornerIsCut(FrameworkElement element, string what)
+        {
+            var clip = element.Clip;
+            Assert.That(clip, Is.Not.Null);
+
+            var width = element.ActualWidth;
+            var height = element.ActualHeight;
+
+            Assert.That(clip!.FillContains(new Point(width / 2, height / 2)), Is.True, $"the middle of the {what} belongs to the clip");
+            Assert.That(clip.FillContains(new Point(1, 1)), Is.False, $"top left of the {what} should be cut");
+            Assert.That(clip.FillContains(new Point(width - 1, 1)), Is.False, $"top right of the {what} should be cut");
+            Assert.That(clip.FillContains(new Point(width - 1, height - 1)), Is.False, $"bottom right of the {what} should be cut");
+            Assert.That(clip.FillContains(new Point(1, height - 1)), Is.False, $"bottom left of the {what} should be cut");
+        }
+
+        [Test]
+        public void TheBoxShouldRoundItsFrameAndInsetItsContent()
+        {
+            var comboBox = this.ShowComboBox();
+
+            var border = comboBox.FindChild<Border>("Border");
+            Assert.That(border, Is.Not.Null, "the template should carry the border");
+            Assert.That(border!.CornerRadius, Is.EqualTo(new CornerRadius(12)), "the frame should take the corner radius of the box");
+
+            // The box itself does not clip: its frame is a border of its own and the text and the buttons
+            // sit next to it in a grid inset by the border thickness. Only the drop down and the items
+            // carry a clip.
+            var textBox = comboBox.FindChild<TextBox>("PART_EditableTextBox");
+            var content = (textBox as FrameworkElement) ?? comboBox.FindChild<ContentPresenter>(string.Empty);
+            Assert.That(content, Is.Not.Null, "the box should carry its content");
+            Assert.That(content!.Clip, Is.Null, "the content of the box is inset rather than clipped");
+        }
+
+        [Test]
+        public void TheDropDownShouldClipItsContentToItsBorder()
+        {
+            var comboBox = this.ShowComboBox();
+            var popupBorder = this.ShowDropDownContent(comboBox);
+
+            var grid = popupBorder.FindChild<Grid>("ContentGrid");
+            Assert.That(grid, Is.Not.Null, "the drop down should carry the grid the clip sits on");
+
+            AssertClipCoversElement(grid!, "drop down");
+        }
+
+        [Test]
+        public void TheDropDownShouldTakeItsBackgroundFromItsOwnThemeKey()
+        {
+            var comboBox = this.ShowComboBox();
+            var popupBorder = this.ShowDropDownContent(comboBox);
+
+            var expected = comboBox.TryFindResource("MahApps.Brushes.ComboBox.PopupBackground") as Brush;
+            Assert.That(expected, Is.Not.Null, "the theme should carry a background of its own for this drop down");
+            Assert.That(popupBorder.Background, Is.SameAs(expected), "the drop down should be recolourable without touching the theme background of everything else");
+        }
+
+        [Test]
+        public void AnItemShouldClipItsContentToItsBorder()
+        {
+            var item = this.ShowItem();
+
+            var grid = item.FindChild<Grid>("ContentGrid");
+            Assert.That(grid, Is.Not.Null, "the item template should carry the grid the clip sits on");
+
+            AssertClipCoversElement(grid!, "item");
+            AssertEveryCornerIsCut(grid!, "item");
+        }
+
+        [Test]
+        public void AnItemWithoutACornerRadiusShouldKeepTheWholeRectangle()
+        {
+            var item = this.ShowItem();
+
+            ControlsHelper.SetCornerRadius(item, new CornerRadius(0));
+            item.UpdateLayout();
+
+            var grid = item.FindChild<Grid>("ContentGrid");
+            Assert.That(grid, Is.Not.Null);
+            Assert.That(grid!.Clip, Is.Not.Null);
+
+            Assert.That(grid.Clip!.FillContains(new Point(0.5, 0.5)), Is.True, "square corners belong to the clip");
+            Assert.That(grid.Clip.FillContains(new Point(grid.ActualWidth - 0.5, grid.ActualHeight - 0.5)), Is.True);
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
@@ -269,12 +269,12 @@ namespace MahApps.Metro.Tests.Tests
         /// Reaches the border around the drop down. It lives in the popup, so it is not part of the
         /// visual tree of the picker itself.
         /// </summary>
-        private static ClipBorder? GetPopupBorder(TimePickerBase picker)
+        private static Border? GetPopupBorder(TimePickerBase picker)
         {
             var popup = picker.FindChild<Popup>("PART_Popup");
             Assert.That(popup, Is.Not.Null, "the template should carry a popup");
 
-            return popup!.Child as ClipBorder;
+            return popup!.Child as Border;
         }
 
         [Test]
@@ -297,6 +297,48 @@ namespace MahApps.Metro.Tests.Tests
 
             Assert.That(border, Is.Not.Null, "the drop down should sit in a ClipBorder, so that rounded corners cut the content too");
             Assert.That(border!.CornerRadius, Is.EqualTo(new CornerRadius(4)), "the drop down should take the corner radius of the picker");
+        }
+
+        [Test]
+        public void TheFieldShouldClipItsContentToItsBorder()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var picker = this.window.TheRoundedDateTimePicker;
+            picker.UpdateLayout();
+
+            var grid = ClipAssert.ContentGrid(picker, "PART_InnerGrid");
+
+            ClipAssert.CoversElement(grid, "field");
+            ClipAssert.CutsEveryCorner(grid, "field");
+        }
+
+        [Test]
+        public void TheDropDownShouldClipItsContentToItsBorder()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var picker = this.window.TheRoundedDateTimePicker;
+
+            var popup = picker.FindChild<Popup>("PART_Popup");
+            Assert.That(popup, Is.Not.Null, "the template should carry a popup");
+
+            // The drop down is measured outside of its popup, which closes again whenever its window
+            // loses activation. The geometry and the names the clip binds to are the same either way.
+            var content = popup!.Child as FrameworkElement;
+            Assert.That(content, Is.Not.Null, "the popup should carry its content");
+            popup.Child = null;
+
+            var host = new Grid { Width = 320, Height = 320 };
+            host.Children.Add(content);
+            this.window.Content = host;
+            this.window.UpdateLayout();
+            ClipAssert.Pump();
+
+            var border = (content as Border) ?? content!.FindChild<Border>("PART_PopupBorder");
+            Assert.That(border, Is.Not.Null, "the drop down should sit in a border");
+
+            ClipAssert.CoversElement(ClipAssert.ContentGrid(border!), "drop down");
         }
 
         [Test]

--- a/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DateTimePickerTests.cs
@@ -284,7 +284,7 @@ namespace MahApps.Metro.Tests.Tests
 
             var border = GetPopupBorder(this.window.TheRoundedDateTimePicker);
 
-            Assert.That(border, Is.Not.Null, "the drop down should sit in a ClipBorder, so that rounded corners cut the content too");
+            Assert.That(border, Is.Not.Null, "the drop down should sit in a border of its own");
             Assert.That(border!.CornerRadius, Is.EqualTo(new CornerRadius(8)), "the drop down should take the corner radius of the picker");
         }
 
@@ -295,7 +295,7 @@ namespace MahApps.Metro.Tests.Tests
 
             var border = GetPopupBorder(this.window.TheRoundedTimePicker);
 
-            Assert.That(border, Is.Not.Null, "the drop down should sit in a ClipBorder, so that rounded corners cut the content too");
+            Assert.That(border, Is.Not.Null, "the drop down should sit in a border of its own");
             Assert.That(border!.CornerRadius, Is.EqualTo(new CornerRadius(4)), "the drop down should take the corner radius of the picker");
         }
 

--- a/src/Mahapps.Metro.Tests/Tests/DoubleUtilTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DoubleUtilTests.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using MahApps.Metro.Controls;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// Comparing two doubles for equality fails on values that only differ by the last bit or two, which
+    /// is what arithmetic on them leaves behind. <see cref="DoubleUtil.AreClose"/> is the comparison the
+    /// library uses instead.
+    /// </summary>
+    [TestFixture]
+    public class DoubleUtilTests
+    {
+        [Test]
+        public void TheSameValueShouldBeClose()
+        {
+            Assert.That(DoubleUtil.AreClose(1.5d, 1.5d), Is.True);
+            Assert.That(DoubleUtil.AreClose(0d, 0d), Is.True);
+            Assert.That(DoubleUtil.AreClose(-42.25d, -42.25d), Is.True);
+        }
+
+        [Test]
+        public void WhatArithmeticLeavesBehindShouldBeClose()
+        {
+            // 0.1 + 0.2 is not 0.3 in binary, it is a few bits off, and every value that has been
+            // through a calculation looks like this.
+            var sum = 0.1d + 0.2d;
+            Assert.That(sum, Is.Not.EqualTo(0.3d), "this is the comparison that fails");
+            Assert.That(DoubleUtil.AreClose(sum, 0.3d), Is.True, "and this is the one that does not");
+        }
+
+        [Test]
+        public void ValuesThatDifferShouldNotBeClose()
+        {
+            Assert.That(DoubleUtil.AreClose(1d, 1.0001d), Is.False);
+            Assert.That(DoubleUtil.AreClose(0d, 0.0001d), Is.False);
+            Assert.That(DoubleUtil.AreClose(-1d, 1d), Is.False);
+        }
+
+        [Test]
+        public void TheToleranceShouldGrowWithTheValues()
+        {
+            // The comparison is relative, so the same absolute gap counts as close between two large
+            // values and as a difference between two small ones.
+            Assert.That(DoubleUtil.AreClose(1e12d, 1e12d + 0.0001d), Is.True, "next to a trillion this gap is noise");
+            Assert.That(DoubleUtil.AreClose(1d, 1d + 0.0001d), Is.False, "next to one it is not");
+        }
+
+        [Test]
+        public void InfinitiesShouldOnlyBeCloseToThemselves()
+        {
+            Assert.That(DoubleUtil.AreClose(double.PositiveInfinity, double.PositiveInfinity), Is.True, "the epsilon check cannot handle these, so they are compared directly");
+            Assert.That(DoubleUtil.AreClose(double.NegativeInfinity, double.NegativeInfinity), Is.True);
+            Assert.That(DoubleUtil.AreClose(double.PositiveInfinity, double.NegativeInfinity), Is.False);
+            Assert.That(DoubleUtil.AreClose(double.PositiveInfinity, double.MaxValue), Is.False);
+        }
+
+        [Test]
+        public void NotANumberShouldBeCloseToNothing()
+        {
+            Assert.That(DoubleUtil.AreClose(double.NaN, double.NaN), Is.False, "NaN equals nothing, itself included");
+            Assert.That(DoubleUtil.AreClose(double.NaN, 1d), Is.False);
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/DoubleUtilTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DoubleUtilTests.cs
@@ -57,6 +57,8 @@ namespace MahApps.Metro.Tests.Tests
             Assert.That(DoubleUtil.AreClose(double.NegativeInfinity, double.NegativeInfinity), Is.True);
             Assert.That(DoubleUtil.AreClose(double.PositiveInfinity, double.NegativeInfinity), Is.False);
             Assert.That(DoubleUtil.AreClose(double.PositiveInfinity, double.MaxValue), Is.False);
+            Assert.That(DoubleUtil.AreClose(double.NegativeInfinity, double.MinValue), Is.False);
+            Assert.That(DoubleUtil.AreClose(0d, double.NegativeInfinity), Is.False, "whichever side the infinity is on");
         }
 
         [Test]

--- a/src/Mahapps.Metro.Tests/Tests/FocusBorderTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/FocusBorderTests.cs
@@ -1,0 +1,131 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// Focus colours the border a control already has. It used to make it thicker as well, through
+    /// ControlsHelper.FocusBorderThickness, which moved the content of the control every time it was
+    /// focused.
+    /// </summary>
+    [TestFixture]
+    public class FocusBorderTests
+    {
+        private TestWindow? window;
+        private ResourceDictionary? buttonDictionary;
+        private ResourceDictionary? eyeDropperDictionary;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>().ConfigureAwait(false);
+            this.buttonDictionary = Load("Styles/Controls.Buttons.xaml");
+            this.eyeDropperDictionary = Load("Themes/ColorPicker/ColorEyeDropper.xaml");
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        private static ResourceDictionary Load(string path)
+        {
+            return new ResourceDictionary { Source = new Uri($"pack://application:,,,/MahApps.Metro;component/{path}", UriKind.Absolute) };
+        }
+
+        private Control Show(Control control)
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            control.Width = 200;
+            control.Height = 48;
+            control.BorderThickness = new Thickness(3);
+
+            this.window!.Content = control;
+            this.window.UpdateLayout();
+            control.UpdateLayout();
+            ClipAssert.Pump();
+
+            return control;
+        }
+
+        private static Border GetBorder(Control control)
+        {
+            var border = control.FindChild<Border>("Border");
+            Assert.That(border, Is.Not.Null, "the template should carry the border");
+
+            return border!;
+        }
+
+        [Test]
+        public void AFocusedButtonShouldKeepTheThicknessOfItsBorder()
+        {
+            var button = new Button { Content = "Beam me up..." };
+            button.SetValue(FrameworkElement.StyleProperty, this.buttonDictionary!["MahApps.Styles.Button"]);
+
+            this.Show(button);
+
+            var border = GetBorder(button);
+            var thickness = border.BorderThickness;
+            Assert.That(thickness, Is.EqualTo(new Thickness(3)), "the border should start out as thick as the button says");
+
+            button.Focus();
+            button.UpdateLayout();
+            ClipAssert.Pump();
+
+            Assert.That(button.IsKeyboardFocusWithin, Is.True, "the button should have the focus, otherwise this test proves nothing");
+            Assert.That(border.BorderThickness, Is.EqualTo(thickness), "focus should not change how thick the border is, only what colour it has");
+        }
+
+        [Test]
+        public void AFocusedButtonShouldTakeTheFocusBrushForItsBorder()
+        {
+            var button = new Button { Content = "Beam me up..." };
+            button.SetValue(FrameworkElement.StyleProperty, this.buttonDictionary!["MahApps.Styles.Button"]);
+            ControlsHelper.SetFocusBorderBrush(button, Brushes.Red);
+
+            this.Show(button);
+
+            var border = GetBorder(button);
+
+            button.Focus();
+            button.UpdateLayout();
+            ClipAssert.Pump();
+
+            Assert.That(button.IsKeyboardFocusWithin, Is.True, "the button should have the focus, otherwise this test proves nothing");
+            Assert.That(border.BorderBrush, Is.SameAs(Brushes.Red), "colouring the border is what marks the focus now");
+        }
+
+        [Test]
+        public void AFocusedEyeDropperShouldKeepTheThicknessOfItsBorder()
+        {
+            var eyeDropper = new ColorEyeDropper();
+            eyeDropper.SetValue(FrameworkElement.StyleProperty, this.eyeDropperDictionary!["MahApps.Styles.ColorEyeDropper"]);
+
+            this.Show(eyeDropper);
+
+            var border = GetBorder(eyeDropper);
+            var thickness = border.BorderThickness;
+            Assert.That(thickness, Is.EqualTo(new Thickness(3)));
+
+            eyeDropper.Focus();
+            eyeDropper.UpdateLayout();
+            ClipAssert.Pump();
+
+            Assert.That(eyeDropper.IsKeyboardFocusWithin, Is.True, "the eye dropper should have the focus, otherwise this test proves nothing");
+            Assert.That(border.BorderThickness, Is.EqualTo(thickness), "focus should not change how thick the border is, only what colour it has");
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/HamburgerMenuItemStyleTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/HamburgerMenuItemStyleTests.cs
@@ -1,0 +1,167 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// The item of a hamburger menu draws its background, its frame and the clip for its content in one
+    /// border. These tests hold the template to what its triggers say, and to a clip that matches the
+    /// element carrying it.
+    /// </summary>
+    [TestFixture]
+    public class HamburgerMenuItemStyleTests
+    {
+        private static readonly SolidColorBrush Selected = new(Colors.Red);
+        private static readonly SolidColorBrush Disabled = new(Colors.Lime);
+        private static readonly SolidColorBrush DisabledSelected = new(Colors.Magenta);
+
+        private static ListBoxItem CreateItem()
+        {
+            var dictionary = new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Themes/HamburgerMenuTemplate.xaml", UriKind.Absolute) };
+
+            var item = new ListBoxItem
+                       {
+                           Width = 200,
+                           Height = 48,
+                           Style = (Style)dictionary["MahApps.Styles.ListBoxItem.HamburgerMenuItem"],
+                           Content = "Item"
+                       };
+            ControlsHelper.SetCornerRadius(item, new CornerRadius(12));
+            ItemHelper.SetSelectedBackgroundBrush(item, Selected);
+            ItemHelper.SetDisabledBackgroundBrush(item, Disabled);
+            ItemHelper.SetDisabledSelectedBackgroundBrush(item, DisabledSelected);
+
+            return item;
+        }
+
+        private static async Task<ListBoxItem> ShowItemAsync(TestWindow window)
+        {
+            var item = CreateItem();
+            var listBox = new ListBox { Width = 220 };
+            listBox.Items.Add(item);
+
+            window.Content = listBox;
+            window.UpdateLayout();
+            listBox.UpdateLayout();
+            item.UpdateLayout();
+
+            await Task.Yield();
+
+            return item;
+        }
+
+        private static Border GetBorder(ListBoxItem item)
+        {
+            var border = item.FindChild<Border>("Border");
+            Assert.That(border, Is.Not.Null, "the template should carry the border");
+
+            return border!;
+        }
+
+        private static FrameworkElement GetContentGrid(ListBoxItem item)
+        {
+            var grid = item.FindChild<Grid>("ContentGrid");
+            Assert.That(grid, Is.Not.Null, "the template should carry the grid the clip sits on");
+
+            return grid!;
+        }
+
+        [Test]
+        public async Task TheClipShouldCoverTheGridItSitsOn()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>();
+
+            try
+            {
+                var item = await ShowItemAsync(window);
+                var grid = GetContentGrid(item);
+
+                Assert.That(grid.ActualWidth, Is.GreaterThan(0), "the item should be laid out, otherwise this test proves nothing");
+                Assert.That(grid.Clip, Is.Not.Null, "the content should be clipped");
+
+                Assert.That(grid.Clip!.Bounds.Width, Is.EqualTo(grid.ActualWidth).Within(0.001), "a wider clip leaves the content unclipped on the right");
+                Assert.That(grid.Clip.Bounds.Height, Is.EqualTo(grid.ActualHeight).Within(0.001), "a taller clip leaves it unclipped at the bottom");
+
+                Assert.That(grid.Clip.FillContains(new Point(1, 1)), Is.False, "the corners should be cut");
+                Assert.That(grid.Clip.FillContains(new Point(grid.ActualWidth - 1, grid.ActualHeight - 1)), Is.False);
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task ASelectedItemShouldPaintTheBorderWithTheSelectedBrush()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>();
+
+            try
+            {
+                var item = await ShowItemAsync(window);
+
+                item.SetCurrentValue(ListBoxItem.IsSelectedProperty, true);
+                item.UpdateLayout();
+
+                Assert.That(Selector.GetIsSelectionActive(item), Is.False, "an invisible window has no focus, so the plain selected trigger is the one that applies here");
+                Assert.That(GetBorder(item).Background, Is.SameAs(Selected), "the selected background belongs on the border that draws the item");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task ADisabledItemShouldPaintTheBorderWithTheDisabledBrush()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>();
+
+            try
+            {
+                var item = await ShowItemAsync(window);
+
+                item.SetCurrentValue(UIElement.IsEnabledProperty, false);
+                item.UpdateLayout();
+
+                Assert.That(GetBorder(item).Background, Is.SameAs(Disabled), "the disabled background belongs on the same border");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task ADisabledAndSelectedItemShouldPaintTheBorderWithItsOwnBrush()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>();
+
+            try
+            {
+                var item = await ShowItemAsync(window);
+
+                item.SetCurrentValue(ListBoxItem.IsSelectedProperty, true);
+                item.SetCurrentValue(UIElement.IsEnabledProperty, false);
+                item.UpdateLayout();
+
+                Assert.That(GetBorder(item).Background, Is.SameAs(DisabledSelected), "disabled and selected has a brush of its own, and it wins over the plain disabled one");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/HamburgerMenuItemStyleTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/HamburgerMenuItemStyleTests.cs
@@ -69,14 +69,6 @@ namespace MahApps.Metro.Tests.Tests
             return border!;
         }
 
-        private static FrameworkElement GetContentGrid(ListBoxItem item)
-        {
-            var grid = item.FindChild<Grid>("ContentGrid");
-            Assert.That(grid, Is.Not.Null, "the template should carry the grid the clip sits on");
-
-            return grid!;
-        }
-
         [Test]
         public async Task TheClipShouldCoverTheGridItSitsOn()
         {
@@ -85,16 +77,10 @@ namespace MahApps.Metro.Tests.Tests
             try
             {
                 var item = await ShowItemAsync(window);
-                var grid = GetContentGrid(item);
+                var grid = ClipAssert.ContentGrid(item);
 
-                Assert.That(grid.ActualWidth, Is.GreaterThan(0), "the item should be laid out, otherwise this test proves nothing");
-                Assert.That(grid.Clip, Is.Not.Null, "the content should be clipped");
-
-                Assert.That(grid.Clip!.Bounds.Width, Is.EqualTo(grid.ActualWidth).Within(0.001), "a wider clip leaves the content unclipped on the right");
-                Assert.That(grid.Clip.Bounds.Height, Is.EqualTo(grid.ActualHeight).Within(0.001), "a taller clip leaves it unclipped at the bottom");
-
-                Assert.That(grid.Clip.FillContains(new Point(1, 1)), Is.False, "the corners should be cut");
-                Assert.That(grid.Clip.FillContains(new Point(grid.ActualWidth - 1, grid.ActualHeight - 1)), Is.False);
+                ClipAssert.CoversElement(grid, "item");
+                ClipAssert.CutsEveryCorner(grid, "item");
             }
             finally
             {

--- a/src/Mahapps.Metro.Tests/Tests/ItemsControlClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ItemsControlClipTests.cs
@@ -1,0 +1,164 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// The items of a list box, a list view and a tree view round their corners and clip what they show
+    /// to them. A clip lives in the coordinates of the element carrying it, so the geometry has to match
+    /// that element rather than the border around it.
+    /// </summary>
+    [TestFixture]
+    public class ItemsControlClipTests
+    {
+        private TestWindow? window;
+        private ResourceDictionary? listBoxDictionary;
+        private ResourceDictionary? listViewDictionary;
+        private ResourceDictionary? treeViewDictionary;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>().ConfigureAwait(false);
+            this.listBoxDictionary = Load("Controls.ListBox.xaml");
+            this.listViewDictionary = Load("Controls.ListView.xaml");
+            this.treeViewDictionary = Load("Controls.TreeView.xaml");
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        private static ResourceDictionary Load(string fileName)
+        {
+            return new ResourceDictionary { Source = new Uri($"pack://application:,,,/MahApps.Metro;component/Styles/{fileName}", UriKind.Absolute) };
+        }
+
+        private T Show<T>(T element)
+            where T : FrameworkElement
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            this.window!.Content = element;
+            this.window.UpdateLayout();
+            element.UpdateLayout();
+            ClipAssert.Pump();
+
+            return element;
+        }
+
+        private T ShowItem<T>(T item, ResourceDictionary dictionary, string styleKey)
+            where T : Control
+        {
+            item.Width = 200;
+            item.Height = 32;
+            item.SetValue(FrameworkElement.StyleProperty, dictionary[styleKey]);
+            ControlsHelper.SetCornerRadius(item, new CornerRadius(12));
+
+            return this.Show(item);
+        }
+
+        [Test]
+        public void AListBoxItemShouldClipItsContentToItsBorder()
+        {
+            var item = this.ShowItem(new ListBoxItem { Content = "Beam me up..." }, this.listBoxDictionary!, "MahApps.Styles.ListBoxItem");
+
+            var grid = ClipAssert.ContentGrid(item);
+
+            ClipAssert.CoversElement(grid, "list box item");
+            ClipAssert.CutsEveryCorner(grid, "list box item");
+        }
+
+        [Test]
+        public void AListBoxItemWithoutACornerRadiusShouldKeepTheWholeRectangle()
+        {
+            var item = this.ShowItem(new ListBoxItem { Content = "Beam me up..." }, this.listBoxDictionary!, "MahApps.Styles.ListBoxItem");
+
+            ControlsHelper.SetCornerRadius(item, new CornerRadius(0));
+            item.UpdateLayout();
+
+            ClipAssert.KeepsEveryCorner(ClipAssert.ContentGrid(item), "list box item");
+        }
+
+        [Test]
+        public void AListViewItemShouldClipItsContentToItsBorder()
+        {
+            var item = this.ShowItem(new ListViewItem { Content = "Beam me up..." }, this.listViewDictionary!, "MahApps.Styles.ListViewItem");
+
+            var grid = ClipAssert.ContentGrid(item);
+
+            ClipAssert.CoversElement(grid, "list view item");
+            ClipAssert.CutsEveryCorner(grid, "list view item");
+        }
+
+        [Test]
+        public void ANonSelectableListViewItemShouldClipItsContentToItsBorder()
+        {
+            var item = this.ShowItem(new ListViewItem { Content = "Beam me up..." }, this.listViewDictionary!, "MahApps.Styles.ListViewItem.NonSelectable");
+
+            var grid = ClipAssert.ContentGrid(item);
+
+            ClipAssert.CoversElement(grid, "list view item");
+            ClipAssert.CutsEveryCorner(grid, "list view item");
+        }
+
+        [Test]
+        public void ATreeViewItemShouldClipItsContentToItsBorder()
+        {
+            var item = this.ShowItem(new TreeViewItem { Header = "Beam me up..." }, this.treeViewDictionary!, "MahApps.Styles.TreeViewItem");
+
+            var grid = ClipAssert.ContentGrid(item);
+
+            ClipAssert.CoversElement(grid, "tree view item");
+            ClipAssert.CutsEveryCorner(grid, "tree view item");
+        }
+
+        [Test]
+        public void ANestedTreeViewItemShouldClipAtTheEdgeOfItsBorder()
+        {
+            var child = new TreeViewItem { Header = "Child" };
+            var parent = new TreeViewItem { Header = "Parent", IsExpanded = true };
+            parent.Items.Add(child);
+
+            var tree = new TreeView { Width = 240, Height = 160 };
+            tree.SetValue(FrameworkElement.StyleProperty, this.treeViewDictionary!["MahApps.Styles.TreeView"]);
+            tree.ItemContainerStyle = (Style)this.treeViewDictionary["MahApps.Styles.TreeViewItem"];
+            tree.Items.Add(parent);
+
+            this.Show(tree);
+
+            ControlsHelper.SetCornerRadius(parent, new CornerRadius(12));
+            ControlsHelper.SetCornerRadius(child, new CornerRadius(12));
+            tree.UpdateLayout();
+            ClipAssert.Pump();
+
+            var border = child.FindChild<Border>("Border");
+            Assert.That(border, Is.Not.Null, "the template should carry the border");
+
+            var grid = ClipAssert.ContentGrid(child);
+
+            // A child sits deeper in the tree, and the header inside it is indented by that depth. The
+            // clip belongs on the whole inside of the border: rounding the indented header would cut a
+            // corner into the middle of the item, where the expander sits.
+            Assert.That(grid.Margin.Left, Is.EqualTo(0), "the clip should sit on the grid that fills the border, not on the indented one");
+            // A border rounds its own thickness to whole device pixels, so the inside is that much off.
+            var inside = border!.ActualWidth - border.BorderThickness.Left - border.BorderThickness.Right - border.Padding.Left - border.Padding.Right;
+            Assert.That(grid.ActualWidth, Is.EqualTo(inside).Within(1), "and that grid covers the whole inside of the border");
+
+            ClipAssert.CoversElement(grid, "nested tree view item");
+            ClipAssert.CutsEveryCorner(grid, "nested tree view item");
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/ItemsControlClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ItemsControlClipTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Tests.TestHelpers;
 using NUnit.Framework;
@@ -68,6 +69,79 @@ namespace MahApps.Metro.Tests.Tests
             ControlsHelper.SetCornerRadius(item, new CornerRadius(12));
 
             return this.Show(item);
+        }
+
+        /// <summary>
+        /// The element the template of the list puts its clip on. It is reached through the visual tree
+        /// rather than by name, because every item in the list carries a grid of that name as well.
+        /// </summary>
+        private static FrameworkElement RootContent(Control list)
+        {
+            var root = VisualTreeHelper.GetChild(list, 0) as FrameworkElement;
+            Assert.That(root, Is.InstanceOf<Border>(), "the template of the list should start with a border");
+
+            var content = VisualTreeHelper.GetChild(root!, 0) as FrameworkElement;
+            Assert.That(content, Is.InstanceOf<Grid>(), "the border should carry the grid that clips what the list shows");
+
+            return content!;
+        }
+
+        /// <summary>
+        /// The list itself rounds its frame, and the items paint an opaque background right up against
+        /// it, so without a clip the first and the last item bite the corners out of the arc.
+        /// </summary>
+        private T ShowList<T>(T list, ResourceDictionary dictionary, string styleKey)
+            where T : ItemsControl
+        {
+            list.Width = 190;
+            list.Height = 120;
+            list.BorderThickness = new Thickness(1);
+            list.SetValue(FrameworkElement.StyleProperty, dictionary[styleKey]);
+            ControlsHelper.SetCornerRadius(list, new CornerRadius(8));
+
+            return this.Show(list);
+        }
+
+        [Test]
+        public void AListBoxShouldClipItsItemsToItsBorder()
+        {
+            var listBox = new ListBox();
+            listBox.Items.Add(new ListBoxItem { Content = "Ada Lovelace" });
+            listBox.Items.Add(new ListBoxItem { Content = "Grace Hopper" });
+            this.ShowList(listBox, this.listBoxDictionary!, "MahApps.Styles.ListBox");
+
+            var content = RootContent(listBox);
+
+            ClipAssert.CoversElement(content, "list box");
+            ClipAssert.CutsEveryCorner(content, "list box");
+        }
+
+        [Test]
+        public void AListViewShouldClipItsItemsToItsBorder()
+        {
+            var listView = new ListView();
+            listView.Items.Add(new ListViewItem { Content = "Ada Lovelace" });
+            listView.Items.Add(new ListViewItem { Content = "Grace Hopper" });
+            this.ShowList(listView, this.listViewDictionary!, "MahApps.Styles.ListView");
+
+            var content = RootContent(listView);
+
+            ClipAssert.CoversElement(content, "list view");
+            ClipAssert.CutsEveryCorner(content, "list view");
+        }
+
+        [Test]
+        public void ATreeViewShouldClipItsItemsToItsBorder()
+        {
+            var treeView = new TreeView();
+            treeView.Items.Add(new TreeViewItem { Header = "Ada Lovelace" });
+            treeView.Items.Add(new TreeViewItem { Header = "Grace Hopper" });
+            this.ShowList(treeView, this.treeViewDictionary!, "MahApps.Styles.TreeView");
+
+            var content = RootContent(treeView);
+
+            ClipAssert.CoversElement(content, "tree view");
+            ClipAssert.CutsEveryCorner(content, "tree view");
         }
 
         [Test]

--- a/src/Mahapps.Metro.Tests/Tests/MenuClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/MenuClipTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Threading;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Tests.TestHelpers;
 using NUnit.Framework;
@@ -48,24 +47,6 @@ namespace MahApps.Metro.Tests.Tests
             return new ResourceDictionary { Source = new Uri($"pack://application:,,,/MahApps.Metro;component/Styles/{fileName}", UriKind.Absolute) };
         }
 
-        /// <summary>
-        /// Lets the dispatcher work, which the templates need before anything has a size.
-        /// </summary>
-        private static void Pump()
-        {
-            var frame = new DispatcherFrame();
-            var timer = new DispatcherTimer(TimeSpan.FromMilliseconds(300), DispatcherPriority.Background, (_, _) => frame.Continue = false, Dispatcher.CurrentDispatcher);
-
-            try
-            {
-                Dispatcher.PushFrame(frame);
-            }
-            finally
-            {
-                timer.Stop();
-            }
-        }
-
         private T Show<T>(T element)
             where T : FrameworkElement
         {
@@ -74,7 +55,7 @@ namespace MahApps.Metro.Tests.Tests
             this.window!.Content = element;
             this.window.UpdateLayout();
             element.UpdateLayout();
-            Pump();
+            ClipAssert.Pump();
 
             return element;
         }
@@ -106,40 +87,6 @@ namespace MahApps.Metro.Tests.Tests
             return border!;
         }
 
-        private static Grid GetContentGrid(FrameworkElement root)
-        {
-            var grid = root.FindChild<Grid>("ContentGrid");
-            Assert.That(grid, Is.Not.Null, "the template should carry the grid the clip sits on");
-
-            return grid!;
-        }
-
-        private static void AssertClipCoversElement(FrameworkElement element, string what)
-        {
-            Assert.That(element.ActualWidth, Is.GreaterThan(0), $"the {what} should be laid out, otherwise this test proves nothing");
-            Assert.That(element.Clip, Is.Not.Null, $"the {what} should be clipped");
-
-            Assert.That(element.Clip!.Bounds.Width, Is.EqualTo(element.ActualWidth).Within(0.001), $"a wider clip leaves the {what} unclipped on the right");
-            Assert.That(element.Clip.Bounds.Height, Is.EqualTo(element.ActualHeight).Within(0.001), $"a taller clip leaves the {what} unclipped at the bottom");
-            Assert.That(element.Clip.Bounds.X, Is.EqualTo(0).Within(0.001));
-            Assert.That(element.Clip.Bounds.Y, Is.EqualTo(0).Within(0.001));
-        }
-
-        private static void AssertEveryCornerIsCut(FrameworkElement element, string what)
-        {
-            var clip = element.Clip;
-            Assert.That(clip, Is.Not.Null);
-
-            var width = element.ActualWidth;
-            var height = element.ActualHeight;
-
-            Assert.That(clip!.FillContains(new Point(width / 2, height / 2)), Is.True, $"the middle of the {what} belongs to the clip");
-            Assert.That(clip.FillContains(new Point(1, 1)), Is.False, $"top left of the {what} should be cut");
-            Assert.That(clip.FillContains(new Point(width - 1, 1)), Is.False, $"top right of the {what} should be cut");
-            Assert.That(clip.FillContains(new Point(width - 1, height - 1)), Is.False, $"bottom right of the {what} should be cut");
-            Assert.That(clip.FillContains(new Point(1, height - 1)), Is.False, $"bottom left of the {what} should be cut");
-        }
-
         private MenuItem ShowMenuItemWithTemplate(string templateResourceId)
         {
             var template = (ControlTemplate)this.menuItemDictionary![new ComponentResourceKey(typeof(MenuItem), templateResourceId)];
@@ -166,10 +113,10 @@ namespace MahApps.Metro.Tests.Tests
 
             this.Show(menu);
 
-            var grid = GetContentGrid(menu);
+            var grid = ClipAssert.ContentGrid(menu);
 
-            AssertClipCoversElement(grid, "menu bar");
-            AssertEveryCornerIsCut(grid, "menu bar");
+            ClipAssert.CoversElement(grid, "menu bar");
+            ClipAssert.CutsEveryCorner(grid, "menu bar");
         }
 
         [Test]
@@ -187,20 +134,20 @@ namespace MahApps.Metro.Tests.Tests
             this.Show(owner);
 
             contextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
-            Pump();
+            ClipAssert.Pump();
             Assert.That(contextMenu.IsOpen, Is.True, "the context menu should be open, otherwise there is nothing to measure");
 
-            var grid = GetContentGrid(contextMenu);
+            var grid = ClipAssert.ContentGrid(contextMenu);
 
             try
             {
-                AssertClipCoversElement(grid, "context menu");
-                AssertEveryCornerIsCut(grid, "context menu");
+                ClipAssert.CoversElement(grid, "context menu");
+                ClipAssert.CutsEveryCorner(grid, "context menu");
             }
             finally
             {
                 contextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, false);
-                Pump();
+                ClipAssert.Pump();
             }
         }
 
@@ -211,9 +158,9 @@ namespace MahApps.Metro.Tests.Tests
             var menuItem = this.ShowMenuItemWithTemplate(templateResourceId);
             var border = this.ShowPopupContent(menuItem);
 
-            var grid = GetContentGrid(border);
+            var grid = ClipAssert.ContentGrid(border);
 
-            AssertClipCoversElement(grid, "submenu");
+            ClipAssert.CoversElement(grid, "submenu");
         }
     }
 }

--- a/src/Mahapps.Metro.Tests/Tests/MenuClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/MenuClipTests.cs
@@ -1,0 +1,219 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Threading;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// A menu rounds four things: the menu bar, a context menu and the two submenu popups a menu item
+    /// can open. A clip lives in the coordinates of the element carrying it, so each geometry has to
+    /// match that element rather than the border around it.
+    /// </summary>
+    [TestFixture]
+    public class MenuClipTests
+    {
+        private TestWindow? window;
+        private ResourceDictionary? menuDictionary;
+        private ResourceDictionary? contextMenuDictionary;
+        private ResourceDictionary? menuItemDictionary;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>().ConfigureAwait(false);
+            this.menuDictionary = Load("Controls.Menu.xaml");
+            this.contextMenuDictionary = Load("Controls.ContextMenu.xaml");
+            this.menuItemDictionary = Load("Controls.MenuItem.xaml");
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        private static ResourceDictionary Load(string fileName)
+        {
+            return new ResourceDictionary { Source = new Uri($"pack://application:,,,/MahApps.Metro;component/Styles/{fileName}", UriKind.Absolute) };
+        }
+
+        /// <summary>
+        /// Lets the dispatcher work, which the templates need before anything has a size.
+        /// </summary>
+        private static void Pump()
+        {
+            var frame = new DispatcherFrame();
+            var timer = new DispatcherTimer(TimeSpan.FromMilliseconds(300), DispatcherPriority.Background, (_, _) => frame.Continue = false, Dispatcher.CurrentDispatcher);
+
+            try
+            {
+                Dispatcher.PushFrame(frame);
+            }
+            finally
+            {
+                timer.Stop();
+            }
+        }
+
+        private T Show<T>(T element)
+            where T : FrameworkElement
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            this.window!.Content = element;
+            this.window.UpdateLayout();
+            element.UpdateLayout();
+            Pump();
+
+            return element;
+        }
+
+        /// <summary>
+        /// Takes the content of a popup out of it and lays it out in the window instead. A menu only
+        /// opens a submenu while it holds the mouse capture, and a popup closes again when its window
+        /// loses activation, so opening one for real is nothing a test run with several hosts on one
+        /// desktop can rely on. The geometry inside is the same either way, and the element names the
+        /// clip binds to travel with it.
+        /// </summary>
+        private Border ShowPopupContent(FrameworkElement templatedControl)
+        {
+            var popup = templatedControl.FindChild<Popup>("PART_Popup");
+            Assert.That(popup, Is.Not.Null, "the template should carry the popup");
+
+            var content = popup!.Child as FrameworkElement;
+            Assert.That(content, Is.Not.Null, "the popup should carry its content");
+
+            popup.Child = null;
+
+            var host = new Grid { Width = 220, Height = 120 };
+            host.Children.Add(content);
+            this.Show(host);
+
+            var border = (content as Border) ?? content!.FindChild<Border>("Border");
+            Assert.That(border, Is.Not.Null, "the submenu should sit in a border");
+
+            return border!;
+        }
+
+        private static Grid GetContentGrid(FrameworkElement root)
+        {
+            var grid = root.FindChild<Grid>("ContentGrid");
+            Assert.That(grid, Is.Not.Null, "the template should carry the grid the clip sits on");
+
+            return grid!;
+        }
+
+        private static void AssertClipCoversElement(FrameworkElement element, string what)
+        {
+            Assert.That(element.ActualWidth, Is.GreaterThan(0), $"the {what} should be laid out, otherwise this test proves nothing");
+            Assert.That(element.Clip, Is.Not.Null, $"the {what} should be clipped");
+
+            Assert.That(element.Clip!.Bounds.Width, Is.EqualTo(element.ActualWidth).Within(0.001), $"a wider clip leaves the {what} unclipped on the right");
+            Assert.That(element.Clip.Bounds.Height, Is.EqualTo(element.ActualHeight).Within(0.001), $"a taller clip leaves the {what} unclipped at the bottom");
+            Assert.That(element.Clip.Bounds.X, Is.EqualTo(0).Within(0.001));
+            Assert.That(element.Clip.Bounds.Y, Is.EqualTo(0).Within(0.001));
+        }
+
+        private static void AssertEveryCornerIsCut(FrameworkElement element, string what)
+        {
+            var clip = element.Clip;
+            Assert.That(clip, Is.Not.Null);
+
+            var width = element.ActualWidth;
+            var height = element.ActualHeight;
+
+            Assert.That(clip!.FillContains(new Point(width / 2, height / 2)), Is.True, $"the middle of the {what} belongs to the clip");
+            Assert.That(clip.FillContains(new Point(1, 1)), Is.False, $"top left of the {what} should be cut");
+            Assert.That(clip.FillContains(new Point(width - 1, 1)), Is.False, $"top right of the {what} should be cut");
+            Assert.That(clip.FillContains(new Point(width - 1, height - 1)), Is.False, $"bottom right of the {what} should be cut");
+            Assert.That(clip.FillContains(new Point(1, height - 1)), Is.False, $"bottom left of the {what} should be cut");
+        }
+
+        private MenuItem ShowMenuItemWithTemplate(string templateResourceId)
+        {
+            var template = (ControlTemplate)this.menuItemDictionary![new ComponentResourceKey(typeof(MenuItem), templateResourceId)];
+
+            var menuItem = new MenuItem { Header = "File", Width = 200, Height = 24 };
+            menuItem.Items.Add(new MenuItem { Header = "Open" });
+            menuItem.Items.Add(new MenuItem { Header = "Close" });
+            menuItem.SetValue(Control.TemplateProperty, template);
+            ControlsHelper.SetCornerRadius(menuItem, new CornerRadius(12));
+
+            this.Show(menuItem);
+            menuItem.ApplyTemplate();
+
+            return menuItem;
+        }
+
+        [Test]
+        public void TheMenuBarShouldClipItsContentToItsBorder()
+        {
+            var menu = new Menu { Width = 200, Height = 32 };
+            menu.Items.Add(new MenuItem { Header = "File" });
+            menu.SetValue(FrameworkElement.StyleProperty, this.menuDictionary!["MahApps.Styles.Menu"]);
+            ControlsHelper.SetCornerRadius(menu, new CornerRadius(12));
+
+            this.Show(menu);
+
+            var grid = GetContentGrid(menu);
+
+            AssertClipCoversElement(grid, "menu bar");
+            AssertEveryCornerIsCut(grid, "menu bar");
+        }
+
+        [Test]
+        public void TheContextMenuShouldClipItsContentToItsBorder()
+        {
+            var owner = new Border { Width = 200, Height = 80 };
+            var contextMenu = new ContextMenu { Width = 200, Height = 80 };
+            contextMenu.Items.Add(new MenuItem { Header = "Cut" });
+            contextMenu.Items.Add(new MenuItem { Header = "Copy" });
+            contextMenu.SetValue(FrameworkElement.StyleProperty, this.contextMenuDictionary!["MahApps.Styles.ContextMenu"]);
+            ControlsHelper.SetCornerRadius(contextMenu, new CornerRadius(12));
+
+            // A context menu refuses to have a parent of its own, so it has to be opened to get a size.
+            owner.ContextMenu = contextMenu;
+            this.Show(owner);
+
+            contextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, true);
+            Pump();
+            Assert.That(contextMenu.IsOpen, Is.True, "the context menu should be open, otherwise there is nothing to measure");
+
+            var grid = GetContentGrid(contextMenu);
+
+            try
+            {
+                AssertClipCoversElement(grid, "context menu");
+                AssertEveryCornerIsCut(grid, "context menu");
+            }
+            finally
+            {
+                contextMenu.SetCurrentValue(ContextMenu.IsOpenProperty, false);
+                Pump();
+            }
+        }
+
+        [TestCase("TopLevelHeaderTemplateKey")]
+        [TestCase("SubmenuHeaderTemplateKey")]
+        public void ASubmenuShouldClipItsContentToItsBorder(string templateResourceId)
+        {
+            var menuItem = this.ShowMenuItemWithTemplate(templateResourceId);
+            var border = this.ShowPopupContent(menuItem);
+
+            var grid = GetContentGrid(border);
+
+            AssertClipCoversElement(grid, "submenu");
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/TemplateClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/TemplateClipTests.cs
@@ -1,0 +1,211 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// The templates that round their corners and clip what they show to them, gathered in one place.
+    /// A clip lives in the coordinates of the element carrying it, so each geometry has to match that
+    /// element rather than the border around it.
+    /// </summary>
+    [TestFixture]
+    public class TemplateClipTests
+    {
+        private TestWindow? window;
+        private ResourceDictionary? colorEyeDropperDictionary;
+        private ResourceDictionary? numericUpDownDictionary;
+        private ResourceDictionary? multiSelectionComboBoxDictionary;
+        private ResourceDictionary? metroWindowDictionary;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>().ConfigureAwait(false);
+            this.colorEyeDropperDictionary = Load("Themes/ColorPicker/ColorEyeDropper.xaml");
+            this.numericUpDownDictionary = Load("Themes/NumericUpDown.xaml");
+            this.multiSelectionComboBoxDictionary = Load("Themes/MultiSelectionComboBox.xaml");
+            this.metroWindowDictionary = Load("Themes/MetroWindow.xaml");
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        private static ResourceDictionary Load(string path)
+        {
+            return new ResourceDictionary { Source = new Uri($"pack://application:,,,/MahApps.Metro;component/{path}", UriKind.Absolute) };
+        }
+
+        /// <summary>
+        /// The name of the element each template puts its clip on, and how to build a control that has it.
+        /// </summary>
+        private static object[] ClippedTemplates =>
+            new object[]
+            {
+                new object[] { "DropDownButton", "ContentGrid" },
+                new object[] { "SplitButton", "PART_Container" },
+                new object[] { "SplitButton vertical", "PART_Container" },
+                new object[] { "Underline", "ContentGrid" },
+                new object[] { "ColorEyeDropper", "ContentGrid" },
+                new object[] { "NumericUpDown spin button", "ContentGrid" },
+                new object[] { "MultiSelectionComboBoxItem", "ContentGrid" }
+            };
+
+        private FrameworkElement Build(string what)
+        {
+            switch (what)
+            {
+                case "DropDownButton":
+                    return new DropDownButton { Content = "Beam me up..." };
+
+                case "SplitButton":
+                    return new SplitButton();
+
+                case "SplitButton vertical":
+                    return new SplitButton { Orientation = Orientation.Vertical };
+
+                case "Underline":
+                    return new Underline();
+
+                case "ColorEyeDropper":
+                    var eyeDropper = new ColorEyeDropper();
+                    eyeDropper.SetValue(FrameworkElement.StyleProperty, this.colorEyeDropperDictionary!["MahApps.Styles.ColorEyeDropper"]);
+                    return eyeDropper;
+
+                case "NumericUpDown spin button":
+                    var spinButton = new Button { Content = "+" };
+                    spinButton.SetValue(FrameworkElement.StyleProperty, this.numericUpDownDictionary!["MahApps.Styles.Button.NumericUpDown.Spin"]);
+                    return spinButton;
+
+                case "MultiSelectionComboBoxItem":
+                    var item = new ListBoxItem { Content = "Beam me up..." };
+                    item.SetValue(FrameworkElement.StyleProperty, this.multiSelectionComboBoxDictionary!["MahApps.Styles.MultiSelectionComboBoxItem.CheckBox"]);
+                    return item;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(what), what, "no such template in this fixture");
+            }
+        }
+
+        private FrameworkElement Show(string what)
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var element = this.Build(what);
+            element.Width = 200;
+            element.Height = 48;
+            ControlsHelper.SetCornerRadius(element, new CornerRadius(12));
+
+            this.window!.Content = element;
+            this.window.UpdateLayout();
+            element.UpdateLayout();
+            ClipAssert.Pump();
+
+            return element;
+        }
+
+        [TestCaseSource(nameof(ClippedTemplates))]
+        public void TheClipShouldCoverTheElementItSitsOn(string what, string gridName)
+        {
+            var element = this.Show(what);
+            var grid = ClipAssert.ContentGrid(element, gridName);
+
+            ClipAssert.CoversElement(grid, what);
+        }
+
+        [TestCaseSource(nameof(ClippedTemplates))]
+        public void TheClipShouldCutEveryCorner(string what, string gridName)
+        {
+            var element = this.Show(what);
+            var grid = ClipAssert.ContentGrid(element, gridName);
+
+            ClipAssert.CutsEveryCorner(grid, what);
+        }
+
+        [TestCaseSource(nameof(ClippedTemplates))]
+        public void WithoutACornerRadiusTheClipShouldKeepTheWholeRectangle(string what, string gridName)
+        {
+            var element = this.Show(what);
+
+            // Some of these templates carry a corner radius of their own, so clearing the local value is
+            // not the same as asking for square corners.
+            ControlsHelper.SetCornerRadius(element, new CornerRadius(0));
+            element.UpdateLayout();
+            ClipAssert.Pump();
+
+            ClipAssert.KeepsEveryCorner(ClipAssert.ContentGrid(element, gridName), what);
+        }
+
+        [TestCase("MahApps.Templates.MetroWindow")]
+        [TestCase("MahApps.Templates.MetroWindow.Center")]
+        public async Task AMetroWindowShouldClipItsContentToItsBorder(string templateKey)
+        {
+            var metroWindow = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>().ConfigureAwait(false);
+
+            try
+            {
+                metroWindow.SetValue(Control.TemplateProperty, this.metroWindowDictionary![templateKey]);
+                ControlsHelper.SetCornerRadius(metroWindow, new CornerRadius(12));
+                metroWindow.UpdateLayout();
+                ClipAssert.Pump();
+
+                var grid = ClipAssert.ContentGrid(metroWindow);
+
+                ClipAssert.CoversElement(grid, "window");
+                ClipAssert.CutsEveryCorner(grid, "window");
+            }
+            finally
+            {
+                metroWindow.Close();
+            }
+        }
+
+        [Test]
+        public void TheDropDownOfAMultiSelectionComboBoxShouldClipItsContentToItsBorder()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var comboBox = new MultiSelectionComboBox { Width = 200, Height = 32 };
+            comboBox.Items.Add("Beam me up...");
+            comboBox.Items.Add("Warp nine");
+
+            this.window!.Content = comboBox;
+            this.window.UpdateLayout();
+            ClipAssert.Pump();
+
+            var popup = comboBox.FindChild<Popup>("PART_Popup");
+            Assert.That(popup, Is.Not.Null, "the template should carry the popup");
+
+            // The drop down is measured outside of its popup: a popup closes again when its window loses
+            // activation, which is nothing a test run with several hosts on one desktop can rely on. The
+            // geometry and the element names the clip binds to are the same either way.
+            var content = popup!.Child as FrameworkElement;
+            Assert.That(content, Is.Not.Null, "the popup should carry its content");
+            popup.Child = null;
+
+            var host = new Grid { Width = 220, Height = 120 };
+            host.Children.Add(content);
+            this.window.Content = host;
+            this.window.UpdateLayout();
+            ClipAssert.Pump();
+
+            var popupBorder = content!.FindChild<Border>("PopupBorder") ?? content as Border;
+            Assert.That(popupBorder, Is.Not.Null, "the drop down should sit in a border");
+
+            ClipAssert.CoversElement(ClipAssert.ContentGrid(popupBorder!), "drop down");
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/VisualStudioButtonClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/VisualStudioButtonClipTests.cs
@@ -73,11 +73,7 @@ namespace MahApps.Metro.Tests.Tests
                 var button = await ShowButtonAsync(window, new Thickness(padding));
                 var content = GetClippedElement(button);
 
-                Assert.That(content.Clip, Is.Not.Null, "the content should be clipped");
-                Assert.That(content.ActualWidth, Is.GreaterThan(0), "the button should be laid out, otherwise this test proves nothing");
-
-                Assert.That(content.Clip!.Bounds.Width, Is.EqualTo(content.ActualWidth).Within(0.001), "a wider clip leaves the content unclipped on the right");
-                Assert.That(content.Clip.Bounds.Height, Is.EqualTo(content.ActualHeight).Within(0.001), "a taller clip leaves it unclipped at the bottom");
+                ClipAssert.CoversElement(content, "button");
             }
             finally
             {
@@ -95,17 +91,8 @@ namespace MahApps.Metro.Tests.Tests
                 var button = await ShowButtonAsync(window, new Thickness(0));
                 var content = GetClippedElement(button);
 
-                Assert.That(content.Clip, Is.Not.Null);
-
-                var clip = content.Clip!;
-                var width = content.ActualWidth;
-                var height = content.ActualHeight;
-
-                Assert.That(clip.FillContains(new Point(width / 2, height / 2)), Is.True, "the middle belongs to the clip");
-                Assert.That(clip.FillContains(new Point(1, 1)), Is.False, "top left should be cut");
-                Assert.That(clip.FillContains(new Point(width - 1, 1)), Is.False, "top right should be cut");
-                Assert.That(clip.FillContains(new Point(width - 1, height - 1)), Is.False, "bottom right should be cut, which is what the report was about");
-                Assert.That(clip.FillContains(new Point(1, height - 1)), Is.False, "bottom left should be cut");
+                // The bottom right corner is what the report was about.
+                ClipAssert.CutsEveryCorner(content, "button");
             }
             finally
             {

--- a/src/Mahapps.Metro.Tests/Tests/VisualStudioButtonClipTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/VisualStudioButtonClipTests.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// A clip lives in the coordinates of the element it sits on, so the geometry of the button has to
+    /// describe the content of the border rather than the border itself.
+    /// </summary>
+    [TestFixture]
+    public class VisualStudioButtonClipTests
+    {
+        private static Button CreateButton(Thickness padding)
+        {
+            var dictionary = new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/VS/Button.xaml", UriKind.Absolute) };
+
+            var button = new Button
+                         {
+                             Width = 200,
+                             Height = 45,
+                             Padding = padding,
+                             BorderThickness = new Thickness(2),
+                             Style = (Style)dictionary["MahApps.Styles.Button.VisualStudio"],
+                             Content = "Beam me up..."
+                         };
+            ControlsHelper.SetCornerRadius(button, new CornerRadius(22));
+
+            return button;
+        }
+
+        private static FrameworkElement GetClippedElement(Button button)
+        {
+            var border = button.FindChild<Border>("Border");
+            Assert.That(border, Is.Not.Null, "the template should carry the border");
+
+            var content = VisualTreeHelper.GetChild(border!, 0) as FrameworkElement;
+            Assert.That(content, Is.Not.Null, "the border should carry the clipped content");
+
+            return content!;
+        }
+
+        private static async Task<Button> ShowButtonAsync(TestWindow window, Thickness padding)
+        {
+            var button = CreateButton(padding);
+
+            window.Content = button;
+            window.UpdateLayout();
+            button.UpdateLayout();
+
+            await Task.Yield();
+
+            return button;
+        }
+
+        [TestCase(0)]
+        [TestCase(4)]
+        public async Task TheClipShouldCoverTheClippedElement(double padding)
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>();
+
+            try
+            {
+                var button = await ShowButtonAsync(window, new Thickness(padding));
+                var content = GetClippedElement(button);
+
+                Assert.That(content.Clip, Is.Not.Null, "the content should be clipped");
+                Assert.That(content.ActualWidth, Is.GreaterThan(0), "the button should be laid out, otherwise this test proves nothing");
+
+                Assert.That(content.Clip!.Bounds.Width, Is.EqualTo(content.ActualWidth).Within(0.001), "a wider clip leaves the content unclipped on the right");
+                Assert.That(content.Clip.Bounds.Height, Is.EqualTo(content.ActualHeight).Within(0.001), "a taller clip leaves it unclipped at the bottom");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+
+        [Test]
+        public async Task TheClipShouldRoundEveryCornerOfTheContent()
+        {
+            var window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>();
+
+            try
+            {
+                var button = await ShowButtonAsync(window, new Thickness(0));
+                var content = GetClippedElement(button);
+
+                Assert.That(content.Clip, Is.Not.Null);
+
+                var clip = content.Clip!;
+                var width = content.ActualWidth;
+                var height = content.ActualHeight;
+
+                Assert.That(clip.FillContains(new Point(width / 2, height / 2)), Is.True, "the middle belongs to the clip");
+                Assert.That(clip.FillContains(new Point(1, 1)), Is.False, "top left should be cut");
+                Assert.That(clip.FillContains(new Point(width - 1, 1)), Is.False, "top right should be cut");
+                Assert.That(clip.FillContains(new Point(width - 1, height - 1)), Is.False, "bottom right should be cut, which is what the report was about");
+                Assert.That(clip.FillContains(new Point(1, height - 1)), Is.False, "bottom left should be cut");
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #4524
Closes #4581

### Why

`ClipBorder` is a `Decorator` that reimplements a handful of `Border` features and, on top of that, assigns a `Clip` to itself in `OnRender`. [#4524](https://github.com/MahApps/MahApps.Metro/issues/4524) is what that costs: put enough of them on screen, around 145 in the report, and the ones after that stop rounding, stop repainting on mouse over and generally fall apart. The clip is what breaks, and nothing about it is fixable from the outside.

So the templates in here stop using it. Where one of them wrapped its content in a `ClipBorder`, it now uses a plain `Border` with a `Grid` inside, and that grid carries the clip geometry:

```xml
<Border x:Name="Border" CornerRadius="{TemplateBinding mah:ControlsHelper.CornerRadius}" ...>
    <Grid x:Name="ContentGrid">
        <Grid.Clip>
            <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
                <Binding ElementName="ContentGrid" Path="ActualWidth" />
                <Binding ElementName="ContentGrid" Path="ActualHeight" />
                <Binding ElementName="Border" Path="CornerRadius" />
                <Binding ElementName="Border" Path="BorderThickness" />
                <Binding ElementName="Border" Path="Padding" />
            </MultiBinding>
        </Grid.Clip>
        ...
```

A clip lives in the coordinates of the element carrying it, which is why the geometry is built from the size of the grid rather than from the border around it. Getting that wrong is what the first commit here fixes: the Visual Studio button clipped its content to the size of the border, so the geometry was a border thickness too large and sat that far up and to the left, which rounded the top corners and never reached the bottom ones.

`ClipBorder` went into the button templates in [#3876](https://github.com/MahApps/MahApps.Metro/pull/3876), so that a rounded button would not answer to a click in the corner of its bounding box. That survives the move: a `Border` hit tests against the background it draws, so the corners outside the rounding stay dead, and a test holds the templates to it.

Templates changed: the button styles and the toggle buttons, the Visual Studio button and menus, `Menu`, `ContextMenu` and `MenuItem` with both of its submenu popups, the combo box with its drop down and its items, the list box, list view and tree view with their items, the hamburger menu item, `MetroWindow` in both of its templates, the drop down button, the split button in both orientations, the multi selection combo box with its drop down, the numeric up down spin button, the eye dropper, the date and time picker with its drop down, and the underline.

### The converter behind it

`ClipGeometryConverter` builds the geometry, and three things in it needed fixing before it could carry all of this:

- A corner cut back to nothing kept the position it would have had at full size, which left every square control unclipped along the right and bottom edge by half a border.
- The top left corner read the thickness of the right side for its height, so it turned into an ellipse whenever the two differed.
- The inset came off the corner radius but not off the padding, which the clip has to clear as well.

What comes off the radius is half the border thickness and the whole padding, the same as the WPF `Border` draws the inner edge of its own frame. Taking the whole thickness leaves a visible gap between the frame and the content along every rounded corner.

### Also in here

**`ClipBorder` and `Utils` are obsolete.** Nothing in the library uses either any more. `Utils` was a set of public extensions written for `ClipBorder`, but two places outside of it compared doubles through `Utils.IsCloseTo`: the numeric up down, checking whether the text still represents the value, and `HSVColor` in its equality. Both moved to the new `DoubleUtil.AreClose`, which carries that one comparison and nothing else. Both types keep working, so nothing breaks for anyone using them.

**`ControlsHelper.FocusBorderThickness` is obsolete and no template reads it any more.** It was added in [#3487](https://github.com/MahApps/MahApps.Metro/pull/3487) for [#3477](https://github.com/MahApps/MahApps.Metro/issues/3477), to let a style change the border thickness of a focused button. Swapping the border thickness while a control has the focus moves its content by the difference every time, and a style built on top of that has no way to hold the layout still. The button and the eye dropper did exactly that; focus now colours the border through `FocusBorderBrush` and leaves it as thick as it was.

**Two clips that never worked.** The field of the date and time picker bound its geometry to an element named `Border`, which that template does not have, so the corner radius never arrived and the field stayed square whatever the picker said. Its drop down was the subject of [#4582](https://github.com/MahApps/MahApps.Metro/issues/4582) and came out of [#4598](https://github.com/MahApps/MahApps.Metro/pull/4598) as a `ClipBorder`; it is a `Border` with a clipped content now, like everything else here. And the border of the underline took no corner radius at all, which left its clip covering the whole rectangle. Both are wired up now.

**A list clips to its own corners** ([#4581](https://github.com/MahApps/MahApps.Metro/issues/4581)). `ControlsHelper.CornerRadius` rounded the frame of a `ListBox`, `ListView` or `TreeView`, but the items paint an opaque background right up against it, so the first and the last one bit the corners out of the arc. The report suggested a `ClipBorder` for those three roots, one per list rather than one per item; it is the control that breaks under load though, not the number of them, so they clip the way everything else here does.

**A missing clip and a misplaced one.** The plain `ListViewItem` came out of the rewrite without a clip while the non selectable variant beside it kept one. And the grid of a `TreeViewItem` is indented by the depth of the item, so clipping it put the rounding somewhere in the middle of the row, right where the expander sits; the clip moved to a grid that fills the border, with the indented one inside it.

**The combo box drop down has a background key of its own**, `MahApps.Brushes.ComboBox.PopupBackground`, instead of the theme background that everything else uses, so it can be recoloured on its own.

**A flaky test is fixed.** `WindowSettingsUpgradeSettingsShouldBeTrueByDefault` set `SaveWindowPosition`, so closing its window wrote the placement into the user configuration of whoever ran the tests. All four target frameworks share that file, and a host writing it while another read it failed on the lock. `GetWindowPlacementSettings` does not look at that property, so the test does without it.

### Tests

Six fixtures, and the assertions they share live in `ClipAssert`: the clip covers the element it sits on, it cuts every corner, or it keeps them all when the corner radius is zero. Every one of them was run against the old templates first and failed there.

The drop downs are measured outside of their popups. A combo box only opens while it holds the mouse capture and a popup closes again when its window loses activation, neither of which a test run with four hosts on one desktop can rely on; the geometry and the element names the clip binds to are the same either way.
