### PR TITLE
fix(NumericUpDown): read the negative sign of the culture, and the hyphen

### DIFF
--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -38,7 +38,7 @@ namespace MahApps.Metro.Controls
         private const int DefaultDelay = 500;
 
         private static readonly Regex RegexStringFormatHexadecimal = new Regex(@"^(?<complexHEX>.*{\d\s*:[Xx]\d*}.*)?(?<simpleHEX>[Xx]\d*)?$", RegexOptions.Compiled);
-        private const string RawRegexNumberString = @"[-+]?(?<![0-9][<DecimalSeparator><GroupSeparator>])[<DecimalSeparator><GroupSeparator>]?[0-9]+(?:[<DecimalSeparator><GroupSeparator>\s][0-9]+)*[<DecimalSeparator><GroupSeparator>]?[0-9]?(?:[eE][-+]?[0-9]+)?(?!\.[0-9])";
+        private const string RawRegexNumberString = @"[<Sign>]?(?<![0-9][<DecimalSeparator><GroupSeparator>])[<DecimalSeparator><GroupSeparator>]?[0-9]+(?:[<DecimalSeparator><GroupSeparator>\s][0-9]+)*[<DecimalSeparator><GroupSeparator>]?[0-9]?(?:[eE][-+]?[0-9]+)?(?!\.[0-9])";
         private Regex? regexNumber = null;
         private static readonly Regex RegexHexadecimal = new Regex(@"^([a-fA-F0-9]{1,2}\s?)+$", RegexOptions.Compiled);
         private static readonly Regex RegexStringFormat = new Regex(@"\{0\s*(:(?<format>.*))?\}", RegexOptions.Compiled);
@@ -1709,20 +1709,38 @@ namespace MahApps.Metro.Controls
             this.intervalValueSinceReset = 0;
         }
 
+        /// <summary>
+        /// The characters that count as a sign here: the ones the culture uses, and the ASCII hyphen
+        /// and plus on top of them. Several cultures sign a number with characters no keyboard has,
+        /// Norwegian with U+2212 for one, so what is typed has to be accepted as well.
+        /// </summary>
+        private string SignCharacters
+        {
+            get
+            {
+                var signs = "-+"
+                            + this.SpecificCultureInfo.NumberFormat.NegativeSign
+                            + this.SpecificCultureInfo.NumberFormat.PositiveSign;
+
+                return new string(signs.Distinct().ToArray());
+            }
+        }
+
+        private bool IsSign(string text)
+        {
+            return text.Length == 1 && this.SignCharacters.Contains(text[0]);
+        }
+
         private bool ValidateText(string text, out double convertedValue)
         {
             convertedValue = 0d;
 
-            if (text == this.SpecificCultureInfo.NumberFormat.PositiveSign
-                || text == this.SpecificCultureInfo.NumberFormat.NegativeSign)
+            if (this.IsSign(text))
             {
                 return true;
             }
 
-            if (text.Count(c => c == this.SpecificCultureInfo.NumberFormat.PositiveSign[0]) > 2
-                || text.Count(c => c == this.SpecificCultureInfo.NumberFormat.NegativeSign[0]) > 2
-                // || text.Count(c => c == this.SpecificCultureInfo.NumberFormat.NumberGroupSeparator[0]) > 1
-               )
+            if (text.Count(c => this.SignCharacters.Contains(c)) > 2)
             {
                 return false;
             }
@@ -1745,11 +1763,13 @@ namespace MahApps.Metro.Controls
                 return this.ConvertNumber(number, out convertedValue);
             }
 
