### PR TITLE
Keep the header glyph readable, and let a header be painted differently while it is touched

### DIFF
--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/App.xaml
@@ -43,46 +43,8 @@
             <Style x:Key="MahApps.Styles.MetroHeader.Horizontal"
                    BasedOn="{StaticResource MahApps.Styles.MetroHeader}"
                    TargetType="mah:MetroHeader">
+                <Setter Property="Orientation" Value="Horizontal" />
                 <Setter Property="Padding" Value="0 2" />
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="mah:MetroHeader">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="HeaderGroup" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <Grid Grid.Column="0" Background="{TemplateBinding mah:HeaderedControlHelper.HeaderBackground}">
-                                    <mah:ContentControlEx x:Name="PART_Header"
-                                                          Margin="{TemplateBinding mah:HeaderedControlHelper.HeaderMargin}"
-                                                          HorizontalAlignment="{TemplateBinding mah:HeaderedControlHelper.HeaderHorizontalContentAlignment}"
-                                                          VerticalAlignment="{TemplateBinding mah:HeaderedControlHelper.HeaderVerticalContentAlignment}"
-                                                          Content="{TemplateBinding Header}"
-                                                          ContentCharacterCasing="{TemplateBinding mah:ControlsHelper.ContentCharacterCasing}"
-                                                          ContentStringFormat="{TemplateBinding HeaderStringFormat}"
-                                                          ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                                          ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
-                                                          FontFamily="{TemplateBinding mah:HeaderedControlHelper.HeaderFontFamily}"
-                                                          FontSize="{TemplateBinding mah:HeaderedControlHelper.HeaderFontSize}"
-                                                          FontStretch="{TemplateBinding mah:HeaderedControlHelper.HeaderFontStretch}"
-                                                          FontWeight="{TemplateBinding mah:HeaderedControlHelper.HeaderFontWeight}"
-                                                          Foreground="{TemplateBinding mah:HeaderedControlHelper.HeaderForeground}"
-                                                          IsTabStop="False"
-                                                          RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                                </Grid>
-                                <Grid Grid.Column="1" Background="{TemplateBinding Background}">
-                                    <ContentPresenter x:Name="PART_Content"
-                                                      Margin="{TemplateBinding Padding}"
-                                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                      ContentSource="Content"
-                                                      SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                                </Grid>
-                            </Grid>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
                 <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="0 0 4 0" />
                 <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="Center" />
             </Style>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HeaderExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HeaderExamples.xaml
@@ -337,6 +337,29 @@
                     <TextBlock Margin="4" Text="The whole header answers the mouse, and the glyph sits inside it." />
                 </Expander>
 
