### PR TITLE
fix(ComboBox): give the editable box the name of the combo box

### DIFF
--- a/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.ComboBox.xaml
@@ -312,6 +312,7 @@
                             <TextBox x:Name="PART_EditableTextBox"
                                      Grid.Row="1"
                                      Grid.Column="0"
+                                     AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                      Margin="0"
                                      Padding="{TemplateBinding Padding}"
                                      HorizontalAlignment="Stretch"

--- a/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
+++ b/src/MahApps.Metro/Themes/MultiSelectionComboBox.xaml
@@ -338,6 +338,7 @@
                             <TextBox x:Name="PART_EditableTextBox"
                                      Grid.Row="1"
                                      Grid.Column="0"
+                                     AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
                                      Margin="0"
                                      Padding="{TemplateBinding Padding}"
                                      HorizontalAlignment="Stretch"

--- a/src/Mahapps.Metro.Tests/Tests/ComboBoxAutomationTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ComboBoxAutomationTests.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// GH-3998: the box an editable combo box is typed into is a focusable element of its own in the
+    /// automation tree, and one without a name is what an accessibility check trips over. WPF's own
+    /// template hands it the name of the combo box, and so should ours.
+    /// </summary>
+    [TestFixture]
+    public class ComboBoxAutomationTests
+    {
+        private TestWindow? window;
+        private ResourceDictionary? dictionary;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>().ConfigureAwait(false);
+            this.dictionary = new ResourceDictionary { Source = new Uri("pack://application:,,,/MahApps.Metro;component/Styles/Controls.ComboBox.xaml", UriKind.Absolute) };
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        [Test]
+        [Description("An editable combo box gives its name to the box that is typed into.")]
+        public void TheEditableBoxOfAComboBoxCarriesTheNameOfTheComboBox()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var comboBox = new ComboBox { Width = 200, IsEditable = true };
+            comboBox.SetValue(FrameworkElement.StyleProperty, this.dictionary!["MahApps.Styles.ComboBox"]);
+            comboBox.Items.Add("Beam me up...");
+            AutomationProperties.SetName(comboBox, "where to");
+
+            this.Show(comboBox);
+
+            Assert.That(NameOfTheEditableBox(comboBox), Is.EqualTo("where to"));
+        }
+
+        [Test]
+        [Description("The same holds for the multi selection combo box, which has a box of its own.")]
+        public void TheEditableBoxOfAMultiSelectionComboBoxCarriesTheNameOfTheComboBox()
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var comboBox = new MultiSelectionComboBox { Width = 200, IsEditable = true };
+            comboBox.Items.Add("Beam me up...");
+            AutomationProperties.SetName(comboBox, "where to");
+
+            this.Show(comboBox);
+
+            Assert.That(NameOfTheEditableBox(comboBox), Is.EqualTo("where to"));
+        }
+
+        private void Show(Control control)
+        {
+            this.window!.Content = control;
+            this.window.UpdateLayout();
+            control.UpdateLayout();
+
+            // Let the box finish loading before a test reaches into its template.
+            ClipAssert.Pump();
+            Assert.That(control.IsLoaded, Is.True, "the box should be loaded before a test looks at it");
+        }
+
+        /// <summary>What an accessibility check reads off the box that is typed into.</summary>
+        private static string? NameOfTheEditableBox(Control comboBox)
+        {
+            var editableBox = comboBox.Template?.FindName("PART_EditableTextBox", comboBox) as TextBox;
+            Assert.That(editableBox, Is.Not.Null, "an editable combo box should have a box to type into");
+
+            var peer = UIElementAutomationPeer.CreatePeerForElement(editableBox!);
+            Assert.That(peer, Is.Not.Null, "and that box should be in the automation tree");
+
+            return peer!.GetName();
+        }
+    }
+}


### PR DESCRIPTION
Closes #3998

Accessibility Insights reports "The Name property of a focusable element must not be null" for an editable `ComboBox`, and the narrator reads the state without saying what it belongs to. The same box without our styles is fine.

### Where it comes from

The box an editable combo box is typed into is a focusable element of its own in the automation tree. Reading the tree in process, with and without our styles on the same box:

| | the inner Edit node |
| --- | --- |
| plain WPF | focusable, name `Box1` |
| with MahApps | focusable, name empty |

WPF's own template binds the name of that box to the name of the combo box. Ours did not bind it at all, so it stayed empty.

### What it does

One line on `PART_EditableTextBox`:

```xml
AutomationProperties.Name="{TemplateBinding AutomationProperties.Name}"
```

After that the tree matches the plain WPF one. The same line was missing from `MultiSelectionComboBox`, which has a box of its own and the same rule applies to it, so it is in here too.

One difference to plain WPF remains and is not a defect: our template has a `Text` node underneath for the watermark. It is not focusable, so the rule does not reach it.
