### PR TITLE
fix(DataGrid): let the clear button wait for the grid to commit

### DIFF
--- a/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
+++ b/src/MahApps.Metro/Controls/Helper/MahAppsCommands.cs
@@ -52,6 +52,15 @@ namespace MahApps.Metro.Controls
             };
         }
 
+        /// <summary>
+        /// Whether this is the box a DataGrid put into a cell to edit in. Such a box hands its text over
+        /// when the grid says so, after CellEditEnding, and writing it through here would get there first.
+        /// </summary>
+        private static bool IsEditingADataGridCell(DependencyObject element)
+        {
+            return element.TryFindParent<DataGridCell>() is { IsEditing: true };
+        }
+
         private static void ClearControl(RoutedEventArgs args)
         {
             if (args.Handled)
@@ -88,7 +97,11 @@ namespace MahApps.Metro.Controls
                     break;
                 case TextBox textBox:
                     textBox.Clear();
-                    textBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
+                    if (!IsEditingADataGridCell(textBox))
+                    {
+                        textBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
+                    }
+
                     break;
                 case PasswordBox passwordBox:
                     passwordBox.Clear();

--- a/src/Mahapps.Metro.Tests/Tests/DataGridClearButtonTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DataGridClearButtonTests.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows.Input;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using MahApps.Metro.Tests.Views;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    [TestFixture]
+    public class DataGridClearButtonTests
+    {
+        private DataGridClearButtonWindow? window;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<DataGridClearButtonWindow>().ConfigureAwait(false);
+            this.window.Invoke(() => this.window.TheGrid.UpdateLayout());
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            this.window.TheGrid.CancelEdit(DataGridEditingUnit.Cell);
+            this.window.TheGrid.CancelEdit(DataGridEditingUnit.Row);
+            this.window.TheGrid.ItemsSource = new System.Collections.ObjectModel.ObservableCollection<DataGridClearButtonRow> { new DataGridClearButtonRow() };
+            this.window.TheGrid.UpdateLayout();
+        }
+
+        /// <summary>
+        /// GH-3966: the clear button used to hand the empty text to the bound object the moment it was
+        /// pressed. A DataGrid gives its cell over at the commit, after CellEditEnding, and a handler that
+        /// wants to refuse the change has nothing left to refuse if the object already took it.
+        /// </summary>
+        [Test]
+        public void ClearingACellLeavesTheObjectAloneUntilTheGridCommits()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var grid = this.window.TheGrid;
+            var row = (DataGridClearButtonRow)grid.Items[0];
+            var column = grid.Columns[0];
+
+            grid.CurrentCell = new DataGridCellInfo(row, column);
+            grid.BeginEdit();
+            grid.UpdateLayout();
+
+            var editor = column.GetCellContent(row) as TextBox;
+            Assert.That(editor, Is.Not.Null, "the cell should be edited in a text box");
+            Assert.That(editor!.Text, Is.EqualTo("123"));
+
+            var clearButton = editor.FindChild<Button>("PART_ClearText");
+            Assert.That(clearButton, Is.Not.Null, "the MahApps style should have put a clear button in the box");
+
+            // what the button does when it is pressed: the command, aimed at the box it belongs to
+            ((RoutedCommand)MahAppsCommands.ClearControlCommand).Execute(null, editor);
+            grid.UpdateLayout();
+
+            Assert.That(editor.Text, Is.Empty, "the box is what the button clears");
+            Assert.That(row.Value, Is.EqualTo("123"), "and the object keeps what it had until the grid says so");
+
+            grid.CommitEdit(DataGridEditingUnit.Row, true);
+
+            Assert.That(row.Value, Is.Empty, "the commit is what hands the empty value over");
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Views/DataGridClearButtonWindow.xaml
+++ b/src/Mahapps.Metro.Tests/Views/DataGridClearButtonWindow.xaml
@@ -1,0 +1,19 @@
+﻿<tests:TestWindow x:Class="MahApps.Metro.Tests.Views.DataGridClearButtonWindow"
+                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:tests="clr-namespace:MahApps.Metro.Tests"
+                  d:DesignHeight="300"
+                  d:DesignWidth="400"
+                  mc:Ignorable="d">
+    <!--  The MahApps style is what puts the clear button into the box a cell is edited in.  -->
+    <DataGrid x:Name="TheGrid"
+              AutoGenerateColumns="False"
+              CanUserAddRows="False"
+              Style="{StaticResource MahApps.Styles.DataGrid}">
+        <DataGrid.Columns>
+            <DataGridTextColumn Binding="{Binding Value}" Header="value" />
+        </DataGrid.Columns>
+    </DataGrid>
+</tests:TestWindow>

--- a/src/Mahapps.Metro.Tests/Views/DataGridClearButtonWindow.xaml.cs
+++ b/src/Mahapps.Metro.Tests/Views/DataGridClearButtonWindow.xaml.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.ObjectModel;
+
+namespace MahApps.Metro.Tests.Views
+{
+    public partial class DataGridClearButtonWindow : TestWindow
+    {
+        public DataGridClearButtonWindow()
+        {
+            this.InitializeComponent();
+
+            this.TheGrid.ItemsSource = new ObservableCollection<DataGridClearButtonRow> { new DataGridClearButtonRow() };
+        }
+    }
+
+    public class DataGridClearButtonRow
+    {
+        public string Value { get; set; } = "123";
+    }
+}


### PR DESCRIPTION
Closes #3966

Pressing the clear button in a `DataGrid` cell put the empty value into the bound object straight away, before `CellEditEnding`. A handler that checks the new value and wants to put the old one back has nothing left to put back, because the object already took the empty one. Clearing the same cell with the backspace key behaves as expected, which is the difference the reporter noticed.

### Where it comes from

The button does more than clear the box:

```csharp
case TextBox textBox:
    textBox.Clear();
    textBox.GetBindingExpression(TextBox.TextProperty)?.UpdateSource();
    break;
```

That second line is there on purpose. Without it, a binding that waits for the focus to leave keeps the old value while the box already shows nothing, which is worse than useless for a search field.

A `DataGrid` is the exception: it hands a cell over at the commit, after `CellEditEnding`, and writing through gets there first. The button is in the cell because of us, `MahApps.Styles.TextBox.DataGrid.Editing` turns `TextBoxHelper.ClearTextButton` on.

### What it does

Inside a `DataGridCell` that is being edited, the text is only cleared and the grid hands it over on its own terms. Everywhere else nothing changes.

| | before | after |
| --- | --- | --- |
| right after the X | box empty, object empty | box empty, object still holds its value |
| in `CellEditEnding` | object already empty | object still holds its value, the handler can refuse |
| after the commit | empty | empty |