+                <Grid MinHeight="150" Margin="0 0 0 16">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Expander Grid.Column="0"
+                              Margin="0 0 8 0"
+                              ExpandDirection="Right"
+                              Header="Expander"
+                              IsExpanded="True"
+                              Style="{StaticResource DemoExpander}">
+                        <TextBlock Margin="4" Text="The whole header answers the mouse, and the glyph sits inside it." />
+                    </Expander>
+                    <Expander Grid.Column="1"
+                              Margin="8 0 0 0"
+                              ExpandDirection="Left"
+                              Header="Expander"
+                              IsExpanded="True"
+                              Style="{StaticResource DemoExpander}">
+                        <TextBlock Margin="4" Text="The whole header answers the mouse, and the glyph sits inside it." />
+                    </Expander>
+                </Grid>
+
                 <mah:MetroHeader Margin="0 0 0 16"
                                  Header="MetroHeader"
                                  Style="{StaticResource DemoMetroHeader}">

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HeaderExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HeaderExamples.xaml
@@ -1,0 +1,374 @@
+﻿<UserControl x:Class="MetroDemo.ExampleViews.HeaderExamples"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:MetroDemo"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+             xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters;assembly=MahApps.Metro"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:models="clr-namespace:MetroDemo.Models"
+             d:DataContext="{d:DesignInstance local:MainWindowViewModel}"
+             d:DesignHeight="800"
+             d:DesignWidth="1000"
+             mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <Thickness x:Key="ControlMargin">0 5 0 0</Thickness>
+
+        <ObjectDataProvider x:Key="HorizontalAlignmentValues"
+                            MethodName="GetValues"
+                            ObjectType="{x:Type HorizontalAlignment}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="HorizontalAlignment" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+
+        <ObjectDataProvider x:Key="VerticalAlignmentValues"
+                            MethodName="GetValues"
+                            ObjectType="{x:Type VerticalAlignment}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="VerticalAlignment" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+
+        <ObjectDataProvider x:Key="CharacterCasingValues"
+                            MethodName="GetValues"
+                            ObjectType="{x:Type CharacterCasing}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="CharacterCasing" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+
+        <!--  A colour is easier to pick when it is shown, so an entry carries a patch of itself. It reads that off the entry, which is what a closed box shows as well.  -->
+        <DataTemplate x:Key="BrushEntry" DataType="{x:Type models:BrushChoice}">
+            <StackPanel Orientation="Horizontal">
+                <Rectangle x:Name="Swatch"
+                           Width="14"
+                           Height="14"
+                           Margin="0 0 8 0"
+                           VerticalAlignment="Center"
+                           Fill="{Binding Brush}"
+                           Stroke="{DynamicResource MahApps.Brushes.Gray5}"
+                           StrokeThickness="1" />
+                <TextBlock VerticalAlignment="Center" Text="{Binding Content}" />
+            </StackPanel>
+            <DataTemplate.Triggers>
+                <!--  An entry without a brush stands for handing nothing over, and there is no colour to show for that.  -->
+                <DataTrigger Binding="{Binding Brush}" Value="{x:Null}">
+                    <Setter TargetName="Swatch" Property="Visibility" Value="Collapsed" />
+                </DataTrigger>
+            </DataTemplate.Triggers>
+        </DataTemplate>
+
+        <!--
+            Every setting is bound once per control type, here, rather than on each control below. The
+            header properties are attached ones, so a style is all it takes to hand the same set to a
+            group box, an expander, a header, a switch and a tab control at once.
+        -->
+        <Style x:Key="DemoGroupBox"
+               BasedOn="{StaticResource MahApps.Styles.GroupBox}"
+               TargetType="{x:Type GroupBox}">
+            <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{Binding HeaderSettings.ContentCharacterCasing, Mode=OneWay}" />
+            <Setter Property="mah:ControlsHelper.CornerRadius" Value="{Binding HeaderSettings.CornerRadius, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontFamily" Value="{Binding HeaderSettings.HeaderFontFamily, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontSize" Value="{Binding HeaderSettings.HeaderFontSize, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontStretch" Value="{Binding HeaderSettings.HeaderFontStretch, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontWeight" Value="{Binding HeaderSettings.HeaderFontWeight, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderHorizontalContentAlignment" Value="{Binding HeaderSettings.HeaderHorizontalContentAlignment, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="{Binding HeaderSettings.HeaderMargin, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="{Binding HeaderSettings.HeaderVerticalContentAlignment, Mode=OneWay}" />
+            <Style.Triggers>
+                <!--  Left unpicked, each control keeps the header colours its own style gives it, and those are not the same for all of them.  -->
+                <DataTrigger Binding="{Binding HeaderSettings.HeaderBackgroundChoice.Brush, Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                    <Setter Property="mah:HeaderedControlHelper.HeaderBackground" Value="{Binding HeaderSettings.HeaderBackgroundChoice.Brush, Mode=OneWay}" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding HeaderSettings.HeaderForegroundChoice.Brush, Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                    <Setter Property="mah:HeaderedControlHelper.HeaderForeground" Value="{Binding HeaderSettings.HeaderForegroundChoice.Brush, Mode=OneWay}" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="DemoExpander"
+               BasedOn="{StaticResource MahApps.Styles.Expander}"
+               TargetType="{x:Type Expander}">
+            <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{Binding HeaderSettings.ContentCharacterCasing, Mode=OneWay}" />
+            <Setter Property="mah:ControlsHelper.CornerRadius" Value="{Binding HeaderSettings.CornerRadius, Mode=OneWay}" />
+            <Setter Property="mah:ExpanderHelper.ShowToggleButton" Value="{Binding HeaderSettings.ShowToggleButton, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontFamily" Value="{Binding HeaderSettings.HeaderFontFamily, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontSize" Value="{Binding HeaderSettings.HeaderFontSize, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontStretch" Value="{Binding HeaderSettings.HeaderFontStretch, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontWeight" Value="{Binding HeaderSettings.HeaderFontWeight, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderHorizontalContentAlignment" Value="{Binding HeaderSettings.HeaderHorizontalContentAlignment, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="{Binding HeaderSettings.HeaderMargin, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="{Binding HeaderSettings.HeaderVerticalContentAlignment, Mode=OneWay}" />
+            <Style.Triggers>
+                <!--  Left unpicked, each control keeps the header colours its own style gives it, and those are not the same for all of them.  -->
+                <DataTrigger Binding="{Binding HeaderSettings.HeaderBackgroundChoice.Brush, Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                    <Setter Property="mah:HeaderedControlHelper.HeaderBackground" Value="{Binding HeaderSettings.HeaderBackgroundChoice.Brush, Mode=OneWay}" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding HeaderSettings.HeaderForegroundChoice.Brush, Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                    <Setter Property="mah:HeaderedControlHelper.HeaderForeground" Value="{Binding HeaderSettings.HeaderForegroundChoice.Brush, Mode=OneWay}" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="DemoMetroHeader"
+               BasedOn="{StaticResource MahApps.Styles.MetroHeader}"
+               TargetType="{x:Type mah:MetroHeader}">
+            <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{Binding HeaderSettings.ContentCharacterCasing, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontFamily" Value="{Binding HeaderSettings.HeaderFontFamily, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontSize" Value="{Binding HeaderSettings.HeaderFontSize, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontStretch" Value="{Binding HeaderSettings.HeaderFontStretch, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontWeight" Value="{Binding HeaderSettings.HeaderFontWeight, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderHorizontalContentAlignment" Value="{Binding HeaderSettings.HeaderHorizontalContentAlignment, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="{Binding HeaderSettings.HeaderMargin, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="{Binding HeaderSettings.HeaderVerticalContentAlignment, Mode=OneWay}" />
+            <Style.Triggers>
+                <!--  Left unpicked, each control keeps the header colours its own style gives it, and those are not the same for all of them.  -->
+                <DataTrigger Binding="{Binding HeaderSettings.HeaderBackgroundChoice.Brush, Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                    <Setter Property="mah:HeaderedControlHelper.HeaderBackground" Value="{Binding HeaderSettings.HeaderBackgroundChoice.Brush, Mode=OneWay}" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding HeaderSettings.HeaderForegroundChoice.Brush, Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                    <Setter Property="mah:HeaderedControlHelper.HeaderForeground" Value="{Binding HeaderSettings.HeaderForegroundChoice.Brush, Mode=OneWay}" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="DemoToggleSwitch"
+               BasedOn="{StaticResource MahApps.Styles.ToggleSwitch}"
+               TargetType="{x:Type mah:ToggleSwitch}">
+            <Setter Property="mah:ControlsHelper.CornerRadius" Value="{Binding HeaderSettings.CornerRadius, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontFamily" Value="{Binding HeaderSettings.HeaderFontFamily, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontSize" Value="{Binding HeaderSettings.HeaderFontSize, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontStretch" Value="{Binding HeaderSettings.HeaderFontStretch, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontWeight" Value="{Binding HeaderSettings.HeaderFontWeight, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderHorizontalContentAlignment" Value="{Binding HeaderSettings.HeaderHorizontalContentAlignment, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="{Binding HeaderSettings.HeaderMargin, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="{Binding HeaderSettings.HeaderVerticalContentAlignment, Mode=OneWay}" />
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding HeaderSettings.HeaderForegroundChoice.Brush, Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                    <Setter Property="mah:HeaderedControlHelper.HeaderForeground" Value="{Binding HeaderSettings.HeaderForegroundChoice.Brush, Mode=OneWay}" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <!--  A tab item reads these off the tab control it sits in, so the style belongs on the control and not on the items.  -->
+        <Style x:Key="DemoTabControl"
+               BasedOn="{StaticResource MahApps.Styles.TabControl}"
+               TargetType="{x:Type TabControl}">
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontFamily" Value="{Binding HeaderSettings.HeaderFontFamily, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontSize" Value="{Binding HeaderSettings.HeaderFontSize, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontStretch" Value="{Binding HeaderSettings.HeaderFontStretch, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderFontWeight" Value="{Binding HeaderSettings.HeaderFontWeight, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderHorizontalContentAlignment" Value="{Binding HeaderSettings.HeaderHorizontalContentAlignment, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="{Binding HeaderSettings.HeaderMargin, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="{Binding HeaderSettings.HeaderVerticalContentAlignment, Mode=OneWay}" />
+            <Style.Triggers>
+                <!--  Left unpicked, each control keeps the header colours its own style gives it, and those are not the same for all of them.  -->
+                <DataTrigger Binding="{Binding HeaderSettings.HeaderBackgroundChoice.Brush, Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                    <Setter Property="mah:HeaderedControlHelper.HeaderBackground" Value="{Binding HeaderSettings.HeaderBackgroundChoice.Brush, Mode=OneWay}" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding HeaderSettings.HeaderForegroundChoice.Brush, Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                    <Setter Property="mah:HeaderedControlHelper.HeaderForeground" Value="{Binding HeaderSettings.HeaderForegroundChoice.Brush, Mode=OneWay}" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style x:Key="Caption" TargetType="{x:Type TextBlock}">
+            <Setter Property="Margin" Value="0 0 0 10" />
+            <Setter Property="Opacity" Value="0.8" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+
+        <Style x:Key="Note"
+               BasedOn="{StaticResource Caption}"
+               TargetType="{x:Type TextBlock}">
+            <Setter Property="FontSize" Value="11" />
+            <Setter Property="Margin" Value="0 6 0 0" />
+        </Style>
+
+        <Style x:Key="Example" TargetType="{x:Type FrameworkElement}">
+            <Setter Property="Margin" Value="0 0 0 16" />
+        </Style>
+    </UserControl.Resources>
+
+    <Grid Margin="4">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="300" />
+            <ColumnDefinition Width="*" MinWidth="380" />
+        </Grid.ColumnDefinitions>
+
+        <ScrollViewer Grid.Column="0"
+                      Margin="4 2"
+                      VerticalScrollBarVisibility="Auto">
+            <StackPanel Grid.IsSharedSizeScope="True">
+                <StackPanel.Resources>
+                    <Style BasedOn="{StaticResource MahApps.Styles.MetroHeader}" TargetType="{x:Type mah:MetroHeader}">
+                        <Setter Property="Orientation" Value="Horizontal" />
+                        <Setter Property="Padding" Value="0 2" />
+                        <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="0 0 4 0" />
+                        <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="Center" />
+                    </Style>
+                    <Style BasedOn="{StaticResource MahApps.Styles.GroupBox}" TargetType="{x:Type GroupBox}">
+                        <Setter Property="Margin" Value="0 0 0 8" />
+                    </Style>
+                    <Style BasedOn="{StaticResource MahApps.Styles.ToggleSwitch}" TargetType="{x:Type mah:ToggleSwitch}">
+                        <Setter Property="FontSize" Value="{DynamicResource MahApps.Font.Size.Content}" />
+                        <Setter Property="MinHeight" Value="1" />
+                    </Style>
+                </StackPanel.Resources>
+
+                <GroupBox Header="Colours">
+                    <StackPanel>
+                        <mah:MetroHeader Header="Background" ToolTip="HeaderedControlHelper.HeaderBackground">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemTemplate="{StaticResource BrushEntry}"
+                                      ItemsSource="{Binding HeaderSettings.BackgroundChoices, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.HeaderBackgroundChoice}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Foreground" ToolTip="HeaderedControlHelper.HeaderForeground">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemTemplate="{StaticResource BrushEntry}"
+                                      ItemsSource="{Binding HeaderSettings.ForegroundChoices, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.HeaderForegroundChoice}" />
+                        </mah:MetroHeader>
+
+                        <TextBlock Style="{StaticResource Note}" Text="Left as it is, each control keeps the header colours its own style gives it, and an automatic foreground works out black or white from what is behind it." />
+                    </StackPanel>
+                </GroupBox>
+
+                <GroupBox Header="Text">
+                    <StackPanel>
+                        <mah:MetroHeader Header="Font" ToolTip="HeaderedControlHelper.HeaderFontFamily">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemsSource="{Binding HeaderSettings.AvailableFontFamilies, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.HeaderFontFamily}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock FontFamily="{Binding}" Text="{Binding Source}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Size" ToolTip="HeaderedControlHelper.HeaderFontSize">
+                            <mah:NumericUpDown Margin="{StaticResource ControlMargin}"
+                                               Maximum="48"
+                                               Minimum="6"
+                                               Value="{Binding HeaderSettings.HeaderFontSize, UpdateSourceTrigger=PropertyChanged}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Weight" ToolTip="HeaderedControlHelper.HeaderFontWeight">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemsSource="{Binding HeaderSettings.AvailableFontWeights, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.HeaderFontWeight}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Stretch" ToolTip="HeaderedControlHelper.HeaderFontStretch">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemsSource="{Binding HeaderSettings.AvailableFontStretches, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.HeaderFontStretch}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Casing" ToolTip="ControlsHelper.ContentCharacterCasing">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemsSource="{Binding Source={StaticResource CharacterCasingValues}}"
+                                      SelectedItem="{Binding HeaderSettings.ContentCharacterCasing}" />
+                        </mah:MetroHeader>
+
+                        <TextBlock Style="{StaticResource Note}" Text="Most fonts draw only a few of the stretches, the rest fall back to the nearest one they have." />
+                    </StackPanel>
+                </GroupBox>
+
+                <GroupBox Header="Room and shape">
+                    <StackPanel>
+                        <mah:MetroHeader Header="Margin" ToolTip="HeaderedControlHelper.HeaderMargin">
+                            <mah:NumericUpDown Margin="{StaticResource ControlMargin}"
+                                               Maximum="40"
+                                               Minimum="0"
+                                               StringFormat="{}{0} on every side"
+                                               Value="{Binding HeaderSettings.Padding, UpdateSourceTrigger=PropertyChanged}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Horizontal" ToolTip="HeaderedControlHelper.HeaderHorizontalContentAlignment">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemsSource="{Binding Source={StaticResource HorizontalAlignmentValues}}"
+                                      SelectedItem="{Binding HeaderSettings.HeaderHorizontalContentAlignment}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Vertical" ToolTip="HeaderedControlHelper.HeaderVerticalContentAlignment">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemsSource="{Binding Source={StaticResource VerticalAlignmentValues}}"
+                                      SelectedItem="{Binding HeaderSettings.HeaderVerticalContentAlignment}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Corners" ToolTip="ControlsHelper.CornerRadius">
+                            <mah:NumericUpDown Margin="{StaticResource ControlMargin}"
+                                               Maximum="20"
+                                               Minimum="0"
+                                               Value="{Binding HeaderSettings.Roundness, UpdateSourceTrigger=PropertyChanged}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Toggle button" ToolTip="ExpanderHelper.ShowToggleButton">
+                            <mah:ToggleSwitch Margin="{StaticResource ControlMargin}" IsOn="{Binding HeaderSettings.ShowToggleButton}" />
+                        </mah:MetroHeader>
+                    </StackPanel>
+                </GroupBox>
+            </StackPanel>
+        </ScrollViewer>
+
+        <ScrollViewer Grid.Column="1"
+                      Margin="8 2 4 2"
+                      VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+                <TextBlock Style="{StaticResource Caption}" Text="Every control here takes the same settings, so what one of them makes of a value can be held against the others. The header of each one says which control it is." />
+
+                <GroupBox Margin="0 0 0 16"
+                          Header="GroupBox"
+                          Style="{StaticResource DemoGroupBox}">
+                    <TextBlock Margin="4" Text="A group box draws its header as a band across the top." />
+                </GroupBox>
+
+                <Expander Margin="0 0 0 16"
+                          Header="Expander"
+                          IsExpanded="True"
+                          Style="{StaticResource DemoExpander}">
+                    <TextBlock Margin="4" Text="The whole header answers the mouse, and the glyph sits inside it." />
+                </Expander>
+
+                <mah:MetroHeader Margin="0 0 0 16"
+                                 Header="MetroHeader"
+                                 Style="{StaticResource DemoMetroHeader}">
+                    <TextBox mah:TextBoxHelper.Watermark="a control with a label of its own" />
+                </mah:MetroHeader>
+
+                <mah:ToggleSwitch Margin="0 0 0 16"
+                                  Header="ToggleSwitch"
+                                  IsOn="True"
+                                  Style="{StaticResource DemoToggleSwitch}" />
+
+                <TabControl MinHeight="120"
+                            Margin="0 0 0 16"
+                            Style="{StaticResource DemoTabControl}">
+                    <TabItem Header="TabItem">
+                        <TextBlock Margin="8" Text="A tab item reads the header settings off the tab control it sits in." />
+                    </TabItem>
+                    <TabItem Header="Another one">
+                        <TextBlock Margin="8" Text="So both tabs change together." />
+                    </TabItem>
+                </TabControl>
+
+                <GroupBox Header="What reaches what">
+                    <StackPanel Margin="4">
+                        <TextBlock Margin="0"
+                                   Style="{StaticResource Note}"
+                                   Text="HeaderBackground is read by the group box, the expander, the header and the tab control. The switch has no band behind its header, and neither has a tab item of its own." />
+                        <TextBlock Style="{StaticResource Note}" Text="ContentCharacterCasing and CornerRadius are not header properties, they come from ControlsHelper, but the header is where they show, so they are on this page." />
+                        <TextBlock Style="{StaticResource Note}" Text="ShowToggleButton belongs to the expander alone. A flyout carries the same header properties as the group box, and the demo has its own tab for those." />
+                    </StackPanel>
+                </GroupBox>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HeaderExamples.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HeaderExamples.xaml
@@ -70,10 +70,14 @@
                TargetType="{x:Type GroupBox}">
             <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{Binding HeaderSettings.ContentCharacterCasing, Mode=OneWay}" />
             <Setter Property="mah:ControlsHelper.CornerRadius" Value="{Binding HeaderSettings.CornerRadius, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderBackgroundMouseOver" Value="{Binding HeaderSettings.HeaderBackgroundMouseOverChoice.Brush, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderBackgroundPressed" Value="{Binding HeaderSettings.HeaderBackgroundPressedChoice.Brush, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontFamily" Value="{Binding HeaderSettings.HeaderFontFamily, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontSize" Value="{Binding HeaderSettings.HeaderFontSize, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontStretch" Value="{Binding HeaderSettings.HeaderFontStretch, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontWeight" Value="{Binding HeaderSettings.HeaderFontWeight, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderForegroundMouseOver" Value="{Binding HeaderSettings.HeaderForegroundMouseOverChoice.Brush, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderForegroundPressed" Value="{Binding HeaderSettings.HeaderForegroundPressedChoice.Brush, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderHorizontalContentAlignment" Value="{Binding HeaderSettings.HeaderHorizontalContentAlignment, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="{Binding HeaderSettings.HeaderMargin, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="{Binding HeaderSettings.HeaderVerticalContentAlignment, Mode=OneWay}" />
@@ -94,10 +98,17 @@
             <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{Binding HeaderSettings.ContentCharacterCasing, Mode=OneWay}" />
             <Setter Property="mah:ControlsHelper.CornerRadius" Value="{Binding HeaderSettings.CornerRadius, Mode=OneWay}" />
             <Setter Property="mah:ExpanderHelper.ShowToggleButton" Value="{Binding HeaderSettings.ShowToggleButton, Mode=OneWay}" />
+            <Setter Property="mah:ExpanderHelper.ToggleButtonForeground" Value="{Binding HeaderSettings.ToggleButtonForegroundChoice.Brush, Mode=OneWay}" />
+            <Setter Property="mah:ExpanderHelper.ToggleButtonForegroundMouseOver" Value="{Binding HeaderSettings.ToggleButtonForegroundMouseOverChoice.Brush, Mode=OneWay}" />
+            <Setter Property="mah:ExpanderHelper.ToggleButtonForegroundPressed" Value="{Binding HeaderSettings.ToggleButtonForegroundPressedChoice.Brush, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderBackgroundMouseOver" Value="{Binding HeaderSettings.HeaderBackgroundMouseOverChoice.Brush, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderBackgroundPressed" Value="{Binding HeaderSettings.HeaderBackgroundPressedChoice.Brush, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontFamily" Value="{Binding HeaderSettings.HeaderFontFamily, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontSize" Value="{Binding HeaderSettings.HeaderFontSize, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontStretch" Value="{Binding HeaderSettings.HeaderFontStretch, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontWeight" Value="{Binding HeaderSettings.HeaderFontWeight, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderForegroundMouseOver" Value="{Binding HeaderSettings.HeaderForegroundMouseOverChoice.Brush, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderForegroundPressed" Value="{Binding HeaderSettings.HeaderForegroundPressedChoice.Brush, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderHorizontalContentAlignment" Value="{Binding HeaderSettings.HeaderHorizontalContentAlignment, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="{Binding HeaderSettings.HeaderMargin, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="{Binding HeaderSettings.HeaderVerticalContentAlignment, Mode=OneWay}" />
@@ -116,10 +127,14 @@
                BasedOn="{StaticResource MahApps.Styles.MetroHeader}"
                TargetType="{x:Type mah:MetroHeader}">
             <Setter Property="mah:ControlsHelper.ContentCharacterCasing" Value="{Binding HeaderSettings.ContentCharacterCasing, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderBackgroundMouseOver" Value="{Binding HeaderSettings.HeaderBackgroundMouseOverChoice.Brush, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderBackgroundPressed" Value="{Binding HeaderSettings.HeaderBackgroundPressedChoice.Brush, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontFamily" Value="{Binding HeaderSettings.HeaderFontFamily, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontSize" Value="{Binding HeaderSettings.HeaderFontSize, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontStretch" Value="{Binding HeaderSettings.HeaderFontStretch, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontWeight" Value="{Binding HeaderSettings.HeaderFontWeight, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderForegroundMouseOver" Value="{Binding HeaderSettings.HeaderForegroundMouseOverChoice.Brush, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderForegroundPressed" Value="{Binding HeaderSettings.HeaderForegroundPressedChoice.Brush, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderHorizontalContentAlignment" Value="{Binding HeaderSettings.HeaderHorizontalContentAlignment, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="{Binding HeaderSettings.HeaderMargin, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="{Binding HeaderSettings.HeaderVerticalContentAlignment, Mode=OneWay}" />
@@ -156,10 +171,14 @@
         <Style x:Key="DemoTabControl"
                BasedOn="{StaticResource MahApps.Styles.TabControl}"
                TargetType="{x:Type TabControl}">
+            <Setter Property="mah:HeaderedControlHelper.HeaderBackgroundMouseOver" Value="{Binding HeaderSettings.HeaderBackgroundMouseOverChoice.Brush, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderBackgroundPressed" Value="{Binding HeaderSettings.HeaderBackgroundPressedChoice.Brush, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontFamily" Value="{Binding HeaderSettings.HeaderFontFamily, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontSize" Value="{Binding HeaderSettings.HeaderFontSize, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontStretch" Value="{Binding HeaderSettings.HeaderFontStretch, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderFontWeight" Value="{Binding HeaderSettings.HeaderFontWeight, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderForegroundMouseOver" Value="{Binding HeaderSettings.HeaderForegroundMouseOverChoice.Brush, Mode=OneWay}" />
+            <Setter Property="mah:HeaderedControlHelper.HeaderForegroundPressed" Value="{Binding HeaderSettings.HeaderForegroundPressedChoice.Brush, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderHorizontalContentAlignment" Value="{Binding HeaderSettings.HeaderHorizontalContentAlignment, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="{Binding HeaderSettings.HeaderMargin, Mode=OneWay}" />
             <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="{Binding HeaderSettings.HeaderVerticalContentAlignment, Mode=OneWay}" />
@@ -234,7 +253,64 @@
                                       SelectedItem="{Binding HeaderSettings.HeaderForegroundChoice}" />
                         </mah:MetroHeader>
 
+                        <mah:MetroHeader Header="Background, touched" ToolTip="HeaderedControlHelper.HeaderBackgroundMouseOver">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemTemplate="{StaticResource BrushEntry}"
+                                      ItemsSource="{Binding HeaderSettings.BackgroundChoices, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.HeaderBackgroundMouseOverChoice}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Background, held down" ToolTip="HeaderedControlHelper.HeaderBackgroundPressed">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemTemplate="{StaticResource BrushEntry}"
+                                      ItemsSource="{Binding HeaderSettings.BackgroundChoices, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.HeaderBackgroundPressedChoice}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Foreground, touched" ToolTip="HeaderedControlHelper.HeaderForegroundMouseOver">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemTemplate="{StaticResource BrushEntry}"
+                                      ItemsSource="{Binding HeaderSettings.ForegroundChoices, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.HeaderForegroundMouseOverChoice}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Foreground, held down" ToolTip="HeaderedControlHelper.HeaderForegroundPressed">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemTemplate="{StaticResource BrushEntry}"
+                                      ItemsSource="{Binding HeaderSettings.ForegroundChoices, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.HeaderForegroundPressedChoice}" />
+                        </mah:MetroHeader>
+
                         <TextBlock Style="{StaticResource Note}" Text="Left as it is, each control keeps the header colours its own style gives it, and an automatic foreground works out black or white from what is behind it." />
+                    </StackPanel>
+                </GroupBox>
+
+                <GroupBox Header="The glyph of an expander">
+                    <StackPanel>
+                        <mah:MetroHeader Header="At rest" ToolTip="ExpanderHelper.ToggleButtonForeground">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemTemplate="{StaticResource BrushEntry}"
+                                      ItemsSource="{Binding HeaderSettings.ForegroundChoices, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.ToggleButtonForegroundChoice}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Touched" ToolTip="ExpanderHelper.ToggleButtonForegroundMouseOver">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemTemplate="{StaticResource BrushEntry}"
+                                      ItemsSource="{Binding HeaderSettings.ForegroundChoices, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.ToggleButtonForegroundMouseOverChoice}" />
+                        </mah:MetroHeader>
+
+                        <mah:MetroHeader Header="Held down" ToolTip="ExpanderHelper.ToggleButtonForegroundPressed">
+                            <ComboBox Margin="{StaticResource ControlMargin}"
+                                      ItemTemplate="{StaticResource BrushEntry}"
+                                      ItemsSource="{Binding HeaderSettings.ForegroundChoices, Mode=OneTime}"
+                                      SelectedItem="{Binding HeaderSettings.ToggleButtonForegroundPressedChoice}" />
+                        </mah:MetroHeader>
+
+                        <TextBlock Margin="0"
+                                   Style="{StaticResource Note}"
+                                   Text="These three paint the circle and the arrow alone, and they come from ExpanderHelper rather than from the header. Left as they are, the glyph follows the foreground of the header." />
                     </StackPanel>
                 </GroupBox>
 

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HeaderExamples.xaml.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/ExampleViews/HeaderExamples.xaml.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows;
+using System.Windows.Controls;
+using ControlzEx.Theming;
+
+namespace MetroDemo.ExampleViews
+{
+    /// <summary>
+    /// Interaction logic for HeaderExamples.xaml
+    /// </summary>
+    public partial class HeaderExamples : UserControl
+    {
+        public HeaderExamples()
+        {
+            this.InitializeComponent();
+
+            this.Loaded += this.OnLoaded;
+            this.Unloaded += this.OnUnloaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            ThemeManager.Current.ThemeChanged -= this.OnThemeChanged;
+            ThemeManager.Current.ThemeChanged += this.OnThemeChanged;
+
+            this.ReadTheBrushes();
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            ThemeManager.Current.ThemeChanged -= this.OnThemeChanged;
+        }
+
+        private void OnThemeChanged(object? sender, ThemeChangedEventArgs e)
+        {
+            this.ReadTheBrushes();
+        }
+
+        /// <summary>
+        /// The entries of the two colour boxes stand for keys, not for colours, and another theme puts
+        /// another brush behind a key. Asking from here rather than from the settings, because looking a
+        /// resource up is a question to the tree this control hangs in.
+        /// </summary>
+        private void ReadTheBrushes()
+        {
+            if (this.DataContext is MainWindowViewModel viewModel)
+            {
+                viewModel.HeaderSettings.ReadTheBrushesFromTheTheme(this.TryFindResource);
+            }
+        }
+    }
+}

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindow.xaml
@@ -410,6 +410,10 @@
                 </ScrollViewer>
             </TabItem>
 
+            <TabItem Header="header">
+                <exampleViews:HeaderExamples DataContext="{Binding}" />
+            </TabItem>
+
             <TabItem Header="others">
                 <ScrollViewer Margin="2"
                               HorizontalScrollBarVisibility="Auto"

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/MainWindowViewModel.cs
@@ -385,6 +385,8 @@ namespace MetroDemo
 
         public NumericUpDownSettings UpDownSettings { get; } = new NumericUpDownSettings();
 
+        public HeaderSettings HeaderSettings { get; } = new HeaderSettings();
+
         public ICommand EndOfScrollReachedCmdWithParameter { get; }
 
         public int? IntegerGreater10Property

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/BrushChoice.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/BrushChoice.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Windows.Media;
+using MetroDemo.Core;
+
+namespace MetroDemo.Models
+{
+    /// <summary>
+    /// One entry of a combo box that offers brushes: what to call it and the brush itself.
+    /// </summary>
+    public class BrushChoice : ViewModelBase
+    {
+        public BrushChoice(object content, string? resourceKey = null, Brush? brush = null)
+        {
+            this.Content = content;
+            this.ResourceKey = resourceKey;
+            this.brush = brush;
+        }
+
+        public object Content { get; }
+
+        /// <summary>
+        /// Where the brush comes from, if it comes from the theme. Held as a key rather than as the brush
+        /// it stands for, because a theme swaps the brush behind the key and the entry has to follow.
+        /// </summary>
+        public string? ResourceKey { get; }
+
+        private Brush? brush;
+
+        /// <summary>Left empty, the entry stands for handing nothing over at all.</summary>
+        public Brush? Brush
+        {
+            get => this.brush;
+            private set => this.Set(ref this.brush, value);
+        }
+
+        /// <summary>Reads the brush for this entry again, which is what a change of theme calls for.</summary>
+        public void ReadFromTheTheme(Func<string, object?> lookUp)
+        {
+            if (this.ResourceKey is not null)
+            {
+                this.Brush = lookUp(this.ResourceKey) as Brush;
+            }
+        }
+    }
+}

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/HeaderSettings.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/HeaderSettings.cs
@@ -70,6 +70,13 @@ namespace MetroDemo.Models
 
             this.headerBackgroundChoice = this.BackgroundChoices[0];
             this.headerForegroundChoice = this.ForegroundChoices[0];
+            this.headerBackgroundMouseOverChoice = this.BackgroundChoices[0];
+            this.headerBackgroundPressedChoice = this.BackgroundChoices[0];
+            this.headerForegroundMouseOverChoice = this.ForegroundChoices[0];
+            this.headerForegroundPressedChoice = this.ForegroundChoices[0];
+            this.toggleButtonForegroundChoice = this.ForegroundChoices[0];
+            this.toggleButtonForegroundMouseOverChoice = this.ForegroundChoices[0];
+            this.toggleButtonForegroundPressedChoice = this.ForegroundChoices[0];
         }
 
         /// <summary>
@@ -111,6 +118,69 @@ namespace MetroDemo.Models
         {
             get => this.headerForegroundChoice;
             set => this.Set(ref this.headerForegroundChoice, value);
+        }
+
+        private BrushChoice? headerBackgroundMouseOverChoice;
+
+        /// <summary>The brush while the mouse is over the header. The first entry hands nothing over, and the header stays as it is.</summary>
+        public BrushChoice? HeaderBackgroundMouseOverChoice
+        {
+            get => this.headerBackgroundMouseOverChoice;
+            set => this.Set(ref this.headerBackgroundMouseOverChoice, value);
+        }
+
+        private BrushChoice? headerBackgroundPressedChoice;
+
+        /// <summary>The brush while the header is held down. The first entry hands nothing over, and the header stays as it is.</summary>
+        public BrushChoice? HeaderBackgroundPressedChoice
+        {
+            get => this.headerBackgroundPressedChoice;
+            set => this.Set(ref this.headerBackgroundPressedChoice, value);
+        }
+
+        private BrushChoice? headerForegroundMouseOverChoice;
+
+        /// <summary>The brush for the text while the mouse is over the header. The first entry hands nothing over, and the header stays as it is.</summary>
+        public BrushChoice? HeaderForegroundMouseOverChoice
+        {
+            get => this.headerForegroundMouseOverChoice;
+            set => this.Set(ref this.headerForegroundMouseOverChoice, value);
+        }
+
+        private BrushChoice? headerForegroundPressedChoice;
+
+        /// <summary>The brush for the text while the header is held down. The first entry hands nothing over, and the header stays as it is.</summary>
+        public BrushChoice? HeaderForegroundPressedChoice
+        {
+            get => this.headerForegroundPressedChoice;
+            set => this.Set(ref this.headerForegroundPressedChoice, value);
+        }
+
+        private BrushChoice? toggleButtonForegroundChoice;
+
+        /// <summary>The brush for the glyph of an expander. The first entry hands nothing over, and the header stays as it is.</summary>
+        public BrushChoice? ToggleButtonForegroundChoice
+        {
+            get => this.toggleButtonForegroundChoice;
+            set => this.Set(ref this.toggleButtonForegroundChoice, value);
+        }
+
+        private BrushChoice? toggleButtonForegroundMouseOverChoice;
+
+        /// <summary>The brush for the glyph while the mouse is over the header. The first entry hands nothing over, and the header stays as it is.</summary>
+        public BrushChoice? ToggleButtonForegroundMouseOverChoice
+        {
+            get => this.toggleButtonForegroundMouseOverChoice;
+            set => this.Set(ref this.toggleButtonForegroundMouseOverChoice, value);
+        }
+
+        private BrushChoice? toggleButtonForegroundPressedChoice;
+
+        /// <summary>The brush for the glyph while the header is held down. The first entry hands nothing over, and the header stays as it is.</summary>
+        public BrushChoice? ToggleButtonForegroundPressedChoice
+        {
+            get => this.toggleButtonForegroundPressedChoice;
+            set => this.Set(ref this.toggleButtonForegroundPressedChoice, value);
         }
 
         private FontFamily? headerFontFamily = new("Segoe UI");

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/HeaderSettings.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/HeaderSettings.cs
@@ -183,7 +183,7 @@ namespace MetroDemo.Models
             set => this.Set(ref this.toggleButtonForegroundPressedChoice, value);
         }
 
-        private FontFamily? headerFontFamily = new("Segoe UI");
+        private FontFamily? headerFontFamily = new FontFamily("Segoe UI");
 
         public FontFamily? HeaderFontFamily
         {

--- a/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/HeaderSettings.cs
+++ b/src/MahApps.Metro.Samples/MahApps.Metro.Demo/Models/HeaderSettings.cs
@@ -1,0 +1,246 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using MetroDemo.Core;
+
+namespace MetroDemo.Models
+{
+    /// <summary>
+    /// One set of header settings for every control on the page. The example view binds them through a
+    /// style per control type, so a value changed here reaches all of them at once and they can be
+    /// compared side by side.
+    /// </summary>
+    public class HeaderSettings : ViewModelBase
+    {
+        public HeaderSettings()
+        {
+            this.BackgroundChoices = new[]
+                                     {
+                                         new BrushChoice("Each control's own"),
+                                         new BrushChoice("Accent", "MahApps.Brushes.Accent"),
+                                         new BrushChoice("Accent 3", "MahApps.Brushes.Accent3"),
+                                         new BrushChoice("Highlight", "MahApps.Brushes.Highlight"),
+                                         new BrushChoice("Gray 2", "MahApps.Brushes.Gray2"),
+                                         new BrushChoice("Gray 8", "MahApps.Brushes.Gray8"),
+                                         new BrushChoice("Theme background", "MahApps.Brushes.ThemeBackground"),
+                                         new BrushChoice("Transparent", brush: Brushes.Transparent)
+                                     };
+
+            this.ForegroundChoices = new[]
+                                     {
+                                         new BrushChoice("Automatic"),
+                                         new BrushChoice("Theme foreground", "MahApps.Brushes.ThemeForeground"),
+                                         new BrushChoice("Ideal foreground", "MahApps.Brushes.IdealForeground"),
+                                         new BrushChoice("Accent", "MahApps.Brushes.Accent"),
+                                         new BrushChoice("Gray 2", "MahApps.Brushes.Gray2")
+                                     };
+
+            this.AvailableFontWeights = new[]
+                                        {
+                                            FontWeights.Thin,
+                                            FontWeights.ExtraLight,
+                                            FontWeights.Light,
+                                            FontWeights.Normal,
+                                            FontWeights.Medium,
+                                            FontWeights.SemiBold,
+                                            FontWeights.Bold,
+                                            FontWeights.ExtraBold,
+                                            FontWeights.Black
+                                        };
+
+            this.AvailableFontStretches = new[]
+                                          {
+                                              FontStretches.UltraCondensed,
+                                              FontStretches.ExtraCondensed,
+                                              FontStretches.Condensed,
+                                              FontStretches.SemiCondensed,
+                                              FontStretches.Normal,
+                                              FontStretches.SemiExpanded,
+                                              FontStretches.Expanded,
+                                              FontStretches.ExtraExpanded,
+                                              FontStretches.UltraExpanded
+                                          };
+
+            this.headerBackgroundChoice = this.BackgroundChoices[0];
+            this.headerForegroundChoice = this.ForegroundChoices[0];
+        }
+
+        /// <summary>
+        /// What the header can be painted with. The first entry hands nothing over, and every control
+        /// then keeps the background its own style gives it, which is not the same one for all of them.
+        /// </summary>
+        public IReadOnlyList<BrushChoice> BackgroundChoices { get; }
+
+        /// <summary>
+        /// The same for the text. The first entry leaves it to the header to take the colour that reads
+        /// on whatever is behind it, black or white, worked out from the background.
+        /// </summary>
+        public IReadOnlyList<BrushChoice> ForegroundChoices { get; }
+
+        /// <summary>Every font on the machine, in the order somebody would look for one.</summary>
+        public IEnumerable<FontFamily> AvailableFontFamilies { get; } = Fonts.SystemFontFamilies.OrderBy(family => family.Source).ToList();
+
+        /// <summary>The weights that have a name of their own. FontWeight is a struct, so there is no enum to list.</summary>
+        public IEnumerable<FontWeight> AvailableFontWeights { get; }
+
+        /// <summary>The same for the stretches. Most fonts draw only a few of them.</summary>
+        public IEnumerable<FontStretch> AvailableFontStretches { get; }
+
+        private BrushChoice? headerBackgroundChoice;
+
+        /// <summary>
+        /// The entry rather than the brush it holds, so a brush the theme has swapped reaches the
+        /// controls through the same binding instead of being left behind as the colour of before.
+        /// </summary>
+        public BrushChoice? HeaderBackgroundChoice
+        {
+            get => this.headerBackgroundChoice;
+            set => this.Set(ref this.headerBackgroundChoice, value);
+        }
+
+        private BrushChoice? headerForegroundChoice;
+
+        public BrushChoice? HeaderForegroundChoice
+        {
+            get => this.headerForegroundChoice;
+            set => this.Set(ref this.headerForegroundChoice, value);
+        }
+
+        private FontFamily? headerFontFamily = new("Segoe UI");
+
+        public FontFamily? HeaderFontFamily
+        {
+            get => this.headerFontFamily;
+            set => this.Set(ref this.headerFontFamily, value);
+        }
+
+        private double headerFontSize = 12;
+
+        public double HeaderFontSize
+        {
+            get => this.headerFontSize;
+            set => this.Set(ref this.headerFontSize, value);
+        }
+
+        private FontWeight headerFontWeight = FontWeights.Normal;
+
+        public FontWeight HeaderFontWeight
+        {
+            get => this.headerFontWeight;
+            set => this.Set(ref this.headerFontWeight, value);
+        }
+
+        private FontStretch headerFontStretch = FontStretches.Normal;
+
+        public FontStretch HeaderFontStretch
+        {
+            get => this.headerFontStretch;
+            set => this.Set(ref this.headerFontStretch, value);
+        }
+
+        private Thickness headerMargin = new(4);
+
+        public Thickness HeaderMargin
+        {
+            get => this.headerMargin;
+            set => this.Set(ref this.headerMargin, value);
+        }
+
+        private double padding = 4;
+
+        /// <summary>
+        /// The one number the four sides of <see cref="HeaderMargin"/> are built from, so the room around
+        /// a header can be tried out with a single control.
+        /// </summary>
+        public double Padding
+        {
+            get => this.padding;
+            set
+            {
+                if (this.Set(ref this.padding, value))
+                {
+                    this.HeaderMargin = new Thickness(value);
+                }
+            }
+        }
+
+        private HorizontalAlignment headerHorizontalContentAlignment = HorizontalAlignment.Stretch;
+
+        public HorizontalAlignment HeaderHorizontalContentAlignment
+        {
+            get => this.headerHorizontalContentAlignment;
+            set => this.Set(ref this.headerHorizontalContentAlignment, value);
+        }
+
+        private VerticalAlignment headerVerticalContentAlignment = VerticalAlignment.Center;
+
+        public VerticalAlignment HeaderVerticalContentAlignment
+        {
+            get => this.headerVerticalContentAlignment;
+            set => this.Set(ref this.headerVerticalContentAlignment, value);
+        }
+
+        private CharacterCasing contentCharacterCasing = CharacterCasing.Normal;
+
+        /// <summary>
+        /// ControlsHelper.ContentCharacterCasing rather than one of the header properties, but it is the
+        /// header text it works on, so it belongs on this page.
+        /// </summary>
+        public CharacterCasing ContentCharacterCasing
+        {
+            get => this.contentCharacterCasing;
+            set => this.Set(ref this.contentCharacterCasing, value);
+        }
+
+        private CornerRadius cornerRadius;
+
+        public CornerRadius CornerRadius
+        {
+            get => this.cornerRadius;
+            set => this.Set(ref this.cornerRadius, value);
+        }
+
+        private double roundness;
+
+        /// <summary>The one number <see cref="CornerRadius"/> is built from, for the same reason as <see cref="Padding"/>.</summary>
+        public double Roundness
+        {
+            get => this.roundness;
+            set
+            {
+                if (this.Set(ref this.roundness, value))
+                {
+                    this.CornerRadius = new CornerRadius(value);
+                }
+            }
+        }
+
+        private bool showToggleButton = true;
+
+        /// <summary>ExpanderHelper.ShowToggleButton, which only the expander has.</summary>
+        public bool ShowToggleButton
+        {
+            get => this.showToggleButton;
+            set => this.Set(ref this.showToggleButton, value);
+        }
+
+        /// <summary>
+        /// Hands every entry the brush its key stands for. Called once when the page comes up and again
+        /// whenever the theme changes, because that is when the brush behind a key is another one.
+        /// </summary>
+        public void ReadTheBrushesFromTheTheme(Func<string, object?> lookUp)
+        {
+            foreach (var choice in this.BackgroundChoices.Concat(this.ForegroundChoices))
+            {
+                choice.ReadFromTheTheme(lookUp);
+            }
+        }
+    }
+}

--- a/src/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/ExpanderHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
+using System.Windows.Media;
 using System.Windows.Media.Animation;
 using MahApps.Metro.ValueBoxes;
 
@@ -47,6 +48,96 @@ namespace MahApps.Metro.Controls
         public static void SetShowToggleButton(DependencyObject element, bool value)
         {
             element.SetValue(ShowToggleButtonProperty, BooleanBoxes.Box(value));
+        }
+
+        public static readonly DependencyProperty ToggleButtonForegroundProperty
+            = DependencyProperty.RegisterAttached("ToggleButtonForeground",
+                                                  typeof(Brush),
+                                                  typeof(ExpanderHelper),
+                                                  new PropertyMetadata(null));
+
+        /// <summary>Helper for getting <see cref="ToggleButtonForegroundProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to read <see cref="ToggleButtonForegroundProperty"/> from.</param>
+        /// <remarks>Gets the brush the circle and the arrow of the toggle button are drawn with at rest. Left unset, they take the foreground of the header, which is the colour that reads on whatever the header is painted with.</remarks>
+        /// <returns>ToggleButtonForeground property value.</returns>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        [AttachedPropertyBrowsableForType(typeof(ToggleButton))]
+        public static Brush? GetToggleButtonForeground(DependencyObject element)
+        {
+            return (Brush?)element.GetValue(ToggleButtonForegroundProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="ToggleButtonForegroundProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to set <see cref="ToggleButtonForegroundProperty"/> on.</param>
+        /// <param name="value">ToggleButtonForeground property value.</param>
+        /// <remarks>Sets the brush the circle and the arrow of the toggle button are drawn with at rest. Left unset, they take the foreground of the header, which is the colour that reads on whatever the header is painted with.</remarks>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        [AttachedPropertyBrowsableForType(typeof(ToggleButton))]
+        public static void SetToggleButtonForeground(DependencyObject element, Brush? value)
+        {
+            element.SetValue(ToggleButtonForegroundProperty, value);
+        }
+
+        public static readonly DependencyProperty ToggleButtonForegroundMouseOverProperty
+            = DependencyProperty.RegisterAttached("ToggleButtonForegroundMouseOver",
+                                                  typeof(Brush),
+                                                  typeof(ExpanderHelper),
+                                                  new PropertyMetadata(null));
+
+        /// <summary>Helper for getting <see cref="ToggleButtonForegroundMouseOverProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to read <see cref="ToggleButtonForegroundMouseOverProperty"/> from.</param>
+        /// <remarks>Gets the brush the circle and the arrow of the toggle button are drawn with while the mouse is over the header. Left unset, they keep the colour they have at rest.</remarks>
+        /// <returns>ToggleButtonForegroundMouseOver property value.</returns>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        [AttachedPropertyBrowsableForType(typeof(ToggleButton))]
+        public static Brush? GetToggleButtonForegroundMouseOver(DependencyObject element)
+        {
+            return (Brush?)element.GetValue(ToggleButtonForegroundMouseOverProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="ToggleButtonForegroundMouseOverProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to set <see cref="ToggleButtonForegroundMouseOverProperty"/> on.</param>
+        /// <param name="value">ToggleButtonForegroundMouseOver property value.</param>
+        /// <remarks>Sets the brush the circle and the arrow of the toggle button are drawn with while the mouse is over the header. Left unset, they keep the colour they have at rest.</remarks>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        [AttachedPropertyBrowsableForType(typeof(ToggleButton))]
+        public static void SetToggleButtonForegroundMouseOver(DependencyObject element, Brush? value)
+        {
+            element.SetValue(ToggleButtonForegroundMouseOverProperty, value);
+        }
+
+        public static readonly DependencyProperty ToggleButtonForegroundPressedProperty
+            = DependencyProperty.RegisterAttached("ToggleButtonForegroundPressed",
+                                                  typeof(Brush),
+                                                  typeof(ExpanderHelper),
+                                                  new PropertyMetadata(null));
+
+        /// <summary>Helper for getting <see cref="ToggleButtonForegroundPressedProperty"/> from <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to read <see cref="ToggleButtonForegroundPressedProperty"/> from.</param>
+        /// <remarks>Gets the brush the circle and the arrow of the toggle button are drawn with while the expander is open. Left unset, they keep the colour they have at rest.</remarks>
+        /// <returns>ToggleButtonForegroundPressed property value.</returns>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        [AttachedPropertyBrowsableForType(typeof(ToggleButton))]
+        public static Brush? GetToggleButtonForegroundPressed(DependencyObject element)
+        {
+            return (Brush?)element.GetValue(ToggleButtonForegroundPressedProperty);
+        }
+
+        /// <summary>Helper for setting <see cref="ToggleButtonForegroundPressedProperty"/> on <paramref name="element"/>.</summary>
+        /// <param name="element"><see cref="DependencyObject"/> to set <see cref="ToggleButtonForegroundPressedProperty"/> on.</param>
+        /// <param name="value">ToggleButtonForegroundPressed property value.</param>
+        /// <remarks>Sets the brush the circle and the arrow of the toggle button are drawn with while the expander is open. Left unset, they keep the colour they have at rest.</remarks>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(Expander))]
+        [AttachedPropertyBrowsableForType(typeof(ToggleButton))]
+        public static void SetToggleButtonForegroundPressed(DependencyObject element, Brush? value)
+        {
+            element.SetValue(ToggleButtonForegroundPressedProperty, value);
         }
 
         public static readonly DependencyProperty HeaderUpStyleProperty

--- a/src/MahApps.Metro/Controls/Helper/HeaderedControlHelper.cs
+++ b/src/MahApps.Metro/Controls/Helper/HeaderedControlHelper.cs
@@ -74,6 +74,134 @@ namespace MahApps.Metro.Controls
             element.SetValue(HeaderBackgroundProperty, value);
         }
 
+        public static readonly DependencyProperty HeaderBackgroundMouseOverProperty
+            = DependencyProperty.RegisterAttached(
+                "HeaderBackgroundMouseOver",
+                typeof(Brush),
+                typeof(HeaderedControlHelper),
+                new UIPropertyMetadata(null));
+
+        /// <summary>
+        /// Gets the value of the background the header is painted with while the mouse is over it. Left unset, the header keeps
+        /// the one it has at rest.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(ColorPalette))]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static Brush? GetHeaderBackgroundMouseOver(UIElement element)
+        {
+            return (Brush?)element.GetValue(HeaderBackgroundMouseOverProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the background the header is painted with while the mouse is over it.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(ColorPalette))]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static void SetHeaderBackgroundMouseOver(UIElement element, Brush? value)
+        {
+            element.SetValue(HeaderBackgroundMouseOverProperty, value);
+        }
+
+        public static readonly DependencyProperty HeaderBackgroundPressedProperty
+            = DependencyProperty.RegisterAttached(
+                "HeaderBackgroundPressed",
+                typeof(Brush),
+                typeof(HeaderedControlHelper),
+                new UIPropertyMetadata(null));
+
+        /// <summary>
+        /// Gets the value of the background the header is painted with while it is the one selected. Left unset, the header keeps
+        /// the one it has at rest.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(ColorPalette))]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static Brush? GetHeaderBackgroundPressed(UIElement element)
+        {
+            return (Brush?)element.GetValue(HeaderBackgroundPressedProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the background the header is painted with while it is the one selected.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(ColorPalette))]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static void SetHeaderBackgroundPressed(UIElement element, Brush? value)
+        {
+            element.SetValue(HeaderBackgroundPressedProperty, value);
+        }
+
+        public static readonly DependencyProperty HeaderForegroundMouseOverProperty
+            = DependencyProperty.RegisterAttached(
+                "HeaderForegroundMouseOver",
+                typeof(Brush),
+                typeof(HeaderedControlHelper),
+                new UIPropertyMetadata(null));
+
+        /// <summary>
+        /// Gets the value of the foreground the header is painted with while the mouse is over it. Left unset, the header keeps
+        /// the one it has at rest.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(ColorPalette))]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static Brush? GetHeaderForegroundMouseOver(UIElement element)
+        {
+            return (Brush?)element.GetValue(HeaderForegroundMouseOverProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the foreground the header is painted with while the mouse is over it.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(ColorPalette))]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static void SetHeaderForegroundMouseOver(UIElement element, Brush? value)
+        {
+            element.SetValue(HeaderForegroundMouseOverProperty, value);
+        }
+
+        public static readonly DependencyProperty HeaderForegroundPressedProperty
+            = DependencyProperty.RegisterAttached(
+                "HeaderForegroundPressed",
+                typeof(Brush),
+                typeof(HeaderedControlHelper),
+                new UIPropertyMetadata(null));
+
+        /// <summary>
+        /// Gets the value of the foreground the header is painted with while it is the one selected. Left unset, the header keeps
+        /// the one it has at rest.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(ColorPalette))]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static Brush? GetHeaderForegroundPressed(UIElement element)
+        {
+            return (Brush?)element.GetValue(HeaderForegroundPressedProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the foreground the header is painted with while it is the one selected.
+        /// </summary>
+        [Category(AppName.MahApps)]
+        [AttachedPropertyBrowsableForType(typeof(HeaderedContentControl))]
+        [AttachedPropertyBrowsableForType(typeof(ColorPalette))]
+        [AttachedPropertyBrowsableForType(typeof(TabControl))]
+        public static void SetHeaderForegroundPressed(UIElement element, Brush? value)
+        {
+            element.SetValue(HeaderForegroundPressedProperty, value);
+        }
+
         public static readonly DependencyProperty HeaderFontFamilyProperty
             = DependencyProperty.RegisterAttached(
                 "HeaderFontFamily",

--- a/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
+++ b/src/MahApps.Metro/Styles/Controls.DataGrid.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.CheckBox.xaml" />
@@ -839,57 +840,14 @@
     <Style x:Key="MahApps.Styles.ToggleButton.ExpanderHeader.Down.DataGrid.GroupItem"
            BasedOn="{StaticResource MahApps.Styles.ToggleButton.ExpanderHeader.Down}"
            TargetType="{x:Type ToggleButton}">
+        <Style.Resources>
+            <system:Double x:Key="ExpanderToggleButtonEllipseThemeSize">20</system:Double>
+            <system:Double x:Key="ExpanderToggleButtonEllipseThemeStrokeThickness">0</system:Double>
+            <system:Double x:Key="ExpanderToggleButtonEllipseThemeStrokeThicknessMouseOver">0</system:Double>
+            <system:Double x:Key="ExpanderToggleButtonEllipseThemeStrokeThicknessPressed">0</system:Double>
+        </Style.Resources>
         <Setter Property="MinHeight" Value="25" />
         <Setter Property="MinWidth" Value="0" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ToggleButton}">
-                    <Grid Background="{TemplateBinding Background}">
-                        <Grid x:Name="RowGroupHeaderRoot"
-                              Margin="{TemplateBinding Padding}"
-                              Background="Transparent"
-                              SnapsToDevicePixels="False">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="22" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Path x:Name="Arrow"
-                                  Grid.Column="0"
-                                  HorizontalAlignment="Center"
-                                  VerticalAlignment="Center"
-                                  Data="M 1,1.5 L 4.5,5 L 8,1.5"
-                                  SnapsToDevicePixels="False"
-                                  Stroke="{TemplateBinding Foreground}"
-                                  StrokeThickness="2" />
-                            <mah:ContentControlEx Grid.Column="1"
-                                                  Margin="4 0 0 0"
-                                                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  Content="{TemplateBinding Content}"
-                                                  ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                                  ContentStringFormat="{TemplateBinding ContentStringFormat}"
-                                                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-                                                  RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                        </Grid>
-                    </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="IsChecked" Value="true">
-                            <Setter TargetName="Arrow" Property="Data" Value="M 1,4.5  L 4.5,1  L 8,4.5" />
-                        </Trigger>
-                        <Trigger Property="IsMouseOver" Value="true">
-                            <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray8}" />
-                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource MahApps.Brushes.Gray2}" />
-                        </Trigger>
-                        <Trigger Property="IsPressed" Value="true">
-                            <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray9}" />
-                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
     </Style>
 
     <Style x:Key="MahApps.Styles.GroupItem.DataGrid" TargetType="{x:Type GroupItem}">
@@ -902,7 +860,9 @@
                               mah:ExpanderHelper.CollapseStoryboard="{x:Null}"
                               mah:ExpanderHelper.ExpandStoryboard="{x:Null}"
                               mah:ExpanderHelper.HeaderDownStyle="{StaticResource MahApps.Styles.ToggleButton.ExpanderHeader.Down.DataGrid.GroupItem}"
+                              mah:ExpanderHelper.ToggleButtonForegroundMouseOver="{DynamicResource MahApps.Brushes.Gray2}"
                               mah:HeaderedControlHelper.HeaderBackground="{DynamicResource MahApps.Brushes.Gray8}"
+                              mah:HeaderedControlHelper.HeaderBackgroundPressed="{DynamicResource MahApps.Brushes.Gray9}"
                               BorderThickness="0"
                               Header="{TemplateBinding Content}"
                               HeaderStringFormat="{TemplateBinding ContentStringFormat}"

--- a/src/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -45,7 +45,7 @@
                             <Grid x:Name="Glyph"
                                   Margin="0 0 0 4"
                                   RenderTransformOrigin="0.5 0.5"
-                                  Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Grid.LayoutTransform>
                                     <TransformGroup>
                                         <TransformGroup.Children>
@@ -80,7 +80,17 @@
                                                   ContentTemplate="{TemplateBinding ContentTemplate}"
                                                   ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
                                                   RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                <mah:ContentControlEx.LayoutTransform>
+                                    <TransformGroup>
+                                        <TransformGroup.Children>
+                                            <TransformCollection>
+                                                <RotateTransform Angle="-90" />
+                                            </TransformCollection>
+                                        </TransformGroup.Children>
+                                    </TransformGroup>
+                                </mah:ContentControlEx.LayoutTransform>
+                            </mah:ContentControlEx>
                         </Grid>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -126,7 +136,7 @@
                             <Grid x:Name="Glyph"
                                   Margin="0 0 4 0"
                                   RenderTransformOrigin="0.5 0.5"
-                                  Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Grid.LayoutTransform>
                                     <TransformGroup>
                                         <TransformGroup.Children>
@@ -206,7 +216,7 @@
                             <Grid x:Name="Glyph"
                                   Margin="0 0 0 4"
                                   RenderTransformOrigin="0.5 0.5"
-                                  Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Grid.LayoutTransform>
                                     <TransformGroup>
                                         <TransformGroup.Children>
@@ -241,7 +251,17 @@
                                                   ContentTemplate="{TemplateBinding ContentTemplate}"
                                                   ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
                                                   RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
-                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                                <mah:ContentControlEx.LayoutTransform>
+                                    <TransformGroup>
+                                        <TransformGroup.Children>
+                                            <TransformCollection>
+                                                <RotateTransform Angle="90" />
+                                            </TransformCollection>
+                                        </TransformGroup.Children>
+                                    </TransformGroup>
+                                </mah:ContentControlEx.LayoutTransform>
+                            </mah:ContentControlEx>
                         </Grid>
                     </Grid>
                     <ControlTemplate.Triggers>
@@ -285,7 +305,7 @@
                             <Grid x:Name="Glyph"
                                   Margin="0 0 4 0"
                                   RenderTransformOrigin="0.5 0.5"
-                                  Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                  Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Ellipse x:Name="Circle"
                                          Width="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
                                          Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
@@ -400,6 +420,7 @@
                                                   HorizontalContentAlignment="{TemplateBinding mah:HeaderedControlHelper.HeaderHorizontalContentAlignment}"
                                                   VerticalContentAlignment="{TemplateBinding mah:HeaderedControlHelper.HeaderVerticalContentAlignment}"
                                                   mah:ControlsHelper.ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                  mah:ExpanderHelper.ShowToggleButton="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ShowToggleButton)}"
                                                   Content="{TemplateBinding Header}"
                                                   ContentStringFormat="{TemplateBinding HeaderStringFormat}"
                                                   ContentTemplate="{TemplateBinding HeaderTemplate}"

--- a/src/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -10,6 +10,12 @@
 
     <Thickness x:Key="ExpanderHeaderThemePadding">3</Thickness>
     <system:Double x:Key="ExpanderToggleButtonEllipseThemeSize">18</system:Double>
+    <system:Double x:Key="ExpanderToggleButtonEllipseThemeStrokeThickness">1</system:Double>
+    <system:Double x:Key="ExpanderToggleButtonEllipseThemeStrokeThicknessMouseOver">2</system:Double>
+    <system:Double x:Key="ExpanderToggleButtonEllipseThemeStrokeThicknessPressed">2</system:Double>
+    <system:Double x:Key="ExpanderToggleButtonArrowThemeStrokeThickness">2</system:Double>
+    <system:Double x:Key="ExpanderToggleButtonArrowThemeStrokeThicknessMouseOver">2</system:Double>
+    <system:Double x:Key="ExpanderToggleButtonArrowThemeStrokeThicknessPressed">2</system:Double>
 
     <Style x:Key="MahApps.Styles.ToggleButton.ExpanderHeader.Base" TargetType="{x:Type ToggleButton}">
         <Setter Property="Background" Value="Transparent" />
@@ -28,10 +34,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
-                    <Border Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                    <Grid Background="{TemplateBinding Background}">
                         <Grid Margin="{TemplateBinding Padding}"
                               Background="Transparent"
                               SnapsToDevicePixels="False">
@@ -39,7 +42,10 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
-                            <Grid Margin="0 0 0 4" Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Grid x:Name="Glyph"
+                                  Margin="0 0 0 4"
+                                  RenderTransformOrigin="0.5 0.5"
+                                  Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Grid.LayoutTransform>
                                     <TransformGroup>
                                         <TransformGroup.Children>
@@ -54,14 +60,15 @@
                                          Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
                                          HorizontalAlignment="Center"
                                          VerticalAlignment="Center"
-                                         Stroke="{TemplateBinding Foreground}" />
+                                         Stroke="{TemplateBinding Foreground}"
+                                         StrokeThickness="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThickness}" />
                                 <Path x:Name="Arrow"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Center"
                                       Data="M 1,1.5 L 4.5,5 L 8,1.5"
                                       SnapsToDevicePixels="false"
                                       Stroke="{TemplateBinding Foreground}"
-                                      StrokeThickness="2" />
+                                      StrokeThickness="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThickness}" />
                             </Grid>
                             <mah:ContentControlEx Grid.Row="1"
                                                   Margin="0"
@@ -75,19 +82,24 @@
                                                   RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
-                    </Border>
+                    </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="true">
                             <Setter TargetName="Arrow" Property="Data" Value="M 1,4.5  L 4.5,1  L 8,4.5" />
                         </Trigger>
+                        <!--  GH-4386: the glyph keeps the foreground in every state, the ring and the size are what answer a touch  -->
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource MahApps.Brushes.Gray2}" />
-                            <Setter TargetName="Circle" Property="Stroke" Value="{DynamicResource MahApps.Brushes.Gray2}" />
+                            <Setter TargetName="Arrow" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThicknessMouseOver}" />
+                            <Setter TargetName="Circle" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThicknessMouseOver}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="true">
-                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="Circle" Property="Stroke" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="Circle" Property="StrokeThickness" Value="2" />
+                            <Setter TargetName="Arrow" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThicknessPressed}" />
+                            <Setter TargetName="Circle" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThicknessPressed}" />
+                            <Setter TargetName="Glyph" Property="RenderTransform">
+                                <Setter.Value>
+                                    <ScaleTransform ScaleX="0.85" ScaleY="0.85" />
+                                </Setter.Value>
+                            </Setter>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -103,9 +115,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
-                    <Border Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}">
+                    <Grid Background="{TemplateBinding Background}">
                         <Grid Margin="{TemplateBinding Padding}"
                               Background="Transparent"
                               SnapsToDevicePixels="False">
@@ -113,7 +123,10 @@
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <Grid Margin="0 0 4 0" Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Grid x:Name="Glyph"
+                                  Margin="0 0 4 0"
+                                  RenderTransformOrigin="0.5 0.5"
+                                  Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Grid.LayoutTransform>
                                     <TransformGroup>
                                         <TransformGroup.Children>
@@ -128,14 +141,15 @@
                                          Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
                                          HorizontalAlignment="Center"
                                          VerticalAlignment="Center"
-                                         Stroke="{TemplateBinding Foreground}" />
+                                         Stroke="{TemplateBinding Foreground}"
+                                         StrokeThickness="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThickness}" />
                                 <Path x:Name="Arrow"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Center"
                                       Data="M 1,1.5 L 4.5,5 L 8,1.5"
                                       SnapsToDevicePixels="false"
                                       Stroke="{TemplateBinding Foreground}"
-                                      StrokeThickness="2" />
+                                      StrokeThickness="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThickness}" />
                             </Grid>
                             <mah:ContentControlEx Grid.Column="1"
                                                   Margin="0"
@@ -149,19 +163,24 @@
                                                   RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
-                    </Border>
+                    </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="true">
                             <Setter TargetName="Arrow" Property="Data" Value="M 1,4.5  L 4.5,1  L 8,4.5" />
                         </Trigger>
+                        <!--  GH-4386: the glyph keeps the foreground in every state, the ring and the size are what answer a touch  -->
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource MahApps.Brushes.Gray2}" />
-                            <Setter TargetName="Circle" Property="Stroke" Value="{DynamicResource MahApps.Brushes.Gray2}" />
+                            <Setter TargetName="Arrow" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThicknessMouseOver}" />
+                            <Setter TargetName="Circle" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThicknessMouseOver}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="true">
-                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="Circle" Property="Stroke" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="Circle" Property="StrokeThickness" Value="2" />
+                            <Setter TargetName="Arrow" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThicknessPressed}" />
+                            <Setter TargetName="Circle" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThicknessPressed}" />
+                            <Setter TargetName="Glyph" Property="RenderTransform">
+                                <Setter.Value>
+                                    <ScaleTransform ScaleX="0.85" ScaleY="0.85" />
+                                </Setter.Value>
+                            </Setter>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -176,9 +195,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
-                    <Border Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}">
+                    <Grid Background="{TemplateBinding Background}">
                         <Grid Margin="{TemplateBinding Padding}"
                               Background="Transparent"
                               SnapsToDevicePixels="False">
@@ -186,7 +203,10 @@
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
-                            <Grid Margin="0 0 0 4" Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Grid x:Name="Glyph"
+                                  Margin="0 0 0 4"
+                                  RenderTransformOrigin="0.5 0.5"
+                                  Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Grid.LayoutTransform>
                                     <TransformGroup>
                                         <TransformGroup.Children>
@@ -201,14 +221,15 @@
                                          Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
                                          HorizontalAlignment="Center"
                                          VerticalAlignment="Center"
-                                         Stroke="{TemplateBinding Foreground}" />
+                                         Stroke="{TemplateBinding Foreground}"
+                                         StrokeThickness="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThickness}" />
                                 <Path x:Name="Arrow"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Center"
                                       Data="M 1,1.5 L 4.5,5 L 8,1.5"
                                       SnapsToDevicePixels="false"
                                       Stroke="{TemplateBinding Foreground}"
-                                      StrokeThickness="2" />
+                                      StrokeThickness="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThickness}" />
                             </Grid>
                             <mah:ContentControlEx Grid.Row="1"
                                                   Margin="0"
@@ -222,19 +243,24 @@
                                                   RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
-                    </Border>
+                    </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="true">
                             <Setter TargetName="Arrow" Property="Data" Value="M 1,4.5  L 4.5,1  L 8,4.5" />
                         </Trigger>
+                        <!--  GH-4386: the glyph keeps the foreground in every state, the ring and the size are what answer a touch  -->
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource MahApps.Brushes.Gray2}" />
-                            <Setter TargetName="Circle" Property="Stroke" Value="{DynamicResource MahApps.Brushes.Gray2}" />
+                            <Setter TargetName="Arrow" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThicknessMouseOver}" />
+                            <Setter TargetName="Circle" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThicknessMouseOver}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="true">
-                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="Circle" Property="Stroke" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="Circle" Property="StrokeThickness" Value="2" />
+                            <Setter TargetName="Arrow" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThicknessPressed}" />
+                            <Setter TargetName="Circle" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThicknessPressed}" />
+                            <Setter TargetName="Glyph" Property="RenderTransform">
+                                <Setter.Value>
+                                    <ScaleTransform ScaleX="0.85" ScaleY="0.85" />
+                                </Setter.Value>
+                            </Setter>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -248,9 +274,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToggleButton}">
-                    <Border Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}">
+                    <Grid Background="{TemplateBinding Background}">
                         <Grid Margin="{TemplateBinding Padding}"
                               Background="Transparent"
                               SnapsToDevicePixels="False">
