### PR TITLE
fix(NumericUpDown): give the parsing back when the string format leaves hexadecimal

### DIFF
--- a/src/MahApps.Metro/Controls/NumericUpDownBase.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDownBase.cs
@@ -256,9 +256,55 @@ namespace MahApps.Metro.Controls
 
                 if (e.NewValue is string format && !string.IsNullOrEmpty(format) && RegexStringFormatHexadecimal.IsMatch(format))
                 {
-                    numericUpDown.SetCurrentValue(ParsingNumberStyleProperty, NumberStyles.HexNumber);
-                    numericUpDown.SetCurrentValue(NumericInputModeProperty, numericUpDown.NumericInputMode | NumericInput.Decimal);
+                    numericUpDown.ReadHexadecimal();
                 }
+                else
+                {
+                    numericUpDown.StopReadingHexadecimal();
+                }
+            }
+        }
+
+        /// <summary>
+        /// What the parsing style and the input mode were before a hexadecimal string format took them
+        /// over, kept so they can be given back when the format stops being hexadecimal.
+        /// </summary>
+        private (NumberStyles ParsingNumberStyle, NumericInput NumericInputMode)? beforeTheFormatReadHexadecimal;
+
+        /// <summary>
+        /// A hexadecimal format only shows what a hexadecimal parse reads back, so the parsing follows the
+        /// format. What it replaces is written down first.
+        /// </summary>
+        private void ReadHexadecimal()
+        {
+            this.beforeTheFormatReadHexadecimal ??= (this.ParsingNumberStyle, this.NumericInputMode);
+
+            this.SetCurrentValue(ParsingNumberStyleProperty, NumberStyles.HexNumber);
+            this.SetCurrentValue(NumericInputModeProperty, this.NumericInputMode | NumericInput.Decimal);
+        }
+
+        /// <summary>
+        /// Gives back what the hexadecimal format took over, so that a format changed back to a plain one
+        /// reads plain numbers again. Only what the format itself set is given back: anything changed
+        /// since then is the consumer's own and is left alone.
+        /// </summary>
+        private void StopReadingHexadecimal()
+        {
+            if (this.beforeTheFormatReadHexadecimal is not { } asItWas)
+            {
+                return;
+            }
+
+            this.beforeTheFormatReadHexadecimal = null;
+
+            if (this.ParsingNumberStyle == NumberStyles.HexNumber)
+            {
+                this.SetCurrentValue(ParsingNumberStyleProperty, asItWas.ParsingNumberStyle);
+            }
+
+            if (this.NumericInputMode == (asItWas.NumericInputMode | NumericInput.Decimal))
+            {
+                this.SetCurrentValue(NumericInputModeProperty, asItWas.NumericInputMode);
             }
         }
 

--- a/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/NumericUpDownTests.cs
@@ -417,6 +417,68 @@ namespace MahApps.Metro.Tests.Tests
             Assert.That(textBox.Text, Is.EqualTo(expectedText));
         }
 
+        /// <summary>
+        /// GH-4499: a string format that stops being hexadecimal hands the parsing back to plain numbers.
+        /// </summary>
+        [Test]
+        public void ShouldParseDecimalTextInputAgainWhenTheStringFormatLeavesHexadecimal()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var textBox = this.window.TheNUD.FindChild<TextBox>();
+            Assert.That(textBox, Is.Not.Null);
+
+            this.window.TheNUD.NumericInputMode = NumericInput.Numbers;
+            this.window.TheNUD.ParsingNumberStyle = NumberStyles.Any;
+
+            this.window.TheNUD.StringFormat = "{}0x{0:X}";
+            Assert.That(this.window.TheNUD.ParsingNumberStyle, Is.EqualTo(NumberStyles.HexNumber), "a hexadecimal format reads hexadecimal");
+
+            this.window.TheNUD.StringFormat = string.Empty;
+
+            Assert.That(this.window.TheNUD.ParsingNumberStyle, Is.EqualTo(NumberStyles.Any), "the style it had before the format should be back");
+            Assert.That(this.window.TheNUD.NumericInputMode, Is.EqualTo(NumericInput.Numbers), "and so should the input mode");
+
+            SetText(textBox, "10");
+
+            Assert.That(this.window.TheNUD.Value, Is.EqualTo(10d), "ten is ten again, not sixteen");
+        }
+
+        /// <summary>
+        /// GH-4499: a parsing style set while the format was hexadecimal belongs to the consumer and stays.
+        /// </summary>
+        [Test]
+        public void ShouldKeepAParsingNumberStyleSetWhileTheStringFormatWasHexadecimal()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            this.window.TheNUD.ParsingNumberStyle = NumberStyles.Any;
+            this.window.TheNUD.StringFormat = "{}0x{0:X}";
+
+            this.window.TheNUD.ParsingNumberStyle = NumberStyles.Integer;
+
+            this.window.TheNUD.StringFormat = string.Empty;
+
+            Assert.That(this.window.TheNUD.ParsingNumberStyle, Is.EqualTo(NumberStyles.Integer), "what was set last should be left alone");
+        }
+
+        /// <summary>
+        /// GH-4499: one hexadecimal format after another still remembers what came before the first.
+        /// </summary>
+        [Test]
+        public void ShouldRememberTheParsingNumberStyleFromBeforeTheFirstHexadecimalStringFormat()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            this.window.TheNUD.ParsingNumberStyle = NumberStyles.Float;
+
+            this.window.TheNUD.StringFormat = "{}0x{0:X}";
+            this.window.TheNUD.StringFormat = "X8";
+            this.window.TheNUD.StringFormat = "N2";
+
+            Assert.That(this.window.TheNUD.ParsingNumberStyle, Is.EqualTo(NumberStyles.Float));
+        }
+
         private static void SetText(TextBox theTextBox, string theText)
         {
             TypeText(theTextBox, theText);


### PR DESCRIPTION
Closes #4499

A hexadecimal `StringFormat` writes letters, and only a hexadecimal parse reads them back, so the control follows the format: it sets `ParsingNumberStyle` to `NumberStyles.HexNumber` and adds `NumericInput.Decimal` to the input mode. There was no way out again. Change the format back to a plain one and the parsing stayed hexadecimal, so a typed `10` came out as `16`.

### What it does

What the format takes over is written down and given back once the format stops being hexadecimal. Only what the format itself set is given back: a parsing style or input mode changed in the meantime belongs to the consumer and is left alone. One hexadecimal format following another still remembers what stood before the first.

Worth knowing for anyone reading the report again: the two properties are set through `SetCurrentValue`, which reaches past a style setter and past a local value alike. That is why the reporter's `ParsingNumberStyle="Any"` setter never came back on its own once the data trigger had swapped the format.

### Checked

| step | before | after |
| --- | --- | --- |
| type 10, plain format | 10, `Any` | 10, `Any` |
| hex on | `0xA`, `HexNumber` | `0xA`, `HexNumber` |
| hex off | 10, `HexNumber` | 10, `Any` |
| type 10 | **16** | 10 |

Since the string format handler sits in `NumericUpDownBase`, this covers `NumericUpDown`, `DecimalUpDown`, `IntegerUpDown` and `LongUpDown` alike.