### PR TITLE
feat(MetroWindow): let a window take its hosted handles out of sight

### DIFF
--- a/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
+++ b/src/MahApps.Metro/Controls/Dialogs/DialogManager.cs
@@ -459,6 +459,8 @@ namespace MahApps.Metro.Controls.Dialogs
             window.metroActiveDialogContainer.Children.Add(dialog); //add the dialog to the container}
 
             window.SetValue(MetroWindow.IsAnyDialogOpenPropertyKey, BooleanBoxes.TrueBox);
+
+            window.RefreshHwndHosts();
         }
 
         private static void RemoveDialog(this MetroWindow window, BaseMetroDialog dialog)
@@ -491,6 +493,8 @@ namespace MahApps.Metro.Controls.Dialogs
             }
 
             window.SetValue(MetroWindow.IsAnyDialogOpenPropertyKey, BooleanBoxes.Box(window.metroActiveDialogContainer.Children.Count > 0));
+
+            window.RefreshHwndHosts();
 
             dialog.ResetOwningWindow();
         }

--- a/src/MahApps.Metro/Controls/MetroWindow.cs
+++ b/src/MahApps.Metro/Controls/MetroWindow.cs
@@ -86,6 +86,118 @@ namespace MahApps.Metro.Controls
         private EventHandler? onOverlayFadeInStoryboardCompleted = null;
         private EventHandler? onOverlayFadeOutStoryboardCompleted = null;
 
+        /// <summary>Identifies the <see cref="CollapseHwndHosts"/> dependency property.</summary>
+        public static readonly DependencyProperty CollapseHwndHostsProperty
+            = DependencyProperty.Register(nameof(CollapseHwndHosts),
+                                          typeof(bool),
+                                          typeof(MetroWindow),
+                                          new PropertyMetadata(BooleanBoxes.FalseBox, OnCollapseHwndHostsChanged));
+
+        private static void OnCollapseHwndHostsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            (d as MetroWindow)?.RefreshHwndHosts();
+        }
+
+        /// <summary>
+        /// Gets or sets whether every <see cref="HwndHost"/> in this window, a WindowsFormsHost or a
+        /// WebBrowser for instance, is collapsed for as long as a dialog or a <see cref="Flyout"/> is open.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A hosted window handle is a window of its own sitting on top of this one. It paints over the WPF
+        /// content around it whatever the z order says, so a dialog or a Flyout drawn over it is cut in
+        /// half. There is nothing to arrange here: the only way to show them whole is for the handle to be
+        /// gone while they are up. The price is that whatever the handle hosts disappears and comes back,
+        /// which is why this is off by default.
+        /// </para>
+        /// <para>
+        /// The way out of this was pointed at by @batzen in GH-3849: Fluent.Ribbon has the same trouble with
+        /// its Backstage, which is drawn in an adorner, and collapses every HwndHost in the window while the
+        /// Backstage is open. See Fluent.Ribbon, Controls/Backstage.cs, CollapseWindowsFormsHosts.
+        /// </para>
+        /// </remarks>
+        public bool CollapseHwndHosts
+        {
+            get => (bool)this.GetValue(CollapseHwndHostsProperty);
+            set => this.SetValue(CollapseHwndHostsProperty, BooleanBoxes.Box(value));
+        }
+
+        private readonly Dictionary<FrameworkElement, Visibility> hostsOutOfSight = new();
+        private bool hwndHostsAreOutOfSight;
+
+        /// <summary>
+        /// Takes the hosted window handles out of sight while a dialog or a <see cref="Flyout"/> is open, and
+        /// gives them back once nothing is left covering them.
+        /// </summary>
+        internal void RefreshHwndHosts()
+        {
+            var somethingIsOverThem = this.IsAnyDialogOpen
+                                      || this.Flyouts?.GetFlyouts().Any(flyout => flyout.IsOpen) == true;
+
+            if (this.CollapseHwndHosts && somethingIsOverThem)
+            {
+                this.HideHwndHosts();
+            }
+            else
+            {
+                this.ShowHwndHosts();
+            }
+        }
+
+        private void HideHwndHosts()
+        {
+            if (this.hwndHostsAreOutOfSight)
+            {
+                return;
+            }
+
+            this.hwndHostsAreOutOfSight = true;
+
+            CollectHwndHosts(this, this.hostsOutOfSight);
+
+            foreach (var host in this.hostsOutOfSight.Keys)
+            {
+                host.Visibility = Visibility.Collapsed;
+            }
+        }
+
+        private void ShowHwndHosts()
+        {
+            if (!this.hwndHostsAreOutOfSight)
+            {
+                return;
+            }
+
+            this.hwndHostsAreOutOfSight = false;
+
+            foreach (var host in this.hostsOutOfSight)
+            {
+                host.Key.Visibility = host.Value;
+            }
+
+            this.hostsOutOfSight.Clear();
+        }
+
+        private static void CollectHwndHosts(DependencyObject parent, IDictionary<FrameworkElement, Visibility> found)
+        {
+            if (parent is HwndHost host)
+            {
+                if (host.Visibility != Visibility.Collapsed)
+                {
+                    found[host] = host.Visibility;
+                }
+
+                // What a hosted handle draws is not ours, so there is nothing below it to walk into.
+                return;
+            }
+
+            var count = VisualTreeHelper.GetChildrenCount(parent);
+            for (var i = 0; i < count; i++)
+            {
+                CollectHwndHosts(VisualTreeHelper.GetChild(parent, i), found);
+            }
+        }
+
         /// <summary>Identifies the <see cref="ShowIconOnTitleBar"/> dependency property.</summary>
         public static readonly DependencyProperty ShowIconOnTitleBarProperty
             = DependencyProperty.Register(nameof(ShowIconOnTitleBar),
@@ -1168,6 +1280,10 @@ namespace MahApps.Metro.Controls
 
             this.DataContextChanged += this.MetroWindow_DataContextChanged;
             this.Loaded += this.MetroWindow_Loaded;
+
+            // A Flyout closes over a quarter of a second. Giving the handles back the moment it is told to
+            // close would let them pop up in front of it while it is still on its way out.
+            this.AddHandler(Flyout.ClosingFinishedEvent, new RoutedEventHandler((_, _) => this.RefreshHwndHosts()));
         }
 
         private void MetroWindow_Loaded(object sender, RoutedEventArgs e)