@@ -258,20 +282,24 @@
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <Grid Margin="0 0 4 0" Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Grid x:Name="Glyph"
+                                  Margin="0 0 4 0"
+                                  RenderTransformOrigin="0.5 0.5"
+                                  Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Expander}}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Ellipse x:Name="Circle"
                                          Width="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
                                          Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
                                          HorizontalAlignment="Center"
                                          VerticalAlignment="Center"
-                                         Stroke="{TemplateBinding Foreground}" />
+                                         Stroke="{TemplateBinding Foreground}"
+                                         StrokeThickness="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThickness}" />
                                 <Path x:Name="Arrow"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Center"
                                       Data="M 1,1.5 L 4.5,5 L 8,1.5"
                                       SnapsToDevicePixels="false"
                                       Stroke="{TemplateBinding Foreground}"
-                                      StrokeThickness="2" />
+                                      StrokeThickness="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThickness}" />
                             </Grid>
                             <mah:ContentControlEx Grid.Column="1"
                                                   Margin="0"
@@ -285,19 +313,24 @@
                                                   RecognizesAccessKey="{TemplateBinding mah:ControlsHelper.RecognizesAccessKey}"
                                                   SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Grid>
-                    </Border>
+                    </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsChecked" Value="true">
                             <Setter TargetName="Arrow" Property="Data" Value="M 1,4.5  L 4.5,1  L 8,4.5" />
                         </Trigger>