-            if (number == this.SpecificCultureInfo.NumberFormat.NumberDecimalSeparator
-                || number == this.SpecificCultureInfo.NumberFormat.CurrencyDecimalSeparator
-                || number == this.SpecificCultureInfo.NumberFormat.PercentDecimalSeparator
-                || number == (this.SpecificCultureInfo.NumberFormat.NegativeSign + this.SpecificCultureInfo.NumberFormat.NumberDecimalSeparator)
-                || number == (this.SpecificCultureInfo.NumberFormat.PositiveSign + this.SpecificCultureInfo.NumberFormat.NumberDecimalSeparator)
+            // A decimal separator on its own is the start of a number typed without its leading zero,
+            // and so is one behind a sign.
+            var withoutSign = number.Length > 0 && this.IsSign(number.Substring(0, 1)) ? number.Substring(1) : number;
+
+            if (withoutSign == this.SpecificCultureInfo.NumberFormat.NumberDecimalSeparator
+                || withoutSign == this.SpecificCultureInfo.NumberFormat.CurrencyDecimalSeparator
+                || withoutSign == this.SpecificCultureInfo.NumberFormat.PercentDecimalSeparator
                )
             {
                 return true;
@@ -1793,7 +1813,8 @@ namespace MahApps.Metro.Controls
 
             if (this.regexNumber is null)
             {
-                this.regexNumber = new Regex(RawRegexNumberString.Replace("<DecimalSeparator>", this.SpecificCultureInfo.NumberFormat.NumberDecimalSeparator)
+                this.regexNumber = new Regex(RawRegexNumberString.Replace("<Sign>", Regex.Escape(this.SignCharacters))
+                                                                 .Replace("<DecimalSeparator>", this.SpecificCultureInfo.NumberFormat.NumberDecimalSeparator)
                                                                  .Replace("<GroupSeparator>", this.SpecificCultureInfo.NumberFormat.NumberGroupSeparator),
                                              RegexOptions.Compiled);
             }

--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1731,6 +1731,33 @@ namespace MahApps.Metro.Controls
             return text.Length == 1 && this.SignCharacters.Contains(text[0]);
         }
 
+        /// <summary>
+        /// Puts the sign of the culture in front of a number that carries the hyphen or the plus. What
+        /// a runtime accepts for a culture whose sign is neither of those differs between frameworks,
+        /// so the text is made to match the culture before it is parsed rather than after.
+        /// </summary>
+        private string WithSignOfCulture(string text)
+        {
+            if (text.Length == 0)
+            {
+                return text;
+            }
+
+            var format = this.SpecificCultureInfo.NumberFormat;
+
+            if (text[0] == '-' && format.NegativeSign != "-")
+            {
+                return format.NegativeSign + text.Substring(1);
+            }
+
+            if (text[0] == '+' && format.PositiveSign != "+")
+            {
+                return format.PositiveSign + text.Substring(1);
+            }
+
+            return text;
+        }
+
         private bool ValidateText(string text, out double convertedValue)
         {
             convertedValue = 0d;
@@ -1755,7 +1782,7 @@ namespace MahApps.Metro.Controls
                         || this.ParsingNumberStyle.HasFlag(NumberStyles.AllowHexSpecifier)
                         || this.ParsingNumberStyle == NumberStyles.HexNumber;
 
-            var number = this.TryGetNumberFromText(text, isHex);
+            var number = this.WithSignOfCulture(this.TryGetNumberFromText(text, isHex));
 
             // If we are only accepting numbers then attempt to parse as an integer.
             if (isNumeric)

--- a/src/Mahapps.Metro.Tests/Tests/FocusBorderTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/FocusBorderTests.cs
@@ -85,7 +85,9 @@ namespace MahApps.Metro.Tests.Tests
             button.UpdateLayout();
             ClipAssert.Pump();
 
-            Assert.That(button.IsKeyboardFocusWithin, Is.True, "the button should have the focus, otherwise this test proves nothing");
+            // A build agent does not always hand out the keyboard focus, and without it there is
+            // nothing to look at here.
+            Assume.That(button.IsKeyboardFocusWithin, Is.True);
             Assert.That(border.BorderThickness, Is.EqualTo(thickness), "focus should not change how thick the border is, only what colour it has");
         }
 
@@ -104,7 +106,9 @@ namespace MahApps.Metro.Tests.Tests
             button.UpdateLayout();
             ClipAssert.Pump();
 
-            Assert.That(button.IsKeyboardFocusWithin, Is.True, "the button should have the focus, otherwise this test proves nothing");
+            // A build agent does not always hand out the keyboard focus, and without it there is
+            // nothing to look at here.
+            Assume.That(button.IsKeyboardFocusWithin, Is.True);
             Assert.That(border.BorderBrush, Is.SameAs(Brushes.Red), "colouring the border is what marks the focus now");
         }
 
@@ -124,7 +128,9 @@ namespace MahApps.Metro.Tests.Tests
             eyeDropper.UpdateLayout();
             ClipAssert.Pump();
 
-            Assert.That(eyeDropper.IsKeyboardFocusWithin, Is.True, "the eye dropper should have the focus, otherwise this test proves nothing");
+            // A build agent does not always hand out the keyboard focus, and without it there is
+            // nothing to look at here.
+            Assume.That(eyeDropper.IsKeyboardFocusWithin, Is.True);
             Assert.That(border.BorderThickness, Is.EqualTo(thickness), "focus should not change how thick the border is, only what colour it has");
         }
     }

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -746,6 +746,32 @@ namespace MahApps.Metro.Tests.Tests
         }
 
         /// <summary>