@@ -1706,6 +1822,11 @@ namespace MahApps.Metro.Controls
             if (this.flyoutModal != null)
             {
                 this.flyoutModal.Visibility = visibleFlyouts.Any(x => x.IsModal) ? Visibility.Visible : Visibility.Hidden;
+            }
+
+            if (visibleFlyouts.Count > 0)
+            {
+                this.RefreshHwndHosts();
             }
 
             this.RaiseEvent(new FlyoutStatusChangedRoutedEventArgs(FlyoutsStatusChangedEvent, this) { ChangedFlyout = flyout });

--- a/src/Mahapps.Metro.Tests/TestHelpers/TestHwndHost.cs
+++ b/src/Mahapps.Metro.Tests/TestHelpers/TestHwndHost.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Interop;
+
+namespace MahApps.Metro.Tests.TestHelpers
+{
+    /// <summary>
+    /// The smallest window handle a window can host: a plain static control. It stands in for a
+    /// WindowsFormsHost or a WebBrowser, which are the same thing to the window around them.
+    /// </summary>
+    public class TestHwndHost : HwndHost
+    {
+        private const int WS_CHILD = 0x40000000;
+        private const int WS_VISIBLE = 0x10000000;
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr CreateWindowExW(int exStyle, string className, string windowName, int style, int x, int y, int width, int height, IntPtr parent, IntPtr menu, IntPtr instance, IntPtr param);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool DestroyWindow(IntPtr hwnd);
+
+        protected override HandleRef BuildWindowCore(HandleRef hwndParent)
+        {
+            var handle = CreateWindowExW(0, "STATIC", string.Empty, WS_CHILD | WS_VISIBLE, 0, 0, 20, 20, hwndParent.Handle, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            return new HandleRef(this, handle);
+        }
+
+        protected override void DestroyWindowCore(HandleRef hwnd)
+        {
+            DestroyWindow(hwnd.Handle);
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/HwndHostTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/HwndHostTests.cs
@@ -1,0 +1,142 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Windows;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Controls.Dialogs;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class HwndHostTests
+    {
+        private HwndHostWindow? window;
+        private TestHwndHost? host;
+        private CustomDialog? dialog;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<HwndHostWindow>().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            this.dialog = new CustomDialog { Title = "a dialog" };
+            this.host = new TestHwndHost { Width = 20, Height = 20 };
+            this.window.TheContent.Children.Add(this.host);
+            this.window.SetCurrentValue(MetroWindow.CollapseHwndHostsProperty, false);
+            this.window.UpdateLayout();
+            ClipAssert.Pump();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (this.window is not null && this.host is not null)
+            {
+                this.window.TheContent.Children.Remove(this.host);
+                this.host.Dispose();
+                this.host = null;
+            }
+        }
+
+        [Test]
+        [Description("Nobody who did not ask for it should see a hosted handle disappear.")]
+        public async Task AHostIsLeftAloneWhileTheSwitchIsOff()
+        {
+            await this.window!.ShowMetroDialogAsync(this.dialog).ConfigureAwait(true);
+            ClipAssert.Pump();
+
+            Assert.That(this.host!.Visibility, Is.EqualTo(Visibility.Visible));
+
+            await this.CloseTheDialogAsync().ConfigureAwait(true);
+        }
+
+        [Test]
+        [Description("A dialog is drawn over the window, so the handle has to be gone for it to be seen whole.")]
+        public async Task AHostGoesOutOfSightWhileADialogIsOpen()
+        {
+            this.window!.SetCurrentValue(MetroWindow.CollapseHwndHostsProperty, true);
+
+            await this.window.ShowMetroDialogAsync(this.dialog).ConfigureAwait(true);
+            ClipAssert.Pump();
+
+            Assert.That(this.host!.Visibility, Is.EqualTo(Visibility.Collapsed), "out of sight while the dialog is up");
+
+            await this.CloseTheDialogAsync().ConfigureAwait(true);
+
+            Assert.That(this.host.Visibility, Is.EqualTo(Visibility.Visible), "and back once it is gone");
+        }
+
+        [Test]
+        [Description("A Flyout is drawn over the window in the same way.")]
+        public void AHostGoesOutOfSightWhileAFlyoutIsOpen()
+        {
+            this.window!.SetCurrentValue(MetroWindow.CollapseHwndHostsProperty, true);
+
+            this.window.TheFlyout.SetCurrentValue(Flyout.IsOpenProperty, true);
+            ClipAssert.Pump();
+
+            Assert.That(this.host!.Visibility, Is.EqualTo(Visibility.Collapsed), "out of sight while the flyout is open");
+
+            this.window.TheFlyout.SetCurrentValue(Flyout.IsOpenProperty, false);
+            ClipAssert.Pump();
+
+            Assert.That(this.host.Visibility, Is.EqualTo(Visibility.Visible), "and back once it has closed");
+        }
+
+        [Test]
+        [Description("The switch is what decides, so turning it on with a dialog already up still hides the host.")]
+        public async Task TurningTheSwitchOnWhileADialogIsUpTakesTheHostOutOfSight()
+        {
+            await this.window!.ShowMetroDialogAsync(this.dialog).ConfigureAwait(true);
+            ClipAssert.Pump();
+            Assert.That(this.host!.Visibility, Is.EqualTo(Visibility.Visible));
+
+            this.window.SetCurrentValue(MetroWindow.CollapseHwndHostsProperty, true);
+
+            Assert.That(this.host.Visibility, Is.EqualTo(Visibility.Collapsed));
+
+            await this.CloseTheDialogAsync().ConfigureAwait(true);
+        }
+
+        [Test]
+        [Description("What comes back is what the host had, not a blanket Visible.")]
+        public async Task AHostThatWasHiddenIsHiddenAgainAfterwards()
+        {
+            this.host!.SetCurrentValue(UIElement.VisibilityProperty, Visibility.Hidden);
+            this.window!.SetCurrentValue(MetroWindow.CollapseHwndHostsProperty, true);
+
+            await this.window.ShowMetroDialogAsync(this.dialog).ConfigureAwait(true);
+            ClipAssert.Pump();
+            Assert.That(this.host.Visibility, Is.EqualTo(Visibility.Collapsed));
+
+            await this.CloseTheDialogAsync().ConfigureAwait(true);
+
+            Assert.That(this.host.Visibility, Is.EqualTo(Visibility.Hidden), "hidden is what it was, so hidden is what it gets back");
+        }
+
+        private async Task CloseTheDialogAsync()
+        {
+            await this.window!.HideMetroDialogAsync(this.dialog).ConfigureAwait(true);
+
+            ClipAssert.Pump();
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Views/HwndHostWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/HwndHostWindow.xaml
@@ -1,0 +1,21 @@
+﻿<tests:TestWindow x:Class="MahApps.Metro.Tests.Views.HwndHostWindow"
+                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                  xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:tests="clr-namespace:MahApps.Metro.Tests"
+                  d:DesignHeight="300"
+                  d:DesignWidth="300"
+                  mc:Ignorable="d">
+    <mah:MetroWindow.Flyouts>
+        <mah:FlyoutsControl>
+            <mah:Flyout x:Name="TheFlyout"
+                        Width="200"
+                        AreAnimationsEnabled="False"
+                        Header="Flyout"
+                        Position="Right" />
+        </mah:FlyoutsControl>
+    </mah:MetroWindow.Flyouts>
+    <Grid x:Name="TheContent" />
+</tests:TestWindow>

--- a/src/Mahapps.Metro.Tests/Views/HwndHostWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/HwndHostWindow.xaml.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MahApps.Metro.Tests.Views
+{
+    public partial class HwndHostWindow : TestWindow
+    {
+        public HwndHostWindow()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Closes #3849

A `WindowsFormsHost`, a `WebBrowser`, anything built on `HwndHost` is a window of its own sitting on top of the WPF one. It paints over the content around it whatever the z order says, so a dialog or a `Flyout` drawn over it is cut in half. That is WPF's airspace rule rather than anything of ours.

There is nothing to arrange around it. The only way to show a dialog whole is for the hosted handle to be gone while it is up.

### What it does

`MetroWindow.CollapseHwndHosts`, off by default, collapses every `HwndHost` in the window for as long as a dialog or a `Flyout` is open, and gives each one back the visibility it had once the last of them is gone.

```xml
<mah:MetroWindow CollapseHwndHosts="True">
    <WindowsFormsHost>
        <wf:ReportViewer x:Name="Viewer" />
    </WindowsFormsHost>
</mah:MetroWindow>
```

A `Flyout` counts as gone when it has finished sliding out rather than when it is told to close, so the host does not pop up in front of it on the way.

The way out of this was pointed at by @batzen in the issue: Fluent.Ribbon has the same trouble with its Backstage, which is drawn in an adorner, and collapses every `HwndHost` in the window while the Backstage is open.

### Why it is off by default

The price is real. The hosted control is only hidden, not rebuilt, so its window handle and everything it holds survive: measured across an open and closed dialog, the handle, the text and the caret position all came back unchanged. But it is visibly gone while the dialog is up and it redraws when it returns, which for a video player or a browser is an interruption rather than a flicker.