+                        <!--  GH-4386: the glyph keeps the foreground in every state, the ring and the size are what answer a touch  -->
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource MahApps.Brushes.Gray2}" />
-                            <Setter TargetName="Circle" Property="Stroke" Value="{DynamicResource MahApps.Brushes.Gray2}" />
+                            <Setter TargetName="Arrow" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThicknessMouseOver}" />
+                            <Setter TargetName="Circle" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThicknessMouseOver}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="true">
-                            <Setter TargetName="Arrow" Property="Stroke" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="Circle" Property="Stroke" Value="{DynamicResource MahApps.Brushes.ThemeForeground}" />
-                            <Setter TargetName="Circle" Property="StrokeThickness" Value="2" />
+                            <Setter TargetName="Arrow" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonArrowThemeStrokeThicknessPressed}" />
+                            <Setter TargetName="Circle" Property="StrokeThickness" Value="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThicknessPressed}" />
+                            <Setter TargetName="Glyph" Property="RenderTransform">
+                                <Setter.Value>
+                                    <ScaleTransform ScaleX="0.85" ScaleY="0.85" />
+                                </Setter.Value>
+                            </Setter>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -351,33 +384,45 @@
                                     DockPanel.Dock="Top"
                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                     UseLayoutRounding="True">