+        /// GH-4560: what a runtime accepts for a culture whose negative sign is neither the hyphen nor
+        /// U+2212 differs between frameworks, so this pins the sign down with one no parser would take
+        /// on its own.
+        /// </summary>
+        [Test]
+        public void ShouldTranslateTheHyphenIntoWhateverSignTheCultureHas()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            var culture = (CultureInfo)CultureInfo.GetCultureInfo("nb-NO").Clone();
+            culture.NumberFormat.NegativeSign = "¬";
+
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MinimumProperty, -1000d);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MaximumProperty, 1000d);
+            this.window.TheNUD.Culture = culture;
+
+            TypeText(textBox!, "-12");
+
+            Assert.That(textBox!.Text, Is.EqualTo("-12"));
+            Assert.That(this.window.TheNUD.Value, Is.EqualTo(-12d), "the hyphen has to reach the parser as the sign the culture uses");
+        }
+
+        /// <summary>
         /// GH-4560: the sign of such a culture is not on any keyboard, so what is typed is the hyphen.
         /// </summary>
         [Test]

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -733,6 +733,112 @@ namespace MahApps.Metro.Tests.Tests
         }
 
         /// <summary>
+        /// A culture whose negative sign is not the ASCII hyphen, which is what ICU gives for Norwegian
+        /// and several others. The test host forces NLS, where those cultures still use the hyphen, so
+        /// the culture is built by hand to reproduce it either way.
+        /// </summary>
+        private static CultureInfo CultureWithMinusSign()
+        {
+            var culture = (CultureInfo)CultureInfo.GetCultureInfo("nb-NO").Clone();
+            culture.NumberFormat.NegativeSign = "−";
+
+            return culture;
+        }
+
+        /// <summary>
+        /// GH-4560: the sign of such a culture is not on any keyboard, so what is typed is the hyphen.
+        /// </summary>
+        [Test]
+        public void ShouldAcceptTheHyphenAsNegativeSignWhateverTheCultureUses()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MinimumProperty, -1000d);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MaximumProperty, 1000d);
+            this.window.TheNUD.Culture = CultureWithMinusSign();
+
+            TypeText(textBox!, "-12");
+
+            Assert.That(textBox!.Text, Is.EqualTo("-12"), "the hyphen has to arrive, it is the only sign there is to type");
+            Assert.That(this.window.TheNUD.Value, Is.EqualTo(-12d));
+        }
+
+        /// <summary>
+        /// GH-4560: the sign of the culture itself, which is what a paste brings in.
+        /// </summary>
+        [Test]
+        public void ShouldReadTheNegativeSignOfTheCulture()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MinimumProperty, -1000d);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MaximumProperty, 1000d);
+            this.window.TheNUD.Culture = CultureWithMinusSign();
+
+            TypeText(textBox!, "−12");
+
+            Assert.That(textBox!.Text, Is.EqualTo("−12"));
+            Assert.That(this.window.TheNUD.Value, Is.EqualTo(-12d), "the text says minus twelve, so the value has to say the same");
+        }
+
+        /// <summary>
+        /// GH-4560: a sign of that culture, typed on its own, is the start of a negative number.
+        /// </summary>
+        [Test]
+        public void ShouldAcceptEitherSignOnItsOwn()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MinimumProperty, -1000d);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MaximumProperty, 1000d);
+            this.window.TheNUD.Culture = CultureWithMinusSign();
+
+            foreach (var sign in new[] { "-", "−" })
+            {
+                textBox!.Clear();
+
+                var args = new TextCompositionEventArgs(Keyboard.PrimaryDevice, new TextComposition(InputManager.Current, textBox, sign))
+                           {
+                               RoutedEvent = UIElement.PreviewTextInputEvent
+                           };
+                textBox.RaiseEvent(args);
+
+                Assert.That(args.Handled, Is.False, $"the sign U+{(int)sign[0]:X4} was swallowed, so a negative number cannot be started");
+            }
+        }
+
+        /// <summary>
+        /// GH-4560: a hyphen and the decimal separator, which is how "-0,5" is typed without the zero.
+        /// </summary>
+        [Test]
+        public void ShouldAcceptAHyphenBeforeTheDecimalSeparator()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MinimumProperty, -1000d);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MaximumProperty, 1000d);
+            this.window.TheNUD.NumericInputMode = NumericInput.All;
+            this.window.TheNUD.Culture = CultureWithMinusSign();
+
+            TypeText(textBox!, "-,5");
+
+            Assert.That(textBox!.Text, Is.EqualTo("-,5"), "the text has to survive being typed one character at a time");
+            Assert.That(this.window.TheNUD.Value, Is.EqualTo(-0.5d));
+        }
+
+        /// <summary>
         /// GH-4565: guards the hexadecimal formatting fallback. A value outside the int range
         /// must not end up at double.ToString("X"), which throws a FormatException.
         /// </summary>


