### PR TITLE
fix(DataGrid): let an up-down cell be edited by typing on it

### DIFF
--- a/src/MahApps.Metro/Controls/DataGridNumericUpDownColumnBase.cs
+++ b/src/MahApps.Metro/Controls/DataGridNumericUpDownColumnBase.cs
@@ -5,10 +5,12 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
+using System.Windows.Input;
 using System.Windows.Media;
 
 namespace MahApps.Metro.Controls
@@ -114,7 +116,44 @@ namespace MahApps.Metro.Controls
 
         protected override FrameworkElement GenerateElement(DataGridCell cell, object dataItem)
         {
+            // A cell hands what is typed on it to its column through DataGridColumn.OnInput, which is
+            // where DataGridTextColumn starts editing. That one is internal to WPF and cannot be
+            // overridden from here, so the cell is asked directly instead.
+            cell.PreviewTextInput -= OnCellTextInput;
+            cell.PreviewTextInput += OnCellTextInput;
+
             return this.GenerateTextBlock(cell);
+        }
+
+        /// <summary>
+        /// Typing on a cell that is only showing its value starts editing it, the same way a text column
+        /// behaves.
+        /// </summary>
+        private static void OnCellTextInput(object sender, TextCompositionEventArgs e)
+        {
+            if (e.Handled
+                || sender is not DataGridCell cell
+                || cell.IsEditing
+                || !HasSomethingToType(e.Text))
+            {
+                return;
+            }
+
+            if (cell.TryFindParent<DataGrid>()?.BeginEdit(e) == true)
+            {
+                // The character has been dealt with by the editor that just opened. Letting it travel on
+                // would put it in a second time.
+                e.Handled = true;
+            }
+        }
+
+        /// <summary>
+        /// Whether there is anything in the text worth starting an edit for. Escape reaches here as text
+        /// when nothing else took it, and opening an editor on escape would puzzle anyone.
+        /// </summary>
+        private static bool HasSomethingToType(string? text)
+        {
+            return !string.IsNullOrEmpty(text) && text!.Any(character => character != '');
         }
 
         /// <summary>Says what a value looks like in this column, for the cell that only shows it.</summary>
@@ -237,8 +276,20 @@ namespace MahApps.Metro.Controls
             if (editingElement is NumericUpDownBase numericUpDown)
             {
                 numericUpDown.Focus();
-                numericUpDown.SelectAll();
-                return this.ValueOf(numericUpDown);
+
+                var unedited = this.ValueOf(numericUpDown);
+
+                if (editingEventArgs is TextCompositionEventArgs typed && HasSomethingToType(typed.Text))
+                {
+                    // Typing is what started this, so what was typed is what the control shows.
+                    numericUpDown.TakeTypedText(typed.Text);
+                }
+                else
+                {
+                    numericUpDown.SelectAll();
+                }
+
+                return unedited;
             }
 
             return null;

--- a/src/MahApps.Metro/Controls/NumericUpDownBase.cs
+++ b/src/MahApps.Metro/Controls/NumericUpDownBase.cs
@@ -1028,6 +1028,21 @@ namespace MahApps.Metro.Controls
             this.valueTextBox?.SelectAll();
         }
 
+        /// <summary>
+        /// Puts the given text in place of what the control holds and leaves the caret behind it, the way
+        /// a text box does when typing is what started the editing.
+        /// </summary>
+        internal void TakeTypedText(string text)
+        {
+            if (this.valueTextBox is null)
+            {
+                return;
+            }
+
+            this.valueTextBox.Text = text;
+            this.valueTextBox.Select(text.Length, 0);
+        }
+
         private void RaiseChangeDelay()
         {
             this.RaiseEvent(new RoutedEventArgs(DelayChangedEvent));

--- a/src/Mahapps.Metro.Tests/Tests/DataGridUpDownColumnTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/DataGridUpDownColumnTests.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
 using MahApps.Metro.Controls;
 using MahApps.Metro.Tests.TestHelpers;
 using MahApps.Metro.Tests.Views;
@@ -273,6 +276,109 @@ namespace MahApps.Metro.Tests.Tests
                         Assert.That(content.Style.TargetType.IsInstanceOfType(content), Is.True, content.GetType().Name);
                     }
                 });