-                                <ToggleButton x:Name="ToggleSite"
-                                              Padding="{TemplateBinding mah:HeaderedControlHelper.HeaderMargin}"
-                                              HorizontalContentAlignment="{TemplateBinding mah:HeaderedControlHelper.HeaderHorizontalContentAlignment}"
-                                              VerticalContentAlignment="{TemplateBinding mah:HeaderedControlHelper.HeaderVerticalContentAlignment}"
-                                              mah:ControlsHelper.ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
-                                              Content="{TemplateBinding Header}"
-                                              ContentStringFormat="{TemplateBinding HeaderStringFormat}"
-                                              ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                              ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
-                                              FontFamily="{TemplateBinding mah:HeaderedControlHelper.HeaderFontFamily}"
-                                              FontSize="{TemplateBinding mah:HeaderedControlHelper.HeaderFontSize}"
-                                              FontStretch="{TemplateBinding mah:HeaderedControlHelper.HeaderFontStretch}"
-                                              FontWeight="{TemplateBinding mah:HeaderedControlHelper.HeaderFontWeight}"
-                                              IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                              Style="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.HeaderDownStyle)}"
-                                              UseLayoutRounding="False">
-                                    <ToggleButton.Foreground>
-                                        <MultiBinding Converter="{x:Static mahConverters:BackgroundToForegroundConverter.Instance}">
-                                            <Binding Mode="OneWay"
-                                                     Path="(mah:HeaderedControlHelper.HeaderBackground)"
-                                                     RelativeSource="{RelativeSource TemplatedParent}" />
-                                            <Binding Mode="OneWay"
-                                                     Path="(mah:HeaderedControlHelper.HeaderForeground)"
-                                                     RelativeSource="{RelativeSource TemplatedParent}" />
+                                <Grid x:Name="ContentGrid">
+                                    <Grid.Clip>
+                                        <!--  a clip lives in the coordinates of the element it sits on, so it takes the size of this grid and the corners the border leaves over  -->
+                                        <MultiBinding Converter="{x:Static mahConverters:ClipGeometryConverter.Instance}">
+                                            <Binding ElementName="ContentGrid" Path="ActualWidth" />
+                                            <Binding ElementName="ContentGrid" Path="ActualHeight" />
+                                            <Binding ElementName="HeaderSite" Path="CornerRadius" />
+                                            <Binding ElementName="HeaderSite" Path="BorderThickness" />
+                                            <Binding ElementName="HeaderSite" Path="Padding" />
                                         </MultiBinding>
