### PR TITLE
fix(NumericUpDown): paste the number out of what was pasted

### DIFF
--- a/src/MahApps.Metro/Controls/NumericUpDownBase.Generic.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDownBase.Generic.cs
@@ -125,6 +125,12 @@ namespace MahApps.Metro.Controls
         }
 
         /// <inheritdoc />
+        protected override string TakeNumberFrom(string text)
+        {
+            return this.TryGetNumberFromText(text, this.ReadsHexadecimal);
+        }
+
+        /// <inheritdoc />
         public override bool HasValue => this.Value.HasValue;
 
         /// <inheritdoc />
@@ -799,17 +805,11 @@ var interval = this.ToDouble(amount) * (toPositive ? 1d : -1d);
                 return false;
             }
 
-            var isNumeric = this.NumericInputMode == NumericInput.Numbers
-                            || this.ParsingNumberStyle.HasFlag(NumberStyles.AllowHexSpecifier)
-                            || this.ParsingNumberStyle == NumberStyles.HexNumber
+            var isNumeric = this.ReadsHexadecimal
                             || this.ParsingNumberStyle == NumberStyles.Integer
                             || this.ParsingNumberStyle == NumberStyles.Number;
 
-            var isHex = this.NumericInputMode == NumericInput.Numbers
-                        || this.ParsingNumberStyle.HasFlag(NumberStyles.AllowHexSpecifier)
-                        || this.ParsingNumberStyle == NumberStyles.HexNumber;
-
-            var number = this.WithSignOfCulture(this.TryGetNumberFromText(text, isHex));
+            var number = this.WithSignOfCulture(this.TryGetNumberFromText(text, this.ReadsHexadecimal));
 
             // If we are only accepting numbers then attempt to parse as an integer.
             if (isNumeric)
@@ -855,6 +855,11 @@ var interval = this.ToDouble(amount) * (toPositive ? 1d : -1d);
             convertedValue = this.Truncate(convertedValue);
             return true;
         }
+
+        /// <summary>Whether text is read as hexadecimal, which is a different shape of number.</summary>
+        private bool ReadsHexadecimal => this.NumericInputMode == NumericInput.Numbers
+                                         || this.ParsingNumberStyle.HasFlag(NumberStyles.AllowHexSpecifier)
+                                         || this.ParsingNumberStyle == NumberStyles.HexNumber;
 
         private string TryGetNumberFromText(string text, bool isHex)
         {

--- a/src/MahApps.Metro/Controls/NumericUpDownBase.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDownBase.cs
@@ -814,6 +814,12 @@ namespace MahApps.Metro.Controls
         /// <summary>Runs the current value through again, after something around it changed.</summary>
         protected abstract void RefreshFromCurrentValue();
 
+        /// <summary>
+        /// Reads the part of a text that looks like a number, the way the culture writes one, and
+        /// hands back what it found. A text with nothing number-shaped in it comes back unchanged.
+        /// </summary>
+        protected abstract string TakeNumberFrom(string text);
+
         /// <summary>Whether a value is set at all. The value itself is a matter for the typed half.</summary>
         public abstract bool HasValue { get; }
 
@@ -1149,17 +1155,25 @@ namespace MahApps.Metro.Controls
                 return;
             }
 
-            var text = e.SourceDataObject.GetData(DataFormats.Text) as string;
+            var text = e.SourceDataObject.GetData(DataFormats.Text) as string ?? string.Empty;
 
-            string newText = string.Concat(textPresent.Substring(0, textBox.SelectionStart), text, textPresent.Substring(textBox.SelectionStart + textBox.SelectionLength));
+            // Only the number is taken out of what arrives. The rest would sit in the field until the
+            // focus leaves and then be dropped anyway, since the value never held it.
+            var number = this.TakeNumberFrom(text);
+
+            var newText = string.Concat(textPresent.Substring(0, textBox.SelectionStart), number, textPresent.Substring(textBox.SelectionStart + textBox.SelectionLength));
             if (!this.ValidateText(newText))
             {
                 e.CancelCommand();
+                return;
             }
-            else
+
+            if (!string.Equals(number, text, StringComparison.Ordinal))
             {
-                this.manualChange = true;
+                e.DataObject = new DataObject(DataFormats.Text, number);
             }
