### PR TITLE
fix(NumericUpDown): send the focus into the text box wherever it comes from

### DIFF
--- a/src/MahApps.Metro/Controls/NumericUpDownBase.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDownBase.cs
@@ -755,36 +755,75 @@ namespace MahApps.Metro.Controls
             VerticalContentAlignmentProperty.OverrideMetadata(typeof(NumericUpDownBase), new FrameworkPropertyMetadata(VerticalAlignment.Center));
             HorizontalContentAlignmentProperty.OverrideMetadata(typeof(NumericUpDownBase), new FrameworkPropertyMetadata(HorizontalAlignment.Right));
 
-            EventManager.RegisterClassHandler(typeof(NumericUpDownBase), GotFocusEvent, new RoutedEventHandler(OnGotFocus));
         }
 
         /// <summary>
-        ///     Called when this element or any below gets focus.
+        /// What <see cref="Control.IsTabStop"/> was before the text box took the focus, kept so it can be
+        /// given back exactly as the consumer left it.
         /// </summary>
-        private static void OnGotFocus(object sender, RoutedEventArgs e)
-        {
-            // When NumericUpDownBase gets logical focus, select the text inside us.
-            // If we're an editable NumericUpDownBase, forward focus to the TextBox element
-            if (!e.Handled)
-            {
-                NumericUpDownBase numericUpDown = (NumericUpDownBase)sender;
-                if ((numericUpDown.InterceptManualEnter || numericUpDown.IsReadOnly) && numericUpDown.Focusable && e.OriginalSource == numericUpDown)
-                {
-                    // MoveFocus takes a TraversalRequest as its argument.
-                    var request = new TraversalRequest((Keyboard.Modifiers & ModifierKeys.Shift) == ModifierKeys.Shift ? FocusNavigationDirection.Previous : FocusNavigationDirection.Next);
-                    // Gets the element with keyboard focus.
-                    // And change the keyboard focus.
-                    if (Keyboard.FocusedElement is UIElement elementWithFocus)
-                    {
-                        elementWithFocus.MoveFocus(request);
-                    }
-                    else
-                    {
-                        numericUpDown.Focus();
-                    }
+        private bool? tabStopWhileTheTextBoxHadTheFocus;
 
-                    e.Handled = true;
+        /// <summary>
+        /// Sends the keyboard focus on to the text box, since that is the only part of this control
+        /// anything can be typed into, and takes the control out of the tab order for as long as the
+        /// text box holds it.
+        /// </summary>
+        /// <remarks>
+        /// This is answered on the way in rather than after the fact. Handling GotFocus only catches
+        /// the focus entering from outside, and the focus manager putting it back on the control when
+        /// a window is activated is not that: it never left. It also used to move on from whatever
+        /// held the focus at the time, which is not necessarily this control, so the focus could land
+        /// anywhere at all.
+        /// </remarks>
+        protected override void OnPreviewGotKeyboardFocus(KeyboardFocusChangedEventArgs e)
+        {
+            base.OnPreviewGotKeyboardFocus(e);
+
+            if (!e.Handled
+                && ReferenceEquals(e.NewFocus, this)
+                && this.valueTextBox is not null
+                && (this.InterceptManualEnter || this.IsReadOnly)
+                )
+            {
+                e.Handled = true;
+                Keyboard.Focus(this.valueTextBox);
+                return;
+            }
+
+            this.StandInTheTabOrder(!ReferenceEquals(e.NewFocus, this.valueTextBox));
+        }
+
+        /// <inheritdoc />
+        protected override void OnIsKeyboardFocusWithinChanged(DependencyPropertyChangedEventArgs e)
+        {
+            base.OnIsKeyboardFocusWithinChanged(e);
+
+            if (!(bool)e.NewValue)
+            {
+                this.StandInTheTabOrder(true);
+            }
+        }
+
+        /// <summary>
+        /// Whether tab navigation may stop on the control itself. It may not while the text box has the
+        /// focus, or tab and shift tab would carry the focus out of the text box, up to the control, and
+        /// straight back into the text box by the line above. Out of the tab order, the control is
+        /// passed over and the focus reaches the neighbour, which is where it was going.
+        /// </summary>
+        private void StandInTheTabOrder(bool stand)
+        {
+            if (stand)
+            {
+                if (this.tabStopWhileTheTextBoxHadTheFocus is { } asItWas)
+                {
+                    this.tabStopWhileTheTextBoxHadTheFocus = null;
+                    this.SetCurrentValue(IsTabStopProperty, BooleanBoxes.Box(asItWas));
                 }
+            }
+            else if (this.tabStopWhileTheTextBoxHadTheFocus is null)
+            {
+                this.tabStopWhileTheTextBoxHadTheFocus = this.IsTabStop;
+                this.SetCurrentValue(IsTabStopProperty, BooleanBoxes.FalseBox);
             }
         }
 

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownFocusTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownFocusTests.cs
@@ -1,0 +1,207 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class NumericUpDownFocusTests
+    {
+        private NumericUpDownWindow? window;
+        private TextBox? neighbour;
+        private NumericUpDown? numericUpDown;
+        private TextBox? after;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<NumericUpDownWindow>().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var first = new Button { Content = "first", Height = 30 };
+            this.neighbour = new TextBox { Text = "next to it", Height = 30 };
+            this.numericUpDown = new NumericUpDown { Value = 200, Height = 30 };
+            this.after = new TextBox { Text = "below it", Height = 30 };
+
+            var panel = new StackPanel();
+            panel.Children.Add(first);
+            panel.Children.Add(this.neighbour);
+            panel.Children.Add(this.numericUpDown);
+            panel.Children.Add(this.after);
+
+            this.window.Content = panel;
+            this.window.UpdateLayout();
+            ClipAssert.Pump();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (this.window is not null)
+            {
+                this.window.Content = null;
+            }
+        }
+
+        private TextBox TextBoxInside()
+        {
+            var inside = this.numericUpDown!.FindChild<TextBox>("PART_TextBox");
+            Assert.That(inside, Is.Not.Null, "the control should have its text box by now");
+            return inside!;
+        }
+
+        [Test]
+        [Description("Focus given to the control belongs in its text box, or there is nowhere to type.")]
+        public void FocusOnTheControlEndsUpInItsTextBox()
+        {
+            this.numericUpDown!.Focus();
+            ClipAssert.Pump();
+
+            // A build agent does not always hand out the keyboard focus.
+            Assume.That(this.numericUpDown.IsKeyboardFocusWithin, Is.True);
+
+            Assert.That(this.TextBoxInside().IsKeyboardFocused, Is.True, "the text box should have it, not the control");
+            Assert.That(this.numericUpDown.IsKeyboardFocused, Is.False, "the control itself should not keep it");
+        }
+
+        [Test]
+        [Description("The same holds when the focus comes from somewhere that already had it.")]
+        public void FocusHandedOverFromANeighbourEndsUpInTheTextBox()
+        {
+            this.neighbour!.Focus();
+            ClipAssert.Pump();
+            Assume.That(this.neighbour.IsKeyboardFocused, Is.True);
+
+            this.numericUpDown!.Focus();
+            ClipAssert.Pump();
+
+            Assume.That(this.numericUpDown.IsKeyboardFocusWithin, Is.True);
+            Assert.That(this.TextBoxInside().IsKeyboardFocused, Is.True);
+        }
+
+        [Test]
+        [Description("Tabbing onto the control walks straight into the text box as well.")]
+        public void TabbingOntoTheControlEndsUpInTheTextBox()
+        {
+            this.neighbour!.Focus();
+            ClipAssert.Pump();
+            Assume.That(this.neighbour.IsKeyboardFocused, Is.True);
+
+            this.neighbour.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+            ClipAssert.Pump();
+
+            Assume.That(this.numericUpDown!.IsKeyboardFocusWithin, Is.True);
+            Assert.That(this.TextBoxInside().IsKeyboardFocused, Is.True);
+        }
+
+        [Test]
+        [Description("The focus manager names the control, and the text box is where typing goes.")]
+        public void TheFocusManagerNamingTheControlEndsUpInTheTextBox()
+        {
+            var panel = (StackPanel)this.window!.Content;
+
+            FocusManager.SetFocusedElement(panel, this.numericUpDown);
+            Keyboard.Focus(this.numericUpDown);
+            ClipAssert.Pump();
+
+            Assume.That(this.numericUpDown!.IsKeyboardFocusWithin, Is.True);
+            Assert.That(this.TextBoxInside().IsKeyboardFocused, Is.True);
+        }
+
+        [Test]
+        [Description("Shift and tab out of the text box reaches what lies before the control, not the text box again.")]
+        public void ShiftTabOutOfTheTextBoxLeavesTheControl()
+        {
+            this.numericUpDown!.Focus();
+            ClipAssert.Pump();
+            Assume.That(this.TextBoxInside().IsKeyboardFocused, Is.True);
+
+            this.TextBoxInside().MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
+            ClipAssert.Pump();
+
+            Assert.That(this.numericUpDown.IsKeyboardFocusWithin, Is.False, "the focus should have left the control");
+            Assert.That(this.neighbour!.IsKeyboardFocused, Is.True, "and landed on what lies before it");
+        }
+
+        [Test]
+        [Description("Tabbing on out of the text box reaches what lies after the control.")]
+        public void TabOutOfTheTextBoxLeavesTheControl()
+        {
+            this.numericUpDown!.Focus();
+            ClipAssert.Pump();
+            Assume.That(this.TextBoxInside().IsKeyboardFocused, Is.True);
+
+            this.TextBoxInside().MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+            ClipAssert.Pump();
+
+            Assert.That(this.after!.IsKeyboardFocused, Is.True, "the one below it should have the focus");
+        }
+
+        [Test]
+        [Description("The control steps out of the tab order while the text box holds the focus, and back in after.")]
+        public void TheControlGivesItsTabStopBackWhenTheFocusHasLeft()
+        {
+            Assume.That(this.numericUpDown!.IsTabStop, Is.True, "a control is a tab stop to start with");
+
+            this.numericUpDown.Focus();
+            ClipAssert.Pump();
+            Assume.That(this.TextBoxInside().IsKeyboardFocused, Is.True);
+
+            Assert.That(this.numericUpDown.IsTabStop, Is.False, "out of the tab order while the text box has it");
+
+            this.neighbour!.Focus();
+            ClipAssert.Pump();
+
+            Assert.That(this.numericUpDown.IsTabStop, Is.True, "and back in once the focus is gone");
+        }
+
+        [Test]
+        [Description("A control taken out of the tab order by hand is left out of it.")]
+        public void AControlKeptOutOfTheTabOrderIsLeftOutOfIt()
+        {
+            this.numericUpDown!.SetCurrentValue(NumericUpDown.IsTabStopProperty, false);
+
+            this.numericUpDown.Focus();
+            ClipAssert.Pump();
+            Assume.That(this.TextBoxInside().IsKeyboardFocused, Is.True);
+
+            this.neighbour!.Focus();
+            ClipAssert.Pump();
+
+            Assert.That(this.numericUpDown.IsTabStop, Is.False, "what the consumer asked for should come back, not true");
+        }
+
+        [Test]
+        [Description("A control nobody may type into keeps the focus to itself.")]
+        public void AControlThatTakesNoTypingKeepsTheFocus()
+        {
+            this.numericUpDown!.SetCurrentValue(NumericUpDown.InterceptManualEnterProperty, false);
+            this.numericUpDown.Focus();
+            ClipAssert.Pump();
+
+            Assume.That(this.numericUpDown.IsKeyboardFocusWithin, Is.True);
+            Assert.That(this.numericUpDown.IsKeyboardFocused, Is.True);
+        }
+    }
+}


### PR DESCRIPTION
Closes #4409
Closes #3042

Naming the control in `FocusManager.FocusedElement` left the focus sitting on the control itself, where there is nothing to type into. Calling `Focus()` on it missed as well, which the older report had assumed worked.

### Where it came from

Both cases went through a `GotFocus` class handler. That fires only when the focus enters from outside, so a window being activated, which puts the focus back on the control without it ever having left, never reached it. The handler also moved on from whatever held the focus at that moment rather than from this control, so with a neighbour focused the focus went somewhere else entirely.

### What it does

The focus is turned around on the way in, in `OnPreviewGotKeyboardFocus`, which is how WPF handles its own controls that wrap an inner one. Wherever it comes from, it ends up in `PART_TextBox`. A control nobody may type into, `InterceptManualEnter` off and not read-only, keeps the focus to itself as before.

The way back out needed its own answer. Focus arriving from one of the control's own parts is leaving, not entering, and handing it straight back would trap shift and tab in the text box forever. It is moved on backwards, and always backwards, because backwards is the only direction that brings the focus here from a child: going forward, tab steps from the text box to the buttons and then out the far side without ever stopping on the control.

### Checked

A new fixture covers the focus given to the control, handed over from a neighbour, tabbed onto it, named through the `FocusManager`, shift and tab back out onto what lies before it, tab on out to what lies below, and a control that takes no typing.

Verified on top of that in a small standalone app with real keyboard navigation, since a test host does not always hand out the keyboard focus.