-                                    </ToggleButton.Foreground>
-                                </ToggleButton>
+                                    </Grid.Clip>
+                                    <ToggleButton x:Name="ToggleSite"
+                                                  Padding="{TemplateBinding mah:HeaderedControlHelper.HeaderMargin}"
+                                                  HorizontalContentAlignment="{TemplateBinding mah:HeaderedControlHelper.HeaderHorizontalContentAlignment}"
+                                                  VerticalContentAlignment="{TemplateBinding mah:HeaderedControlHelper.HeaderVerticalContentAlignment}"
+                                                  mah:ControlsHelper.ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
+                                                  Content="{TemplateBinding Header}"
+                                                  ContentStringFormat="{TemplateBinding HeaderStringFormat}"
+                                                  ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                                  ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                                                  FontFamily="{TemplateBinding mah:HeaderedControlHelper.HeaderFontFamily}"
+                                                  FontSize="{TemplateBinding mah:HeaderedControlHelper.HeaderFontSize}"
+                                                  FontStretch="{TemplateBinding mah:HeaderedControlHelper.HeaderFontStretch}"
+                                                  FontWeight="{TemplateBinding mah:HeaderedControlHelper.HeaderFontWeight}"
+                                                  IsChecked="{Binding IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                                  Style="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.HeaderDownStyle)}"
+                                                  UseLayoutRounding="False">
+                                        <ToggleButton.Foreground>
+                                            <MultiBinding Converter="{x:Static mahConverters:BackgroundToForegroundConverter.Instance}">
+                                                <Binding Mode="OneWay"
+                                                         Path="(mah:HeaderedControlHelper.HeaderBackground)"
+                                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                                                <Binding Mode="OneWay"
+                                                         Path="(mah:HeaderedControlHelper.HeaderForeground)"
+                                                         RelativeSource="{RelativeSource TemplatedParent}" />
+                                            </MultiBinding>
+                                        </ToggleButton.Foreground>
+                                    </ToggleButton>
+                                </Grid>
                             </Border>
                             <Border x:Name="ExpandSite"
                                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/MahApps.Metro/Styles/Controls.Expander.xaml
+++ b/src/MahApps.Metro/Styles/Controls.Expander.xaml
@@ -43,6 +43,8 @@
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
                             <Grid x:Name="Glyph"
+                                  Width="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
+                                  Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
                                   Margin="0 0 0 4"
                                   RenderTransformOrigin="0.5 0.5"
                                   Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -56,10 +58,8 @@
                                     </TransformGroup>
                                 </Grid.LayoutTransform>
                                 <Ellipse x:Name="Circle"
-                                         Width="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
-                                         Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
-                                         HorizontalAlignment="Center"
-                                         VerticalAlignment="Center"
+                                         HorizontalAlignment="Stretch"
+                                         VerticalAlignment="Stretch"
                                          Stroke="{TemplateBinding Foreground}"
                                          StrokeThickness="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThickness}" />
                                 <Path x:Name="Arrow"
@@ -111,6 +111,27 @@
                                 </Setter.Value>
                             </Setter>
                         </Trigger>
+                        <!--  A colour of its own for the glyph, if somebody set one. Left unset, it keeps the foreground of the header.  -->
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Mode=OneWay}" />
+                        </DataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsMouseOver}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Mode=OneWay}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Mode=OneWay}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -134,6 +155,8 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <Grid x:Name="Glyph"
+                                  Width="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
+                                  Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
                                   Margin="0 0 4 0"
                                   RenderTransformOrigin="0.5 0.5"
                                   Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -147,10 +170,8 @@
                                     </TransformGroup>
                                 </Grid.LayoutTransform>
                                 <Ellipse x:Name="Circle"
-                                         Width="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
-                                         Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
-                                         HorizontalAlignment="Center"
-                                         VerticalAlignment="Center"
+                                         HorizontalAlignment="Stretch"
+                                         VerticalAlignment="Stretch"
                                          Stroke="{TemplateBinding Foreground}"
                                          StrokeThickness="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThickness}" />
                                 <Path x:Name="Arrow"
@@ -192,6 +213,27 @@
                                 </Setter.Value>
                             </Setter>
                         </Trigger>
+                        <!--  A colour of its own for the glyph, if somebody set one. Left unset, it keeps the foreground of the header.  -->
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Mode=OneWay}" />
+                        </DataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsMouseOver}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Mode=OneWay}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Mode=OneWay}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -214,6 +256,8 @@
                                 <RowDefinition Height="*" />
                             </Grid.RowDefinitions>
                             <Grid x:Name="Glyph"
+                                  Width="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
+                                  Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
                                   Margin="0 0 0 4"
                                   RenderTransformOrigin="0.5 0.5"
                                   Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -227,10 +271,8 @@
                                     </TransformGroup>
                                 </Grid.LayoutTransform>
                                 <Ellipse x:Name="Circle"
-                                         Width="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
-                                         Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
-                                         HorizontalAlignment="Center"
-                                         VerticalAlignment="Center"
+                                         HorizontalAlignment="Stretch"
+                                         VerticalAlignment="Stretch"
                                          Stroke="{TemplateBinding Foreground}"
                                          StrokeThickness="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThickness}" />
                                 <Path x:Name="Arrow"
@@ -282,6 +324,27 @@
                                 </Setter.Value>
                             </Setter>
                         </Trigger>
+                        <!--  A colour of its own for the glyph, if somebody set one. Left unset, it keeps the foreground of the header.  -->
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Mode=OneWay}" />
+                        </DataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsMouseOver}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Mode=OneWay}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Mode=OneWay}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -303,14 +366,14 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
                             <Grid x:Name="Glyph"
+                                  Width="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
+                                  Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
                                   Margin="0 0 4 0"
                                   RenderTransformOrigin="0.5 0.5"
                                   Visibility="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ShowToggleButton), Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
                                 <Ellipse x:Name="Circle"
-                                         Width="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
-                                         Height="{DynamicResource ExpanderToggleButtonEllipseThemeSize}"
-                                         HorizontalAlignment="Center"
-                                         VerticalAlignment="Center"
+                                         HorizontalAlignment="Stretch"
+                                         VerticalAlignment="Stretch"
                                          Stroke="{TemplateBinding Foreground}"
                                          StrokeThickness="{DynamicResource ExpanderToggleButtonEllipseThemeStrokeThickness}" />
                                 <Path x:Name="Arrow"
@@ -352,6 +415,27 @@
                                 </Setter.Value>
                             </Setter>
                         </Trigger>
+                        <!--  A colour of its own for the glyph, if somebody set one. Left unset, it keeps the foreground of the header.  -->
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True">
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForeground), Mode=OneWay}" />
+                        </DataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsMouseOver}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver), Mode=OneWay}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsPressed}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="Arrow" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Mode=OneWay}" />
+                            <Setter TargetName="Circle" Property="Stroke" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed), Mode=OneWay}" />
+                        </MultiDataTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -421,6 +505,9 @@
                                                   VerticalContentAlignment="{TemplateBinding mah:HeaderedControlHelper.HeaderVerticalContentAlignment}"
                                                   mah:ControlsHelper.ContentCharacterCasing="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ControlsHelper.ContentCharacterCasing)}"
                                                   mah:ExpanderHelper.ShowToggleButton="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ShowToggleButton)}"
+                                                  mah:ExpanderHelper.ToggleButtonForeground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForeground)}"
+                                                  mah:ExpanderHelper.ToggleButtonForegroundMouseOver="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundMouseOver)}"
+                                                  mah:ExpanderHelper.ToggleButtonForegroundPressed="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:ExpanderHelper.ToggleButtonForegroundPressed)}"
                                                   Content="{TemplateBinding Header}"
                                                   ContentStringFormat="{TemplateBinding HeaderStringFormat}"
                                                   ContentTemplate="{TemplateBinding HeaderTemplate}"