+
+            this.manualChange = true;
         }
 
         /// <summary>Puts the speed up back to where it starts, unless the control is read only.</summary>

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownPasteTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownPasteTests.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class NumericUpDownPasteTests
+    {
+        private NumericUpDownWindow? window;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.window?.TheNUD.ClearDependencyProperties();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.window?.TheNUD.FindChild<TextBox>()?.RaiseEvent(new RoutedEventArgs(UIElement.LostFocusEvent));
+        }
+
+        [TestCase("hello 42 world", "42", TestName = "words around a number")]
+        [TestCase("12abc", "12", TestName = "letters behind a number")]
+        [TestCase("abc12", "12", TestName = "letters in front of a number")]
+        [TestCase("$1,234.50", "1,234.50", TestName = "a formatted amount keeps its separators")]
+        [TestCase("42", "42", TestName = "a plain number is left alone")]
+        [TestCase("-3.5", "-3.5", TestName = "a negative number is left alone")]
+        [TestCase("1e5", "1e5", TestName = "an exponent is left alone")]
+        [Description("Only the number is taken out of what was pasted, so nothing else ever shows up in the field.")]
+        public void OnlyTheNumberIsPasted(string pasted, string expected)
+        {
+            var textBox = this.TextBox();
+
+            var args = Paste(textBox, pasted);
+
+            Assert.That(args.CommandCancelled, Is.False, "the paste should go through");
+            Assert.That(args.DataObject.GetData(DataFormats.Text), Is.EqualTo(expected));
+        }
+
+        [Test]
+        [Description("Text without a number in it is refused, as before.")]
+        public void TextWithoutANumberIsRefused()
+        {
+            var textBox = this.TextBox();
+
+            var args = Paste(textBox, "abc");
+
+            Assert.That(args.CommandCancelled, Is.True);
+        }
+
+        [Test]
+        [Description("What is pasted joins what is already there, so a number split over two pastes still adds up.")]
+        public void APasteJoinsWhatIsAlreadyThere()
+        {
+            var textBox = this.TextBox();
+            textBox.Text = "12";
+            textBox.CaretIndex = 2;
+            textBox.SelectionStart = 2;
+            textBox.SelectionLength = 0;
+
+            var args = Paste(textBox, "34");
+
+            Assert.That(args.CommandCancelled, Is.False);
+            Assert.That(args.DataObject.GetData(DataFormats.Text), Is.EqualTo("34"));
+        }
+
+        private TextBox TextBox()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            textBox.Clear();
+            return textBox;
+        }
+
+        private static DataObjectPastingEventArgs Paste(TextBox textBox, string text)
+        {
+            var args = new DataObjectPastingEventArgs(new DataObject(DataFormats.Text, text), false, DataFormats.Text);
+            textBox.RaiseEvent(args);
+            return args;
+        }
+    }
+}


### PR DESCRIPTION
Closes #3847

Typing has been held to numbers for a while now: a key that would make the text unreadable never reaches the field, so the screenshot in the report cannot be produced that way any more.

| typed | ends up in the field |
| --- | --- |
| `abc` | nothing |
| `12abc` | `12` |
| `hello 42 world` | `42` |
| `1e5` | `100000` |

Pasting was the way in that was left. Text with a number anywhere in it went in whole and sat there until the focus left, and only then fell back to the number the value had held all along.

| pasted | before | now |
| --- | --- | --- |
| `hello 42 world` | `hello 42 world` until focus left | `42` |
| `12abc` | `12abc` until focus left | `12` |
| `abc12` | `abc12` until focus left | `12` |
| `$1,234.50` | unchanged | `1,234.50` |
| `42`, `-3.5`, `1e5` | unchanged | unchanged |
| `abc` | refused | refused |

The number is taken out of what arrives and the rest is left behind. What was pasted is only touched when something actually falls away, so a plain number, a sign or an exponent goes in as it is.

### What stays as forgiving as it was

The check behind this looks for a number inside the text rather than asking the whole text to be one, and that is on purpose. With a `StringFormat` the field holds things the control put there itself:

| StringFormat | in the field | value when the field is left |
| --- | --- | --- |
| `C2` | `$1,234.50` | 1234.5 |
| `P0` | `50%` | 0.5 |
| `{}{0:N0} pieces` | `42 pieces` | 42 |

If the whole text had to be a number, a field with `C2` or `pieces` could not be left without losing the value. That text does not come through the paste path, so it is untouched by this.

Scientific notation, asked about in the report, is read as before.