### PR TITLE
fix(Dialogs): let a dialog take its theme without changing the window's

### DIFF
--- a/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/BaseMetroDialog.cs
@@ -366,7 +366,7 @@ namespace MahApps.Metro.Controls.Dialogs
             switch (this.DialogSettings.ColorScheme)
             {
                 case MetroDialogColorScheme.Theme:
-                    ThemeManager.Current.ChangeTheme(this, this.Resources, theme);
+                    ThemeManager.Current.ApplyThemeResourcesFromTheme(this.Resources, theme);
                     this.SetCurrentValue(BackgroundProperty, TryGetResource(theme, "MahApps.Brushes.Dialog.Background"));
                     this.SetCurrentValue(ForegroundProperty, TryGetResource(theme, "MahApps.Brushes.Dialog.Foreground"));
                     break;
@@ -379,13 +379,13 @@ namespace MahApps.Metro.Controls.Dialogs
                                                             "See ThemeManager.GetInverseAppTheme for more infos");
                     }
 
-                    ThemeManager.Current.ChangeTheme(this, this.Resources, theme);
+                    ThemeManager.Current.ApplyThemeResourcesFromTheme(this.Resources, theme);
                     this.SetCurrentValue(BackgroundProperty, TryGetResource(theme, "MahApps.Brushes.Dialog.Background"));
                     this.SetCurrentValue(ForegroundProperty, TryGetResource(theme, "MahApps.Brushes.Dialog.Foreground"));
                     break;
 
                 case MetroDialogColorScheme.Accented:
-                    ThemeManager.Current.ChangeTheme(this, this.Resources, theme);
+                    ThemeManager.Current.ApplyThemeResourcesFromTheme(this.Resources, theme);
                     this.SetCurrentValue(BackgroundProperty, TryGetResource(theme, "MahApps.Brushes.Dialog.Background.Accent"));
                     this.SetCurrentValue(ForegroundProperty, TryGetResource(theme, "MahApps.Brushes.Dialog.Foreground.Accent"));
                     break;


### PR DESCRIPTION
A dialog with `MetroDialogColorScheme.Inverted` or `Accented` left the window it was shown in, and every other window of the application, in the wrong colours. The background came from the inverse theme while the text kept the colours of the current one, so headers, button captions and check box labels were barely readable. Closing the dialog did not put it back.

The demo shows it: open the Clean window and press its `Dialog` button, which asks for the inverted scheme, and the main window goes with it.

### What it does

`ChangeTheme` is the call for a window or for the application. It swaps the theme dictionary in the target and then tells the whole application about the change. A dialog is neither of those, it only wants the theme resources for itself, and that is what `ApplyThemeResourcesFromTheme` does: it writes them into the dictionary it is given and leaves everyone else alone.

Three call sites in `BaseMetroDialog.HandleThemeChange`, one per colour scheme.

### Before
<img width="1290" height="970" alt="vorher" src="https://github.com/user-attachments/assets/ad9d17bc-7e2d-42d1-a524-185837e9951e" />

### After
<img width="1290" height="970" alt="nachher" src="https://github.com/user-attachments/assets/c6ab9bf8-1996-4478-b233-31bd37c1a6ba" />