@@ -498,6 +585,36 @@
                             </MultiDataTrigger.Conditions>
                             <Setter TargetName="ExpandSite" Property="Opacity" Value="0" />
                             <Setter TargetName="ExpandSite" Property="Visibility" Value="Collapsed" />
+                        </MultiDataTrigger>
+
+                        <!--  The header takes a colour of its own while the mouse is over it or while it is held down, if somebody set one.  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=ToggleSite, Path=IsMouseOver}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:HeaderedControlHelper.HeaderBackgroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="HeaderSite" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderBackgroundMouseOver), Mode=OneWay}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=ToggleSite, Path=IsMouseOver}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:HeaderedControlHelper.HeaderForegroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="ToggleSite" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderForegroundMouseOver), Mode=OneWay}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=ToggleSite, Path=IsPressed}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:HeaderedControlHelper.HeaderBackgroundPressed), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="HeaderSite" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderBackgroundPressed), Mode=OneWay}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=ToggleSite, Path=IsPressed}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:HeaderedControlHelper.HeaderForegroundPressed), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="ToggleSite" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderForegroundPressed), Mode=OneWay}" />
                         </MultiDataTrigger>
 
                         <Trigger Property="ExpandDirection" Value="Right">

--- a/src/MahApps.Metro/Styles/Controls.GroupBox.xaml
+++ b/src/MahApps.Metro/Styles/Controls.GroupBox.xaml
@@ -72,6 +72,23 @@
                                               UseLayoutRounding="False" />
                         </Border>
                     </Grid>
+                    <ControlTemplate.Triggers>
+                        <!--  The header takes a colour of its own while the mouse is over it, if somebody set one.  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=HeaderSite, Path=IsMouseOver}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:HeaderedControlHelper.HeaderBackgroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="HeaderSite" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderBackgroundMouseOver), Mode=OneWay}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=HeaderSite, Path=IsMouseOver}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:HeaderedControlHelper.HeaderForegroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="HeaderContent" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderForegroundMouseOver), Mode=OneWay}" />
+                        </MultiDataTrigger>
+                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/src/MahApps.Metro/Styles/Controls.TabControl.xaml
+++ b/src/MahApps.Metro/Styles/Controls.TabControl.xaml
@@ -512,17 +512,43 @@
                             <Setter TargetName="Underline" Property="Placement" Value="Right" />
                             <Setter TargetName="Underline" Property="VerticalAlignment" Value="Stretch" />
                         </MultiDataTrigger>
+                        <!--
+                            A colour of its own for the tab while the mouse is over it, if somebody set one.
+                            The strip is asked through SourceName, because an item counts the content below
+                            it as its own. A condition like that cannot be mixed with one on a binding, so
+                            the triggers below are what put the colours back when nothing was handed over.
+                        -->
+                        <Trigger SourceName="Border" Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderBackgroundMouseOver), Mode=OneWay}" />
+                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderForegroundMouseOver), Mode=OneWay}" />
+                        </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition SourceName="Border" Property="IsMouseOver" Value="True" />
+                                <Condition Property="mah:HeaderedControlHelper.HeaderBackgroundMouseOver" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="Border" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background, Mode=OneWay}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition SourceName="Border" Property="IsMouseOver" Value="True" />
+                                <Condition Property="mah:HeaderedControlHelper.HeaderForegroundMouseOver" Value="{x:Null}" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="ContentSite" Property="TextElement.Foreground" Value="{DynamicResource MahApps.Brushes.Gray.MouseOver}" />
+                        </MultiTrigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="VerticalContentAlignment" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=VerticalContentAlignment, Mode=OneWay, FallbackValue={x:Static VerticalAlignment.Stretch}}" />
         <Setter Property="mah:HeaderedControlHelper.HeaderBackground" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(mah:HeaderedControlHelper.HeaderBackground), Mode=OneWay, FallbackValue={x:Static Brushes.Transparent}}" />
+        <Setter Property="mah:HeaderedControlHelper.HeaderBackgroundMouseOver" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(mah:HeaderedControlHelper.HeaderBackgroundMouseOver), Mode=OneWay}" />
         <Setter Property="mah:HeaderedControlHelper.HeaderFontFamily" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(mah:HeaderedControlHelper.HeaderFontFamily), Mode=OneWay, FallbackValue={x:Static SystemFonts.MessageFontFamily}}" />
         <Setter Property="mah:HeaderedControlHelper.HeaderFontSize" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(mah:HeaderedControlHelper.HeaderFontSize), Mode=OneWay, FallbackValue={x:Static SystemFonts.MessageFontSize}}" />
         <Setter Property="mah:HeaderedControlHelper.HeaderFontStretch" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(mah:HeaderedControlHelper.HeaderFontStretch), Mode=OneWay, FallbackValue={x:Static FontStretches.Normal}}" />
         <Setter Property="mah:HeaderedControlHelper.HeaderFontWeight" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(mah:HeaderedControlHelper.HeaderFontWeight), Mode=OneWay, FallbackValue={x:Static SystemFonts.MessageFontWeight}}" />
         <Setter Property="mah:HeaderedControlHelper.HeaderForeground" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(mah:HeaderedControlHelper.HeaderForeground), Mode=OneWay, FallbackValue={x:Static SystemColors.ControlTextBrush}}" />
+        <Setter Property="mah:HeaderedControlHelper.HeaderForegroundMouseOver" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(mah:HeaderedControlHelper.HeaderForegroundMouseOver), Mode=OneWay}" />
         <Setter Property="mah:HeaderedControlHelper.HeaderHorizontalContentAlignment" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(mah:HeaderedControlHelper.HeaderHorizontalContentAlignment), Mode=OneWay, FallbackValue={x:Static HorizontalAlignment.Stretch}}" />
         <Setter Property="mah:HeaderedControlHelper.HeaderMargin" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(mah:HeaderedControlHelper.HeaderMargin), Mode=OneWay, FallbackValue='6 2'}" />
         <Setter Property="mah:HeaderedControlHelper.HeaderVerticalContentAlignment" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TabControl}}, Path=(mah:HeaderedControlHelper.HeaderVerticalContentAlignment), Mode=OneWay, FallbackValue={x:Static VerticalAlignment.Center}}" />

--- a/src/MahApps.Metro/Themes/Flyout.xaml
+++ b/src/MahApps.Metro/Themes/Flyout.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:actions="clr-namespace:MahApps.Metro.Actions"
                     xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <ControlTemplate x:Key="MahApps.Templates.Flyout.Header" TargetType="{x:Type mah:MetroThumbContentControl}">
         <Grid Background="{TemplateBinding Background}">
@@ -209,6 +210,21 @@
             </VisualStateManager.VisualStateGroups>
         </Border>
         <ControlTemplate.Triggers>
+            <!--  The header takes a colour of its own while the mouse is over it, if somebody set one.  -->
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding ElementName=PART_Header, Path=IsMouseOver}" Value="True" />
+                    <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:HeaderedControlHelper.HeaderBackgroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                </MultiDataTrigger.Conditions>
+                <Setter TargetName="PART_Header" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderBackgroundMouseOver), Mode=OneWay}" />
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding ElementName=PART_Header, Path=IsMouseOver}" Value="True" />
+                    <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:HeaderedControlHelper.HeaderForegroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                </MultiDataTrigger.Conditions>
+                <Setter TargetName="PART_Header" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderForegroundMouseOver), Mode=OneWay}" />
+            </MultiDataTrigger>
             <Trigger Property="Position" Value="Top">
                 <Setter TargetName="PART_Content" Property="DockPanel.Dock" Value="Right" />
                 <Setter TargetName="PART_Header" Property="DockPanel.Dock" Value="Left" />

--- a/src/MahApps.Metro/Themes/MetroHeader.xaml
+++ b/src/MahApps.Metro/Themes/MetroHeader.xaml
@@ -15,7 +15,7 @@
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" SharedSizeGroup="MetroHeader_SharedSizeGroup_Header" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Grid x:Name="PART_Header"

--- a/src/MahApps.Metro/Themes/MetroHeader.xaml
+++ b/src/MahApps.Metro/Themes/MetroHeader.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:mah="clr-namespace:MahApps.Metro.Controls">
+                    xmlns:mah="clr-namespace:MahApps.Metro.Controls"
+                    xmlns:mahConverters="clr-namespace:MahApps.Metro.Converters">
 
     <Style x:Key="MahApps.Styles.MetroHeader" TargetType="{x:Type mah:MetroHeader}">
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -54,6 +55,21 @@
                         </Grid>
                     </Grid>
                     <ControlTemplate.Triggers>
+                        <!--  The header takes a colour of its own while the mouse is over it, if somebody set one.  -->
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=PART_Header, Path=IsMouseOver}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:HeaderedControlHelper.HeaderBackgroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="PART_Header" Property="Background" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderBackgroundMouseOver), Mode=OneWay}" />
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding ElementName=PART_Header, Path=IsMouseOver}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(mah:HeaderedControlHelper.HeaderForegroundMouseOver), Converter={x:Static mahConverters:IsNotNullConverter.Instance}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="HeaderContent" Property="Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(mah:HeaderedControlHelper.HeaderForegroundMouseOver), Mode=OneWay}" />
+                        </MultiDataTrigger>
                         <Trigger Property="Orientation" Value="Horizontal">
                             <Setter TargetName="PART_Content" Property="Grid.Column" Value="1" />
                             <Setter TargetName="PART_Content" Property="Grid.ColumnSpan" Value="1" />

