### PR TITLE
fix(NumericUpDown): show a value the way it would be typed

### DIFF
--- a/src/MahApps.Metro/Controls/NumericUpDown.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDown.cs
@@ -1363,7 +1363,34 @@ namespace MahApps.Metro.Controls
                 }
             }
 
-            return newValue.ToString(culture);
+            return PlainValueString(newValue, culture);
+        }
+
+        /// <summary>
+        /// The lowest and the highest magnitude that reads better without an exponent. Past the upper
+        /// one a decimal format would drop digits, since a custom format rounds at the fifteenth
+        /// significant one; past the lower one the zeroes in front of the number take over.
+        /// </summary>
+        private const double SmallestPlainValue = 1e-15;
+
+        private const double LargestPlainValue = 1e15;
+
+        /// <summary>
+        /// Writes a value the way it would be typed, for as long as that reads better than an exponent.
+        /// Without this the framework decides, and it answers 5E-05 for a small number and every digit
+        /// a calculation left behind for the rest, neither of which belongs in a text box that was
+        /// never asked to format anything.
+        /// </summary>
+        private static string PlainValueString(double value, CultureInfo culture)
+        {
+            var magnitude = Math.Abs(value);
+
+            if (magnitude != 0 && (magnitude < SmallestPlainValue || magnitude >= LargestPlainValue))
+            {
+                return value.ToString(culture);
+            }
+
+            return value.ToString("0.############################", culture);
         }
 
         private static double FormattedValue(double newValue, string format, CultureInfo culture)

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -865,6 +865,113 @@ namespace MahApps.Metro.Tests.Tests
         }
 
         /// <summary>
+        /// GH-3673: without a StringFormat the value used to be handed to double.ToString(), which
+        /// writes an exponent for small numbers and, since .NET Core 3.0, every digit a calculation
+        /// left behind. Both of those reach the text box of a control nobody asked to format anything.
+        /// </summary>
+        [TestCase(0.00005d, "0.00005")]
+        [TestCase(1e-7d, "0.0000001")]
+        [TestCase(1.23e-15d, "0.00000000000000123")]
+        [TestCase(2.5d, "2.5")]
+        [TestCase(0.1d, "0.1")]
+        [TestCase(123.456d, "123.456")]
+        [TestCase(-42.75d, "-42.75")]
+        [TestCase(0d, "0")]
+        public void ShouldShowAValueWithoutAnExponent(double value, string expected)
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.Culture = CultureInfo.InvariantCulture;
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MinimumProperty, double.MinValue);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MaximumProperty, double.MaxValue);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.ValueProperty, value);
+
+            Assert.That(textBox!.Text, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// GH-3673: what a calculation leaves behind is not something to put in front of a user.
+        /// </summary>
+        [Test]
+        public void ShouldNotShowWhatArithmeticLeavesBehind()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.Culture = CultureInfo.InvariantCulture;
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MinimumProperty, double.MinValue);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MaximumProperty, double.MaxValue);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.ValueProperty, 0.1d + 0.2d);
+
+            Assert.That(textBox!.Text, Is.EqualTo("0.3"));
+        }
+
+        /// <summary>
+        /// GH-3673: past those bounds plain decimal notation is the worse of the two, so the value is
+        /// shown the way the framework writes it.
+        /// </summary>
+        [TestCase(1e20d, "1E+20")]
+        [TestCase(1e-16d, "1E-16")]
+        [TestCase(1e-20d, "1E-20")]
+        public void ShouldLeaveAValueOutsideTheReadableRangeAsItIs(double value, string expected)
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.Culture = CultureInfo.InvariantCulture;
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MinimumProperty, double.MinValue);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MaximumProperty, double.MaxValue);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.ValueProperty, value);
+
+            Assert.That(textBox!.Text, Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// GH-3673: a large whole number keeps every digit it has, which a decimal format would round
+        /// away at the fifteenth.
+        /// </summary>
+        [Test]
+        public void ShouldKeepEveryDigitOfALargeWholeNumber()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.Culture = CultureInfo.InvariantCulture;
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MinimumProperty, double.MinValue);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.MaximumProperty, double.MaxValue);
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.ValueProperty, 1234567890123456d);
+
+            Assert.That(textBox!.Text, Is.EqualTo("1234567890123456"));
+        }
+
+        /// <summary>
+        /// GH-3673: a StringFormat of your own still decides everything.
+        /// </summary>
+        [Test]
+        public void ShouldLeaveAFormatOfYourOwnAlone()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.Culture = CultureInfo.InvariantCulture;
+            this.window.TheNUD.StringFormat = "E2";
+            this.window.TheNUD.SetCurrentValue(NumericUpDown.ValueProperty, 0.00005d);
+
+            Assert.That(textBox!.Text, Is.EqualTo("5.00E-005"));
+        }
+
+        /// <summary>
         /// GH-4565: guards the hexadecimal formatting fallback. A value outside the int range
         /// must not end up at double.ToString("X"), which throws a FormatException.
         /// </summary>


### PR DESCRIPTION
Closes #3673

Without a `StringFormat` the value went straight to `double.ToString()`, which answers `5E-05` for a small number. Since .NET Core 3.0 it also writes every digit a calculation left behind, so `0.1 + 0.2` reached the text box as `0.30000000000000004`. Neither belongs in a control nobody asked to format anything.

| value | before | now |
| --- | --- | --- |
| `0.00005` | `5E-05` | `0.00005` |
| `0.1 + 0.2` | `0.30000000000000004` | `0.3` |
| `1d / 3d` | `0.3333333333333333` | `0.333333333333333` |
| `1e-7` | `1E-07` | `0.0000001` |
| `1.23e-15` | `1.23E-15` | `0.00000000000000123` |
| `2.5`, `0.1`, `123.456`, `-42.75` | unchanged | unchanged |
| `1234567890123456` | unchanged | unchanged |
| `1e20`, `1e-16`, `double.MaxValue` | unchanged | unchanged |

### Where the bounds come from

Plain decimal notation is used while the magnitude stays between `1e-15` and `1e15`.

Past the upper one a decimal format would drop digits: a custom format rounds at the fifteenth significant digit, so `1234567890123456` would come out as `1234567890123460`. Past the lower one the zeroes in front of the number take over, `1e-20` reading as `0.00000000000000000001`. In both of those the exponent is the better answer, so outside the bounds the framework still decides, exactly as it did everywhere before.

### What this changes for anyone using it

An application that sets no `StringFormat` will show calculated values differently, which is the point of the change. A `StringFormat` of your own decides everything as before, and a test pins that down.

The sixteenth and seventeenth significant digit are no longer shown, though they are still held in the value. Only code that pushes `double` to its limit would notice.

### Not in here

The report also asks why a `decimal` binding loses precision, and that is not something a display format can answer: `Value` is a `double?`, so a `decimal` is converted on the way in. Binding a `decimal?` also writes a `SystemConvertConverter` error to the trace whenever the value is null, which still happens. Both belong to the type, not to the formatting, and are for the typed controls that come next.