+        }
+
+        /// <summary>The cell of a column in the first row, whether it is being edited or not.</summary>
+        private DataGridCell Cell(int column)
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var grid = this.window.TheGrid;
+            grid.CancelEdit(DataGridEditingUnit.Cell);
+            grid.CancelEdit(DataGridEditingUnit.Row);
+            grid.CurrentCell = new DataGridCellInfo(grid.Items[0], grid.Columns[column]);
+            grid.UpdateLayout();
+
+            var cell = Descendants(grid).OfType<DataGridCell>().FirstOrDefault(c => ReferenceEquals(c.Column, grid.Columns[column]));
+            Assert.That(cell, Is.Not.Null, "column " + column + " should have a cell in the first row");
+            return cell!;
+        }
+
+        /// <summary>Types the text at the cell the way a keyboard would.</summary>
+        private static void Type(DataGridCell cell, string text)
+        {
+            cell.RaiseEvent(new TextCompositionEventArgs(Keyboard.PrimaryDevice, new TextComposition(InputManager.Current, cell, text))
+                            {
+                                RoutedEvent = UIElement.PreviewTextInputEvent
+                            });
+        }
+
+        private static TextBox? TextBoxIn(DependencyObject? root)
+        {
+            return root is null ? null : Descendants(root).OfType<TextBox>().FirstOrDefault();
+        }
+
+        private static System.Collections.Generic.IEnumerable<DependencyObject> Descendants(DependencyObject root)
+        {
+            var count = VisualTreeHelper.GetChildrenCount(root);
+            for (var i = 0; i < count; i++)
+            {
+                var child = VisualTreeHelper.GetChild(root, i);
+                yield return child;
+
+                foreach (var deeper in Descendants(child))
+                {
+                    yield return deeper;
+                }
+            }
+        }
+
+        /// <summary>
+        /// GH-4432: a text column is edited by typing on it, without pressing F2 first, and a column of
+        /// ours should be no different.
+        /// </summary>
+        [TestCase(0, TestName = "typing on a double column")]
+        [TestCase(1, TestName = "typing on a decimal column")]
+        [TestCase(2, TestName = "typing on an integer column")]
+        [TestCase(3, TestName = "typing on a long column")]
+        public void TypingOnACellStartsEditingAndKeepsWhatWasTyped(int column)
+        {
+            var cell = this.Cell(column);
+            Assume.That(cell.IsEditing, Is.False, "the cell should not be edited yet");
+
+            Type(cell, "7");
+            this.window!.TheGrid.UpdateLayout();
+
+            Assert.That(cell.IsEditing, Is.True, "typing is what starts the editing");
+
+            var control = this.EditingContentOfTheCurrentCell(column);
+            Assert.That(control, Is.Not.Null, "the cell should hold the control to edit in");
+
+            var box = TextBoxIn(control);
+            Assert.That(box, Is.Not.Null, "and that control should have a box to type into");
+            Assert.That(box!.Text, Is.EqualTo("7"), "what was typed is what stands there");
+            Assert.That(box.CaretIndex, Is.EqualTo(1), "and the caret is behind it, not in front");
+        }
+
+        [Test]
+        [Description("GH-4432: escape reaches a cell as text when nothing else took it, and it starts nothing.")]
+        public void EscapeOnACellStartsNothing()
+        {
+            var cell = this.Cell(0);
+
+            Type(cell, "");
+            this.window!.TheGrid.UpdateLayout();
+
+            Assert.That(cell.IsEditing, Is.False);
+        }
+
+        [Test]
+        [Description("GH-4432: a cell that is edited without typing still offers its value for replacing.")]
+        public void EditingWithoutTypingSelectsTheValue()
+        {
+            var content = this.EditingContent(0);
+            var box = TextBoxIn(content);
+
+            Assert.That(box, Is.Not.Null);
+            Assert.That(box!.SelectedText, Is.EqualTo(box.Text), "all of it, so the next key replaces it");
+        }
+
+        private FrameworkElement? EditingContentOfTheCurrentCell(int column)
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var grid = this.window.TheGrid;
+            return grid.Columns[column].GetCellContent(grid.Items[0]);
         }
 
         [Test]


### PR DESCRIPTION
Closes #4432

A `DataGridTextColumn` is edited by typing on it, no F2 first. A cell of one of our up-down columns did nothing at all: the keystroke was swallowed and the cell kept showing its value.

Measured with real keyboard input, one `7` on the focused cell:

| column | cell afterwards | what it holds |
| --- | --- | --- |
| `DataGridTextColumn` | TextBox | `7`, caret behind it |
| `DataGridNumericUpDownColumn`, before | TextBlock, nothing happened | |
| `DataGridNumericUpDownColumn`, now | NumericUpDown | `7`, caret behind it |

### Two pieces were missing, and the first one is awkward

A cell hands what is typed on it to its column through `DataGridColumn.OnInput`, which is where `DataGridTextColumn` starts the edit. That method is internal to WPF and carries a note of its own:

```csharp
// Consider making a protected virtual.
// If made public, look for PUBLIC_ONINPUT (in DataGridCell) and enable.
internal virtual void OnInput(InputEventArgs e)
```

So a column from outside PresentationFramework cannot override it. The cell is asked directly instead: the column listens to `PreviewTextInput` on the cell it is given in `GenerateElement` and starts the edit from there.

The second piece is the character itself. `PrepareCellForEdit` now takes the text that started the edit and puts it into the control with the caret behind it, the way a text column does, and only selects the old value when something else started the edit.

Two details worth keeping: the event is marked as handled once the editor is up, or the character arrives a second time and one keystroke leaves `77` in the cell. And escape, which reaches a cell as text when nothing else took it, starts nothing, the same exception a text column makes.