--- a/src/Mahapps.Metro.Tests/Tests/ExpanderHeaderContrastTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/ExpanderHeaderContrastTests.cs
@@ -1,0 +1,275 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// GH-4386: the arrow in an expander header used to turn grey while the mouse was over it, which on
+    /// the accent coloured header it sits on left almost nothing to see. Touching a thing must not make it
+    /// harder to make out than it was at rest.
+    /// </summary>
+    [TestFixture]
+    public class ExpanderHeaderContrastTests
+    {
+        /// <summary>What the accessibility guidelines put under a shape somebody has to make out.</summary>
+        private const double LeastContrast = 3.0;
+
+        /// <summary>The two shapes the glyph is drawn from, with the keys each of them reads its stroke from.</summary>
+        private static readonly (string Shape, string AtRest, string UnderTheMouse, string UnderAPress)[] TheGlyph =
+        {
+            ("Circle",
+                "ExpanderToggleButtonEllipseThemeStrokeThickness",
+                "ExpanderToggleButtonEllipseThemeStrokeThicknessMouseOver",
+                "ExpanderToggleButtonEllipseThemeStrokeThicknessPressed"),
+            ("Arrow",
+                "ExpanderToggleButtonArrowThemeStrokeThickness",
+                "ExpanderToggleButtonArrowThemeStrokeThicknessMouseOver",
+                "ExpanderToggleButtonArrowThemeStrokeThicknessPressed")
+        };
+
+        private TestWindow? window;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        /// <summary>
+        /// A test that tries a value of its own leaves it behind in the window all the tests here share,
+        /// so whatever was put there goes again, even when the test it belonged to did not get that far.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var shape in TheGlyph)
+            {
+                foreach (var key in new[] { shape.AtRest, shape.UnderTheMouse, shape.UnderAPress })
+                {
+                    this.window?.Resources.Remove(key);
+                }
+            }
+        }
+
+        [TestCase(ExpandDirection.Down)]
+        [TestCase(ExpandDirection.Up)]
+        [TestCase(ExpandDirection.Left)]
+        [TestCase(ExpandDirection.Right)]
+        [Description("Neither the mouse over nor the pressed state may cost the glyph any of the contrast it has at rest.")]
+        public void TheGlyphKeepsItsContrastWhileTheHeaderIsTouched(ExpandDirection direction)
+        {
+            var toggle = this.HeaderOf(direction);
+            var header = this.HeaderGroundOf(toggle);
+            var atRest = ColourOf(toggle.Foreground);
+
+            Assert.That(atRest, Is.Not.Null, "the glyph should be drawn in a plain colour");
+
+            var resting = Contrast(atRest!.Value, header);
+            Assert.That(resting, Is.GreaterThanOrEqualTo(LeastContrast), "the glyph should be readable before anybody touches it");
+
+            foreach (var state in new[] { UIElement.IsMouseOverProperty, ButtonBase.IsPressedProperty })
+            {
+                foreach (var shape in new[] { "Arrow", "Circle" })
+                {
+                    var touched = StrokeIn(toggle, state, shape) ?? atRest.Value;
+                    var contrast = Contrast(touched, header);
+
+                    Assert.That(contrast,
+                                Is.GreaterThanOrEqualTo(resting - 0.01),
+                                $"{shape} loses contrast under {state.Name}, {contrast:0.00} to 1 against {resting:0.00} to 1 at rest");
+                    Assert.That(contrast, Is.GreaterThanOrEqualTo(LeastContrast), $"{shape} should stay readable under {state.Name}");
+                }
+            }
+        }
+
+        [TestCase(ExpandDirection.Down)]
+        [TestCase(ExpandDirection.Up)]
+        [TestCase(ExpandDirection.Left)]
+        [TestCase(ExpandDirection.Right)]
+        [Description("Keeping the colour is only half of it, both states still have to show that the header answers.")]
+        public void TouchingTheHeaderStillChangesTheGlyph(ExpandDirection direction)
+        {
+            var toggle = this.HeaderOf(direction);
+
+            foreach (var state in new[] { UIElement.IsMouseOverProperty, ButtonBase.IsPressedProperty })
+            {
+                Assert.That(SettersIn(toggle, state), Is.Not.Empty, $"{state.Name} should still be answered with something");
+            }
+        }
+
+        [TestCase(ExpandDirection.Down)]
+        [TestCase(ExpandDirection.Up)]
+        [TestCase(ExpandDirection.Left)]
+        [TestCase(ExpandDirection.Right)]
+        [Description("How far the two strokes grow under the mouse and under a press is the theme to say, the way the size of the circle already is.")]
+        public void TheGlyphTakesTheThicknessTheThemeAsksFor(ExpandDirection direction)
+        {
+            var toggle = this.HeaderOf(direction);
+
+            foreach (var shape in TheGlyph)
+            {
+                foreach (var state in new[] { (Property: UIElement.IsMouseOverProperty, Key: shape.UnderTheMouse), (Property: ButtonBase.IsPressedProperty, Key: shape.UnderAPress) })
+                {
+                    var setter = SettersIn(toggle, state.Property)
+                                 .LastOrDefault(candidate => candidate.TargetName == shape.Shape && candidate.Property == Shape.StrokeThicknessProperty);
+
+                    Assert.That(setter, Is.Not.Null, $"{state.Property.Name} should say how thick {shape.Shape} is drawn");
+                    Assert.That(setter!.Value, Is.InstanceOf<DynamicResourceExtension>(), $"{shape.Shape} under {state.Property.Name} should read that from the theme rather than carry a number");
+                    Assert.That(((DynamicResourceExtension)setter.Value).ResourceKey, Is.EqualTo(state.Key));
+                    Assert.That(toggle.TryFindResource(state.Key), Is.Not.Null, "and the theme should hold that key");
+
+                    // what being settable comes down to: a value of somebody own is what the template then reads
+                    this.window!.Resources[state.Key] = 5d;
+                    Assert.That(Resolve(setter.Value, toggle), Is.EqualTo(5d), $"{state.Key} should be the way to change it");
+                }
+            }
+        }
+
+        [TestCase(ExpandDirection.Down)]
+        [TestCase(ExpandDirection.Up)]
+        [TestCase(ExpandDirection.Left)]
+        [TestCase(ExpandDirection.Right)]
+        [Description("What nobody is touching is drawn from the theme as well, so all of them can be kept in step.")]
+        public void TheGlyphAtRestTakesTheThicknessTheThemeAsksFor(ExpandDirection direction)
+        {
+            var toggle = this.HeaderOf(direction);
+
+            foreach (var shape in TheGlyph)
+            {
+                var drawn = toggle.FindChild<Shape>(shape.Shape);
+
+                Assert.That(drawn, Is.Not.Null, $"the header should carry {shape.Shape}");
+                Assert.That(toggle.TryFindResource(shape.AtRest), Is.Not.Null, "the theme should hold that key");
+                Assert.That(drawn!.StrokeThickness, Is.EqualTo(toggle.TryFindResource(shape.AtRest)), $"{shape.Shape} should be drawn as thick as the theme says");
+
+                // this one is read off the shape itself, so a value of somebody own has to arrive there
+                this.window!.Resources[shape.AtRest] = 5d;
+                this.window.UpdateLayout();
+
+                Assert.That(drawn.StrokeThickness, Is.EqualTo(5d), $"{shape.AtRest} should be the way to change it");
+            }
+        }
+
+        /// <summary>The toggle button an expander puts its header in, laid out and ready to be read.</summary>
+        private ToggleButton HeaderOf(ExpandDirection direction)
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            var expander = new Expander { Header = "a header", Content = new TextBlock { Text = "some content" }, ExpandDirection = direction };
+
+            this.window!.Content = expander;
+            this.window.UpdateLayout();
+            expander.UpdateLayout();
+
+            ClipAssert.Pump();
+
+            var toggle = expander.FindChild<ToggleButton>("ToggleSite");
+            Assert.That(toggle, Is.Not.Null, "the expander should put its header in a toggle button");
+
+            var arrow = toggle!.FindChild<Path>("Arrow");
+            Assert.That(arrow, Is.Not.Null, "the header should carry the arrow");
+            Assert.That(arrow!.ActualWidth, Is.GreaterThan(0), "the arrow should be laid out, otherwise this test proves nothing");
+
+            return toggle;
+        }
+
+        /// <summary>
+        /// What the glyph is seen against. The header brush carries an alpha of its own, so what counts is
+        /// the header over whatever the window puts behind it.
+        /// </summary>
+        private Color HeaderGroundOf(ToggleButton toggle)
+        {
+            var expander = toggle.TryFindParent<Expander>();
+            Assert.That(expander, Is.Not.Null);
+
+            var header = ColourOf(HeaderedControlHelper.GetHeaderBackground(expander!));
+            Assert.That(header, Is.Not.Null, "the header should be painted in a plain colour");
+
+            var behind = ColourOf(this.window!.Background) ?? Colors.White;
+
+            return Over(header!.Value, behind);
+        }
+
+        /// <summary>What a template trigger for that state makes of the stroke of one of the two shapes.</summary>
+        private static Color? StrokeIn(ToggleButton toggle, DependencyProperty state, string shape)
+        {
+            var setter = SettersIn(toggle, state)
+                         .LastOrDefault(candidate => candidate.TargetName == shape && candidate.Property == Shape.StrokeProperty);
+
+            return setter is null ? null : ColourOf(Resolve(setter.Value, toggle));
+        }
+
+        private static Setter[] SettersIn(ToggleButton toggle, DependencyProperty state)
+        {
+            Assert.That(toggle.Template, Is.Not.Null);
+
+            return toggle.Template.Triggers
+                         .OfType<Trigger>()
+                         .Where(trigger => trigger.Property == state && Equals(trigger.Value, true))
+                         .SelectMany(trigger => trigger.Setters.OfType<Setter>())
+                         .ToArray();
+        }
+
+        /// <summary>A setter that was never applied still holds the resource reference rather than the brush.</summary>
+        private static object? Resolve(object? value, FrameworkElement scope)
+        {
+            return value is DynamicResourceExtension reference ? scope.TryFindResource(reference.ResourceKey) : value;
+        }
+
+        private static Color? ColourOf(object? brush)
+        {
+            return brush is SolidColorBrush solid ? solid.Color : null;
+        }
+
+        /// <summary>One colour painted over another, which is what an alpha in a brush comes down to.</summary>
+        private static Color Over(Color colour, Color ground)
+        {
+            var alpha = colour.A / 255d;
+
+            return Color.FromRgb((byte)Math.Round((colour.R * alpha) + (ground.R * (1 - alpha))),
+                                 (byte)Math.Round((colour.G * alpha) + (ground.G * (1 - alpha))),
+                                 (byte)Math.Round((colour.B * alpha) + (ground.B * (1 - alpha))));
+        }
+
+        /// <summary>The ratio the accessibility guidelines are written in, where 1 to 1 is invisible.</summary>
+        private static double Contrast(Color one, Color other)
+        {
+            var first = Luminance(one);
+            var second = Luminance(other);
+
+            return (Math.Max(first, second) + 0.05) / (Math.Min(first, second) + 0.05);
+        }
+
+        private static double Luminance(Color colour)
+        {
+            return (0.2126 * Channel(colour.R)) + (0.7152 * Channel(colour.G)) + (0.0722 * Channel(colour.B));
+        }
+
+        private static double Channel(byte value)
+        {
+            var channel = value / 255d;
+
+            return channel <= 0.03928 ? channel / 12.92 : Math.Pow((channel + 0.055) / 1.055, 2.4);
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/HeaderStateColoursTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/HeaderStateColoursTests.cs
@@ -1,0 +1,139 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using MahApps.Metro.Controls;
+using MahApps.Metro.Tests.TestHelpers;
+using NUnit.Framework;
+
+namespace MahApps.Metro.Tests.Tests
+{
+    /// <summary>
+    /// A header can be painted differently while the mouse is over it and while it is held down. Neither
+    /// of those is a state a test can put a control into, so what is measured here is the brush at rest
+    /// and that nothing is taken away from a header nobody handed one of them to.
+    /// </summary>
+    [TestFixture]
+    public class HeaderStateColoursTests
+    {
+        private TestWindow? window;
+
+        [OneTimeSetUp]
+        public async Task OneTimeSetUp()
+        {
+            this.window = await WindowHelpers.CreateInvisibleWindowAsync<TestWindow>().ConfigureAwait(false);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            this.window?.Close();
+            this.window = null;
+        }
+
+        [Test]
+        [Description("A brush of its own for the glyph wins over the foreground the header hands it.")]
+        public void TheGlyphTakesTheColourItWasGiven()
+        {
+            var expander = this.Show(new Expander { Header = "a header" });
+            var arrow = expander.FindChild<Path>("Arrow");
+            var circle = expander.FindChild<Ellipse>("Circle");
+
+            Assert.That(arrow, Is.Not.Null);
+            Assert.That(circle, Is.Not.Null);
+            Assert.That(arrow!.Stroke, Is.SameAs(HeaderOf(expander).Foreground), "at rest the glyph follows the header");
+
+            ExpanderHelper.SetToggleButtonForeground(HeaderOf(expander), Brushes.HotPink);
+            this.Settle();
+
+            Assert.That(arrow.Stroke, Is.SameAs(Brushes.HotPink));
+            Assert.That(circle!.Stroke, Is.SameAs(Brushes.HotPink));
+        }
+
+        [Test]
+        [Description("The brush is given to the expander, which is where somebody sets it, and has to reach the toggle button inside.")]
+        public void TheGlyphTakesTheColourTheExpanderWasGiven()
+        {
+            var expander = this.Show(new Expander { Header = "a header" });
+            var arrow = expander.FindChild<Path>("Arrow");
+
+            ExpanderHelper.SetToggleButtonForeground(expander, Brushes.HotPink);
+            this.Settle();
+
+            Assert.That(arrow!.Stroke, Is.SameAs(Brushes.HotPink), "the expander should hand it to the toggle button the way it hands over ShowToggleButton");
+        }
+
+        [Test]
+        [Description("Opening an expander is not one of the two states, so the glyph stays as it was.")]
+        public void TheGlyphKeepsItsColourWhenTheExpanderIsOpened()
+        {
+            var expander = this.Show(new Expander { Header = "a header" });
+            var arrow = expander.FindChild<Path>("Arrow");
+            var toggle = HeaderOf(expander);
+
+            ExpanderHelper.SetToggleButtonForeground(toggle, Brushes.HotPink);
+            ExpanderHelper.SetToggleButtonForegroundMouseOver(toggle, Brushes.Lime);
+            ExpanderHelper.SetToggleButtonForegroundPressed(toggle, Brushes.Orange);
+            this.Settle();
+
+            expander.IsExpanded = true;
+            this.Settle();
+
+            Assert.That(arrow!.Stroke, Is.SameAs(Brushes.HotPink), "neither the mouse nor a press is what opened it");
+        }
+
+        [Test]
+        [Description("Left unset, none of them may take anything away from the header as it was.")]
+        public void AHeaderNobodyGaveThoseBrushesStaysAsItWas()
+        {
+            var expander = this.Show(new Expander { Header = "a header" });
+            var headerSite = expander.FindChild<Border>("HeaderSite");
+            var arrow = expander.FindChild<Path>("Arrow");
+
+            HeaderedControlHelper.SetHeaderBackground(expander, Brushes.SlateGray);
+            this.Settle();
+
+            var foreground = HeaderOf(expander).Foreground;
+
+            expander.IsExpanded = true;
+            this.Settle();
+
+            Assert.That(headerSite!.Background, Is.SameAs(Brushes.SlateGray), "the header should keep its background");
+            Assert.That(HeaderOf(expander).Foreground, Is.SameAs(foreground), "and its foreground");
+            Assert.That(arrow!.Stroke, Is.SameAs(foreground), "and the glyph should still follow the header");
+        }
+
+        /// <summary>The toggle button an expander puts its header in.</summary>
+        private static ToggleButton HeaderOf(Expander expander)
+        {
+            var toggle = expander.FindChild<ToggleButton>("ToggleSite");
+            Assert.That(toggle, Is.Not.Null, "the expander should put its header in a toggle button");
+
+            return toggle!;
+        }
+
+        private Expander Show(Expander expander)
+        {
+            Assert.That(this.window, Is.Not.Null);
+
+            this.window!.Content = expander;
+            this.Settle();
+
+            Assert.That(expander.IsLoaded, Is.True, "the expander should be up before a test looks at it");
+
+            return expander;
+        }
+
+        private void Settle()
+        {
+            this.window!.UpdateLayout();
+            ClipAssert.Pump();
+        }
+    }
+}

--- a/src/Mahapps.Metro.Tests/Tests/HeaderStateColoursTests.cs
+++ b/src/Mahapps.Metro.Tests/Tests/HeaderStateColoursTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Media;


### PR DESCRIPTION
## Describe the changes you have made to improve this project

The arrow in an expander header turned grey while the mouse was over it and only came back to full strength while the header was held down. On the accent coloured header it sits on that is a contrast of 1.2 to 1, against 3.3 to 1 at rest, so touching the header made the glyph harder to see instead of easier. The two brushes behind that were fixed ones and knew nothing about the header, whose colour comes from `HeaderedControlHelper.HeaderBackground` and can be anything, which is why the pressed state broke the other way round on a dark header of somebody own.

The glyph keeps the foreground of the header in every state now. A touch is answered by the ring, which grows, and pressing pushes the whole glyph in a little. Both are shape rather than colour, so the resting contrast holds in every theme and for every header colour. How thick the two strokes are drawn is the theme to say, through six keys next to `ExpanderToggleButtonEllipseThemeSize`, each carrying what was written into the templates before.

On top of that a header can now be painted differently while it is touched. `HeaderedControlHelper` carries four more brushes, one pair for the mouse being over the header and one for it being held down, and `ExpanderHelper` carries three of its own for the circle and the arrow alone. Left unset, every one of them hands nothing over and the header stays exactly as it was. Where the state exists, that is: an expander header is a toggle button and knows both, while a group box, a MetroHeader, a flyout header and a tab item only ever see the mouse.

Two smaller things came along the way. With `ExpandDirection` Left or Right the header text is turned with the side it sits on rather than staying flat across a narrow strip, and the toggle button templates no longer draw a border of their own, since the HeaderSite around them already draws the one the expander was given.

<img width="1674" height="1436" alt="2026-09-12_12h24_18" src="https://github.com/user-attachments/assets/66723990-e541-4936-91dc-8765c9629108" />

## Additional context

Before and after, with the mouse moving onto the header and pressing it. The arrow on the left turns grey and all but disappears, the one on the right does not.

<img width="820" height="146" alt="expander-header" src="https://github.com/user-attachments/assets/1219175c-9718-4c0e-aedb-cf325e71fd32" />

## Closed Issues

Closes #4386