### PR DESCRIPTION
Closes #4560

Several cultures sign a number with a character no keyboard has, Norwegian with `U+2212` for one. Two things went wrong there, and both come from the same place.

Typing the hyphen was swallowed, so a negative number could not be entered at all. Pasting the sign of the culture was worse: it arrived, but the value did not follow it.

```
typed U+2212: text '−',   value 0
typed '1':    text '−1',  value 1
typed '2':    text '−12', value 12
```

The field reads minus twelve while the value is plus twelve.

### Why

The number is cut out of the text with a regex that is built per culture, but only its separators were taken from there:

```csharp
private const string RawRegexNumberString = @"[-+]?(?<![0-9]...";
```

The sign stayed at the ASCII `[-+]`, so `U+2212` was never read as one and only the digits behind it were parsed. `double.TryParse` itself handles both signs against that culture, so nothing below this was wrong.

### The fix

`SignCharacters` gathers the signs of the culture and adds the hyphen and the plus, because those are what gets typed. Three places read it: the regex, through a `<Sign>` placeholder filled in the same pass as the separators; the check that lets a single sign through; and the one that counts how many signs a text may hold, which read `NegativeSign[0]` before and so only ever looked at the first character of a sign.

### Also fixed

A sign in front of the decimal separator, which is how `-0,5` is typed without its zero. That was compared against `NegativeSign + NumberDecimalSeparator`, so a hyphen did not match it either and `-,5` came out as `-5`. The check now takes a leading sign off and compares the rest, which covers the case with and without one.

### Tests

Four, all failing before the change. The culture is built by hand, `nb-NO` cloned with `NegativeSign` set to `U+2212`, because the test project forces NLS where that culture still uses the hyphen. That way the tests reproduce the report whether the host runs NLS or ICU.
